### PR TITLE
managed hidden fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
   project. @tiberiuichim @sneridagh
 
 ### Bugfix
+- managed hidden fields @giuliaghisini
+
 
 ### Internal
 

--- a/src/components/manage/Form/Field.jsx
+++ b/src/components/manage/Form/Field.jsx
@@ -9,6 +9,7 @@ import { DragSource, DropTarget } from 'react-dnd';
 import { settings, widgets } from '~/config';
 import { injectIntl } from 'react-intl';
 
+const MODE_HIDDEN = 'hidden'; //hidden mode. If mode is hidden, field is not rendered
 /**
  * Get default widget
  * @method getViewDefault
@@ -108,6 +109,10 @@ const Field = (props, { intl }) => {
     getWidgetByVocabularyFromHint(props) ||
     getWidgetByType(props.type) ||
     getWidgetDefault();
+
+  if (props.mode === MODE_HIDDEN) {
+    return null;
+  }
 
   if (props.onOrder) {
     const WrappedWidget = DropTarget(


### PR DESCRIPTION
if field has property mode setted to 'hidden' (from plone), the field is not rendered. 