### PR TITLE
Avoid console warnings in QuerystringWidget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changes
 
+- Avoid console warnings in QuerystringWidget @tiberich
+
 ## 4.0.0-alpha.21 (2020-01-02)
 
 ### Changes

--- a/src/components/manage/Widgets/QuerystringWidget.jsx
+++ b/src/components/manage/Widgets/QuerystringWidget.jsx
@@ -338,7 +338,7 @@ class QuerystringWidget extends Component {
                 </div>
               )}
               {map(value, (row, index) => (
-                <Form.Group>
+                <Form.Group key={index}>
                   <Form.Field width={4}>
                     <Select
                       id={`field-${id}`}


### PR DESCRIPTION
Small fix to add a missing map() key.