### PR TITLE
Attach request to api promise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Upgrade to Razzle 3 @sneridagh
 - contact-form view @cekk
 - Add cypress setup for both Plone and Guillotina @sneridagh
+- Expose request on the promise returned by the api helper @csenger
 
 ### Changes
 

--- a/src/helpers/Api/Api.js
+++ b/src/helpers/Api/Api.js
@@ -33,9 +33,10 @@ export class Api {
    */
   constructor() {
     methods.forEach(method => {
-      this[method] = (path, { params, data, type, headers = {} } = {}) =>
-        new Promise((resolve, reject) => {
-          const request = superagent[method](formatUrl(path));
+      this[method] = (path, { params, data, type, headers = {} } = {}) => {
+        let request;
+        let promise = new Promise((resolve, reject) => {
+          request = superagent[method](formatUrl(path));
 
           if (params) {
             request.query(params);
@@ -62,6 +63,9 @@ export class Api {
             (err, { body } = {}) => (err ? reject(err) : resolve(body)),
           );
         });
+        promise.request = request;
+        return promise;
+      };
     });
   }
 }


### PR DESCRIPTION
This exposes the superagent request on the promise returned by the api helper/actions.

When you use a action that sends many requests in order and expects the result of the latest request that has a successful response in the redux store this is not guaranteed. 
An example is a type ahead search. The @search requests take various amounts of time and don't come back in order. If you type a search for "foo bar" the response for "foo bar" might be earlier than the response for "foo". So you might up with having the results for foo in the store while the frontend input contains "foo bar".

With this change a component that calls an action like searchContent repeatedly can abort every previous search request before it sends a new one to make sure the result for the latest action will end up in the store.