### PR TITLE
Deprecate `utils.less` as it is a leftover and it collides with some …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Japanese translation @terapyon
 - Site settings styling fixed in the Controlpanel
 - Increase ObjectBrowser limit per folder to 1000, partially fixes #1259 @sneridagh
+- Deprecate `utils.less` as it's a leftover and it collides with some use cases depending on the viewport, see: #1265
 
 ### Internal
 

--- a/theme/themes/pastanaga/extras/main.less
+++ b/theme/themes/pastanaga/extras/main.less
@@ -267,7 +267,8 @@ button {
   flex-direction: column;
 }
 
-@import 'utils';
+// Deprecated as per https://github.com/plone/volto/issues/1265
+// @import 'utils';
 @import 'toolbar';
 @import 'draftjs';
 @import 'blocks';


### PR DESCRIPTION
…use cases depending on the viewport, see: #1265