### PR TITLE
fix overflow in contents with long titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Fix overflow in folder contents with long titles @nzambello
+
 ### Internal
 
 ## 6.2.0 (2020-06-14)

--- a/theme/themes/pastanaga/extras/contents.less
+++ b/theme/themes/pastanaga/extras/contents.less
@@ -75,9 +75,22 @@
 
   .ui.table .icon-align-name {
     display: flex;
+    overflow: hidden;
+    max-width: 330px;
     align-items: center;
     justify-content: space-between;
     padding-top: 4px;
+
+    svg {
+      flex-shrink: 0;
+    }
+
+    span {
+      display: block;
+      overflow: hidden;
+      max-width: 100%;
+      text-overflow: ellipsis;
+    }
   }
 
   .ui.table .expire-align {


### PR DESCRIPTION
![contets](https://user-images.githubusercontent.com/21101435/84889770-b7e5d880-b099-11ea-9c63-6821fd36139b.png)
