### PR TITLE
Fix SSR for "undetected" browsers [fixes #1262]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Changes
 
+- Fixes #1262 - SSR support for "undetected" browsers
 - Japanese translation @terapyon
 - Site settings styling fixed in the Controlpanel
 - Increase ObjectBrowser limit per folder to 1000, partially fixes #1259 @sneridagh

--- a/src/components/theme/OutdatedBrowser/OutdatedBrowser.jsx
+++ b/src/components/theme/OutdatedBrowser/OutdatedBrowser.jsx
@@ -7,7 +7,7 @@ import { settings } from '~/config';
 const OutdatedBrowser = () => {
   const browserdetect = useSelector(state => state.browserdetect);
   return (
-    settings.notSupportedBrowsers.includes(browserdetect.name) && (
+    settings.notSupportedBrowsers.includes(browserdetect?.name) && (
       <Container style={{ marginBottom: '20px' }}>
         <Message negative>
           <Message.Header>


### PR DESCRIPTION
Fixes issue were SSR rendered page version could not be loaded with `curl`, `lynx`, `elinks`, because browser detect returned null.