### PR TITLE
Fetch components along with content, for synced UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Implementation of `Portuguese (BR)` translation @LeuAlmeida
 - Added translations to spanish @macagua
+- Added ``settings.contentExpand`` and ``settings.minimizeNetworkFetch``, tweaked action calls and reducers, to allow synchronized UI updates @tiberiuichim
 
 ### Changes
 

--- a/api/versions.cfg
+++ b/api/versions.cfg
@@ -17,3 +17,5 @@ requests = 2.18.4
 towncrier = 19.2.0
 zestreleaser.towncrier = 1.1.0
 docutils = 0.13.1
+
+lxml = 4.4.2

--- a/src/actions/content/content.js
+++ b/src/actions/content/content.js
@@ -127,8 +127,6 @@ export function getContent(url, version = null, subrequest = null) {
       path: `${url}${
         version ? `/@history/${version}` : ''
       }?fullobjects${expand}`,
-      // should also include ``types`` here, but it explicitely raises
-      // Unauthorized for anonymous in plone.restapi
     },
   };
 }

--- a/src/actions/content/content.js
+++ b/src/actions/content/content.js
@@ -119,7 +119,11 @@ export function getContent(url, version = null, subrequest = null) {
     subrequest,
     request: {
       op: 'get',
-      path: `${url}${version ? `/@history/${version}` : ''}?fullobjects`,
+      path: `${url}${
+        version ? `/@history/${version}` : ''
+      }?fullobjects&expand=breadcrumbs,navigation,actions,workflow`,
+      // should also include ``types`` here, but it explicitely raises
+      // Unauthorized for anonymous in plone.restapi
     },
   };
 }

