### PR TITLE
Add babel and externals support in Webpack for add-on infrastructure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Feature
 
+- Add babel and externals support in Webpack for add-on infrastructure @sneridagh
+
 ### Bugfix
 
 ### Internal

--- a/razzle.config.js
+++ b/razzle.config.js
@@ -287,11 +287,14 @@ module.exports = {
     if (packageJson.name !== '@plone/volto') {
       include.push(fs.realpathSync(`${voltoPath}/src`));
     }
-    packageJson.addons.forEach(addon =>
-      include.push(
-        fs.realpathSync(`${projectRootPath}/node_modules/${addon}/src`),
-      ),
-    );
+    // Add babel support external (ie. node_modules npm published packages)
+    if (packageJson.addons) {
+      packageJson.addons.forEach(addon =>
+        include.push(
+          fs.realpathSync(`${projectRootPath}/node_modules/${addon}/src`),
+        ),
+      );
+    }
 
     config.module.rules[babelRuleIndex] = Object.assign(
       config.module.rules[babelRuleIndex],
@@ -299,12 +302,10 @@ module.exports = {
         include,
       },
     );
-    console.log(config.module.rules[babelRuleIndex]);
 
     const addonsAsExternals = packageJson.addons.map(
       addon => new RegExp(addon),
     );
-    console.log(addonsAsExternals);
 
     config.externals =
       target === 'node'
@@ -316,6 +317,7 @@ module.exports = {
                 /\.(svg|png|jpg|jpeg|gif|ico)$/,
                 /\.(mp4|mp3|ogg|swf|webp)$/,
                 /\.(css|scss|sass|sss|less)$/,
+                // Add support for whitelist external (ie. node_modules npm published packages)
                 ...addonsAsExternals,
                 /^@plone\/volto/,
               ].filter(Boolean),

--- a/razzle.config.js
+++ b/razzle.config.js
@@ -303,9 +303,10 @@ module.exports = {
       },
     );
 
-    const addonsAsExternals = packageJson.addons.map(
-      addon => new RegExp(addon),
-    );
+    let addonsAsExternals = [];
+    if (packageJson.addons) {
+      addonsAsExternals = packageJson.addons.map(addon => new RegExp(addon));
+    }
 
     config.externals =
       target === 'node'

--- a/razzle.config.js
+++ b/razzle.config.js
@@ -287,12 +287,25 @@ module.exports = {
     if (packageJson.name !== '@plone/volto') {
       include.push(fs.realpathSync(`${voltoPath}/src`));
     }
+    packageJson.addons.forEach(addon =>
+      include.push(
+        fs.realpathSync(`${projectRootPath}/node_modules/${addon}/src`),
+      ),
+    );
+
     config.module.rules[babelRuleIndex] = Object.assign(
       config.module.rules[babelRuleIndex],
       {
         include,
       },
     );
+    console.log(config.module.rules[babelRuleIndex]);
+
+    const addonsAsExternals = packageJson.addons.map(
+      addon => new RegExp(addon),
+    );
+    console.log(addonsAsExternals);
+
     config.externals =
       target === 'node'
         ? [
@@ -303,6 +316,7 @@ module.exports = {
                 /\.(svg|png|jpg|jpeg|gif|ico)$/,
                 /\.(mp4|mp3|ogg|swf|webp)$/,
                 /\.(css|scss|sass|sss|less)$/,
+                ...addonsAsExternals,
                 /^@plone\/volto/,
               ].filter(Boolean),
             }),


### PR DESCRIPTION
So this is it.

I couldn't made it work with bare Volto, I have no clue why... but it works in a standard Volto project... I guess that's where it counts 😀😀

package.json
```json
...
"addons": [
    "volto-myaddon"
]
...
```

So it's left the config aggregator and what else?

