### PR TITLE
Added FISE website as deployed Volto in production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changes
 
+- Added forest.eea.europa.eu as deployed Volto in production
+
 ## 4.0.0-alpha.36 (2020-02-03)
 
 ### Changes

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Volto is actively developed since 2017 and used in production since early 2018 o
 - [VHS Ehrenamtsportal](https://vhs-ehrenamtsportal.de) (Website to help volunteers that help refugees for the [German Adult Education Association](https://www.dvv-vhs.de/en/home/), developed by [kitconcept GmbH](https://kitconcept.com))
 - [Zeelandia](https://zeelandia.de) (Corporate website for one of the leading backery ingrediences manufactors in Germany, developed by [kitconcept GmbH](https://kitconcept.com))
 - [Excellence at Humboldt-Universität zu Berlin](https://www.alles-beginnt-mit-einer-frage.de) (Website for the excellence initiative of the [Humboldt University Berlin](https://hu-berlin.de), developed by [kitconcept GmbH](https://kitconcept.com))
+- [Forest Information System for Europe (FISE)](https://forest.eea.europa.eu) (Thematic website focusing on European forests, developed by [Eaudeweb](https://eaudeweb.ro))
 - Please create a new [issue](https://github.com/plone/volto/issues/new) or [pull request](https://github.com/plone/volto/pulls) to add your Volto-site here!
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Volto is actively developed since 2017 and used in production since early 2018 o
 - [VHS Ehrenamtsportal](https://vhs-ehrenamtsportal.de) (Website to help volunteers that help refugees for the [German Adult Education Association](https://www.dvv-vhs.de/en/home/), developed by [kitconcept GmbH](https://kitconcept.com))
 - [Zeelandia](https://zeelandia.de) (Corporate website for one of the leading backery ingrediences manufactors in Germany, developed by [kitconcept GmbH](https://kitconcept.com))
 - [Excellence at Humboldt-Universität zu Berlin](https://www.alles-beginnt-mit-einer-frage.de) (Website for the excellence initiative of the [Humboldt University Berlin](https://hu-berlin.de), developed by [kitconcept GmbH](https://kitconcept.com))
-- [Forest Information System for Europe (FISE)](https://forest.eea.europa.eu) (Thematic website focusing on European forests, developed by [Eaudeweb](https://eaudeweb.ro))
+- [Forest Information System for Europe](https://forest.eea.europa.eu) (Thematic website focusing on European forests, developed by [Eau de Web](https://www.eaudeweb.ro))
 - Please create a new [issue](https://github.com/plone/volto/issues/new) or [pull request](https://github.com/plone/volto/pulls) to add your Volto-site here!
 
 ## Documentation


### PR DESCRIPTION
I've added the newly published forest.eea.europa.eu/ to Volto production websites.