### PR TITLE
Convert api url in rich text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Add `flattenHTMLToAppURL` helper method for remove api url from TinyMCE generated HTML @cekk
+
 ### Changes
 
 - Improve the UX of the listing block when queries are running @sneridagh

--- a/src/components/theme/View/EventView.jsx
+++ b/src/components/theme/View/EventView.jsx
@@ -5,7 +5,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Helmet } from '@plone/volto/helpers';
+import { Helmet, flattenHTMLToAppURL } from '@plone/volto/helpers';
 import { Container, Image, Segment, Header, List } from 'semantic-ui-react';
 
 import {
@@ -112,7 +112,11 @@ const EventView = ({ content }) => (
       )}
     </Segment>
     {content.text && (
-      <div dangerouslySetInnerHTML={{ __html: content.text.data }} />
+      <div
+        dangerouslySetInnerHTML={{
+          __html: flattenHTMLToAppURL(content.text.data),
+        }}
+      />
     )}
   </Container>
 );

--- a/src/components/theme/View/EventView.test.jsx
+++ b/src/components/theme/View/EventView.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
-
 import EventView from './EventView';
+import { settings } from '~/config';
 
 test('renders an event view component with all props', () => {
   const component = renderer.create(
@@ -40,6 +40,25 @@ test('renders an event view component with only required props', () => {
         end: '2019-06-23T16:20:00+00:00',
         start: '2019-06-23T15:20:00+00:00',
         subjects: [],
+      }}
+    />,
+  );
+  const json = component.toJSON();
+  expect(json).toMatchSnapshot();
+});
+
+test('renders an event view component without links to api in the text', () => {
+  const component = renderer.create(
+    <EventView
+      content={{
+        title: 'Hello World!',
+        attendees: [],
+        end: '2019-06-23T16:20:00+00:00',
+        start: '2019-06-23T15:20:00+00:00',
+        subjects: [],
+        text: {
+          data: `<p>Hello World!</p><p>This is an <a href="${settings.apiPath}/foo/bar">internal link</a> and a <a href="${settings.apiPath}/foo/baz">second link</a></p>`,
+        },
       }}
     />,
   );

--- a/src/components/theme/View/NewsItemView.jsx
+++ b/src/components/theme/View/NewsItemView.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import { Helmet } from '@plone/volto/helpers';
 import { Container, Image } from 'semantic-ui-react';
 
-import { flattenToAppURL } from '@plone/volto/helpers';
+import { flattenToAppURL, flattenHTMLToAppURL } from '@plone/volto/helpers';
 
 /**
  * NewsItemView view component class.
@@ -42,7 +42,11 @@ const NewsItemView = ({ content }) => (
       />
     )}
     {content.text && (
-      <div dangerouslySetInnerHTML={{ __html: content.text.data }} />
+      <div
+        dangerouslySetInnerHTML={{
+          __html: flattenHTMLToAppURL(content.text.data),
+        }}
+      />
     )}
   </Container>
 );

--- a/src/components/theme/View/NewsItemView.test.jsx
+++ b/src/components/theme/View/NewsItemView.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import NewsItemView from './NewsItemView';
+import { settings } from '~/config';
 
 test('renders a news item view component', () => {
   const component = renderer.create(
@@ -10,6 +11,22 @@ test('renders a news item view component', () => {
         description: 'Hi',
         text: {
           data: '<p>Hello World!',
+        },
+      }}
+    />,
+  );
+  const json = component.toJSON();
+  expect(json).toMatchSnapshot();
+});
+
+test('renders a news item view component without links to api', () => {
+  const component = renderer.create(
+    <NewsItemView
+      content={{
+        title: 'Hello World!',
+        description: 'Hi',
+        text: {
+          data: `<p>Hello World!</p><p>This is an <a href="${settings.apiPath}/foo/bar">internal link</a> and a <a href="${settings.apiPath}/foo/baz">second link</a></p>`,
         },
       }}
     />,

--- a/src/components/theme/View/__snapshots__/EventView.test.jsx.snap
+++ b/src/components/theme/View/__snapshots__/EventView.test.jsx.snap
@@ -260,3 +260,52 @@ exports[`renders an event view component with only required props 1`] = `
   </div>
 </div>
 `;
+
+exports[`renders an event view component without links to api in the text 1`] = `
+<div
+  className="ui container view-wrapper event-view"
+>
+  <h1
+    className="documentFirstHeading"
+  >
+    Hello World!
+  </h1>
+  <div
+    className="ui right floated segment"
+  >
+    <div
+      className="ui dividing sub header"
+    >
+      When
+    </div>
+    <p
+      className="event-when same-day"
+    >
+      <span
+        className="start-date"
+      >
+        Jun 23, 2019
+      </span>
+       from 
+      <span
+        className="start-time"
+      >
+        3:20 PM
+      </span>
+       to 
+      <span
+        className="end-time"
+      >
+        4:20 PM
+      </span>
+    </p>
+  </div>
+  <div
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "<p>Hello World!</p><p>This is an <a href=\\"/foo/bar\\">internal link</a> and a <a href=\\"/foo/baz\\">second link</a></p>",
+      }
+    }
+  />
+</div>
+`;

--- a/src/components/theme/View/__snapshots__/NewsItemView.test.jsx.snap
+++ b/src/components/theme/View/__snapshots__/NewsItemView.test.jsx.snap
@@ -23,3 +23,27 @@ exports[`renders a news item view component 1`] = `
   />
 </div>
 `;
+
+exports[`renders a news item view component without links to api 1`] = `
+<div
+  className="ui container view-wrapper"
+>
+  <h1
+    className="documentFirstHeading"
+  >
+    Hello World!
+  </h1>
+  <p
+    className="documentDescription"
+  >
+    Hi
+  </p>
+  <div
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "<p>Hello World!</p><p>This is an <a href=\\"/foo/bar\\">internal link</a> and a <a href=\\"/foo/baz\\">second link</a></p>",
+      }
+    }
+  />
+</div>
+`;

--- a/src/helpers/Url/Url.js
+++ b/src/helpers/Url/Url.js
@@ -95,6 +95,19 @@ export function flattenToAppURL(url) {
 }
 
 /**
+ * Flatten to app server HTML - Given a text if it contains some urls that starts
+ * with the API server URL this method flattens it (removes) the server part.
+ * TODO: Update it when implementing non-root based app location (on a
+ * directory other than /, eg. /myapp)
+ * @method flattenHTMLToAppURL
+ * @param {string} html Some html snippet
+ * @returns {string} Same HTML with Flattened URLs to the app server
+ */
+export function flattenHTMLToAppURL(html) {
+  return html.replace(new RegExp(settings.apiPath, 'g'), '');
+}
+
+/**
  * Add the app url
  * @method addAppURL
  * @param {string} url URL of the object

--- a/src/helpers/Url/Url.test.js
+++ b/src/helpers/Url/Url.test.js
@@ -1,6 +1,12 @@
 import { settings } from '~/config';
 
-import { flattenToAppURL, getBaseUrl, getIcon, getView } from './Url';
+import {
+  flattenToAppURL,
+  flattenHTMLToAppURL,
+  getBaseUrl,
+  getIcon,
+  getView,
+} from './Url';
 
 describe('Url', () => {
   describe('getBaseUrl', () => {
@@ -80,6 +86,14 @@ describe('Url', () => {
   describe('flattenToAppURL', () => {
     it('flattens a given URL to the app URL', () => {
       expect(flattenToAppURL(`${settings.apiPath}/edit`)).toBe('/edit');
+    });
+  });
+  describe('flattenHTMLToAppURL', () => {
+    it('flattens all occurences of the api URL from an html snippet', () => {
+      const html = `<a href="${settings.apiPath}/foo/bar">An internal link</a><a href="${settings.apiPath}/foo/baz">second link</a>`;
+      expect(flattenHTMLToAppURL(html)).toBe(
+        '<a href="/foo/bar">An internal link</a><a href="/foo/baz">second link</a>',
+      );
     });
   });
 });

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -13,6 +13,7 @@ export {
 } from '@plone/volto/helpers/AuthToken/AuthToken';
 export {
   addAppURL,
+  flattenHTMLToAppURL,
   flattenToAppURL,
   isInternalURL,
   getBaseUrl,


### PR DESCRIPTION
Internal links in rich text fields are converted by restapi with the backend url.
This means that Volto then expose links to the backend Plone site.

With this change all references to api url are cleaned.
I didn't find a better way to do this in general and not in every single view.