### PR TITLE
Fixes for contact form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Bugfix
 
+- Fixes for contact form @nzambello
+
+
 ### Internal
 
 ## 5.0.0 (2020-04-12)

--- a/src/components/manage/Form/Form.jsx
+++ b/src/components/manage/Form/Form.jsx
@@ -594,7 +594,7 @@ class Form extends Component {
     const { formData } = this.state;
     const blocksFieldname = getBlocksFieldname(formData);
     const blocksLayoutFieldname = getBlocksLayoutFieldname(formData);
-    const renderBlocks = formData[blocksLayoutFieldname].items;
+    const renderBlocks = formData[blocksLayoutFieldname]?.items;
     const blocksDict = formData[blocksFieldname];
     const schema = this.removeBlocksLayoutFields(originalSchema);
 

--- a/src/components/theme/ContactForm/ContactForm.jsx
+++ b/src/components/theme/ContactForm/ContactForm.jsx
@@ -121,7 +121,7 @@ class ContactForm extends Component {
         <Toast
           success
           title={this.props.intl.formatMessage(messages.success)}
-          content={this.props.intl.formatMessage(messages.saved)}
+          content={this.props.intl.formatMessage(messages.messageSent)}
         />,
       );
     }


### PR DESCRIPTION
Submitting the contact form I had errors in the frontend and the form went broken.
I resolved the issue with an error boundary that is the `?` in ```formData[blocksLayoutFieldname]?.items```

I also saw that the success toast for the form was broken due to an incorrect id for the translation, so I picked up the correct one. 