### PR TITLE
add makefiles,backend scripts to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,10 @@ api/.Python
 api/include
 api/lib
 api/pip-selfcheck.json
+api/Makefile
+api/plone-4.3.x.cfg
+api/plone-5.1.x.cfg
+api/travis.cfg
 /bin
 /lib
 include

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Add Backend scripts to .gitignore @nileshgulia1
 ### Changes
 
 ## 3.0.3 (2019-05-13)


### PR DESCRIPTION
Not sure, some scripts in `api/` should be in gitignore?

-cc @sneridagh 