### PR TITLE
Adding fallback in the edit form, in case the fields are empty, so we…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix unable to login from /logout page (#1147) @sneridagh
 - Fix sitemap.xml by increasing the batch size @robgietema
 - Browser detect feature, adding a deprecation message for ancient browsers in the `App` component @sneridagh
+- Adding fallback in the edit form, in case the blocks related fields are empty, so we are sure that the edit form shows at least the default blocks @sneridagh
 
 ## 4.0.0-alpha.35 (2020-01-31)
 

--- a/src/components/manage/Form/Form.jsx
+++ b/src/components/manage/Form/Form.jsx
@@ -5,7 +5,7 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { keys, map, mapValues, omit, uniq, without } from 'lodash';
+import { isEmpty, keys, map, mapValues, omit, uniq, without } from 'lodash';
 import move from 'lodash-move';
 import isBoolean from 'lodash/isBoolean';
 import {
@@ -145,12 +145,17 @@ class Form extends Component {
       formData = mapValues(props.schema.properties, 'default');
     }
     // defaults for block editor; should be moved to schema on server side
-    if (!formData[blocksLayoutFieldname]) {
+    // Adding fallback in case the fields are empty, so we are sure that the edit form
+    // shows at least the default blocks
+    if (
+      !formData[blocksLayoutFieldname] ||
+      isEmpty(formData[blocksLayoutFieldname].items)
+    ) {
       formData[blocksLayoutFieldname] = {
         items: [ids.title, ids.text],
       };
     }
-    if (!formData[blocksFieldname]) {
+    if (!formData[blocksFieldname] || isEmpty(formData[blocksFieldname])) {
       formData[blocksFieldname] = {
         [ids.title]: {
           '@type': 'title',


### PR DESCRIPTION
… are sure that the edit form shows at least the default blocks