### PR TITLE
📖UPDATE DOC: Fix grammar and make doc precise

### DIFF
--- a/docs/source/00-introduction/introduction.md
+++ b/docs/source/00-introduction/introduction.md
@@ -2,20 +2,12 @@
 
 Volto is a React-based frontend for content management systems (CMS), currently supporting three backend implementations: Plone, Guillotina, and a NodeJS reference implementation.
 
-Plone is a CMS built on Python born back in 2001, and unmatched experience in the subject.
+Plone is an CMS, which was written in Python back in 2001 and cherishes an unmatched experience in the subject. It has exciting features that are still appealing to developers and users alike. Such as customizable content types, hierarchical URL object traversing, and a sophisticated content workflow powered by a granular permissions model that allows you to build from simple websites to huge complex intranets.
 
-Plone has exciting features that are still appealing to developers and users alike. Such as customizable content types, hierarchical URL object traversing, and a sophisticated content workflow powered by a granular permissions model that allows you to build from simple websites to huge complex intranets.
+Volto exposes all those features and communicates with Plone via its mature REST API. It can be highly themeable and customizable. Volto also supports other APIs like Guillotina, a Python resource management system, which is inspired on Plone using the same basic concepts like traversal, content types, and permissions model.
 
-Volto exposes all those features and communicates with Plone via its mature REST API. It can be highly themeable and customizable.
-
-Volto also supports other APIs like Guillotina, a Python resource management system, which is inspired on Plone using the same basic concepts like traversal, content types and permissions model.
-
-Last but not least, it also supports a Volto Nodejs-based backend reference API implementation that demos how other systems could also use Volto to display and create content through it.
-
-Like any CMS, Volto is capable of taking care of Server Side Rendering (SSR) to support SEO.
+Last but not least, it also supports a Volto Nodejs-based backend reference API implementation that demos how other systems could also use Volto to display and create content through it. Like any CMS, Volto is capable of taking care of Server Side Rendering (SSR) to support SEO.
 
 ## Vision
 
-!!! note
-    Under construction ;) sorry for the inconvenience. Please consider to
-    contribute to this documentation.
+The vision behind this project is to enable the React developers to make use of a stable, mature, and feature-rich backend to provide Content Management functionality without having to learn Plone or Python. Developing websites with Volto is done purely in React using SemanticUI components. `plone.restapi` — Which is a Plone REST API, is used to power Volto. It allows website developers to utilize Plone features while essentially treating it as a 'black box.' 

--- a/docs/source/00-introduction/introduction.md
+++ b/docs/source/00-introduction/introduction.md
@@ -1,30 +1,18 @@
-# Introduction to Volto
+# Introduction
 
-Volto is a React-based frontend for content management systems (CMS), currently
-supporting three backend implementations: Plone, Guillotina and a NodeJS
-reference implementation.
+Volto is a React-based frontend for content management systems (CMS), currently supporting three backend implementations: Plone, Guillotina, and a NodeJS reference implementation.
 
-Plone is a CMS built on Python born back in 2001, and unmatched experience in
-the subject.
+Plone is a CMS built on Python born back in 2001, and unmatched experience in the subject.
 
-Plone has very interesting features that are still appealing to developers and
-users alike as customizable content types, hierarchical URL object traversing
-and a complex content workflow powered by a granular permissions model that
-allows you to build from simple websites to complex huge intranets.
+Plone has exciting features that are still appealing to developers and users alike. Such as customizable content types, hierarchical URL object traversing, and a sophisticated content workflow powered by a granular permissions model that allows you to build from simple websites to huge complex intranets.
 
-Volto exposes all that features and communicates with Plone via its mature REST
-API. It has the ability of being highly themable and customizable.
+Volto exposes all those features and communicates with Plone via its mature REST API. It can be highly themeable and customizable.
 
-Volto also supports other APIs like Guillotina, a Python resource management
-system, which is inspired on Plone using the same basic concepts like
-traversal, content types and permissions model.
+Volto also supports other APIs like Guillotina, a Python resource management system, which is inspired on Plone using the same basic concepts like traversal, content types and permissions model.
 
-Last but not least, it also supports a Volto Nodejs-based backend reference API
-implementation that demos how other systems could also use Volto to display and
-create content through it.
+Last but not least, it also supports a Volto Nodejs-based backend reference API implementation that demos how other systems could also use Volto to display and create content through it.
 
-As any CMS, Volto is capable of take care of Server Side Rendering (SSR) in
-order to support SEO.
+Like any CMS, Volto is capable of taking care of Server Side Rendering (SSR) to support SEO.
 
 ## Vision
 

--- a/docs/source/00-introduction/introduction.md
+++ b/docs/source/00-introduction/introduction.md
@@ -4,7 +4,7 @@ Volto is a React-based frontend for content management systems (CMS), currently 
 
 Plone is an CMS, which was written in Python back in 2001 and cherishes an unmatched experience in the subject. It has exciting features that are still appealing to developers and users alike. Such as customizable content types, hierarchical URL object traversing, and a sophisticated content workflow powered by a granular permissions model that allows you to build from simple websites to huge complex intranets.
 
-Volto exposes all those features and communicates with Plone via its mature REST API. It can be highly themeable and customizable. Volto also supports other APIs like Guillotina, a Python resource management system, which is inspired on Plone using the same basic concepts like traversal, content types, and permissions model.
+Volto exposes all those features and communicates with Plone via its mature REST API. It can be highly themeable and customizable. Volto also supports other APIs like Guillotina, a Python resource management system, which is inspired by Plone using the same basic concepts like traversal, content types, and permissions model.
 
 Last but not least, it also supports a Volto Nodejs-based backend reference API implementation that demos how other systems could also use Volto to display and create content through it. Like any CMS, Volto is capable of taking care of Server Side Rendering (SSR) to support SEO.
 


### PR DESCRIPTION
Update Heading: It's obvious that's it's an introduction to Volto. So, `to Volto` is excessive in the heading.
Minor Grammar Fixes: A few minor grammar fixes are introduced to remove `fluff`. Resulting in a more objective and precise document.