### PR TITLE
Update CheckboxWidget.jsx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Bugfix
 
 - Fix local build when no RAZZLE_API_PATH is set @sneridagh
+- Fix Checkbox widget label htmlFor @nzambello
 
 ### Internal
 

--- a/src/components/manage/Widgets/CheckboxWidget.jsx
+++ b/src/components/manage/Widgets/CheckboxWidget.jsx
@@ -131,7 +131,7 @@ const CheckboxWidget = ({
                 checked={value}
                 disabled={onEdit !== null}
                 onChange={(event, { checked }) => onChange(id, checked)}
-                label={<label for={`field-${id}`}>{title}</label>}
+                label={<label htmlFor={`field-${id}`}>{title}</label>}
               />
             </div>
             {map(error, (message) => (


### PR DESCRIPTION
Fix `htmlFor`  attribute for label.
In JSX for is a reserved keyword for JS `for` loop, so it's `htmlFor`