### PR TITLE
fix: handling target for external links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Fix handling of external links in ToHTML config @nzambello
+
 ### Internal
 
 - Periodical upgrade of `browserlist` lib @sneridagh

--- a/src/config/RichTextEditor/ToHTML.jsx
+++ b/src/config/RichTextEditor/ToHTML.jsx
@@ -147,7 +147,7 @@ const blocks = {
 
 const LinkEntity = connect(state => ({
   token: state.userSession.token,
-}))(({ token, key, url, target, targetUrl, download, children }) => {
+}))(({ token, key, url, target = '_blank', targetUrl, download, children }) => {
   const to = token ? url : targetUrl || url;
   if (download) {
     return token ? (


### PR DESCRIPTION
Fixes #1440 .

Now with '_blank' as default value for `target` attribute, external links are opening in a new tab, while internal ones are rendered by Link component as before.