### PR TITLE
In the Display menu, only show views that are implemented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changes
 
+- In the Display menu, only show views that are implemented @pnicolli
+
 ## 4.0.0-alpha.36 (2020-02-03)
 
 ### Changes

--- a/src/components/manage/Display/Display.jsx
+++ b/src/components/manage/Display/Display.jsx
@@ -3,15 +3,16 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import Select, { components } from 'react-select';
 
-import { getSchema, updateContent, getContent } from '../../../actions';
-import layouts from '../../../constants/Layouts';
-import { getLayoutFieldname } from '../../../helpers';
-import { Icon } from '../../../components';
+import { getSchema, updateContent, getContent } from '@plone/volto/actions';
+import layouts from '@plone/volto/constants/Layouts';
+import { getLayoutFieldname } from '@plone/volto/helpers';
+import { Icon } from '@plone/volto/components';
 import { FormattedMessage } from 'react-intl';
+import { views } from '~/config';
 
-import downSVG from '../../../icons/down-key.svg';
-import upSVG from '../../../icons/up-key.svg';
-import checkSVG from '../../../icons/check.svg';
+import downSVG from '@plone/volto/icons/down-key.svg';
+import upSVG from '@plone/volto/icons/up-key.svg';
+import checkSVG from '@plone/volto/icons/check.svg';
 
 const Option = props => {
   return (
@@ -194,10 +195,16 @@ class DisplaySelect extends Component {
           name="display-select"
           className="react-select-container"
           classNamePrefix="react-select"
-          options={this.props.layouts.map(item => ({
-            value: item,
-            label: layouts[item] || item,
-          }))}
+          options={this.props.layouts
+            .filter(
+              layout =>
+                Object.keys(views.contentTypesViews).includes(layout) ||
+                Object.keys(views.layoutViews).includes(layout),
+            )
+            .map(item => ({
+              value: item,
+              label: layouts[item] || item,
+            }))}
           styles={customSelectStyles}
           theme={selectTheme}
           components={{ DropdownIndicator, Option }}

--- a/src/components/manage/Toolbar/More.jsx
+++ b/src/components/manage/Toolbar/More.jsx
@@ -11,11 +11,11 @@ import { compose } from 'redux';
 import { Link } from 'react-router-dom';
 import { find } from 'lodash';
 
-import { Icon, Display, Workflow } from '../../../components';
-import { getBaseUrl } from '../../../helpers';
+import { Icon, Display, Workflow } from '@plone/volto/components';
+import { getBaseUrl } from '@plone/volto/helpers';
 
-import rightArrowSVG from '../../../icons/right-key.svg';
-import userSVG from '../../../icons/user.svg';
+import rightArrowSVG from '@plone/volto/icons/right-key.svg';
+import userSVG from '@plone/volto/icons/user.svg';
 
 const messages = defineMessages({
   personalTools: {

--- a/src/components/manage/Toolbar/Toolbar.jsx
+++ b/src/components/manage/Toolbar/Toolbar.jsx
@@ -20,18 +20,18 @@ import Types from './Types';
 import PersonalInformation from '../Preferences/PersonalInformation';
 import PersonalPreferences from '../Preferences/PersonalPreferences';
 import StandardWrapper from './StandardWrapper';
-import { getTypes, listActions } from '../../../actions';
-import { Icon } from '../../../components';
-import { BodyClass, getBaseUrl } from '../../../helpers';
+import { getTypes, listActions } from '@plone/volto/actions';
+import { Icon } from '@plone/volto/components';
+import { BodyClass, getBaseUrl } from '@plone/volto/helpers';
 
 import pastanagaSmall from './pastanaga-small.svg';
 import pastanagalogo from './pastanaga.svg';
-import penSVG from '../../../icons/pen.svg';
-import folderSVG from '../../../icons/folder.svg';
-import addSVG from '../../../icons/add-document.svg';
-import moreSVG from '../../../icons/more.svg';
-import userSVG from '../../../icons/user.svg';
-import clearSVG from '../../../icons/clear.svg';
+import penSVG from '@plone/volto/icons/pen.svg';
+import folderSVG from '@plone/volto/icons/folder.svg';
+import addSVG from '@plone/volto/icons/add-document.svg';
+import moreSVG from '@plone/volto/icons/more.svg';
+import userSVG from '@plone/volto/icons/user.svg';
+import clearSVG from '@plone/volto/icons/clear.svg';
 
 const messages = defineMessages({
   edit: {

--- a/src/components/theme/View/View.jsx
+++ b/src/components/theme/View/View.jsx
@@ -12,9 +12,13 @@ import { injectIntl } from 'react-intl';
 import qs from 'query-string';
 import { views } from '~/config';
 
-import { Comments, Tags, Toolbar } from '../../../components';
-import { listActions, getContent } from '../../../actions';
-import { BodyClass, getBaseUrl, getLayoutFieldname } from '../../../helpers';
+import { Comments, Tags, Toolbar } from '@plone/volto/components';
+import { listActions, getContent } from '@plone/volto/actions';
+import {
+  BodyClass,
+  getBaseUrl,
+  getLayoutFieldname,
+} from '@plone/volto/helpers';
 
 /**
  * View container class.


### PR DESCRIPTION
This way we are offering a better user experience, imho.
Is this something you would be interested into?

The way it's implemented, they automatically show up when you configure a component to render that view. Also tested with sites created with ``create-volto-app``.