### PR TITLE
No listing results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Breaking
 
+- Listing block: removed message 'No results found' only in view mode on public site, in editMode is still present. @giuliaghisini
+
 ### Feature
 
 - /sitemap to view sitemap based on @navigation with depth 4 @giuliaghisini

--- a/src/components/manage/Blocks/Listing/ListingBody.jsx
+++ b/src/components/manage/Blocks/Listing/ListingBody.jsx
@@ -137,7 +137,7 @@ const ListingBody = ({ data, properties, intl, path, isEditMode }) => {
               </div>
             )}
         </>
-      ) : (
+      ) : isEditMode ? (
         <div className="listing message">
           {data?.query?.length === 0 && (
             <FormattedMessage
@@ -152,7 +152,7 @@ const ListingBody = ({ data, properties, intl, path, isEditMode }) => {
             />
           )}
         </div>
-      )}
+      ) : null}
     </>
   );
 };

--- a/src/components/manage/Blocks/Listing/__snapshots__/ListingBody.test.jsx.snap
+++ b/src/components/manage/Blocks/Listing/__snapshots__/ListingBody.test.jsx.snap
@@ -1,9 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders a ListingBody component 1`] = `
-<div
-  className="listing message"
->
-  No results found.
-</div>
-`;
+exports[`renders a ListingBody component 1`] = `null`;


### PR DESCRIPTION
Removed message for 'no results found' in view component of ListingBody for Listing block. 
On the public site it's not always nice to see the message 'no results found'.
