### PR TITLE
maintain some styling when pasting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Changes
 
 - More cleaning the body classname from the current displayname view @sneridagh
-- Make it possible to paste links into text-blocks @jackahl
+- Make it possible to paste links, lists, b and i Elements into text-blocks @jackahl
 
 ## 4.0.0-alpha.22 (2020-01-04)
 

--- a/src/components/manage/Blocks/Text/Edit.jsx
+++ b/src/components/manage/Blocks/Text/Edit.jsx
@@ -153,8 +153,8 @@ class Edit extends Component {
         let filteredState = editorState;
         filteredState = filterEditorState(
           {
-            blocks: [],
-            styles: [],
+            blocks: ['unordered-list-item', 'ordered-list-item'],
+            styles: ['BOLD', 'ITALIC'],
             entities: [
               {
                 type: 'LINK',


### PR DESCRIPTION
b,i,ul and ol Elements are maintained when pasted into normal textblocks. Headings and most stuff is disabled due to very inconsistent behaviours. 