### PR TITLE
Querystring broken if index value is missing from vocab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Disable submit button on save, to avoid multiple content creation @tiberiuichim
 - Fix focus on sidebar @robgietema
+- Fix a problem with Querystring selections when vocab doesn't have current index value @tiberiuichim
 
 ## 4.0.0-alpha.19 (2019-12-20)
 

--- a/src/components/manage/Widgets/QuerystringWidget.jsx
+++ b/src/components/manage/Widgets/QuerystringWidget.jsx
@@ -206,7 +206,7 @@ class QuerystringWidget extends Component {
               }}
               isMulti={true}
               value={map(row.v, value => ({
-                label: values[value].title,
+                label: (values[value] && values[value].title) || value,
                 value,
               }))}
             />


### PR DESCRIPTION
Fix Querystring widget problem when content has an index value that is missing from vocabulary