### PR TITLE
internal: Improve i18n script, so shadowed components are not overriding their …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Internal
 
+- Improve i18n script, so shadowed components are not overriding their original translations. For the record, any override of i18n messages, should be done somewhere else (eg. config object) @sneridagh
+
 ## 5.0.1 (2020-04-16)
 
 ### Bugfix

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -48,6 +48,7 @@ nav:
   - Recipes:
       - App component insertion point: 'recipes/appextras.md'
       - Lazy loading and code splitting: 'recipes/lazyload.md'
+      - Overriding i18n messages: 'recipes/overridei18n'
   - Deploying:
       - Simple deployment: 'deploying/simple.md'
       - Using PM2: 'deploying/pm2.md'

--- a/docs/source/recipes/overridei18n.md
+++ b/docs/source/recipes/overridei18n.md
@@ -1,0 +1,32 @@
+# Overriding i18n messages
+
+If you want to override an existing translation, you should declare the original message
+again somewhere else in your project, e.g in `src/config.js`, like this:
+
+```js
+import { defineMessages } from 'react-intl';
+
+defineMessages({
+  back: {
+    id: 'Back',
+    defaultMessage: 'Back',
+  },
+}
+```
+
+Then run `yarn i18n` and you'll find the translation ready to override in your `locales`
+directory, e.g `locales/de/LC_MESSAGES/volto.po`.
+
+```
+#: src/config
+msgid "Back"
+msgstr "My overriden translation"
+```
+
+After setting the override, then run `yarn i18n` again, to create the `de.json`
+translation files. Restart Volto to see the changes applied.
+
+!!! note
+    Shadowed components do NOT override translations, since 99% of the time, you
+    don't want them to do that, so the `customizations` folder is excluded from the
+    i18n build.

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -33,11 +33,18 @@ function getMessages() {
   return reduce(
     concat(
       {},
-      ...map(glob('build/messages/src/**/*.json'), filename =>
-        map(JSON.parse(fs.readFileSync(filename, 'utf8')), message => ({
-          ...message,
-          filename: filename.match(/build\/messages\/src\/(.*).json$/)[1],
-        })),
+      ...map(
+        // We ignore the existing customized shadowed components ones, since most
+        // probably we won't be overriding them
+        // If so, we should do it in the config object or somewhere else
+        glob('build/messages/src/**/*.json', {
+          ignore: 'build/messages/src/customizations/**',
+        }),
+        filename =>
+          map(JSON.parse(fs.readFileSync(filename, 'utf8')), message => ({
+            ...message,
+            filename: filename.match(/build\/messages\/src\/(.*).json$/)[1],
+          })),
       ),
     ),
     (current, value) => {


### PR DESCRIPTION
…original translations. For the record, any override of i18n messages, should be done somewhere else