--- a/src/actions/content/content.js
+++ b/src/actions/content/content.js
@@ -115,9 +115,10 @@ export function sortContent(url, on, order) {
  * @returns {Object} Get content action
  */
 export function getContent(url, version = null, subrequest = null) {
-  const expand = settings.minimizeNetworkFetch
-    ? '&expand=breadcrumbs,navigation,actions,workflow'
-    : '';
+  const expand =
+    !subrequest && settings.minimizeNetworkFetch
+      ? `&expand=${settings.contentExpand.join(',')}`
+      : '';
   return {
     type: GET_CONTENT,
     subrequest,

--- a/src/actions/content/content.js
+++ b/src/actions/content/content.js
@@ -12,6 +12,7 @@ import {
   RESET_CONTENT,
 } from '../../constants/ActionTypes';
 import { nestContent } from '../../helpers';
+import { settings } from '~/config';
 
 /**
  * Create content function.
@@ -114,6 +115,9 @@ export function sortContent(url, on, order) {
  * @returns {Object} Get content action
  */
 export function getContent(url, version = null, subrequest = null) {
+  const expand = settings.minimizeNetworkFetch
+    ? '&expand=breadcrumbs,navigation,actions,workflow'
+    : '';
   return {
     type: GET_CONTENT,
     subrequest,
@@ -121,7 +125,7 @@ export function getContent(url, version = null, subrequest = null) {
       op: 'get',
       path: `${url}${
         version ? `/@history/${version}` : ''
-      }?fullobjects&expand=breadcrumbs,navigation,actions,workflow`,
+      }?fullobjects${expand}`,
       // should also include ``types`` here, but it explicitely raises
       // Unauthorized for anonymous in plone.restapi
     },

--- a/src/actions/content/content.test.js
+++ b/src/actions/content/content.test.js
@@ -15,6 +15,7 @@ import {
   ORDER_CONTENT,
   RESET_CONTENT,
 } from '../../constants/ActionTypes';
+import { settings } from '../../config';
 
 describe('Content action', () => {
   describe('createContent', () => {
@@ -134,6 +135,19 @@ describe('Content action', () => {
   });
 
   describe('getContent', () => {
+    it('should create an action to get content with expand', () => {
+      settings.minimizeNetworkFetch = true;
+      const url = 'http://localhost';
+      const action = getContent(url);
+
+      expect(action.type).toEqual(GET_CONTENT);
+      expect(action.request.op).toEqual('get');
+      expect(action.request.path).toEqual(
+        `${url}?fullobjects&expand=breadcrumbs,navigation,actions,workflow`,
+      );
+      settings.minimizeNetworkFetch = false;
+    });
+
     it('should create an action to get content', () => {
       const url = 'http://localhost';
       const action = getContent(url);

--- a/src/components/manage/Toolbar/Toolbar.jsx
+++ b/src/components/manage/Toolbar/Toolbar.jsx
@@ -21,6 +21,7 @@ import StandardWrapper from './StandardWrapper';
 import { getTypes, listActions } from '../../../actions';
 import { Icon } from '../../../components';
 import { BodyClass, getBaseUrl } from '../../../helpers';
+import { settings } from '~/config';
 
 import pastanagaSmall from './pastanaga-small.svg';
 import pastanagalogo from './pastanaga.svg';
@@ -114,7 +115,8 @@ class Toolbar extends Component {
    * @returns {undefined}
    */
   componentDidMount() {
-    this.props.listActions(getBaseUrl(this.props.pathname));
+    !settings.minimizeNetworkFetch &&
+      this.props.listActions(getBaseUrl(this.props.pathname));
     this.props.getTypes(getBaseUrl(this.props.pathname));
     document.addEventListener('mousedown', this.handleClickOutside, false);
   }
@@ -127,7 +129,8 @@ class Toolbar extends Component {
    */
   UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.pathname !== this.props.pathname) {
-      this.props.listActions(getBaseUrl(nextProps.pathname));
+      !settings.minimizeNetworkFetch &&
+        this.props.listActions(getBaseUrl(nextProps.pathname));
       this.props.getTypes(getBaseUrl(nextProps.pathname));
     }
   }

--- a/src/components/manage/Workflow/Workflow.jsx
+++ b/src/components/manage/Workflow/Workflow.jsx
@@ -195,9 +195,10 @@ class Workflow extends Component {
    * @method componentWillMount
    * @returns {undefined}
    */
-  // UNSAFE_componentWillMount() {
-  //   this.props.getWorkflow(this.props.pathname);
-  // }
+  UNSAFE_componentWillMount() {
+    if (settings.minimizeNetworkFetch)
+      this.props.getWorkflow(this.props.pathname);
+  }
 
   /**
    * Component will receive props
@@ -206,10 +207,17 @@ class Workflow extends Component {
    * @returns {undefined}
    */
   UNSAFE_componentWillReceiveProps(nextProps) {
-    // if (nextProps.pathname !== this.props.pathname) {
-    //   this.props.getWorkflow(nextProps.pathname);
-    // }
-    if (!this.props.loaded && nextProps.loaded) {
+    if (
+      settings.minimizeNetworkFetch &&
+      nextProps.pathname !== this.props.pathname
+    ) {
+      this.props.getWorkflow(nextProps.pathname);
+    }
+    if (
+      settings.minimizeNetworkFetch &&
+      !this.props.loaded &&
+      nextProps.loaded
+    ) {
       // this.props.getWorkflow(nextProps.pathname);
       this.props.getContent(nextProps.pathname);
     }

--- a/src/components/manage/Workflow/Workflow.jsx
+++ b/src/components/manage/Workflow/Workflow.jsx
@@ -196,7 +196,7 @@ class Workflow extends Component {
    * @returns {undefined}
    */
   UNSAFE_componentWillMount() {
-    if (settings.minimizeNetworkFetch)
+    if (!settings.minimizeNetworkFetch)
       this.props.getWorkflow(this.props.pathname);
   }
 
@@ -208,17 +208,17 @@ class Workflow extends Component {
    */
   UNSAFE_componentWillReceiveProps(nextProps) {
     if (
-      settings.minimizeNetworkFetch &&
+      !settings.minimizeNetworkFetch &&
       nextProps.pathname !== this.props.pathname
     ) {
       this.props.getWorkflow(nextProps.pathname);
     }
     if (
-      settings.minimizeNetworkFetch &&
+      !settings.minimizeNetworkFetch &&
       !this.props.loaded &&
       nextProps.loaded
     ) {
-      // this.props.getWorkflow(nextProps.pathname);
+      this.props.getWorkflow(nextProps.pathname);
       this.props.getContent(nextProps.pathname);
     }
   }

--- a/src/components/manage/Workflow/Workflow.jsx
+++ b/src/components/manage/Workflow/Workflow.jsx
@@ -195,9 +195,9 @@ class Workflow extends Component {
    * @method componentWillMount
    * @returns {undefined}
    */
-  UNSAFE_componentWillMount() {
-    this.props.getWorkflow(this.props.pathname);
-  }
+  // UNSAFE_componentWillMount() {
+  //   this.props.getWorkflow(this.props.pathname);
+  // }
 
   /**
    * Component will receive props
@@ -206,11 +206,11 @@ class Workflow extends Component {
    * @returns {undefined}
    */
   UNSAFE_componentWillReceiveProps(nextProps) {
-    if (nextProps.pathname !== this.props.pathname) {
-      this.props.getWorkflow(nextProps.pathname);
-    }
+    // if (nextProps.pathname !== this.props.pathname) {
+    //   this.props.getWorkflow(nextProps.pathname);
+    // }
     if (!this.props.loaded && nextProps.loaded) {
-      this.props.getWorkflow(nextProps.pathname);
+      // this.props.getWorkflow(nextProps.pathname);
       this.props.getContent(nextProps.pathname);
     }
   }

--- a/src/components/theme/App/App.jsx
+++ b/src/components/theme/App/App.jsx
@@ -169,32 +169,32 @@ export const __test__ = connect(
 
 export default compose(
   asyncConnect([
-    {
-      key: 'breadcrumbs',
-      promise: ({ location, store: { dispatch } }) => {
-        __SERVER__ && dispatch(getBreadcrumbs(getBaseUrl(location.pathname)));
-      },
-    },
+    // {
+    //   key: 'breadcrumbs',
+    //   promise: ({ location, store: { dispatch } }) => {
+    //     __SERVER__ && dispatch(getBreadcrumbs(getBaseUrl(location.pathname)));
+    //   },
+    // },
     {
       key: 'content',
       promise: ({ location, store: { dispatch } }) =>
         __SERVER__ && dispatch(getContent(getBaseUrl(location.pathname))),
     },
-    {
-      key: 'navigation',
-      promise: ({ location, store: { dispatch } }) =>
-        __SERVER__ && dispatch(getNavigation(getBaseUrl(location.pathname))),
-    },
+    // {
+    //   key: 'navigation',
+    //   promise: ({ location, store: { dispatch } }) =>
+    //     __SERVER__ && dispatch(getNavigation(getBaseUrl(location.pathname))),
+    // },
     {
       key: 'types',
       promise: ({ location, store: { dispatch } }) =>
         __SERVER__ && dispatch(getTypes(getBaseUrl(location.pathname))),
     },
-    {
-      key: 'workflow',
-      promise: ({ location, store: { dispatch } }) =>
-        __SERVER__ && dispatch(getWorkflow(getBaseUrl(location.pathname))),
-    },
+    // {
+    //   key: 'workflow',
+    //   promise: ({ location, store: { dispatch } }) =>
+    //     __SERVER__ && dispatch(getWorkflow(getBaseUrl(location.pathname))),
+    // },
   ]),
   connect((state, props) => ({ pathname: props.location.pathname }), {}),
 )(App);

--- a/src/components/theme/App/App.jsx
+++ b/src/components/theme/App/App.jsx
@@ -16,6 +16,7 @@ import split from 'lodash/split';
 import join from 'lodash/join';
 import trim from 'lodash/trim';
 import cx from 'classnames';
+import { settings } from '~/config';
 
 import Error from '../../../error';
 
@@ -169,32 +170,38 @@ export const __test__ = connect(
 
 export default compose(
   asyncConnect([
-    // {
-    //   key: 'breadcrumbs',
-    //   promise: ({ location, store: { dispatch } }) => {
-    //     __SERVER__ && dispatch(getBreadcrumbs(getBaseUrl(location.pathname)));
-    //   },
-    // },
+    {
+      key: 'breadcrumbs',
+      promise: ({ location, store: { dispatch } }) => {
+        __SERVER__ &&
+          !settings.minimizeNetworkFetch &&
+          dispatch(getBreadcrumbs(getBaseUrl(location.pathname)));
+      },
+    },
     {
       key: 'content',
       promise: ({ location, store: { dispatch } }) =>
         __SERVER__ && dispatch(getContent(getBaseUrl(location.pathname))),
     },
-    // {
-    //   key: 'navigation',
-    //   promise: ({ location, store: { dispatch } }) =>
-    //     __SERVER__ && dispatch(getNavigation(getBaseUrl(location.pathname))),
-    // },
+    {
+      key: 'navigation',
+      promise: ({ location, store: { dispatch } }) =>
+        __SERVER__ &&
+        !settings.minimizeNetworkFetch &&
+        dispatch(getNavigation(getBaseUrl(location.pathname))),
+    },
     {
       key: 'types',
       promise: ({ location, store: { dispatch } }) =>
         __SERVER__ && dispatch(getTypes(getBaseUrl(location.pathname))),
     },
-    // {
-    //   key: 'workflow',
-    //   promise: ({ location, store: { dispatch } }) =>
-    //     __SERVER__ && dispatch(getWorkflow(getBaseUrl(location.pathname))),
-    // },
+    {
+      key: 'workflow',
+      promise: ({ location, store: { dispatch } }) =>
+        __SERVER__ &&
+        !settings.minimizeNetworkFetch &&
+        dispatch(getWorkflow(getBaseUrl(location.pathname))),
+    },
   ]),
   connect((state, props) => ({ pathname: props.location.pathname }), {}),
 )(App);

--- a/src/components/theme/Breadcrumbs/Breadcrumbs.jsx
+++ b/src/components/theme/Breadcrumbs/Breadcrumbs.jsx
@@ -16,6 +16,7 @@ import { getBreadcrumbs } from '../../../actions';
 import { getBaseUrl } from '../../../helpers';
 
 import homeSVG from '@plone/volto/icons/home.svg';
+import { settings } from '~/config';
 
 const messages = defineMessages({
   home: {
@@ -51,9 +52,10 @@ class Breadcrumbs extends Component {
    * @method componentWillMount
    * @returns {undefined}
    */
-  // UNSAFE_componentWillMount() {
-  //   this.props.getBreadcrumbs(getBaseUrl(this.props.pathname));
-  // }
+  UNSAFE_componentWillMount() {
+    if (!settings.minimizeNetworkFetch)
+      this.props.getBreadcrumbs(getBaseUrl(this.props.pathname));
+  }
 
   /**
    * Component will receive props
@@ -61,11 +63,14 @@ class Breadcrumbs extends Component {
    * @param {Object} nextProps Next properties
    * @returns {undefined}
    */
-  // UNSAFE_componentWillReceiveProps(nextProps) {
-  //   if (nextProps.pathname !== this.props.pathname) {
-  //     this.props.getBreadcrumbs(getBaseUrl(nextProps.pathname));
-  //   }
-  // }
+  UNSAFE_componentWillReceiveProps(nextProps) {
+    if (
+      !settings.minimizeNetworkFetch &&
+      nextProps.pathname !== this.props.pathname
+    ) {
+      this.props.getBreadcrumbs(getBaseUrl(nextProps.pathname));
+    }
+  }
 
   /**
    * Render method.

--- a/src/components/theme/Breadcrumbs/Breadcrumbs.jsx
+++ b/src/components/theme/Breadcrumbs/Breadcrumbs.jsx
@@ -51,9 +51,9 @@ class Breadcrumbs extends Component {
    * @method componentWillMount
    * @returns {undefined}
    */
-  UNSAFE_componentWillMount() {
-    this.props.getBreadcrumbs(getBaseUrl(this.props.pathname));
-  }
+  // UNSAFE_componentWillMount() {
+  //   this.props.getBreadcrumbs(getBaseUrl(this.props.pathname));
+  // }
 
   /**
    * Component will receive props
@@ -61,11 +61,11 @@ class Breadcrumbs extends Component {
    * @param {Object} nextProps Next properties
    * @returns {undefined}
    */
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    if (nextProps.pathname !== this.props.pathname) {
-      this.props.getBreadcrumbs(getBaseUrl(nextProps.pathname));
-    }
-  }
+  // UNSAFE_componentWillReceiveProps(nextProps) {
+  //   if (nextProps.pathname !== this.props.pathname) {
+  //     this.props.getBreadcrumbs(getBaseUrl(nextProps.pathname));
+  //   }
+  // }
 
   /**
    * Render method.

--- a/src/components/theme/Navigation/Navigation.jsx
+++ b/src/components/theme/Navigation/Navigation.jsx
@@ -13,6 +13,7 @@ import { defineMessages, injectIntl } from 'react-intl';
 import { Menu } from 'semantic-ui-react';
 import cx from 'classnames';
 import { getBaseUrl } from '../../../helpers';
+import { settings } from '~/config';
 
 import { getNavigation } from '../../../actions';
 
@@ -69,9 +70,10 @@ class Navigation extends Component {
    * @method componentWillMount
    * @returns {undefined}
    */
-  // UNSAFE_componentWillMount() {
-  //   this.props.getNavigation(getBaseUrl(this.props.pathname));
-  // }
+  UNSAFE_componentWillMount() {
+    if (!settings.minimizeNetworkFetch)
+      this.props.getNavigation(getBaseUrl(this.props.pathname));
+  }
 
   /**
    * Component will receive props
@@ -79,11 +81,14 @@ class Navigation extends Component {
    * @param {Object} nextProps Next properties
    * @returns {undefined}
    */
-  // UNSAFE_componentWillReceiveProps(nextProps) {
-  //   if (nextProps.pathname !== this.props.pathname) {
-  //     this.props.getNavigation(getBaseUrl(nextProps.pathname));
-  //   }
-  // }
+  UNSAFE_componentWillReceiveProps(nextProps) {
+    if (
+      !settings.minimizeNetworkFetch &&
+      nextProps.pathname !== this.props.pathname
+    ) {
+      this.props.getNavigation(getBaseUrl(nextProps.pathname));
+    }
+  }
 
   /**
    * Check if menu is active

--- a/src/components/theme/Navigation/Navigation.jsx
+++ b/src/components/theme/Navigation/Navigation.jsx
@@ -69,9 +69,9 @@ class Navigation extends Component {
    * @method componentWillMount
    * @returns {undefined}
    */
-  UNSAFE_componentWillMount() {
-    this.props.getNavigation(getBaseUrl(this.props.pathname));
-  }
+  // UNSAFE_componentWillMount() {
+  //   this.props.getNavigation(getBaseUrl(this.props.pathname));
+  // }
 
   /**
    * Component will receive props
@@ -79,11 +79,11 @@ class Navigation extends Component {
    * @param {Object} nextProps Next properties
    * @returns {undefined}
    */
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    if (nextProps.pathname !== this.props.pathname) {
-      this.props.getNavigation(getBaseUrl(nextProps.pathname));
-    }
-  }
+  // UNSAFE_componentWillReceiveProps(nextProps) {
+  //   if (nextProps.pathname !== this.props.pathname) {
+  //     this.props.getNavigation(getBaseUrl(nextProps.pathname));
+  //   }
+  // }
 
   /**
    * Check if menu is active

--- a/src/components/theme/View/View.jsx
+++ b/src/components/theme/View/View.jsx
@@ -10,7 +10,7 @@ import { compose } from 'redux';
 import { Portal } from 'react-portal';
 import { injectIntl } from 'react-intl';
 import qs from 'query-string';
-import { views } from '~/config';
+import { views, settings } from '~/config';
 
 import { Comments, Tags, Toolbar } from '../../../components';
 import { listActions, getContent } from '../../../actions';
@@ -110,7 +110,8 @@ class View extends Component {
    * @returns {undefined}
    */
   UNSAFE_componentWillMount() {
-    this.props.listActions(getBaseUrl(this.props.pathname));
+    !settings.minimizeNetworkFetch &&
+      this.props.listActions(getBaseUrl(this.props.pathname));
     this.props.getContent(
       getBaseUrl(this.props.pathname),
       this.props.versionId,
@@ -125,7 +126,8 @@ class View extends Component {
    */
   UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.pathname !== this.props.pathname) {
-      this.props.listActions(getBaseUrl(nextProps.pathname));
+      !settings.minimizeNetworkFetch &&
+        this.props.listActions(getBaseUrl(nextProps.pathname));
       this.props.getContent(
         getBaseUrl(nextProps.pathname),
         this.props.versionId,

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -32,6 +32,8 @@ export const settings = {
   internalApiPath: process.env.RAZZLE_INTERNAL_API_PATH || undefined,
   websockets: process.env.RAZZLE_WEBSOCKETS || false,
   minimizeNetworkFetch: true,
+  // should also include ``types`` here, but it explicitely raises Unauthorized
+  // for anonymous in plone.restapi
   contentExpand: ['breadcrumbs', 'navigation', 'actions', 'workflow'],
   nonContentRoutes,
   extendedBlockRenderMap,

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -41,7 +41,7 @@ export const settings = {
   ToHTMLRenderers,
   ToHTMLOptions,
   imageObjects: ['Image'],
-  minimizeNetworkFetch: false,
+  minimizeNetworkFetch: true,
 };
 
 export const widgets = {

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -31,6 +31,8 @@ export const settings = {
   // apiPath: process.env.RAZZLE_API_PATH || 'http://localhost:8081/db/web', // for guillotina
   internalApiPath: process.env.RAZZLE_INTERNAL_API_PATH || undefined,
   websockets: process.env.RAZZLE_WEBSOCKETS || false,
+  minimizeNetworkFetch: true,
+  contentExpand: ['breadcrumbs', 'navigation', 'actions', 'workflow'],
   nonContentRoutes,
   extendedBlockRenderMap,
   blockStyleFn,
@@ -41,7 +43,6 @@ export const settings = {
   ToHTMLRenderers,
   ToHTMLOptions,
   imageObjects: ['Image'],
-  minimizeNetworkFetch: false,
 };
 
 export const widgets = {

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -41,6 +41,7 @@ export const settings = {
   ToHTMLRenderers,
   ToHTMLOptions,
   imageObjects: ['Image'],
+  minimizeNetworkFetch: false,
 };
 
 export const widgets = {

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -41,7 +41,7 @@ export const settings = {
   ToHTMLRenderers,
   ToHTMLOptions,
   imageObjects: ['Image'],
-  minimizeNetworkFetch: true,
+  minimizeNetworkFetch: false,
 };
 
 export const widgets = {

--- a/src/reducers/actions/actions.js
+++ b/src/reducers/actions/actions.js
@@ -54,7 +54,7 @@ export default function actions(state = initialState, action = {}) {
         loading: false,
       };
     case `${GET_CONTENT}_SUCCESS`:
-      return settings.minimizeNetworkFetch
+      return !action.subrequest && settings.minimizeNetworkFetch
         ? {
             ...state,
             error: null,

--- a/src/reducers/actions/actions.js
+++ b/src/reducers/actions/actions.js
@@ -37,7 +37,7 @@ export default function actions(state = initialState, action = {}) {
         loading: true,
       };
     case `${GET_CONTENT}_PENDING`:
-      return settings.minimizeNetworkFetch
+      return !action.subrequest && settings.minimizeNetworkFetch
         ? {
             ...state,
             error: null,
@@ -72,7 +72,7 @@ export default function actions(state = initialState, action = {}) {
         loading: false,
       };
     case `${GET_CONTENT}_FAIL`:
-      return settings.minimizeNetworkFetch
+      return !action.subrequest && settings.minimizeNetworkFetch
         ? {
             ...state,
             error: action.error,

--- a/src/reducers/actions/actions.js
+++ b/src/reducers/actions/actions.js
@@ -4,6 +4,7 @@
  */
 
 import { LIST_ACTIONS, GET_CONTENT } from '../../constants/ActionTypes';
+import { settings } from '~/config';
 
 const initialState = {
   error: null,
@@ -29,25 +30,40 @@ const initialState = {
 export default function actions(state = initialState, action = {}) {
   switch (action.type) {
     case `${LIST_ACTIONS}_PENDING`:
-    case `${GET_CONTENT}_PENDING`:
       return {
         ...state,
         error: null,
         loaded: false,
         loading: true,
       };
+    case `${GET_CONTENT}_PENDING`:
+      return settings.minimizeNetworkFetch
+        ? {
+            ...state,
+            error: null,
+            loaded: false,
+            loading: true,
+          }
+        : state;
     case `${LIST_ACTIONS}_SUCCESS`:
-    case `${GET_CONTENT}_SUCCESS`:
-      const result = action.result['@components']?.actions || action.result;
       return {
         ...state,
         error: null,
-        actions: result,
+        actions: action.result,
         loaded: true,
         loading: false,
       };
+    case `${GET_CONTENT}_SUCCESS`:
+      return settings.minimizeNetworkFetch
+        ? {
+            ...state,
+            error: null,
+            actions: action.result['@components'].actions,
+            loaded: true,
+            loading: false,
+          }
+        : state;
     case `${LIST_ACTIONS}_FAIL`:
-    case `${GET_CONTENT}_FAIL`:
       return {
         ...state,
         error: action.error,
@@ -55,6 +71,16 @@ export default function actions(state = initialState, action = {}) {
         loaded: false,
         loading: false,
       };
+    case `${GET_CONTENT}_FAIL`:
+      return settings.minimizeNetworkFetch
+        ? {
+            ...state,
+            error: action.error,
+            actions: {},
+            loaded: false,
+            loading: false,
+          }
+        : state;
     default:
       return state;
   }

--- a/src/reducers/actions/actions.js
+++ b/src/reducers/actions/actions.js
@@ -3,7 +3,7 @@
  * @module reducers/actions/actions
  */
 
-import { LIST_ACTIONS } from '../../constants/ActionTypes';
+import { LIST_ACTIONS, GET_CONTENT } from '../../constants/ActionTypes';
 
 const initialState = {
   error: null,
@@ -29,6 +29,7 @@ const initialState = {
 export default function actions(state = initialState, action = {}) {
   switch (action.type) {
     case `${LIST_ACTIONS}_PENDING`:
+    case `${GET_CONTENT}_PENDING`:
       return {
         ...state,
         error: null,
@@ -36,14 +37,17 @@ export default function actions(state = initialState, action = {}) {
         loading: true,
       };
     case `${LIST_ACTIONS}_SUCCESS`:
+    case `${GET_CONTENT}_SUCCESS`:
+      const result = action.result['@components']?.actions || action.result;
       return {
         ...state,
         error: null,
-        actions: action.result,
+        actions: result,
         loaded: true,
         loading: false,
       };
     case `${LIST_ACTIONS}_FAIL`:
+    case `${GET_CONTENT}_FAIL`:
       return {
         ...state,
         error: action.error,

--- a/src/reducers/breadcrumbs/breadcrumbs.js
+++ b/src/reducers/breadcrumbs/breadcrumbs.js
@@ -70,16 +70,21 @@ export default function breadcrumbs(state = initialState, action = {}) {
         loading: false,
       };
     case `${GET_CONTENT}_SUCCESS`:
-      return {
-        ...state,
-        error: null,
-        items: map(action.result['@components'].breadcrumbs.items, item => ({
-          title: item.title,
-          url: item['@id'].replace(settings.apiPath, ''),
-        })),
-        loaded: true,
-        loading: false,
-      };
+      return settings.minimizeNetworkFetch
+        ? {
+            ...state,
+            error: null,
+            items: map(
+              action.result['@components'].breadcrumbs.items,
+              item => ({
+                title: item.title,
+                url: item['@id'].replace(settings.apiPath, ''),
+              }),
+            ),
+            loaded: true,
+            loading: false,
+          }
+        : state;
     default:
       return state;
   }

--- a/src/reducers/breadcrumbs/breadcrumbs.js
+++ b/src/reducers/breadcrumbs/breadcrumbs.js
@@ -25,15 +25,22 @@ const initialState = {
 export default function breadcrumbs(state = initialState, action = {}) {
   switch (action.type) {
     case `${GET_BREADCRUMBS}_PENDING`:
-    case `${GET_CONTENT}_PENDING`:
       return {
         ...state,
         error: null,
         loaded: false,
         loading: true,
       };
+    case `${GET_CONTENT}_PENDING`:
+      return settings.minimizeNetworkFetch
+        ? {
+            ...state,
+            error: null,
+            loaded: false,
+            loading: true,
+          }
+        : state;
     case `${GET_BREADCRUMBS}_FAIL`:
-    case `${GET_CONTENT}_FAIL`:
       return {
         ...state,
         error: action.error,
@@ -41,6 +48,16 @@ export default function breadcrumbs(state = initialState, action = {}) {
         loaded: false,
         loading: false,
       };
+    case `${GET_CONTENT}_FAIL`:
+      return settings.minimizeNetworkFetch
+        ? {
+            ...state,
+            error: action.error,
+            items: [],
+            loaded: false,
+            loading: false,
+          }
+        : state;
     case `${GET_BREADCRUMBS}_SUCCESS`:
       return {
         ...state,

--- a/src/reducers/breadcrumbs/breadcrumbs.js
+++ b/src/reducers/breadcrumbs/breadcrumbs.js
@@ -32,7 +32,7 @@ export default function breadcrumbs(state = initialState, action = {}) {
         loading: true,
       };
     case `${GET_CONTENT}_PENDING`:
-      return settings.minimizeNetworkFetch
+      return !action.subrequest && settings.minimizeNetworkFetch
         ? {
             ...state,
             error: null,
@@ -49,7 +49,7 @@ export default function breadcrumbs(state = initialState, action = {}) {
         loading: false,
       };
     case `${GET_CONTENT}_FAIL`:
-      return settings.minimizeNetworkFetch
+      return !action.subrequest && settings.minimizeNetworkFetch
         ? {
             ...state,
             error: action.error,

--- a/src/reducers/breadcrumbs/breadcrumbs.js
+++ b/src/reducers/breadcrumbs/breadcrumbs.js
@@ -70,7 +70,7 @@ export default function breadcrumbs(state = initialState, action = {}) {
         loading: false,
       };
     case `${GET_CONTENT}_SUCCESS`:
-      return settings.minimizeNetworkFetch
+      return !action.subrequest && settings.minimizeNetworkFetch
         ? {
             ...state,
             error: null,

--- a/src/reducers/breadcrumbs/breadcrumbs.js
+++ b/src/reducers/breadcrumbs/breadcrumbs.js
@@ -6,7 +6,7 @@
 import { map } from 'lodash';
 import { settings } from '~/config';
 
-import { GET_BREADCRUMBS } from '../../constants/ActionTypes';
+import { GET_BREADCRUMBS, GET_CONTENT } from '../../constants/ActionTypes';
 
 const initialState = {
   error: null,
@@ -25,11 +25,21 @@ const initialState = {
 export default function breadcrumbs(state = initialState, action = {}) {
   switch (action.type) {
     case `${GET_BREADCRUMBS}_PENDING`:
+    case `${GET_CONTENT}_PENDING`:
       return {
         ...state,
         error: null,
         loaded: false,
         loading: true,
+      };
+    case `${GET_BREADCRUMBS}_FAIL`:
+    case `${GET_CONTENT}_FAIL`:
+      return {
+        ...state,
+        error: action.error,
+        items: [],
+        loaded: false,
+        loading: false,
       };
     case `${GET_BREADCRUMBS}_SUCCESS`:
       return {
@@ -42,12 +52,15 @@ export default function breadcrumbs(state = initialState, action = {}) {
         loaded: true,
         loading: false,
       };
-    case `${GET_BREADCRUMBS}_FAIL`:
+    case `${GET_CONTENT}_SUCCESS`:
       return {
         ...state,
-        error: action.error,
-        items: [],
-        loaded: false,
+        error: null,
+        items: map(action.result['@components'].breadcrumbs.items, item => ({
+          title: item.title,
+          url: item['@id'].replace(settings.apiPath, ''),
+        })),
+        loaded: true,
         loading: false,
       };
     default:

--- a/src/reducers/navigation/navigation.js
+++ b/src/reducers/navigation/navigation.js
@@ -6,7 +6,7 @@
 import { map } from 'lodash';
 import { settings } from '~/config';
 
-import { GET_NAVIGATION } from '../../constants/ActionTypes';
+import { GET_NAVIGATION, GET_CONTENT } from '../../constants/ActionTypes';
 
 const initialState = {
   error: null,
@@ -40,11 +40,21 @@ function getRecursiveItems(items) {
 export default function navigation(state = initialState, action = {}) {
   switch (action.type) {
     case `${GET_NAVIGATION}_PENDING`:
+    case `${GET_CONTENT}_PENDING`:
       return {
         ...state,
         error: null,
         loaded: false,
         loading: true,
+      };
+    case `${GET_NAVIGATION}_FAIL`:
+    case `${GET_CONTENT}_FAIL`:
+      return {
+        ...state,
+        error: action.error,
+        items: [],
+        loaded: false,
+        loading: false,
       };
     case `${GET_NAVIGATION}_SUCCESS`:
       return {
@@ -54,12 +64,12 @@ export default function navigation(state = initialState, action = {}) {
         loaded: true,
         loading: false,
       };
-    case `${GET_NAVIGATION}_FAIL`:
+    case `${GET_CONTENT}_SUCCESS`:
       return {
         ...state,
-        error: action.error,
-        items: [],
-        loaded: false,
+        error: null,
+        items: getRecursiveItems(action.result['@components'].navigation.items),
+        loaded: true,
         loading: false,
       };
     default:

--- a/src/reducers/navigation/navigation.js
+++ b/src/reducers/navigation/navigation.js
@@ -82,7 +82,7 @@ export default function navigation(state = initialState, action = {}) {
         loading: false,
       };
     case `${GET_CONTENT}_SUCCESS`:
-      return settings.minimizeNetworkFetch
+      return !action.subrequest && settings.minimizeNetworkFetch
         ? {
             ...state,
             error: null,

--- a/src/reducers/navigation/navigation.js
+++ b/src/reducers/navigation/navigation.js
@@ -47,7 +47,7 @@ export default function navigation(state = initialState, action = {}) {
         loading: true,
       };
     case `${GET_CONTENT}_PENDING`:
-      return settings.minimizeNetworkFetch
+      return !action.subrequest && settings.minimizeNetworkFetch
         ? {
             ...state,
             error: null,
@@ -64,7 +64,7 @@ export default function navigation(state = initialState, action = {}) {
         loading: false,
       };
     case `${GET_CONTENT}_FAIL`:
-      return settings.minimizeNetworkFetch
+      return !action.subrequest && settings.minimizeNetworkFetch
         ? {
             ...state,
             error: action.error,

--- a/src/reducers/navigation/navigation.js
+++ b/src/reducers/navigation/navigation.js
@@ -40,15 +40,22 @@ function getRecursiveItems(items) {
 export default function navigation(state = initialState, action = {}) {
   switch (action.type) {
     case `${GET_NAVIGATION}_PENDING`:
-    case `${GET_CONTENT}_PENDING`:
       return {
         ...state,
         error: null,
         loaded: false,
         loading: true,
       };
+    case `${GET_CONTENT}_PENDING`:
+      return settings.minimizeNetworkFetch
+        ? {
+            ...state,
+            error: null,
+            loaded: false,
+            loading: true,
+          }
+        : state;
     case `${GET_NAVIGATION}_FAIL`:
-    case `${GET_CONTENT}_FAIL`:
       return {
         ...state,
         error: action.error,
@@ -56,6 +63,16 @@ export default function navigation(state = initialState, action = {}) {
         loaded: false,
         loading: false,
       };
+    case `${GET_CONTENT}_FAIL`:
+      return settings.minimizeNetworkFetch
+        ? {
+            ...state,
+            error: action.error,
+            items: [],
+            loaded: false,
+            loading: false,
+          }
+        : state;
     case `${GET_NAVIGATION}_SUCCESS`:
       return {
         ...state,
@@ -65,13 +82,17 @@ export default function navigation(state = initialState, action = {}) {
         loading: false,
       };
     case `${GET_CONTENT}_SUCCESS`:
-      return {
-        ...state,
-        error: null,
-        items: getRecursiveItems(action.result['@components'].navigation.items),
-        loaded: true,
-        loading: false,
-      };
+      return settings.minimizeNetworkFetch
+        ? {
+            ...state,
+            error: null,
+            items: getRecursiveItems(
+              action.result['@components'].navigation.items,
+            ),
+            loaded: true,
+            loading: false,
+          }
+        : state;
     default:
       return state;
   }

--- a/src/reducers/workflow/workflow.js
+++ b/src/reducers/workflow/workflow.js
@@ -83,7 +83,7 @@ export default function content(state = initialState, action = {}) {
         },
       };
     case `${GET_CONTENT}_SUCCESS`:
-      return settings.minimizeNetworkFetch
+      return !action.subrequest && settings.minimizeNetworkFetch
         ? {
             ...state,
             history: action.result['@components']?.workflow?.history

--- a/src/reducers/workflow/workflow.js
+++ b/src/reducers/workflow/workflow.js
@@ -7,6 +7,7 @@ import {
   TRANSITION_WORKFLOW,
   GET_WORKFLOW,
   GET_WORKFLOW_MULTIPLE,
+  GET_CONTENT,
 } from '../../constants/ActionTypes';
 
 const initialState = {
@@ -47,6 +48,7 @@ export default function content(state = initialState, action = {}) {
     case `${GET_WORKFLOW}_PENDING`:
     case `${GET_WORKFLOW_MULTIPLE}_PENDING`:
     case `${TRANSITION_WORKFLOW}_PENDING`:
+    case `${GET_CONTENT}_PENDING`:
       return {
         ...state,
         [getRequestKey(action.type)]: {
@@ -57,11 +59,13 @@ export default function content(state = initialState, action = {}) {
       };
     case `${GET_WORKFLOW}_SUCCESS`:
     case `${TRANSITION_WORKFLOW}_SUCCESS`:
+    case `${GET_CONTENT}_SUCCESS`:
+      const result = action.result['@components']?.workflow || action.result;
       return {
         ...state,
-        history: action.result.history ? action.result.history : state.history,
-        transitions: action.result.transitions
-          ? action.result.transitions
+        history: result.history ? result.history : state.history,
+        transitions: result.transitions
+          ? result.transitions
           : state.transitions,
         [getRequestKey(action.type)]: {
           loading: false,
@@ -81,6 +85,7 @@ export default function content(state = initialState, action = {}) {
       };
     case `${GET_WORKFLOW}_FAIL`:
     case `${TRANSITION_WORKFLOW}_FAIL`:
+    case `${GET_CONTENT}_FAIL`:
       return {
         ...state,
         history: [],

--- a/src/reducers/workflow/workflow.js
+++ b/src/reducers/workflow/workflow.js
@@ -86,7 +86,7 @@ export default function content(state = initialState, action = {}) {
       return settings.minimizeNetworkFetch
         ? {
             ...state,
-            history: action.result['@components'].workflow.history
+            history: action.result['@components']?.workflow?.history
               ? action.result['@components'].workflow.history
               : state.history,
             transitions: action.result.transitions

--- a/src/reducers/workflow/workflow.js
+++ b/src/reducers/workflow/workflow.js
@@ -89,8 +89,8 @@ export default function content(state = initialState, action = {}) {
             history: action.result['@components']?.workflow?.history
               ? action.result['@components'].workflow.history
               : state.history,
-            transitions: action.result.transitions
-              ? action.result.transitions
+            transitions: action.result['@components']?.workflow?.transitions
+              ? action.result['@components']?.workflow?.transitions
               : state.transitions,
             [getRequestKey(action.type)]: {
               loading: false,

--- a/src/reducers/workflow/workflow.js
+++ b/src/reducers/workflow/workflow.js
@@ -58,7 +58,7 @@ export default function content(state = initialState, action = {}) {
         },
       };
     case `${GET_CONTENT}_PENDING`:
-      return settings.minimizeNetworkFetch
+      return !action.subrequest && settings.minimizeNetworkFetch
         ? {
             ...state,
             [getRequestKey(action.type)]: {
@@ -122,7 +122,7 @@ export default function content(state = initialState, action = {}) {
         },
       };
     case `${GET_CONTENT}_FAIL`:
-      return settings.minimizeNetworkFetch
+      return !action.subrequest && settings.minimizeNetworkFetch
         ? {
             ...state,
             history: [],


### PR DESCRIPTION
For discussions. This introduces two new settings (``minimizeNetworkFetch`` and ``contentExpand``), to fetch all the needed ``@components`` as expands. This has the effect of making the whole UI work "in sync", more details in #1070. This behavior is toggleable using the minimiseNetworkFetch setting.

The introduction of ``contentExpand`` makes it also possible for integrators to hitch on ``App.jsx``'s asyncConnect call and properly SSR render any other expand that they might need.