### PR TITLE
Fixed tiles outline in pastanaga editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Removed the delete button from the title tile @pnicolli
 - Rewrite sidebar @robgietma @sneridagh
 - Added SidebarPortal component for easier sidebar handling @pnicolli
+- Fixed tiles outline in Pastanaga editor @pnicolli
 
 ### Internal
 

--- a/theme/themes/pastanaga/extras/tiles.less
+++ b/theme/themes/pastanaga/extras/tiles.less
@@ -3,8 +3,9 @@
   outline: none;
 }
 
-.tile .tile:not(.inner)::after {
+.tile .tile:not(.inner)::before {
   position: absolute;
+  z-index: -1;
   top: -9px;
   left: -9px;
   width: ~'calc(100% + 18px)';
@@ -22,13 +23,13 @@
   display: inline-block;
 }
 
-.tile .tile.selected::after,
-.tile .tile.selected:hover::after {
+.tile .tile.selected::before,
+.tile .tile.selected:hover::before {
   border-width: 1px;
   border-color: rgba(120, 192, 215, 0.75);
 }
 
-.tile .tile:hover::after {
+.tile .tile:hover::before {
   border-color: rgba(120, 192, 215, 0.375);
 }
 


### PR DESCRIPTION
Tiles in the Pastanaga Editor have a light blue outline placed on an `::after` pseudo-element. This actually creates an element floating above the tile, not allowing clicks on the tile content unless we place the tile above this element with CSS tricks (`position: relative` and/or `z-index`).

This small fix aims to place the outline below the tile content, while keeping its aspect unchanged.

I have tested it with the following tiles:
- Title
- Summary
- Text
- HTML
- Map
- Image
- Video
- Hero