### PR TITLE
Fix add content dropdown if a type is not translatable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Fix the toolbar dropdown to add content types if isMultilingual is enabled
+  but a type is not marked as translatable. @csenger
 - Usage of Contettype label in Add component. @giuliaghisini
 
 ### Internal

--- a/src/components/manage/Toolbar/Types.jsx
+++ b/src/components/manage/Toolbar/Types.jsx
@@ -42,6 +42,7 @@ const Types = ({ types, pathname, content, currentLanguage }) => {
         </ul>
       </div>
       {settings.isMultilingual &&
+        content['@components'].translations &&
         (() => {
           const translationsLeft = filter(
             settings.supportedLanguages,


### PR DESCRIPTION
If the config setting isMultilingual is true it does not mean all content types are marked as translatable. In those case the resonse lacks the component "translations".