### PR TITLE
Automatically select next/previous block on block deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Feature
 
+- On block deletion, automatically select previous block (or next block, if the first block is deleted). @tiberiuichim
+
 ### Bugfix
 
 ### Internal

--- a/src/components/manage/Blocks/Block/Edit.jsx
+++ b/src/components/manage/Blocks/Block/Edit.jsx
@@ -156,7 +156,7 @@ class Edit extends Component {
           <Button
             icon
             basic
-            onClick={() => this.props.onDeleteBlock(id)}
+            onClick={() => this.props.onDeleteBlock(id, true)}
             className="delete-button"
             aria-label={this.props.intl.formatMessage(messages.delete)}
           >

--- a/src/components/manage/Form/Form.jsx
+++ b/src/components/manage/Form/Form.jsx
@@ -309,15 +309,23 @@ class Form extends Component {
   }
 
   /**
-   * Delete block handler
+   * Delete block handler.
    * @method onDeleteBlock
    * @param {string} id Id of the field
-   * @param {bool} selectPrev True if previous should be selected
+   * @param {bool} selectNeighbor True if adjacent block should be selected
    * @returns {undefined}
    */
-  onDeleteBlock(id, selectPrev) {
+  onDeleteBlock(id, selectNeighbor) {
     const blocksFieldname = getBlocksFieldname(this.state.formData);
     const blocksLayoutFieldname = getBlocksLayoutFieldname(this.state.formData);
+
+    const index = this.state.formData[blocksLayoutFieldname].items.indexOf(id);
+
+    const selected = selectNeighbor
+      ? index === 0
+        ? this.state.formData[blocksLayoutFieldname].items[1]
+        : this.state.formData[blocksLayoutFieldname].items[index - 1]
+      : null;
 
     this.setState({
       formData: {
@@ -327,11 +335,7 @@ class Form extends Component {
         },
         [blocksFieldname]: omit(this.state.formData[blocksFieldname], [id]),
       },
-      selected: selectPrev
-        ? this.state.formData[blocksLayoutFieldname].items[
-            this.state.formData[blocksLayoutFieldname].items.indexOf(id) - 1
-          ]
-        : null,
+      selected,
     });
   }
 


### PR DESCRIPTION
This is already implemented when using backspace in draftjs editor, but not if using delete button in Block/Edit. This "hardcodes" selectPrev as true and enhances the implementation to also automatically select next block if previous block is not possible (for example when deleting the first block).

Closes #1671