### PR TITLE
fixed object browser widget when a selected items is deleted. Plone.r…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- fixed object browser widget when a selected items is deleted. Plone.restapi returns a null object. @giuliaghisini
+
 ### Internal
 
 ## 6.2.0 (2020-06-14)
@@ -24,11 +26,11 @@
 
 ### Feature
 
-- Include ``config.addonRoutes`` in router configuration. This allows addons to
-  override route children defined for the ``App`` component.
+- Include `config.addonRoutes` in router configuration. This allows addons to
+  override route children defined for the `App` component.
 - Added param 'wrapped' for widgets, to use widgets without form wrappers. @giuliaghisini
 - Added internationalization for Romanian language @alecghica #1521
-- Support loading additional reducers from the ``config.addonReducers`` key,
+- Support loading additional reducers from the `config.addonReducers` key,
   to allow addons to provide their own reducers @tiberiuichim
 - Add a no brainer image sizing option, using scales. This will be vastly improved when
   we adopt srcsets. @sneridagh

--- a/src/components/manage/Sidebar/ObjectBrowserNav.jsx
+++ b/src/components/manage/Sidebar/ObjectBrowserNav.jsx
@@ -19,11 +19,13 @@ const ObjectBrowserNav = ({
   const isSelected = (item) => {
     let ret = false;
     if (selected) {
-      selected.forEach((_item) => {
-        if (flattenToAppURL(_item['@id']) === flattenToAppURL(item['@id'])) {
-          ret = true;
-        }
-      });
+      selected
+        .filter((item) => item != null)
+        .forEach((_item) => {
+          if (flattenToAppURL(_item['@id']) === flattenToAppURL(item['@id'])) {
+            ret = true;
+          }
+        });
     }
     return ret;
   };

--- a/src/components/manage/Widgets/ObjectBrowserWidget.jsx
+++ b/src/components/manage/Widgets/ObjectBrowserWidget.jsx
@@ -116,6 +116,7 @@ class ObjectBrowserWidget extends Component {
 
   onChange = (item) => {
     let value = this.props.mode === 'multiple' ? [...this.props.value] : [];
+    value = value.filter((item) => item != null);
 
     let exists = false;
     let index = -1;
@@ -147,6 +148,8 @@ class ObjectBrowserWidget extends Component {
         this.onChange(item);
       },
       propDataName: 'value',
+      selectableTypes: this.props.widgetOptions?.pattern_options
+        ?.selectableTypes,
     });
   };
 
@@ -188,6 +191,8 @@ class ObjectBrowserWidget extends Component {
             onChange(id, []);
           };
 
+    let items = value ? value.filter((item) => item != null) : [];
+
     return (
       <Form.Field
         inline
@@ -221,9 +226,9 @@ class ObjectBrowserWidget extends Component {
                   tabIndex={0}
                   ref={this.selectedItemsRef}
                 >
-                  {value.map((item) => this.renderLabel(item))}
+                  {items.map((item) => this.renderLabel(item))}
 
-                  {value.length === 0 && (
+                  {items.length === 0 && (
                     <div className="placeholder" ref={this.placeholderRef}>
                       {this.props.intl.formatMessage(messages.placeholder)}
                     </div>


### PR DESCRIPTION
…estapi returns a null object. @giuliaghisini

If an item referenced in a field that uses objectBrowserWidget is delete, restapi returns a null item in array. 

Fixed widget to discard null items