### PR TITLE
fix(Guillotina) Fixing travis tests on Guillotina backend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ matrix:
     - name: 'Plone'
       python: 3.7
       env: TEST_SUITE=plone ZSERVER_PORT=55001
-    # - name: 'Guillotina Tests'
-    #   python: 3.7
-    #   env: TEST_SUITE=guillotina
+    - name: 'Guillotina Tests'
+      python: 3.7
+      env: TEST_SUITE=guillotina
     - name: 'Unit Tests'
       env: TEST_SUITE=unit
 cache:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changes
 
 - Fix `RichText` Widget on normal forms @sneridagh
+- Fix Guillotina tests @bloodbare
 
 ## 4.0.0-alpha.39 (2020-02-18)
 

--- a/g-api/config.yml
+++ b/g-api/config.yml
@@ -51,6 +51,39 @@ default_blocks:
   Document:
   - type: title
   - type: text
+layouts:
+  Document:
+  - default
+  - document_view
+  - layout_view
+  News:
+  - default
+  - document_view
+  - layout_view
+  Event:
+  - default
+  - document_view
+  - layout_view
+  Image:
+  - default
+  - document_view
+  - layout_view
+  File:
+  - default
+  - document_view
+  - layout_view
+  Link:
+  - default
+  - document_view
+  - layout_view
+  CMSFolder:
+  - default
+  - listing_view
+  - event_listing
+  - album_view
+  - summary_view
+  - full_view
+  - layout_view
 workflows:
   basic:
     initial_state: private

--- a/g-api/docker-compose.yml
+++ b/g-api/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   postgres:
-    image: postgres:10
+    image: postgres:9.6.16
     container_name: postgres_test
     environment:
         POSTGRES_DB: guillotina


### PR DESCRIPTION
The problem was that postgres docker maintainers decided to change the image forcing that now a password is needed. Just forced an old version of postgres makes it work again.