### PR TITLE
Provide a new webpack alias that makes it easier to reference Volto themes folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### Feature
 
+- Provide a new webpack alias, `volto-themes`, which points to Volto's theme
+  folder. See details in the https://docs.voltocms.com/upgrade-guide/
+
 ### Bugfix
 
 ### Internal

--- a/docs/source/upgrade-guide/index.md
+++ b/docs/source/upgrade-guide/index.md
@@ -22,14 +22,16 @@ As a "nice to have", a new alias is provided that points to Volto's theme
 folder. So, in your project's `theme.config` file, you can replace:
 
 ```less
-@themesFolder : '../../node_modules/@plone/volto/theme/themes';
-@siteFolder  : "../../theme";
+@themesFolder: '../../node_modules/@plone/volto/theme/themes';
+@siteFolder: "../../theme";
+@fontPath : "../../@{theme}/assets/fonts";
 ```
 with:
 
 ```less
-@themesFolder  : '~volto-themes';
-@siteFolder  : '~@package/../theme';
+@themesFolder: '~volto-themes';
+@siteFolder: '~@package/../theme';
+@fontPath: "~volto-themes/@{theme}/assets/fonts";
 ```
 
 You might consider moving your theme files to a subfolder called `site`, to
@@ -37,7 +39,7 @@ prepare for the arival of addons theming and their overrides.  In that case,
 you would set your `@siteFolder` to:
 
 ```
-@siteFolder  : '~@package/../theme/site';
+@siteFolder: '~@package/../theme/site';
 ```
 
 ## Upgrading to Volto 6.x.x

--- a/docs/source/upgrade-guide/index.md
+++ b/docs/source/upgrade-guide/index.md
@@ -16,10 +16,10 @@ A misspelled file has been renamed. If you import `strickthrough.svg` in your
 project, you'll now find that file at `@plone/volto/icons/strikethrough.svg`.
 
 
-### New theming webpack alias
+### New webpack resolve alias for Volto themes
 
-As a "nice to have", a new alias is provided that points to Volto's theme
-folder. So, in your project's `theme.config` file, you can replace:
+As a "nice to have", a new resolve alias is provided that points to Volto's 
+theme folder. So, in your project's `theme.config` file, you can replace:
 
 ```less
 @themesFolder: '../../node_modules/@plone/volto/theme/themes';

--- a/docs/source/upgrade-guide/index.md
+++ b/docs/source/upgrade-guide/index.md
@@ -15,6 +15,31 @@ This upgrade guide lists all breaking changes in Volto and explains the
 A misspelled file has been renamed. If you import `strickthrough.svg` in your
 project, you'll now find that file at `@plone/volto/icons/strikethrough.svg`.
 
+
+### New theming webpack alias
+
+As a "nice to have", a new alias is provided that points to Volto's theme
+folder. So, in your project's `theme.config` file, you can replace:
+
+```less
+@themesFolder : '../../node_modules/@plone/volto/theme/themes';
+@siteFolder  : "../../theme";
+```
+with:
+
+```less
+@themesFolder  : '~volto-themes';
+@siteFolder  : '~@package/../theme';
+```
+
+You might consider moving your theme files to a subfolder called `site`, to
+prepare for the arival of addons theming and their overrides.  In that case,
+you would set your `@siteFolder` to:
+
+```
+@siteFolder  : '~@package/../theme/site';
+```
+
 ## Upgrading to Volto 6.x.x
 
 First, update the `package.json` of your Volto project to Volto 6.x.x.

--- a/razzle.config.js
+++ b/razzle.config.js
@@ -247,6 +247,7 @@ const defaultModify = (config, { target, dev }, webpack) => {
     ...customizations,
     ...config.resolve.alias,
     '../../theme.config$': `${projectRootPath}/theme/theme.config`,
+    'volto-themes': `${registry.voltoPath}/theme/themes`,
     'load-volto-addons': addonsLoaderPath,
     ...registry.getResolveAliases(),
     '@plone/volto': `${registry.voltoPath}/src`,


### PR DESCRIPTION
This is just a convenience alias to make some bits nicer in `theme.config`.

So instead of having:

```
/* Path to theme packages */
@themesFolder : '../../node_modules/@plone/volto/theme/themes';

/* Path to site override folder */
@siteFolder  : "../../theme";
```

We can have:

```
/* Path to theme packages */
@themesFolder  : '~volto-themes'

/* Path to site override folder */
@siteFolder  : '~@package/../theme';
```

For the first one, themesFolder, it's a matter of cosmetics. The second one will make it easier for people new to Volto to understand which path it's about.

I'm also recommending to move themes to their own folder, to prepare for the addition of addon theming, so you could override an addon theme.