### PR TITLE
selectableTypes in ObjectBrowserWidget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Feature
 
+- selectableTypes in ObjectBrowserWidget @giuliaghisini
+
 ### Bugfix
 
 ### Internal
@@ -24,11 +26,11 @@
 
 ### Feature
 
-- Include ``config.addonRoutes`` in router configuration. This allows addons to
-  override route children defined for the ``App`` component.
+- Include `config.addonRoutes` in router configuration. This allows addons to
+  override route children defined for the `App` component.
 - Added param 'wrapped' for widgets, to use widgets without form wrappers. @giuliaghisini
 - Added internationalization for Romanian language @alecghica #1521
-- Support loading additional reducers from the ``config.addonReducers`` key,
+- Support loading additional reducers from the `config.addonReducers` key,
   to allow addons to provide their own reducers @tiberiuichim
 - Add a no brainer image sizing option, using scales. This will be vastly improved when
   we adopt srcsets. @sneridagh

--- a/src/components/manage/Sidebar/ObjectBrowser.jsx
+++ b/src/components/manage/Sidebar/ObjectBrowser.jsx
@@ -53,6 +53,7 @@ const withObjectBrowser = (WrappedComponent) =>
       onSelectItem = null,
       dataName = null,
       propDataName = null,
+      selectableTypes,
     } = {}) =>
       this.setState({
         isObjectBrowserOpen: true,
@@ -60,6 +61,7 @@ const withObjectBrowser = (WrappedComponent) =>
         onSelectItem,
         dataName,
         propDataName,
+        selectableTypes,
       });
 
     closeObjectBrowser = () => this.setState({ isObjectBrowserOpen: false });
@@ -90,6 +92,7 @@ const withObjectBrowser = (WrappedComponent) =>
               mode={this.state.mode}
               onSelectItem={this.state.onSelectItem}
               dataName={this.state.dataName}
+              selectableTypes={this.state.selectableTypes}
             />
           </CSSTransition>
         </>

--- a/src/components/manage/Sidebar/ObjectBrowserBody.jsx
+++ b/src/components/manage/Sidebar/ObjectBrowserBody.jsx
@@ -292,6 +292,12 @@ class ObjectBrowserBody extends Component {
     });
   };
 
