### PR TITLE
Add .gitattributes file to avoid most Changelog merge conflicts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+CHANGELOG.md merge=union

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ## Added
 
+- Add .gitattributes file to avoid most Changelog merge conflicts @pnicolli
 - Buildout for Python 3 @pbauer
 
 ## 1.0.0 (2018-10-31)


### PR DESCRIPTION
I've seen merge conflicts in Changelog files in pull requests and I figured we might as well use the same strategy we use with plone packages: setting gitattributes to use the `union` style for merging the Changelog file. What do you think about it?
Quick article for reference: http://krlmlr.github.io/using-gitattributes-to-avoid-merge-conflicts/