### PR TITLE
Revert "Table Content: Fix content overflow"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,6 @@
 - Fix Video and Maps blocks hydration quirks on view mode @sneridagh
 - Deleted Empty Select Component @aryamanpuri
 - Fix `RichText` Widget on normal forms @sneridagh
-- Fix Scrolling Functionality if there are many columns in table @sumukhah
 - Fix Guillotina tests @bloodbare
 - Fix problem with not wrapped element in `Provider` store in `WysiwygWidget` component
   due that now, the links are wrapped with a connected component @sneridagh

--- a/theme/themes/pastanaga/collections/table.overrides
+++ b/theme/themes/pastanaga/collections/table.overrides
@@ -3,8 +3,6 @@
   td.selected {
     border: solid 1px rgba(120, 192, 215, 1) !important;
   }
-  display: block;
-  overflow-x: scroll;
 }
 
 /* Headers */


### PR DESCRIPTION
Reverts plone/volto#1216 because it breaks the layout for table blocks.