### PR TITLE
[WIP] - fix date widget

### DIFF
--- a/src/components/manage/Widgets/DatetimeWidget.jsx
+++ b/src/components/manage/Widgets/DatetimeWidget.jsx
@@ -5,8 +5,9 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Form, Grid, Input, Label } from 'semantic-ui-react';
+import { Form, Grid, Input, Label, Button } from 'semantic-ui-react';
 import { map } from 'lodash';
+import moment from 'moment';
 
 /**
  * DatetimeWidget component class.
@@ -22,7 +23,9 @@ const DatetimeWidget = ({
   value,
   onChange,
 }) => {
-  const [datetime, timezone] = value.split('+');
+  const datetime = value
+    ? moment(new Date(value)).format('YYYY-MM-DDTHH:mm:ss')
+    : '';
   return (
     <Form.Field
       inline
@@ -44,11 +47,11 @@ const DatetimeWidget = ({
               type="datetime-local"
               value={datetime || ''}
               onChange={({ target }) => {
-                const newValue = target.value;
-                onChange(
-                  id,
-                  newValue === '' ? undefined : `${newValue}+${timezone}`,
-                );
+                const newDate = new Date(target.value);
+                const newDateStr = moment
+                  .utc(newDate)
+                  .format('YYYY-MM-DDTHH:mm:ssZ');
+                onChange(id, newDateStr === '' ? undefined : newDateStr);
               }}
             />
             {map(error, message => (

--- a/src/components/manage/Widgets/DatetimeWidget.jsx
+++ b/src/components/manage/Widgets/DatetimeWidget.jsx
@@ -21,47 +21,54 @@ const DatetimeWidget = ({
   error,
   value,
   onChange,
-}) => (
-  <Form.Field
-    inline
-    required={required}
-    error={error.length > 0}
-    className={description ? 'help' : ''}
-  >
-    <Grid>
-      <Grid.Row stretched>
-        <Grid.Column width="4">
-          <div className="wrapper">
-            <label htmlFor={`field-${id}`}>{title}</label>
-          </div>
-        </Grid.Column>
-        <Grid.Column width="8">
-          <Input
-            id={`field-${id}`}
-            name={id}
-            type="datetime-local"
-            value={value || ''}
-            onChange={({ target }) =>
-              onChange(id, target.value === '' ? undefined : target.value)
-            }
-          />
-          {map(error, message => (
-            <Label key={message} basic color="red" pointing>
-              {message}
-            </Label>
-          ))}
-        </Grid.Column>
-      </Grid.Row>
-      {description && (
+}) => {
+  const [datetime, timezone] = value.split('+');
+  return (
+    <Form.Field
+      inline
+      required={required}
+      error={error.length > 0}
+      className={description ? 'help' : ''}
+    >
+      <Grid>
         <Grid.Row stretched>
-          <Grid.Column stretched width="12">
-            <p className="help">{description}</p>
+          <Grid.Column width="4">
+            <div className="wrapper">
+              <label htmlFor={`field-${id}`}>{title}</label>
+            </div>
+          </Grid.Column>
+          <Grid.Column width="8">
+            <Input
+              id={`field-${id}`}
+              name={id}
+              type="datetime-local"
+              value={datetime || ''}
+              onChange={({ target }) => {
+                const newValue = target.value;
+                onChange(
+                  id,
+                  newValue === '' ? undefined : `${newValue}+${timezone}`,
+                );
+              }}
+            />
+            {map(error, message => (
+              <Label key={message} basic color="red" pointing>
+                {message}
+              </Label>
+            ))}
           </Grid.Column>
         </Grid.Row>
-      )}
-    </Grid>
-  </Form.Field>
-);
+        {description && (
+          <Grid.Row stretched>
+            <Grid.Column stretched width="12">
+              <p className="help">{description}</p>
+            </Grid.Column>
+          </Grid.Row>
+        )}
+      </Grid>
+    </Form.Field>
+  );
+};
 
 /**
  * Property types.


### PR DESCRIPTION
Related to #632 

The problem was on date format: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/datetime-local#Setting_timezones

We receive a date like _2019-04-17T10:00:00+00:00_ with also timezone info, but datetime-local html field doesn't like timezone anymore.

I needed to convert UTC datetime into local datetime and pass the value without timezone to the input field.
And on change i re-convert the date into UTC for plone.restapi.

I haven't touched the widget to use something better because i don't know what's your plans about date widgets. There are some nice plugins for React.

One other thing: right now a new event has empty dates. In Plone these dates are set as now.
Is it a good idea provide now as default when invoking this widget for event fields?
Also adding a button that sets the date as now like in Plone.