### PR TITLE
Fix bug with namespace packages; cleanup some code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Bugfix
 - managed hidden fields @giuliaghisini
+- Fix bug in addon loading with namespaced packages @tiberiuichim
 
 
 - Japanese translation @terapyon

--- a/__tests__/create-addons-loader.test.js
+++ b/__tests__/create-addons-loader.test.js
@@ -136,6 +136,10 @@ describe('create-addons-loader default name generation', () => {
     const name = getName('~/addons/volto-addon1');
     expect(name).toBe('addonsvoltoAddon1');
   });
+  test('passing a namespace package strips @', () => {
+    const name = getName('@plone/volto-addon1');
+    expect(name).toBe('plonevoltoAddon1');
+  });
   test('passing a tilda relative path strips tilda', () => {
     const name = getName('~/../');
     expect(name.length).toBe(10);

--- a/addon-registry.js
+++ b/addon-registry.js
@@ -9,7 +9,6 @@ const fs = require('fs');
 // - packageContent (customizable files)
 // - extraConfigLoaders (function references)
 // - razzleExtender ({plugins, modify})
-// - serverConfig (function reference)
 
 function getPackageBasePath(base) {
   while (!fs.existsSync(`${base}/package.json`)) {
@@ -115,7 +114,6 @@ class AddonConfigurationRegistry {
   /*
    * Maps extra configuration loaders for addons:
    * - extra loaders (from the addon loader string in package.addons
-   * - the server.config.js files
    */
   initAddonLoaders() {
     (this.packageJson.addons || []).forEach((addonConfigString) => {
@@ -128,11 +126,6 @@ class AddonConfigurationRegistry {
 
       const addon = this.packages[pkgName];
       addon.extraConfigLoaders = extras;
-
-      // const serverModule = path.resolve(`${addon.modulePath}/server.config.js`);
-      // if (fs.existsSync(serverModule)) {
-      //   addon.serverConfig = serverModule;
-      // }
     });
   }
 

--- a/create-addons-loader.js
+++ b/create-addons-loader.js
@@ -10,12 +10,19 @@ const titleCase = (w) => w.slice(0, 1).toUpperCase() + w.slice(1, w.length);
  */
 function nameFromPackage(name) {
   if (
+    name.startsWith('@') ||
     name.startsWith('~') ||
     name.startsWith('.') ||
     name.startsWith(path.sep)
   ) {
     name =
-      name.replace('~', '').split('.').join('').split(path.sep).join('') ||
+      name
+        .replace('@', '')
+        .replace('~', '')
+        .split('.')
+        .join('')
+        .split(path.sep)
+        .join('') ||
       cryptoRandomString({ length: 10, characters: 'abcdefghijk' });
   }
   return name


### PR DESCRIPTION
Fixed a bug with @ in package name. Now you can use namespace packages.

The configuration is like this:

- in `package.json` use the package name in the 'addons' key. So, `addons: ['@kitconcept/volto-form-builder']`
- in `mrs.developer.json` need to add the `package` property, like:

```
{
  "volto-form-builder": {
    "package": "@kitconcept/volto-form-builder",
    "local": "../../"
  }
}
```

Beware, the `local` path, if testing with local checkouts, needs to be relative to the `src` folder in the Volto project. And right now only `src` is supported, as this error I got from razzle tells us:

```
 ERROR  Your project's `baseUrl` can only be set to `src` or `node_modules`. Razzle does not support other values at this time.
```