### PR TITLE
add smaller aligmend options to image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Feature
 
+- add smaller aligmend options to imagesidebar as requested in #1163 @jackahl
+
 ### Bugfix
 
 ### Internal

--- a/src/components/manage/Blocks/Image/__snapshots__/ImageSidebar.test.jsx.snap
+++ b/src/components/manage/Blocks/Image/__snapshots__/ImageSidebar.test.jsx.snap
@@ -236,6 +236,62 @@ exports[`renders an Image Block Sidebar component 1`] = `
                 className="ui buttons"
               >
                 <button
+                  aria-label="Left"
+                  className="ui basic icon button"
+                  onClick={[Function]}
+                >
+                  <svg
+                    className="icon"
+                    dangerouslySetInnerHTML={
+                      Object {
+                        "__html": undefined,
+                      }
+                    }
+                    onClick={null}
+                    style={
+                      Object {
+                        "fill": "currentColor",
+                        "height": "24px",
+                        "width": "auto",
+                      }
+                    }
+                    viewBox=""
+                    xmlns=""
+                  />
+                </button>
+              </div>
+              <div
+                className="ui buttons"
+              >
+                <button
+                  aria-label="Right"
+                  className="ui basic icon button"
+                  onClick={[Function]}
+                >
+                  <svg
+                    className="icon"
+                    dangerouslySetInnerHTML={
+                      Object {
+                        "__html": undefined,
+                      }
+                    }
+                    onClick={null}
+                    style={
+                      Object {
+                        "fill": "currentColor",
+                        "height": "24px",
+                        "width": "auto",
+                      }
+                    }
+                    viewBox=""
+                    xmlns=""
+                  />
+                </button>
+              </div>
+              <div
+                className="ui buttons"
+              >
+                <button
                   aria-label="Right"
                   className="ui basic icon button"
                   onClick={[Function]}

--- a/src/components/manage/Blocks/LeadImage/__snapshots__/LeadImageSidebar.test.jsx.snap
+++ b/src/components/manage/Blocks/LeadImage/__snapshots__/LeadImageSidebar.test.jsx.snap
@@ -155,6 +155,62 @@ exports[`renders a Lead Image block Sidebar component 1`] = `
                 className="ui buttons"
               >
                 <button
+                  aria-label="Left"
+                  className="ui basic icon button"
+                  onClick={[Function]}
+                >
+                  <svg
+                    className="icon"
+                    dangerouslySetInnerHTML={
+                      Object {
+                        "__html": undefined,
+                      }
+                    }
+                    onClick={null}
+                    style={
+                      Object {
+                        "fill": "currentColor",
+                        "height": "24px",
+                        "width": "auto",
+                      }
+                    }
+                    viewBox=""
+                    xmlns=""
+                  />
+                </button>
+              </div>
+              <div
+                className="ui buttons"
+              >
+                <button
+                  aria-label="Right"
+                  className="ui basic icon button"
+                  onClick={[Function]}
+                >
+                  <svg
+                    className="icon"
+                    dangerouslySetInnerHTML={
+                      Object {
+                        "__html": undefined,
+                      }
+                    }
+                    onClick={null}
+                    style={
+                      Object {
+                        "fill": "currentColor",
+                        "height": "24px",
+                        "width": "auto",
+                      }
+                    }
+                    viewBox=""
+                    xmlns=""
+                  />
+                </button>
+              </div>
+              <div
+                className="ui buttons"
+              >
+                <button
                   aria-label="Right"
                   className="ui basic icon button"
                   onClick={[Function]}

--- a/src/components/manage/Blocks/Maps/__snapshots__/MapsSidebar.test.jsx.snap
+++ b/src/components/manage/Blocks/Maps/__snapshots__/MapsSidebar.test.jsx.snap
@@ -147,6 +147,62 @@ exports[`renders an Image Block Sidebar component 1`] = `
                 className="ui buttons"
               >
                 <button
+                  aria-label="Left"
+                  className="ui basic icon button"
+                  onClick={[Function]}
+                >
+                  <svg
+                    className="icon"
+                    dangerouslySetInnerHTML={
+                      Object {
+                        "__html": undefined,
+                      }
+                    }
+                    onClick={null}
+                    style={
+                      Object {
+                        "fill": "currentColor",
+                        "height": "24px",
+                        "width": "auto",
+                      }
+                    }
+                    viewBox=""
+                    xmlns=""
+                  />
+                </button>
+              </div>
+              <div
+                className="ui buttons"
+              >
+                <button
+                  aria-label="Right"
+                  className="ui basic icon button"
+                  onClick={[Function]}
+                >
+                  <svg
+                    className="icon"
+                    dangerouslySetInnerHTML={
+                      Object {
+                        "__html": undefined,
+                      }
+                    }
+                    onClick={null}
+                    style={
+                      Object {
+                        "fill": "currentColor",
+                        "height": "24px",
+                        "width": "auto",
+                      }
+                    }
+                    viewBox=""
+                    xmlns=""
+                  />
+                </button>
+              </div>
+              <div
+                className="ui buttons"
+              >
+                <button
                   aria-label="Right"
                   className="ui basic icon button"
                   onClick={[Function]}

--- a/src/components/manage/Blocks/Video/__snapshots__/VideoSidebar.test.jsx.snap
+++ b/src/components/manage/Blocks/Video/__snapshots__/VideoSidebar.test.jsx.snap
@@ -147,6 +147,62 @@ exports[`renders an Image Block Sidebar component 1`] = `
                 className="ui buttons"
               >
                 <button
