### PR TITLE
Fix searching for tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ## 4.0.0-alpha.1 (2019-09-17)
 
+- Fix parameter handling in Search view to avoid limiting search results with empty parameters #845 @csenger
+- Fix SearchTags handling of keyword vocabulary for anonymous users @csenger
+
 ### Changes
 
 - Fix test failure for `VersionOverview` component in master after release process @sneridagh

--- a/src/components/theme/Search/Search.jsx
+++ b/src/components/theme/Search/Search.jsx
@@ -19,6 +19,18 @@ import { searchContent } from '../../../actions';
 
 import { SearchTags, Toolbar } from '../../../components';
 
+const toSearchOptions = (searchableText, subject, path) => {
+  return {
+    ...(searchableText && { SearchableText: searchableText }),
+    ...(subject && {
+      Subject: subject,
+    }),
+    ...(path && {
+      path: path,
+    }),
+  };
+};
+
 /**
  * Search class.
  * @class SearchComponent
@@ -64,15 +76,11 @@ class Search extends Component {
    * @returns {undefined}
    */
   componentWillMount() {
-    this.props.searchContent('', {
-      SearchableText: this.props.searchableText,
-      ...(this.props.subject && {
-        Subject: this.props.subject,
-      }),
-      ...(this.props.path && {
-        path: this.props.path,
-      }),
-    });
+    this.doSearch(
+      this.props.searchableText,
+      this.props.subject,
+      this.props.path,
+    );
   }
 
   /**
@@ -81,19 +89,34 @@ class Search extends Component {
    * @param {Object} nextProps Next properties
    * @returns {undefined}
    */
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.searchableText !== this.props.searchableText) {
-      this.props.searchContent('', {
-        SearchableText: nextProps.searchableText,
-        ...(this.props.subject && {
-          Subject: this.props.subject,
-        }),
-        ...(this.props.path && {
-          path: this.props.path,
-        }),
-      });
+  componentWillReceiveProps = nextProps => {
+    if (
+      nextProps.searchableText !== this.props.searchableText ||
+      nextProps.subject !== this.props.subject
+    ) {
+      this.doSearch(
+        nextProps.searchableText,
+        nextProps.subject,
+        this.props.path,
+      );
     }
-  }
+  };
+
+  /**
+   * Search based on the given searchableText, subject and path.
+   * @method doSearch
+   * @param {string} searchableText The searchable text string
+   * @param {string} subject The subject (tag)
+   * @param {string} path The path to restrict the search to
+   * @returns {undefined}
+   */
+
+  doSearch = (searchableText, subject, path) => {
+    this.props.searchContent(
+      '',
+      toSearchOptions(searchableText, subject, path),
+    );
+  };
 
   /**
    * Render method.
@@ -195,10 +218,14 @@ export default compose(
       key: 'search',
       promise: ({ location, store: { dispatch } }) =>
         dispatch(
-          searchContent('', {
-            SearchableText: qs.parse(location.search).SearchableText,
-            Subject: qs.parse(location.search).Subject,
-          }),
+          searchContent(
+            '',
+            toSearchOptions(
+              qs.parse(location.search).SearchableText,
+              qs.parse(location.search).Subject,
+              qs.parse(location.search).path,
+            ),
+          ),
         ),
     },
   ]),

--- a/src/components/theme/Search/SearchTags.jsx
+++ b/src/components/theme/Search/SearchTags.jsx
@@ -67,9 +67,10 @@ class SearchTags extends Component {
 
 export default connect(
   state => ({
-    terms: state.vocabularies[vocabulary]
-      ? state.vocabularies[vocabulary].terms
-      : [],
+    terms:
+      state.vocabularies[vocabulary] && state.vocabularies[vocabulary].terms
+        ? state.vocabularies[vocabulary].terms
+        : [],
   }),
   { getVocabulary },
 )(SearchTags);


### PR DESCRIPTION
* Fix parameter handling in Search view #845 
* Fix keywords vocabulary condition in SearchTags

Still does double @search requests when you type in another search term after the Search view was mounted.
