### PR TITLE
[WIP] - Fix link redirection

### DIFF
--- a/src/components/index.js
+++ b/src/components/index.js
@@ -9,6 +9,7 @@ export ContactForm from '@plone/volto/components/theme/ContactForm/ContactForm';
 export Footer from '@plone/volto/components/theme/Footer/Footer';
 export Header from '@plone/volto/components/theme/Header/Header';
 export Icon from '@plone/volto/components/theme/Icon/Icon';
+export Link from '@plone/volto/components/theme/Link/Link';
 export Logo from '@plone/volto/components/theme/Logo/Logo';
 export Navigation from '@plone/volto/components/theme/Navigation/Navigation';
 export SearchWidget from '@plone/volto/components/theme/SearchWidget/SearchWidget';

--- a/src/components/theme/Link/Link.jsx
+++ b/src/components/theme/Link/Link.jsx
@@ -1,0 +1,29 @@
+/**
+ * Logo component.
+ * @module components/theme/Logo/Logo
+ */
+
+import React from 'react';
+import { Link as RouterLink } from 'react-router-dom';
+import { isExternalLink } from '@plone/volto/helpers';
+
+/**
+ * Link component class.
+ * @function Link
+ * @param {string} url
+ * @returns {string} Markup of the component.
+ */
+const Link = props => {
+  const { to, children, ...attrs } = props;
+  return isExternalLink(to) ? (
+    <a href={to} {...attrs}>
+      {children}
+    </a>
+  ) : (
+    <RouterLink to={to} {...attrs}>
+      {children}
+    </RouterLink>
+  );
+};
+
+export default Link;