+                  aria-label="Left"
+                  className="ui basic icon button"
+                  onClick={[Function]}
+                >
+                  <svg
+                    className="icon"
+                    dangerouslySetInnerHTML={
+                      Object {
+                        "__html": undefined,
+                      }
+                    }
+                    onClick={null}
+                    style={
+                      Object {
+                        "fill": "currentColor",
+                        "height": "24px",
+                        "width": "auto",
+                      }
+                    }
+                    viewBox=""
+                    xmlns=""
+                  />
+                </button>
+              </div>
+              <div
+                className="ui buttons"
+              >
+                <button
+                  aria-label="Right"
+                  className="ui basic icon button"
+                  onClick={[Function]}
+                >
+                  <svg
+                    className="icon"
+                    dangerouslySetInnerHTML={
+                      Object {
+                        "__html": undefined,
+                      }
+                    }
+                    onClick={null}
+                    style={
+                      Object {
+                        "fill": "currentColor",
+                        "height": "24px",
+                        "width": "auto",
+                      }
+                    }
+                    viewBox=""
+                    xmlns=""
+                  />
+                </button>
+              </div>
+              <div
+                className="ui buttons"
+              >
+                <button
                   aria-label="Right"
                   className="ui basic icon button"
                   onClick={[Function]}

--- a/src/components/manage/Sidebar/__snapshots__/ObjectBrowserBody.test.jsx.snap
+++ b/src/components/manage/Sidebar/__snapshots__/ObjectBrowserBody.test.jsx.snap
@@ -202,6 +202,62 @@ exports[`renders an Image Block Sidebar component 1`] = `
                 className="ui buttons"
               >
                 <button
+                  aria-label="Left"
+                  className="ui basic icon button"
+                  onClick={[Function]}
+                >
+                  <svg
+                    className="icon"
+                    dangerouslySetInnerHTML={
+                      Object {
+                        "__html": undefined,
+                      }
+                    }
+                    onClick={null}
+                    style={
+                      Object {
+                        "fill": "currentColor",
+                        "height": "24px",
+                        "width": "auto",
+                      }
+                    }
+                    viewBox=""
+                    xmlns=""
+                  />
+                </button>
+              </div>
+              <div
+                className="ui buttons"
+              >
+                <button
+                  aria-label="Right"
+                  className="ui basic icon button"
+                  onClick={[Function]}
+                >
+                  <svg
+                    className="icon"
+                    dangerouslySetInnerHTML={
+                      Object {
+                        "__html": undefined,
+                      }
+                    }
+                    onClick={null}
+                    style={
+                      Object {
+                        "fill": "currentColor",
+                        "height": "24px",
+                        "width": "auto",
+                      }
+                    }
+                    viewBox=""
+                    xmlns=""
+                  />
+                </button>
+              </div>
+              <div
+                className="ui buttons"
+              >
+                <button
                   aria-label="Right"
                   className="ui basic icon button"
                   onClick={[Function]}

--- a/src/helpers/AlignBlock/AlignBlock.jsx
+++ b/src/helpers/AlignBlock/AlignBlock.jsx
@@ -57,9 +57,31 @@ const AlignBlock = ({ align, onChangeBlock, data, intl, block }) => {
         <Button
           icon
           basic
+          aria-label={intl.formatMessage(messages.left)}
+          onClick={() => onAlignBlock('left small')}
+          active={data.align === 'left small'}
+        >
+          <Icon name={imageLeftSVG} size="24px" />
+        </Button>
+      </Button.Group>
+      <Button.Group>
+        <Button
+          icon
+          basic
           aria-label={intl.formatMessage(messages.right)}
           onClick={() => onAlignBlock('right')}
           active={data.align === 'right'}
+        >
+          <Icon name={imageRightSVG} size="24px" />
+        </Button>
+      </Button.Group>
+      <Button.Group>
+        <Button
+          icon
+          basic
+          aria-label={intl.formatMessage(messages.right)}
+          onClick={() => onAlignBlock('right small')}
+          active={data.align === 'right small'}
         >
           <Icon name={imageRightSVG} size="24px" />
         </Button>

--- a/theme/themes/pastanaga/extras/blocks.less
+++ b/theme/themes/pastanaga/extras/blocks.less
@@ -117,6 +117,13 @@
   img {
     max-width: 50%;
   }
+
+  &.small {
+    .ui.image,
+    img {
+      max-width: 25%;
+    }
+  }
 }
 
 .block.align.right {
@@ -142,6 +149,13 @@
   .ui.image,
   img {
     max-width: 50%;
+  }
+
+  &.small {
+    .ui.image,
+    img {
+      max-width: 25%;
+    }
   }
 }
 


### PR DESCRIPTION
Adds feature requested in #1163

The additional buttons use the same icon as the normal left/right align buttons. We probably need new icons for the smaller options.