### PR TITLE
Fix order of arguments when calling the emailNotification action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changes
 
+- Fix order of arguments when sending the contact form @csenger
+
 ## 3.0.3 (2019-05-13)
 
 ### Internal

--- a/src/components/theme/ContactForm/ContactForm.jsx
+++ b/src/components/theme/ContactForm/ContactForm.jsx
@@ -139,10 +139,10 @@ export class ContactForm extends Component {
    */
   onSubmit(data) {
     this.props.emailNotification(
-      data.name,
       data.from,
-      data.subject,
       data.message,
+      data.name,
+      data.subject,
     );
   }
 


### PR DESCRIPTION
ContactForm.onSubmit() passed the data to emailNotification() in the wrong order. 