### PR TITLE
Load custom express middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Feature
 
 - Added uploading image preview in FileWidget @iFlameing
+- Allow custom express middleware declared with ``settings.expressMiddleware``. See [Customizing Express](docs/customizing/express.md) @tiberiuichim
 
 ### Bugfix
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -42,6 +42,7 @@ nav:
       - Creating new views: 'customizing/creating-views.md'
       - Creating Add-on packages: 'customizing/add-ons.md'
       - Internationalization: 'customizing/i18n.md'
+      - Express middleware: 'customizing/express.md'
   - Blocks:
       - Introduction: 'blocks/introduction.md'
       - Anatomy: 'blocks/anatomy.md'

--- a/docs/source/customizing/express.md
+++ b/docs/source/customizing/express.md
@@ -1,17 +1,14 @@
 # Custom Express middleware
 
 Volto uses the popular [Express](https://expressjs.com/) server for its
-Server-Side Rendering implementation and static resource serving.
-In some cases it is useful to extend this
-server with new functionality. For example, Volto includes an Express proxy
-middleware for the backend that can be used during development. Another use
-case might include a CORS proxy server, a proxy to protect a database such as
-ElasticSearch or MongoDB, etc.
+Server-Side Rendering implementation and static resource serving.  In some
+cases it is useful to extend this server with new functionality. For example,
+Volto includes a middleware that proxies the backend and that can be used
+during development. Other use cases might include a CORS proxy server, a proxy
+to protect a database such as ElasticSearch or MongoDB, etc.
 
 To add new middleware, use the ``settings.expressMiddleware`` configuration
-key. This is a list that takes objects with ``id`` and ``middleware`` as
-keys. The ``id`` should be a simple identification string for that
-middleware. For example:
+key. This is a list that takes Express middleware functions.  For example:
 
 ```js
 import {
@@ -28,13 +25,11 @@ if (__SERVER__) {
   middleware.all('/test-middleware', function (req, res, next) {
     res.send('Hello world');
   });
+  middleware.id = 'test-middleware'
 
   settings.expressMiddleware = [
     ...defaultSettings.expressMiddleware,
-    {
-      id: 'just-a-test-middleware',
-      middleware,
-    }
+    middleware,
   ] ;
 }
 ```
@@ -49,4 +44,5 @@ project's ``config.js`` gets executed by both the server and the client
 See [ExpressJS](https://expressjs.com/) website for more documentation.
 
 !!! note
-    This documentation is a work in progress. Please consider to contribute to this documentation.
+    Addon authors should add the ``id`` property to the middleware so that it
+    can be identified and manipulated in Volto projects configuration.

--- a/docs/source/customizing/express.md
+++ b/docs/source/customizing/express.md
@@ -1,7 +1,8 @@
 # Custom Express middleware
 
 Volto uses the popular [Express](https://expressjs.com/) server for its
-Server-Side Rendering implementation. In some cases it is useful to extend this
+Server-Side Rendering implementation and static resource serving.
+In some cases it is useful to extend this
 server with new functionality. For example, Volto includes an Express proxy
 middleware for the backend that can be used during development. Another use
 case might include a CORS proxy server, a proxy to protect a database such as

--- a/docs/source/customizing/express.md
+++ b/docs/source/customizing/express.md
@@ -17,7 +17,6 @@ import {
 
 const settings = { ...defaultSettings };
 
-
 if (__SERVER__) {
   const express = require('express');
   const middleware = express.Router();

--- a/docs/source/customizing/express.md
+++ b/docs/source/customizing/express.md
@@ -1,0 +1,51 @@
+# Custom Express middleware
+
+Volto uses the popular [Express](https://expressjs.com/) server for its
+Server-Side Rendering implementation. In some cases it is useful to extend this
+server with new functionality. For example, Volto includes an Express proxy
+middleware for the backend that can be used during development. Another use
+case might include a CORS proxy server, a proxy to protect a database such as
+ElasticSearch or MongoDB, etc.
+
+To add new middleware, use the ``settings.expressMiddleware`` configuration
+key. This is a list that takes objects with ``id`` and ``middleware`` as
+keys. The ``id`` should be a simple identification string for that
+middleware. For example:
+
+```js
+import {
+  settings as defaultSettings,
+} from '@plone/volto/config';
+
+const settings = { ...defaultSettings };
+
+
+if (__SERVER__) {
+  const express = require('express');
+  const middleware = express.Router();
+
+  middleware.all('/test-middleware', function (req, res, next) {
+    res.send('Hello world');
+  });
+
+  settings.expressMiddleware = [
+    ...defaultSettings.expressMiddleware,
+    {
+      id: 'just-a-test-middleware',
+      middleware,
+    }
+  ] ;
+}
+```
+
+Now the [test-middleware](http://localhost:3000/test-middleware) page can be
+visited and it will return the simple string and not the usual Volto pages.
+
+Notice the use of the ``__SERVER__`` condition. Because the code in a Volto
+project's ``config.js`` gets executed by both the server and the client
+(browser), the server-side libraries need to "excluded" with conditions.
+
+See [ExpressJS](https://expressjs.com/) website for more documentation.
+
+!!! note
+    This documentation is a work in progress. Please consider to contribute to this documentation.

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -68,6 +68,7 @@ export const settings = {
   supportedLanguages: ['en'],
   defaultLanguage: 'en',
   navDepth: 1,
+  expressMiddleware: [],
 };
 
 export const addonRoutes = [];

--- a/src/server.jsx
+++ b/src/server.jsx
@@ -67,7 +67,7 @@ if (__DEVELOPMENT__ && settings.devProxyToApiPath) {
   );
 }
 
-if (settings.expressMiddleware) server.use('/', settings.expressMiddleware);
+if ((settings.expressMiddleware || []).length) server.use('/', settings.expressMiddleware);
 
 server
   .disable('x-powered-by')

--- a/src/server.jsx
+++ b/src/server.jsx
@@ -67,8 +67,7 @@ if (__DEVELOPMENT__ && settings.devProxyToApiPath) {
   );
 }
 
-const middleware = (settings.expressMiddleware || []).map((m) => m.middleware);
-if (middleware.length) server.use('/', middleware);
+if (settings.expressMiddleware) server.use('/', settings.expressMiddleware);
 
 server
   .disable('x-powered-by')

--- a/src/server.jsx
+++ b/src/server.jsx
@@ -66,6 +66,10 @@ if (__DEVELOPMENT__ && settings.devProxyToApiPath) {
     }),
   );
 }
+
+const middleware = (settings.expressMiddleware || []).map((m) => m.middleware);
+if (middleware.length) server.use('/', middleware);
+
 server
   .disable('x-powered-by')
   .use(express.static(process.env.RAZZLE_PUBLIC_DIR))


### PR DESCRIPTION
Simple server.use() call for custom middleware. I've also added a doc.

@tisto fortunately no dedicated server module is needed, I was able to use ``__SERVER__`` to conditionally load the server code. All explained in the new doc.