### PR TITLE
Fix `ArrayWidget` to support multiselect schema `schema.List`/`schema…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Bugfix
 
+- Fix `ArrayWidget` to support multiselect schema `schema.List`/`schema.Set`-> `schema.Choice` hardcoded (not using vocabularies) combination @sneridagh
+
 ### Internal
 
 ## 5.0.1 (2020-04-16)

--- a/src/components/manage/Widgets/ArrayWidget.jsx
+++ b/src/components/manage/Widgets/ArrayWidget.jsx
@@ -115,7 +115,7 @@ class ArrayWidget extends Component {
       selectedOption: props.value
         ? props.value.map(item =>
             isObject(item)
-              ? { label: item.title, value: item.token }
+              ? { label: item.title || item.token, value: item.token }
               : { label: item, value: item },
           )
         : [],

--- a/src/components/manage/Widgets/ArrayWidget.jsx
+++ b/src/components/manage/Widgets/ArrayWidget.jsx
@@ -230,7 +230,11 @@ class ArrayWidget extends Component {
                       ? [
                           ...this.props.choices.map(option => ({
                             value: option[0],
-                            label: option[1],
+                            label:
+                              // Fix "None" on the serializer, to remove when fixed in p.restapi
+                              option[1] !== 'None' && option[1]
+                                ? option[1]
+                                : option[0],
                           })),
                           {
                             label: this.props.intl.formatMessage(


### PR DESCRIPTION
….Set`-> `schema.Choice` hardcoded (not using vocabularies) combination