### PR TITLE
Hide Blocks fields in Layout fieldset in Add/Edit form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changes
 
+- Hide Blocks fields in Layout fieldset in Add/Edit forms @pnicolli
+
 ## 4.0.0-alpha.36 (2020-02-03)
 
 ### Changes


### PR DESCRIPTION
The ``blocks`` and ``blocks_layout`` fields are visible in the Add/Edit form of content that has the Pastanaga editor enabled. These fields should not be visible there, because they are used and modified by the Pastanaga editor itself.