### PR TITLE
fix text overflow in pastanaga-menu header if title is too long

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Bugfix
 
+- fix text overflow in pastanaga-menu header if title is too long. @giuliaghisini
+
 ### Internal
 
 - Upgrade insecure packages `http-proxy`, `http-proxy-middleware` and `handlebars` @tiberiuichim
@@ -24,13 +26,13 @@
 
 ### Bugfix
 
-- Fix styling and use of csss classes in ``InlineForm.jsx`` @tiberiuichim
+- Fix styling and use of csss classes in `InlineForm.jsx` @tiberiuichim
 
 - Fixing bug for Image Preview on upload @iFlameing
 
 ### Internal
 
-- Fix formatting of ``src/server.jsx`` @tiberiuichim
+- Fix formatting of `src/server.jsx` @tiberiuichim
 
 ## 6.4.0 (2020-06-29)
 

--- a/theme/themes/pastanaga/extras/toolbar.less
+++ b/theme/themes/pastanaga/extras/toolbar.less
@@ -442,10 +442,14 @@
       border-bottom: 4px solid @silver-blue;
 
       h2 {
+        overflow: hidden;
+        max-width: 100%;
         flex: 1 0 auto;
         margin: 0;
         font-size: 16px;
         font-weight: 500;
+        text-overflow: ellipsis;
+        white-space: nowrap;
       }
 
       a {


### PR DESCRIPTION
If page title was too long, it overflowed from the menu.
Fixed: 
<img width="619" alt="Schermata 2020-07-02 alle 11 29 38" src="https://user-images.githubusercontent.com/51911425/86342240-9f5bed80-bc57-11ea-8aee-cacdd4bba5d2.png">
