### PR TITLE
fix: first characters in title tile are not clickable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changes
 
+- fixed issue where it was not possible to click into the title tile above the small red bar at the beginning of the line in some browsers.
+
 ## 2.1.1 (2019-04-04)
 
 ### Changes

--- a/theme/themes/pastanaga/extras/main.less
+++ b/theme/themes/pastanaga/extras/main.less
@@ -31,6 +31,7 @@ body {
     bottom: -3px;
     left: 0;
     width: 30px;
+    height: 0;
     border-bottom: 3px solid @pink;
     content: '';
   }


### PR DESCRIPTION
Fix for this issue: https://github.com/plone/volto/issues/703