+  isSelectable = (item) => {
+    return this.props.selectableTypes.length > 0
+      ? this.props.selectableTypes.indexOf(item['@type']) >= 0
+      : true;
+  };
+
   handleClickOnItem = (item) => {
     if (this.props.mode === 'image') {
       if (item.is_folderish) {
@@ -301,13 +307,10 @@ class ObjectBrowserBody extends Component {
         this.onSelectItem(item);
       }
     } else {
-      if (
-        this.props.selectableTypes.length > 0 &&
-        this.props.selectableTypes.indexOf(item['@type']) < 0
-      ) {
-        this.navigateTo(item['@id']);
-      } else {
+      if (this.isSelectable(item)) {
         this.onSelectItem(item);
+      } else {
+        this.navigateTo(item['@id']);
       }
     }
   };
@@ -431,6 +434,7 @@ class ObjectBrowserBody extends Component {
             handleDoubleClickOnItem={this.handleDoubleClickOnItem}
             mode={this.props.mode}
             navigateTo={this.navigateTo}
+            isSelectable={this.isSelectable}
           />
         </Segment.Group>
       </aside>,

--- a/src/components/manage/Sidebar/ObjectBrowserBody.jsx
+++ b/src/components/manage/Sidebar/ObjectBrowserBody.jsx
@@ -70,6 +70,7 @@ class ObjectBrowserBody extends Component {
     href: '',
     onSelectItem: null,
     dataName: null,
+    selectableTypes: [],
   };
 
   /**
@@ -300,7 +301,14 @@ class ObjectBrowserBody extends Component {
         this.onSelectItem(item);
       }
     } else {
-      this.onSelectItem(item);
+      if (
+        this.props.selectableTypes.length > 0 &&
+        this.props.selectableTypes.indexOf(item['@type']) < 0
+      ) {
+        this.navigateTo(item['@id']);
+      } else {
+        this.onSelectItem(item);
+      }
     }
   };
 
@@ -314,8 +322,15 @@ class ObjectBrowserBody extends Component {
         this.props.closeObjectBrowser();
       }
     } else {
-      this.onSelectItem(item);
-      this.props.closeObjectBrowser();
+      if (
+        this.props.selectableTypes.length > 0 &&
+        this.props.selectableTypes.indexOf(item['@type']) < 0
+      ) {
+        this.navigateTo(item['@id']);
+      } else {
+        this.onSelectItem(item);
+        this.props.closeObjectBrowser();
+      }
     }
   };
 

--- a/src/components/manage/Sidebar/ObjectBrowserNav.jsx
+++ b/src/components/manage/Sidebar/ObjectBrowserNav.jsx
@@ -15,6 +15,7 @@ const ObjectBrowserNav = ({
   handleDoubleClickOnItem,
   mode,
   navigateTo,
+  isSelectable,
 }) => {
   const isSelected = (item) => {
     let ret = false;
@@ -37,22 +38,23 @@ const ObjectBrowserNav = ({
             key={item.id}
             className={cx('', {
               'selected-item': isSelected(item),
+
               disabled:
                 mode === 'image'
                   ? !settings.imageObjects.includes(item['@type']) &&
                     !item.is_folderish
-                  : false,
+                  : !isSelectable(item),
             })}
             onClick={() => handleClickOnItem(item)}
             onDoubleClick={() => handleDoubleClickOnItem(item)}
           >
-            <span title={item['@id']}>
+            <span title={`${item['@id']} (${item['@type']})`}>
               <Popup
                 key={item['@id']}
                 content={
                   <>
                     <Icon name={homeSVG} size="18px" />{' '}
-                    {flattenToAppURL(item['@id'])}
+                    {flattenToAppURL(item['@id'])} ( {item['@type']})
                   </>
                 }
                 trigger={<span>{getIcon(item['@type'])}</span>}

--- a/src/components/manage/Sidebar/ObjectBrowserNav.test.jsx
+++ b/src/components/manage/Sidebar/ObjectBrowserNav.test.jsx
@@ -102,6 +102,9 @@ test('renders a view image component', () => {
     <ObjectBrowserNav
       currentSearchResults={currentSearchResults}
       getIcon={() => {}}
+      isSelectable={() => {
+        return true;
+      }}
     />,
   );
   const json = component.toJSON();

--- a/src/components/manage/Sidebar/__snapshots__/ObjectBrowserNav.test.jsx.snap
+++ b/src/components/manage/Sidebar/__snapshots__/ObjectBrowserNav.test.jsx.snap
@@ -11,7 +11,7 @@ exports[`renders a view image component 1`] = `
     role="presentation"
   >
     <span
-      title="/front-page"
+      title="/front-page (Document)"
     >
       <span
         onBlur={[Function]}
@@ -30,7 +30,7 @@ exports[`renders a view image component 1`] = `
     role="presentation"
   >
     <span
-      title="/news"
+      title="/news (Folder)"
     >
       <span
         onBlur={[Function]}

--- a/src/components/manage/Widgets/ObjectBrowserWidget.jsx
+++ b/src/components/manage/Widgets/ObjectBrowserWidget.jsx
@@ -147,6 +147,8 @@ class ObjectBrowserWidget extends Component {
         this.onChange(item);
       },
       propDataName: 'value',
+      selectableTypes: this.props.widgetOptions?.pattern_options
+        ?.selectableTypes,
     });
   };
 
@@ -187,6 +189,8 @@ class ObjectBrowserWidget extends Component {
             e.preventDefault();
             onChange(id, []);
           };
+
+    console.log('props', this.props);
 
     return (
       <Form.Field

--- a/src/components/manage/Widgets/ObjectBrowserWidget.jsx
+++ b/src/components/manage/Widgets/ObjectBrowserWidget.jsx
@@ -190,7 +190,6 @@ class ObjectBrowserWidget extends Component {
             onChange(id, []);
           };
 
-    console.log('props', this.props);
 
     return (
       <Form.Field

--- a/src/components/manage/Widgets/ObjectBrowserWidget.jsx
+++ b/src/components/manage/Widgets/ObjectBrowserWidget.jsx
@@ -190,7 +190,6 @@ class ObjectBrowserWidget extends Component {
             onChange(id, []);
           };
 
-
     return (
       <Form.Field
         inline


### PR DESCRIPTION
if in content schema are defined some selectableTypes for a specific field (in widgetOptions.patterns_options), the objectBrowser allows to select only elements of those types 