### PR TITLE
Fix the folder_contents view component bby preventing the SearchableT…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@
 ### Changes
 
 - fixed issue where it was not possible to click into the title tile above the small red bar at the beginning of the line in some browsers.
-
 - Docs content editing. @esteele
+- Fix the folder_contents view component bby preventing the SearchableText be
+  empty if you haven't typed anything in the filter fields yet. This is caused
+  by the new ZCatalog in Zope 4. @sneridagh
 
 ## 2.1.1 (2019-04-04)
 

--- a/src/components/manage/Contents/Contents.jsx
+++ b/src/components/manage/Contents/Contents.jsx
@@ -720,7 +720,7 @@ export default class ContentsComponent extends Component {
       'path.depth': 1,
       sort_on: 'getObjPositionInParent',
       metadata_fields: '_all',
-      SearchableText: this.state.filter ? `${this.state.filter}*` : '',
+      ...(this.state.filter && { SearchableText: `${this.state.filter}*` }),
       b_size: this.state.pageSize,
       b_start: this.state.currentPage * this.state.pageSize,
     });


### PR DESCRIPTION
…ext be empty if you haven't typed anything in the filter fields yet. This is caused by the new ZCatalog in Zope 4.