### PR TITLE
Trim whitespace of form fields on form submission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Add image to listing view @robgietema
 - Fix `SchemaWidget` @robgietema
 - Move styles import to a separate file @pnicolli
+- Fix crash when user enters only whitespace in required fields @JeffersonBledsoe
 
 ### Internal
 

--- a/src/components/manage/Form/Form.jsx
+++ b/src/components/manage/Form/Form.jsx
@@ -350,7 +350,10 @@ class Form extends Component {
     map(this.props.schema.fieldsets, fieldset =>
       map(fieldset.fields, fieldId => {
         const field = this.props.schema.properties[fieldId];
-        const data = this.state.formData[fieldId];
+        var data = this.state.formData[fieldId];
+        if (typeof data === 'string' || data instanceof String) {
+          data = data.trim();
+        }
         if (this.props.schema.required.indexOf(fieldId) !== -1) {
           if (field.type !== 'boolean' && !data) {
             errors[fieldId] = errors[field] || [];


### PR DESCRIPTION
As shown in https://github.com/plone/volto/issues/933, it's currently possible to submit a required form field with just whitespace as the data, causing the front-end to crash. While there probably should be a way to fail more gracefully if a form was submitted with erroneous data, this PR should at least solve this situation.

As an aside, it would be great to have a method of failing gracefully when running Volto in develop mode, such as showing the backend error message to the developer, rather than just showing where React crashed.