### PR TITLE
Removed the delete button from the title tile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changes
 
 - Small UX/UI fixes @sneridagh
+- Removed the delete button from the title tile @pnicolli
 
 ### Internal
 

--- a/src/components/manage/Tiles/Tile/Edit.jsx
+++ b/src/components/manage/Tiles/Tile/Edit.jsx
@@ -9,6 +9,7 @@ import { DragSource, DropTarget } from 'react-dnd';
 import { findDOMNode } from 'react-dom';
 import { tiles } from '~/config';
 import { Button } from 'semantic-ui-react';
+import includes from 'lodash/includes';
 
 import Icon from '../../../../components/theme/Icon/Icon';
 import dragSVG from '../../../../icons/drag.svg';
@@ -156,7 +157,7 @@ export default class Edit extends Component {
               </div>,
             )}
           {Tile !== null ? <Tile {...this.props} /> : <div />}
-          {selected && (
+          {selected && !includes(tiles.requiredTiles, type) && (
             <Button
               icon
               basic

--- a/src/config/Tiles.jsx
+++ b/src/config/Tiles.jsx
@@ -82,4 +82,12 @@ const defaultTilesEditMap = {
   html: EditHTMLTile,
 };
 
-export { customTiles, defaultTilesViewMap, defaultTilesEditMap, messagesTiles };
+const requiredTiles = ['title'];
+
+export {
+  customTiles,
+  defaultTilesViewMap,
+  defaultTilesEditMap,
+  messagesTiles,
+  requiredTiles,
+};

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -26,6 +26,7 @@ import {
   defaultTilesViewMap,
   defaultTilesEditMap,
   messagesTiles,
+  requiredTiles,
 } from './Tiles';
 
 export const settings = {
@@ -63,4 +64,5 @@ export const tiles = {
   defaultTilesViewMap,
   defaultTilesEditMap,
   messagesTiles,
+  requiredTiles,
 };


### PR DESCRIPTION
Fixes #205 

Added a `requiredTiles` global configuration.
The delete button will not be shown if the current tile is in that list of required tiles.

I could have just checked for the `title` tile instead of creating a configuration option, I can change it to that if you prefer.

I created this because in #205 one idea for the future was "what if we had required tiles based on the content type?". The implementation I propose here allows for that by simply changing the `requiredTiles` array to a function returning an array, for example, or a simple object or whatever will be the best way to represent required tiles.