--- a/src/components/theme/Link/Link.test.jsx
+++ b/src/components/theme/Link/Link.test.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { MemoryRouter } from 'react-router-dom';
+
+import Link from './Link';
+
+describe('Link', () => {
+  it('renders a Link component', () => {
+    const component = renderer.create(
+      <MemoryRouter>
+        <Link />
+      </MemoryRouter>,
+    );
+    const json = component.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+});

--- a/src/components/theme/Link/__snapshots__/Link.test.jsx.snap
+++ b/src/components/theme/Link/__snapshots__/Link.test.jsx.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Link renders a Link component 1`] = `
+<a
+  href=""
+  onClick={[Function]}
+/>
+`;

--- a/src/components/theme/Navigation/Navigation.jsx
+++ b/src/components/theme/Navigation/Navigation.jsx
@@ -8,12 +8,12 @@ import PropTypes from 'prop-types';
 import { isMatch } from 'lodash';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
-import { Link } from 'react-router-dom';
+// import { Link } from 'react-router-dom';
+import Link from '../Link/Link';
 import { defineMessages, injectIntl } from 'react-intl';
 import { Menu } from 'semantic-ui-react';
 import cx from 'classnames';
-import { getBaseUrl } from '../../../helpers';
-
+import { getBaseUrl } from '@plone/volto/helpers';
 import { getNavigation } from '../../../actions';
 
 const messages = defineMessages({

--- a/src/components/theme/View/LinkView.jsx
+++ b/src/components/theme/View/LinkView.jsx
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 import Helmet from 'react-helmet';
 import { Link } from 'react-router-dom';
 import { Container } from 'semantic-ui-react';
+import { isExternalLink } from '@plone/volto/helpers';
 
 /**
  * View container class.
@@ -46,7 +47,12 @@ class LinkView extends Component {
    */
   componentWillMount() {
     if (!this.props.token) {
-      this.props.history.replace(this.props.content.remoteUrl);
+      const { remoteUrl } = this.props.content;
+      if (isExternalLink(remoteUrl)) {
+        window.location.href = remoteUrl;
+      } else {
+        this.props.history.replace(remoteUrl);
+      }
     }
   }
 
@@ -58,6 +64,7 @@ class LinkView extends Component {
    */
   componentWillReceiveProps(nextProps) {
     if (nextProps.pathname !== this.props.pathname && !nextProps.token) {
+      console.log('QUO');
       nextProps.history.replace(nextProps.content.remoteUrl);
     }
   }
@@ -68,6 +75,9 @@ class LinkView extends Component {
    * @returns {string} Markup for the component.
    */
   render() {
+    if (!this.props.token) {
+      return '';
+    }
     return (
       <Container id="page-document">
         <Helmet title={this.props.content.title} />

--- a/src/components/theme/View/View.jsx
+++ b/src/components/theme/View/View.jsx
@@ -208,7 +208,6 @@ class View extends Component {
     }
     const RenderedView =
       this.getViewByType() || this.getViewByLayout() || this.getViewDefault();
-
     return (
       <div id="view">
         {/* Body class if displayName in component is set */}

--- a/src/helpers/Url/Url.js
+++ b/src/helpers/Url/Url.js
@@ -83,3 +83,20 @@ export function getIcon(type, isFolderish) {
 export function flattenToAppURL(url) {
   return url.replace(settings.apiPath, '');
 }
+
+/**
+ * Check if a given url is inside the same domain or is an external link
+ * TODO: Re-check this method when we implement dynamic internal links
+ * like in Plone using ${portal_url}, because that could be a good way
+ * to understand if url is internal or external.
+ * @method isExternalLink
+ * @param {string} url an URL
+ * @returns {boolean}
+ */
+export function isExternalLink(url) {
+  const clientUrl = window.location ? window.location.href : settings.apiPath;
+  const currentUrl = new URL(clientUrl);
+  // if url is relative, we use current hostname as base.
+  const linkUrl = new URL(url, currentUrl.origin);
+  return linkUrl.hostname !== currentUrl.hostname;
+}

--- a/src/helpers/Url/Url.test.js
+++ b/src/helpers/Url/Url.test.js
@@ -1,6 +1,12 @@
 import { settings } from '~/config';
 
-import { flattenToAppURL, getBaseUrl, getIcon, getView } from './Url';
+import {
+  flattenToAppURL,
+  getBaseUrl,
+  getIcon,
+  getView,
+  isExternalLink,
+} from './Url';
 
 describe('Url', () => {
   describe('getBaseUrl', () => {
@@ -58,6 +64,12 @@ describe('Url', () => {
   describe('flattenToAppURL', () => {
     it('flattens a given URL to the app URL', () => {
       expect(flattenToAppURL(`${settings.apiPath}/edit`)).toBe('/edit');
+    });
+  });
+  describe.only('isExternalLink', () => {
+    it('flattens a given URL to the app URL', () => {
+      expect(isExternalLink('/news')).toBe(false);
+      expect(isExternalLink('https://github.com')).toBe(true);
     });
   });
 });

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -18,6 +18,7 @@ export {
   getBaseUrl,
   getIcon,
   getView,
+  isExternalLink,
 } from '@plone/volto/helpers/Url/Url';
 export { generateSitemap } from '@plone/volto/helpers/Sitemap/Sitemap';
 export {


### PR DESCRIPTION
This is still a work in progress because every time that i scratch the surface of links, i found new edge cases that need to be fixed/covered.

As i said during the sprint, <Link> component doesn't work well with links outside the router routes. We also don't need the router with external links.

I fixed LinkView checking if the url has the same domain as the window.location one.
Probably in the future this check should be overriden by a simple check on how the link string is made (when we implement internal links into Link objects).
btw right now it kinda works.

The other thing that i wanted to fix, is the link generated into Navigation component.
In Plone, if the user has the permission to edit that object, the link in Navigation is the url of the object itself, otherwise, if the user can't edit it, the url is remoteUrl.

I created a new wrapper component for manage links: this check if the link is internal or external, and creates a simple <a> or a router's <Link>.
It's a proof of concept because i don't know how you want to handle links into Volto.

There are some problems:
- The first (and most important) is that right now in "isExternalLink" function i'm checking the link's domain with the one from window.location, but in SSR we don't have "window" so i cheated using the apiPath. This could probably fixed in the near future when we develop link's widget for handling internal and external links.
- Links should have different behaviors if the current user can edit it or not. Do we want to emulate all the Plone features (for example in Navigation show absolute_url or remoteUrl, in contents view, always show the absolute_url and then let the view make the redirect) or we decide that in Volto they should work in a different way?