### PR TITLE
Set image width in Volto editor to 50% for images that float left/right.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Set image width in Volto editor to 50% for images that float left/right @timo
 - Ability to navigate through the existing tiles with the cursors. @sneridagh
  - HTML Tile for Volto Editor with preview and code prettifier
    @ajayns @nileshgulia1 @sneridagh

--- a/theme/themes/pastanaga/globals/site.overrides
+++ b/theme/themes/pastanaga/globals/site.overrides
@@ -596,6 +596,7 @@ body {
   }
 
   iframe {
+    width: 50%;
     height: 25vw;
   }
 

--- a/theme/themes/pastanaga/globals/site.overrides
+++ b/theme/themes/pastanaga/globals/site.overrides
@@ -596,12 +596,12 @@ body {
   }
 
   iframe {
-    width: 50%;
     height: 25vw;
   }
 
-  .ui.image {
-    width: auto;
+  .ui.image,
+  img {
+    width: 50%;
   }
 }
 
@@ -619,8 +619,9 @@ body {
     height: 25vw;
   }
 
-  .ui.image {
-    width: auto;
+  .ui.image,
+  img {
+    width: 50%;
   }
 
 }

--- a/theme/themes/pastanaga/globals/site.overrides
+++ b/theme/themes/pastanaga/globals/site.overrides
@@ -601,7 +601,7 @@ body {
 
   .ui.image,
   img {
-    width: 50%;
+    min-width: 50%;
   }
 }
 
@@ -621,7 +621,7 @@ body {
 
   .ui.image,
   img {
-    width: 50%;
+    min-width: 50%;
   }
 
 }


### PR DESCRIPTION
This fixes #645