### PR TITLE
Integration improvements

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -29,7 +29,9 @@
     "import/prefer-default-export": "off",
     "react/prefer-stateless-function": 0,
     "import/no-unresolved": 0,
-    "import/extensions": 0
+    "import/extensions": 0,
+    "import/no-extraneous-dependencies": 0,
+    "react/no-unused-prop-types": 0
   },
   "settings": {
     "import/resolver": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 1.1.1 (unreleased)
 
+### Added
+
+- be able to work with mr.developer @vangheem
+- add alias `@plone/volto-original` and `@package` webpack aliases @vangheem
+- add `errorViews` configuration @vangheem
+
 ### Changes
 
 ## 1.1.0 (2018-12-24)

--- a/src/components/theme/View/View.jsx
+++ b/src/components/theme/View/View.jsx
@@ -112,7 +112,7 @@ export default class View extends Component {
       /**
        * Error type
        */
-      type: PropTypes.string,
+      status: PropTypes.number,
     }),
     intl: intlShape.isRequired,
   };
@@ -214,9 +214,13 @@ export default class View extends Component {
    */
   render() {
     if (this.props.error) {
+      let FoundView = views.errorViews[this.props.error.status.toString()];
+      if (!FoundView) {
+        FoundView = views.errorViews['404']; // default to 404
+      }
       return (
         <div id="view">
-          <NotFound />
+          <FoundView />
         </div>
       );
     }

--- a/src/config/Views.jsx
+++ b/src/config/Views.jsx
@@ -5,6 +5,7 @@ import ListingView from '@plone/volto/components/theme/View/ListingView';
 import NewsItemView from '@plone/volto/components/theme/View/NewsItemView';
 import SummaryView from '@plone/volto/components/theme/View/SummaryView';
 import TabularView from '@plone/volto/components/theme/View/TabularView';
+import NotFoundView from '@plone/volto/components/theme/NotFound/NotFound';
 
 // Layout View Registry
 export const layoutViews = {
@@ -22,3 +23,7 @@ export const contentTypesViews = {
 
 // Default view
 export const defaultView = DocumentView;
+
+export const errorViews = {
+  '404': NotFoundView,
+};

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -4,7 +4,12 @@
  */
 
 import { defaultWidget, widgetMapping } from './Widgets';
-import { layoutViews, contentTypesViews, defaultView } from './Views';
+import {
+  layoutViews,
+  contentTypesViews,
+  defaultView,
+  errorViews,
+} from './Views';
 import { nonContentRoutes } from './NonContentRoutes';
 import ToHTMLRenderers, {
   options as ToHTMLOptions,
@@ -45,6 +50,7 @@ export const views = {
   layoutViews,
   contentTypesViews,
   defaultView,
+  errorViews,
 };
 
 export const tiles = {

--- a/src/helpers/Api/Api.js
+++ b/src/helpers/Api/Api.js
@@ -57,7 +57,7 @@ export class Api {
           }
 
           request.end(
-            (err, { body } = {}) => (err ? reject(body || err) : resolve(body)),
+            (err, { body } = {}) => (err ? reject(err) : resolve(body)),
           );
         });
     });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "compilerOptions": {
+        "experimentalDecorators": true,
+        "allowJs": true
+    }
+}


### PR DESCRIPTION
- work with mr.developer
- add alias to `@plone/volto-original` to be able to reimport overridden components
- add alias to `@package` for current dev package to be able to import modules in the current project from customizations folder
- be able to override error views based on status code of error message(previously only had 404 view)