### PR TITLE
Prevent Volto hit the @types endpoint (via its action, getTypes()) if…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### Changes
 
+- Prevent Volto hit the @types endpoint (via its action, getTypes()) if the
+  user is not authenticated, since it's useless and always returns a 401
+  @sneridagh
+
 ## 1.4.0 (2019-02-15)
 
 ### Added

--- a/src/actions/types/types.js
+++ b/src/actions/types/types.js
@@ -12,11 +12,15 @@ import { GET_TYPES } from '../../constants/ActionTypes';
  * @returns {Object} Get types action.
  */
 export function getTypes(url) {
-  return {
-    type: GET_TYPES,
-    request: {
-      op: 'get',
-      path: `${url}/@types`,
-    },
+  return (dispatch, getState) => {
+    if (getState().userSession.token) {
+      dispatch({
+        type: GET_TYPES,
+        request: {
+          op: 'get',
+          path: `${url}/@types`,
+        },
+      });
+    }
   };
 }

--- a/src/actions/types/types.test.js
+++ b/src/actions/types/types.test.js
@@ -4,12 +4,23 @@ import { GET_TYPES } from '../../constants/ActionTypes';
 describe('Types action', () => {
   describe('getTypes', () => {
     it('should create an action to get the types', () => {
+      const getState = () => ({
+        userSession: {
+          token: 'thetoken',
+        },
+      });
       const url = '/blog';
-      const action = getTypes(url);
+      const dispatch = jest.fn();
 
-      expect(action.type).toEqual(GET_TYPES);
-      expect(action.request.op).toEqual('get');
-      expect(action.request.path).toEqual(`${url}/@types`);
+      getTypes(url)(dispatch, getState);
+
+      expect(dispatch).toHaveBeenCalledWith({
+        type: GET_TYPES,
+        request: {
+          op: 'get',
+          path: `${url}/@types`,
+        },
+      });
     });
   });
 });

--- a/src/components/manage/Types/Types.test.jsx
+++ b/src/components/manage/Types/Types.test.jsx
@@ -2,10 +2,11 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 import configureStore from 'redux-mock-store';
 import { Provider } from 'react-intl-redux';
+import thunk from 'redux-thunk';
 
 import Types from './Types';
 
-const mockStore = configureStore();
+const mockStore = configureStore([thunk]);
 
 describe('Types', () => {
   it('renders an empty types component', () => {
@@ -15,6 +16,9 @@ describe('Types', () => {
       intl: {
         locale: 'en',
         messages: {},
+      },
+      userSession: {
+        token: 'thetoken',
       },
     });
     const component = renderer.create(
@@ -34,6 +38,9 @@ describe('Types', () => {
         locale: 'en',
         messages: {},
       },
+      userSession: {
+        token: 'thetoken',
+      },
     });
     const component = renderer.create(
       <Provider store={store}>
@@ -51,6 +58,30 @@ describe('Types', () => {
       intl: {
         locale: 'en',
         messages: {},
+      },
+      userSession: {
+        token: 'thetoken',
+      },
+    });
+    const component = renderer.create(
+      <Provider store={store}>
+        <Types pathname="/test" active />
+      </Provider>,
+    );
+    const json = component.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('types component if the user is anonymous', () => {
+    const store = mockStore({
+      types: { types: [{ title: 'Document' }] },
+      content: { data: {} },
+      intl: {
+        locale: 'en',
+        messages: {},
+      },
+      userSession: {
+        token: '',
       },
     });
     const component = renderer.create(

--- a/src/components/manage/Types/__snapshots__/Types.test.jsx.snap
+++ b/src/components/manage/Types/__snapshots__/Types.test.jsx.snap
@@ -5,3 +5,5 @@ exports[`Types renders a types component 1`] = `<span />`;
 exports[`Types renders an active types component 1`] = `<span />`;
 
 exports[`Types renders an empty types component 1`] = `<span />`;
+
+exports[`Types types component if the user is anonymous 1`] = `<span />`;


### PR DESCRIPTION
… the

  user is not authenticated, since it's useless and always returns a 401