### PR TITLE
enable to paste links into textfields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changes
 
 - More cleaning the body classname from the current displayname view @sneridagh
+- Make it possible to paste links into text-blocks @jackahl
 
 ## 4.0.0-alpha.22 (2020-01-04)
 

--- a/package.json
+++ b/package.json
@@ -240,6 +240,7 @@
     "draft-js-inline-toolbar-plugin": "2.0.1",
     "draft-js-plugins-editor": "2.0.4",
     "draft-js-plugins-utils": "2.0.3",
+    "draftjs-filters": "2.3.0",
     "eslint": "5.16.0",
     "eslint-config-airbnb": "17.1.0",
     "eslint-config-prettier": "4.1.0",

--- a/src/components/manage/Blocks/Text/Edit.jsx
+++ b/src/components/manage/Blocks/Text/Edit.jsx
@@ -154,6 +154,7 @@ class Edit extends Component {
         filteredState = filterEditorState(
           {
             blocks: [],
+            styles: [],
             entities: [
               {
                 type: 'LINK',

--- a/yarn.lock
+++ b/yarn.lock
@@ -4729,6 +4729,11 @@ draft-js@0.10.5:
     immutable "~3.7.4"
     object-assign "^4.1.0"
 
+draftjs-filters@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/draftjs-filters/-/draftjs-filters-2.3.0.tgz#75b4a52458d40c099fbccbc0a03973bd5be882e2"
+  integrity sha512-Yi4G3zbbJwrTxFCtCooXLuIeThrY4YFvRrrL3Ck+zYi1V1/3z+j+QXHE/tNa182eb7Tq7t0AxNKE+mOFlqG8tw==
+
 duplexer3@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"


### PR DESCRIPTION
This makes it possible to paste links into the normal text-blocks. All other styling is still stripped.