### PR TITLE
Make Jest only looks up in `src` folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Internal
 
+- Make Jest only looks up in `src` folder @sneridagh
+
 ## 4.6.0 (2020-04-06)
 
 ### Feature

--- a/package.json
+++ b/package.json
@@ -78,6 +78,9 @@
     ]
   },
   "jest": {
+    "testMatch": [
+      "<rootDir>/src/**/?(*.)+(spec|test).[jt]s?(x)"
+    ],
     "transform": {
       "^.+\\.js(x)?$": "babel-jest",
       "^.+\\.css$": "jest-css-modules",


### PR DESCRIPTION
This fixes tests fail when it found the Plone JS resources in `api` folder.