### PR TITLE
Dates widget: show past dates and mark differently default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - Japanese translation @terapyon
 - Fix `ArrayWidget` to support multiselect schema `schema.List`/`schema.Set`-> `schema.Choice` hardcoded (not using vocabularies) combination @sneridagh
+- Show past dates in date time widget calendar @nzambello
 
 ### Internal
 

--- a/src/components/manage/Widgets/DatetimeWidget.jsx
+++ b/src/components/manage/Widgets/DatetimeWidget.jsx
@@ -165,6 +165,7 @@ class DatetimeWidget extends Component {
       error,
       fieldSet,
       dateOnly,
+      noPastDates,
       intl,
     } = this.props;
     const { datetime, isDefault, focused } = this.state;
@@ -196,8 +197,7 @@ class DatetimeWidget extends Component {
                     onDateChange={this.onDateChange}
                     focused={focused}
                     numberOfMonths={1}
-                    enableOutsideDays
-                    isOutsideRange={() => false}
+                    {...(noPastDates ? {} : { isOutsideRange: () => false })}
                     onFocusChange={this.onFocusChange}
                     noBorder
                     displayFormat={moment
@@ -261,6 +261,7 @@ DatetimeWidget.propTypes = {
   required: PropTypes.bool,
   error: PropTypes.arrayOf(PropTypes.string),
   dateOnly: PropTypes.bool,
+  noPastDates: PropTypes.bool,
   value: PropTypes.string,
   onChange: PropTypes.func.isRequired,
 };
@@ -275,6 +276,7 @@ DatetimeWidget.defaultProps = {
   required: false,
   error: [],
   dateOnly: false,
+  noPastDates: false,
   value: null,
 };
 

--- a/src/components/manage/Widgets/DatetimeWidget.jsx
+++ b/src/components/manage/Widgets/DatetimeWidget.jsx
@@ -11,6 +11,7 @@ import { map } from 'lodash';
 import moment from 'moment';
 import { SingleDatePicker } from 'react-dates';
 import TimePicker from 'rc-time-picker';
+import cx from 'classnames';
 import leftKey from '../../../icons/left-key.svg';
 import rightKey from '../../../icons/right-key.svg';
 import { Icon } from '../../../components';
@@ -87,6 +88,11 @@ class DatetimeWidget extends Component {
 
     this.state = {
       focused: false,
+      isDefault:
+        datetime.toISOString() ===
+        moment()
+          .utc()
+          .toISOString(),
       datetime,
     };
   }
@@ -107,6 +113,7 @@ class DatetimeWidget extends Component {
             date: date.date(),
             ...(this.props.dateOnly ? defaultTimeDateOnly : {}),
           }),
+          isDefault: false,
         }),
         () => this.onDateTimeChange(),
       );
@@ -126,6 +133,7 @@ class DatetimeWidget extends Component {
           minutes: time.minutes(),
           seconds: 0,
         }),
+        isDefault: false,
       }),
       () => this.onDateTimeChange(),
     );
@@ -159,7 +167,7 @@ class DatetimeWidget extends Component {
       dateOnly,
       intl,
     } = this.props;
-    const { datetime, focused } = this.state;
+    const { datetime, isDefault, focused } = this.state;
 
     return (
       <Form.Field
@@ -178,12 +186,18 @@ class DatetimeWidget extends Component {
             </Grid.Column>
             <Grid.Column width="8">
               <div>
-                <div className="ui input date-input">
+                <div
+                  className={cx('ui input date-input', {
+                    'default-date': isDefault,
+                  })}
+                >
                   <SingleDatePicker
                     date={datetime}
                     onDateChange={this.onDateChange}
                     focused={focused}
                     numberOfMonths={1}
+                    enableOutsideDays
+                    isOutsideRange={() => false}
                     onFocusChange={this.onFocusChange}
                     noBorder
                     displayFormat={moment
@@ -195,7 +209,11 @@ class DatetimeWidget extends Component {
                   />
                 </div>
                 {!dateOnly && (
-                  <div className="ui input time-input">
+                  <div
+                    className={cx('ui input time-input', {
+                      'default-date': isDefault,
+                    })}
+                  >
                     <TimePicker
                       defaultValue={datetime}
                       onChange={this.onTimeChange}

--- a/theme/themes/pastanaga/extras/react-dates-overrides.less
+++ b/theme/themes/pastanaga/extras/react-dates-overrides.less
@@ -41,10 +41,6 @@ td.CalendarDay__today {
   font-weight: bold;
 }
 
-// .SingleDatePicker_picker {
-//   top: 0 !important;
-// }
-
 .DayPickerKeyboardShortcuts_show__bottomRight {
   width: 2.5rem;
   height: 2.5rem;
@@ -74,10 +70,20 @@ td.CalendarDay__today {
   display: none;
 }
 
-.CalendarMonth_caption {
-  padding-bottom: 15px;
-  margin-bottom: 45px;
-  border-bottom: 1px solid #edf1f2;
+.default-date {
+  .DateInput {
+    input.DateInput_input[type='text'] {
+      color: @lightGrey;
+    }
+  }
+}
+
+.CalendarMonth {
+  .CalendarMonth_caption {
+    padding-bottom: 22px;
+    margin-bottom: 45px;
+    border-bottom: 1px solid #edf1f2;
+  }
 }
 
 .CalendarMonth_caption strong {

--- a/theme/themes/pastanaga/extras/time-picker-overrides.less
+++ b/theme/themes/pastanaga/extras/time-picker-overrides.less
@@ -10,6 +10,10 @@
 
   input.rc-time-picker-input {
     max-width: 100%;
+
+    .default-date &[type='text'] {
+      color: @lightGrey;
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #1391 .

Shown past dates in calendar and added a prop to hide past dates in calendar (false as default).

I also marked default date vs edited because in CT dates like expire date should be visible as non saved value (so now it's grey).