### PR TITLE
Move block selector into the empty text block on smaller screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - Improve the UX of the listing block when queries are running @sneridagh
 
+- Move block selector into the empty text block on smaller screens when sidebar is open, partially fixes #1272 @fredvd
+
 ## 4.0.1 (2020-03-09)
 
 ### Changes

--- a/api/pyvenv.cfg
+++ b/api/pyvenv.cfg
@@ -1,0 +1,3 @@
+home = /usr/local/bin
+include-system-site-packages = false
+version = 3.7.6

--- a/theme/themes/pastanaga/elements/container.overrides
+++ b/theme/themes/pastanaga/elements/container.overrides
@@ -15,7 +15,7 @@
     margin-right 0.3s cubic-bezier(0.6, -0.28, 0.735, 0.045);
 }
 
-.contentWidthMedia(@width, @gutter, @offset) {
+.contentWidthMedia(@width, @gutter, @offset, @addoffset) {
   .ui.container {
     width: @width !important;
     margin-right: @gutter !important;
@@ -26,6 +26,14 @@
     margin-left: @offset !important;
   }
 
+  .button.block-add-button {
+    left: @addoffset !important;
+  }
+
+  .blocks-chooser {
+    left: -9px + @addoffset !important;
+  }
+
   .block .delete-button {
     margin-right: @offset !important;
   }
@@ -33,7 +41,7 @@
 
 .contentWidth(@offset) {
   @media only screen and (max-width: @largestMobileScreen + @offset) {
-    .contentWidthMedia(@mobileWidth, @mobileGutter, -12px);
+    .contentWidthMedia(@mobileWidth, @mobileGutter, -12px, 24px);
 
     [class*='mobile hidden'],
     [class*='tablet only']:not(.mobile),
@@ -45,7 +53,7 @@
     }
   }
   @media only screen and (min-width: @tabletBreakpoint + @offset) and (max-width: @largestTabletScreen + @offset) {
-    .contentWidthMedia(@tabletWidth, @tabletGutter, -30px);
+    .contentWidthMedia(@tabletWidth, @tabletGutter, -30px, 0px);
 
     [class*='mobile only']:not(.tablet),
     [class*='tablet hidden'],
@@ -57,7 +65,7 @@
     }
   }
   @media only screen and (min-width: @computerBreakpoint + @offset) and (max-width: @largestSmallMonitor + @offset) {
-    .contentWidthMedia(@computerWidth, @computerGutter, -30px);
+    .contentWidthMedia(@computerWidth, @computerGutter, -30px, 0px);
 
     [class*='mobile only']:not(.computer),
     [class*='tablet only']:not(.computer),
@@ -69,7 +77,7 @@
     }
   }
   @media only screen and (min-width: @largeMonitorBreakpoint + @offset) {
-    .contentWidthMedia(@largeMonitorWidth, @largeMonitorGutter, -30px);
+    .contentWidthMedia(@largeMonitorWidth, @largeMonitorGutter, -30px, 0px);
 
     [class*='mobile only']:not([class*='large screen']),
     [class*='tablet only']:not([class*='large screen']),


### PR DESCRIPTION
When sidebar is open. See #1272 

This at least makes the block selector visible again similar with how the drag handle and the delete icon are shifted when it's required.

Technically I had to add a new offset parameter (addoffset), the drag & delete icons are handled relatively, but the (+) icon is using absolute positioning. The BlockChooser is at the moment shifted with the same amount.

The current nested -> .contentWitdh() -> .contentwidthMedia() less functions are a bit problematic with fine tuning the icon positions.  If you look closely to the trash icon, the mobile shift is not exactly right, the \@offset variable is used by both the drag handle & the trashcan. For every element we'd need to pass in a new variable.  But maybe 3 variables is enough, there's only limited space for more icons :-P

I would like to shift the Draf.js Placeholder text a bit (15px?) more to the right so that the (+) can be moved completely inside the editor line, but I cannot find the place where to edit this. As soon as someone starts typing the (+) button disappears again, then the actual text can be at the beginning of the editor line again. 

Current WIP position of the (+) on mobile. Can anybody with more semantic uid experience fix this a bit more? 

<img width="788" alt="block chooser icon visible wip" src="https://user-images.githubusercontent.com/394784/76541289-9fa36380-6483-11ea-8a48-0892ae9a2849.png">
