### PR TITLE
Wrap form in FormContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Feature
 
 - Added Placeholder attribute to Textwidget and TextAreaWidget @iFlameing
+- Separate the Form.jsx state in its own component exposed as a context. This enables clean multi-block editing from other blocks, exposes the form state to widgets and many other advanced scenarios. @tiberiuichim
 
 ### Bugfix
 

--- a/src/components/manage/Blocks/Description/Edit.jsx
+++ b/src/components/manage/Blocks/Description/Edit.jsx
@@ -10,6 +10,7 @@ import { stateFromHTML } from 'draft-js-import-html';
 import { Editor, DefaultDraftBlockRenderMap, EditorState } from 'draft-js';
 import { defineMessages, injectIntl } from 'react-intl';
 import cx from 'classnames';
+import { FormStateContext } from '@plone/volto/components/manage/Form/FormContext';
 
 const messages = defineMessages({
   description: {
@@ -38,7 +39,7 @@ class Edit extends Component {
    * @static
    */
   static propTypes = {
-    properties: PropTypes.objectOf(PropTypes.any).isRequired,
+    // properties: PropTypes.objectOf(PropTypes.any).isRequired,
     selected: PropTypes.bool.isRequired,
     block: PropTypes.string.isRequired,
     index: PropTypes.number.isRequired,
@@ -49,6 +50,7 @@ class Edit extends Component {
     onFocusPreviousBlock: PropTypes.func.isRequired,
     onFocusNextBlock: PropTypes.func.isRequired,
   };
+  static contextType = FormStateContext;
 
   /**
    * Constructor
@@ -61,8 +63,9 @@ class Edit extends Component {
 
     if (!__SERVER__) {
       let editorState;
-      if (props.properties && props.properties.description) {
-        const contentState = stateFromHTML(props.properties.description);
+      const properties = context.contextData?.formData || {};
+      if (properties && properties.description) {
+        const contentState = stateFromHTML(properties.description);
         editorState = EditorState.createWithContent(contentState);
       } else {
         editorState = EditorState.createEmpty();

--- a/src/components/manage/Blocks/LeadImage/Edit.jsx
+++ b/src/components/manage/Blocks/LeadImage/Edit.jsx
@@ -14,6 +14,7 @@ import { LeadImageSidebar, SidebarPortal } from '@plone/volto/components';
 import { flattenToAppURL } from '@plone/volto/helpers';
 
 import imageBlockSVG from '@plone/volto/components/manage/Blocks/Image/block-image.svg';
+import { FormStateContext } from '@plone/volto/components/manage/Form/FormContext';
 
 /**
  * Edit image block class.
@@ -36,6 +37,7 @@ class Edit extends Component {
     onChangeBlock: PropTypes.func.isRequired,
     openObjectBrowser: PropTypes.func.isRequired,
   };
+  static contextType = FormStateContext;
 
   /**
    * Align block handler
@@ -58,7 +60,8 @@ class Edit extends Component {
    * @returns {string} Markup for the component.
    */
   render() {
-    const { data, properties } = this.props;
+    const properties = this.context?.contextData?.formData || {};
+    const { data } = this.props;
 
     return (
       <div
@@ -95,7 +98,7 @@ class Edit extends Component {
           />
         )}
         <SidebarPortal selected={this.props.selected}>
-          <LeadImageSidebar {...this.props} />
+          <LeadImageSidebar {...{ ...this.props, properties }} />
         </SidebarPortal>
       </div>
     );

--- a/src/components/manage/Blocks/LeadImage/Edit.jsx
+++ b/src/components/manage/Blocks/LeadImage/Edit.jsx
@@ -28,7 +28,7 @@ class Edit extends Component {
    * @static
    */
   static propTypes = {
-    properties: PropTypes.objectOf(PropTypes.any).isRequired,
+    // properties: PropTypes.objectOf(PropTypes.any).isRequired,
     selected: PropTypes.bool.isRequired,
     block: PropTypes.string.isRequired,
     index: PropTypes.number.isRequired,

--- a/src/components/manage/Blocks/LeadImage/Edit.test.jsx
+++ b/src/components/manage/Blocks/LeadImage/Edit.test.jsx
@@ -2,6 +2,10 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 import configureStore from 'redux-mock-store';
 import { Provider } from 'react-intl-redux';
+import {
+  FormStateContext,
+  FormStateProvider,
+} from '@plone/volto/components/manage/Form/FormContext';
 
 import Edit from './Edit';
 
@@ -14,28 +18,40 @@ test('renders an edit Lead Image block component', () => {
       messages: {},
     },
   });
+  const properties = {
+    formData: {
+      image: {
+        download: 'image.png',
+      },
+    },
+  };
   const component = renderer.create(
     <Provider store={store}>
-      <Edit
-        data={{}}
-        properties={{
-          image: {
-            download: 'image.png',
-          },
-        }}
-        selected={false}
-        block="1234"
-        content={{}}
-        request={{
-          loading: false,
-          loaded: false,
-        }}
-        pathname="/news"
-        onChangeBlock={() => {}}
-        onChangeField={() => {}}
-        index={1}
-        openObjectBrowser={() => {}}
-      />
+      <FormStateProvider initialValue={properties}>
+        <FormStateContext.Consumer>
+          {({ setContextData, contextData }) => {
+            const { formData } = contextData;
+            return (
+              <Edit
+                data={{}}
+                properties={formData}
+                selected={false}
+                block="1234"
+                content={{}}
+                request={{
+                  loading: false,
+                  loaded: false,
+                }}
+                pathname="/news"
+                onChangeBlock={() => {}}
+                onChangeField={() => {}}
+                index={1}
+                openObjectBrowser={() => {}}
+              />
+            );
+          }}
+        </FormStateContext.Consumer>
+      </FormStateProvider>
     </Provider>,
   );
   const json = component.toJSON();

--- a/src/components/manage/Blocks/Listing/Edit.jsx
+++ b/src/components/manage/Blocks/Listing/Edit.jsx
@@ -8,6 +8,7 @@ import {
   ListingBlockSidebar as ListingSidebar,
 } from '@plone/volto/components';
 import { getBaseUrl } from '@plone/volto/helpers';
+import { useFormStateContext } from '@plone/volto/components/manage/Form/FormContext';
 
 const Edit = ({
   data,
@@ -29,6 +30,9 @@ const Edit = ({
     /* eslint-disable react-hooks/exhaustive-deps */
   }, []);
 
+  const { contextData } = useFormStateContext();
+  const { formData } = contextData;
+
   return (
     <>
       {data?.query?.length === 0 && (
@@ -43,7 +47,7 @@ const Edit = ({
       )}
       <ListingBody
         data={data}
-        properties={properties}
+        properties={formData}
         block={block}
         path={getBaseUrl(pathname)}
         isEditMode

--- a/src/components/manage/Blocks/Listing/Edit.jsx
+++ b/src/components/manage/Blocks/Listing/Edit.jsx
@@ -70,7 +70,7 @@ Edit.propTypes = {
   block: PropTypes.string.isRequired,
   onSelectBlock: PropTypes.func.isRequired,
   items: PropTypes.arrayOf(PropTypes.any),
-  properties: PropTypes.objectOf(PropTypes.any).isRequired,
+  // properties: PropTypes.objectOf(PropTypes.any).isRequired,
   pathname: PropTypes.string.isRequired,
 };
 

--- a/src/components/manage/Blocks/Title/Edit.jsx
+++ b/src/components/manage/Blocks/Title/Edit.jsx
@@ -9,6 +9,8 @@ import PropTypes from 'prop-types';
 import { stateFromHTML } from 'draft-js-import-html';
 import { Editor, DefaultDraftBlockRenderMap, EditorState } from 'draft-js';
 import { defineMessages, injectIntl } from 'react-intl';
+import { settings } from '~/config';
+import { FormStateContext } from '@plone/volto/components/manage/Form/FormContext';
 
 const messages = defineMessages({
   title: {
@@ -37,7 +39,7 @@ class Edit extends Component {
    * @static
    */
   static propTypes = {
-    properties: PropTypes.objectOf(PropTypes.any).isRequired,
+    // properties: PropTypes.objectOf(PropTypes.any).isRequired,
     selected: PropTypes.bool.isRequired,
     index: PropTypes.number.isRequired,
     onChangeField: PropTypes.func.isRequired,
@@ -48,6 +50,7 @@ class Edit extends Component {
     onFocusNextBlock: PropTypes.func.isRequired,
     block: PropTypes.string.isRequired,
   };
+  static contextType = FormStateContext;
 
   /**
    * Constructor
@@ -55,13 +58,14 @@ class Edit extends Component {
    * @param {Object} props Component properties
    * @constructs WysiwygEditor
    */
-  constructor(props) {
+  constructor(props, context) {
     super(props);
 
     if (!__SERVER__) {
       let editorState;
-      if (props.properties && props.properties.title) {
-        const contentState = stateFromHTML(props.properties.title);
+      const properties = context.contextData?.formData || {};
+      if (properties && properties.title) {
+        const contentState = stateFromHTML(properties.title);
         editorState = EditorState.createWithContent(contentState);
       } else {
         editorState = EditorState.createEmpty();
@@ -78,6 +82,7 @@ class Edit extends Component {
    * @returns {undefined}
    */
   componentDidMount() {
+    this.setState({ mounted: true });
     if (this.node) {
       this.node.focus();
       this.node._onBlur = () => this.setState({ focus: false });
@@ -142,7 +147,10 @@ class Edit extends Component {
         blockRenderMap={extendedBlockRenderMap}
         handleReturn={() => {
           this.props.onSelectBlock(
-            this.props.onAddBlock('text', this.props.index + 1),
+            this.props.onAddBlock(
+              settings.defaultBlockType,
+              this.props.index + 1,
+            ),
           );
           return 'handled';
         }}

--- a/src/components/manage/Blocks/Title/Edit.jsx
+++ b/src/components/manage/Blocks/Title/Edit.jsx
@@ -9,7 +9,6 @@ import PropTypes from 'prop-types';
 import { stateFromHTML } from 'draft-js-import-html';
 import { Editor, DefaultDraftBlockRenderMap, EditorState } from 'draft-js';
 import { defineMessages, injectIntl } from 'react-intl';
-import { settings } from '~/config';
 import { FormStateContext } from '@plone/volto/components/manage/Form/FormContext';
 
 const messages = defineMessages({
@@ -82,7 +81,6 @@ class Edit extends Component {
    * @returns {undefined}
    */
   componentDidMount() {
-    this.setState({ mounted: true });
     if (this.node) {
       this.node.focus();
       this.node._onBlur = () => this.setState({ focus: false });
@@ -147,10 +145,7 @@ class Edit extends Component {
         blockRenderMap={extendedBlockRenderMap}
         handleReturn={() => {
           this.props.onSelectBlock(
-            this.props.onAddBlock(
-              settings.defaultBlockType,
-              this.props.index + 1,
-            ),
+            this.props.onAddBlock('text', this.props.index + 1),
           );
           return 'handled';
         }}

--- a/src/components/manage/Blocks/ToC/Edit.jsx
+++ b/src/components/manage/Blocks/ToC/Edit.jsx
@@ -14,7 +14,7 @@ import { useFormStateContext } from '@plone/volto/components/manage/Form/FormCon
  * @class Edit
  * @extends Component
  */
-const Edit = ({ properties }) => {
+const Edit = () => {
   const { contextData } = useFormStateContext();
   const { formData } = contextData;
   return <View properties={formData} />;

--- a/src/components/manage/Blocks/ToC/Edit.jsx
+++ b/src/components/manage/Blocks/ToC/Edit.jsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import PropTypes from 'prop-types';
+// import PropTypes from 'prop-types';
 
 import View from '@plone/volto/components/manage/Blocks/ToC/View';
 import { useFormStateContext } from '@plone/volto/components/manage/Form/FormContext';
@@ -26,7 +26,7 @@ const Edit = () => {
  * @static
  */
 Edit.propTypes = {
-  properties: PropTypes.objectOf(PropTypes.any).isRequired,
+  // properties: PropTypes.objectOf(PropTypes.any).isRequired,
 };
 
 export default Edit;

--- a/src/components/manage/Blocks/ToC/Edit.jsx
+++ b/src/components/manage/Blocks/ToC/Edit.jsx
@@ -7,13 +7,18 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import View from '@plone/volto/components/manage/Blocks/ToC/View';
+import { useFormStateContext } from '@plone/volto/components/manage/Form/FormContext';
 
 /**
  * Edit toc block class.
  * @class Edit
  * @extends Component
  */
-const Edit = ({ properties }) => <View properties={properties} />;
+const Edit = ({ properties }) => {
+  const { contextData } = useFormStateContext();
+  const { formData } = contextData;
+  return <View properties={formData} />;
+};
 
 /**
  * Property types.

--- a/src/components/manage/Blocks/ToC/Edit.test.jsx
+++ b/src/components/manage/Blocks/ToC/Edit.test.jsx
@@ -2,6 +2,10 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 import configureStore from 'redux-mock-store';
 import { Provider } from 'react-intl-redux';
+import {
+  FormStateContext,
+  FormStateProvider,
+} from '@plone/volto/components/manage/Form/FormContext';
 
 import Edit from './Edit';
 
@@ -14,44 +18,50 @@ test('renders an edit toc block component', () => {
       messages: {},
     },
   });
+  const formData = {
+    blocks_layout: {
+      items: ['a', 'b', 'c'],
+    },
+    blocks: {
+      a: {
+        '@type': 'text',
+        text: {
+          blocks: [
+            {
+              type: 'header-two',
+              key: 'a',
+              text: 'Heading 1',
+            },
+          ],
+        },
+      },
+      b: {
+        '@type': 'text',
+        text: {
+          blocks: [
+            {
+              type: 'header-three',
+              key: 'b',
+              text: 'Heading 2',
+            },
+          ],
+        },
+      },
+      c: {
+        '@type': 'title',
+      },
+    },
+  };
   const component = renderer.create(
     <Provider store={store}>
-      <Edit
-        properties={{
-          blocks_layout: {
-            items: ['a', 'b', 'c'],
-          },
-          blocks: {
-            a: {
-              '@type': 'text',
-              text: {
-                blocks: [
-                  {
-                    type: 'header-two',
-                    key: 'a',
-                    text: 'Heading 1',
-                  },
-                ],
-              },
-            },
-            b: {
-              '@type': 'text',
-              text: {
-                blocks: [
-                  {
-                    type: 'header-three',
-                    key: 'b',
-                    text: 'Heading 2',
-                  },
-                ],
-              },
-            },
-            c: {
-              '@type': 'title',
-            },
-          },
-        }}
-      />
+      <FormStateProvider initialValue={{ formData }}>
+        <FormStateContext.Consumer>
+          {({ setContextData, contextData }) => {
+            const { formData } = contextData;
+            return <Edit properties={formData} />;
+          }}
+        </FormStateContext.Consumer>
+      </FormStateProvider>
     </Provider>,
   );
   const json = component.toJSON();

--- a/src/components/manage/Form/Form.jsx
+++ b/src/components/manage/Form/Form.jsx
@@ -154,6 +154,28 @@ class Form extends Component {
    */
   constructor(props) {
     super(props);
+
+    this.onChangeField = this.onChangeField.bind(this);
+    this.onChangeBlock = this.onChangeBlock.bind(this);
+    this.onMutateBlock = this.onMutateBlock.bind(this);
+    this.onSelectBlock = this.onSelectBlock.bind(this);
+    this.onDeleteBlock = this.onDeleteBlock.bind(this);
+    this.onAddBlock = this.onAddBlock.bind(this);
+    this.onMoveBlock = this.onMoveBlock.bind(this);
+    this.onSubmit = this.onSubmit.bind(this);
+    this.onFocusPreviousBlock = this.onFocusPreviousBlock.bind(this);
+    this.onFocusNextBlock = this.onFocusNextBlock.bind(this);
+    this.handleKeyDown = this.handleKeyDown.bind(this);
+
+    // We use these as instance fields, to be initialized in the render() meth
+    // from the context provider
+    this.contextData = null;
+    this.setContextData = null;
+
+    this.state = this.getInitialState(props);
+  }
+
+  getInitialState(props) {
     const ids = {
       title: uuid(),
       text: uuid(),
@@ -195,7 +217,8 @@ class Form extends Component {
         };
       }
     }
-    this.state = {
+
+    const state = {
       formData,
       initialFormData: { ...formData },
       errors: {},
@@ -206,22 +229,20 @@ class Form extends Component {
           : null,
       placeholderProps: {},
     };
-    this.onChangeField = this.onChangeField.bind(this);
-    this.onChangeBlock = this.onChangeBlock.bind(this);
-    this.onMutateBlock = this.onMutateBlock.bind(this);
-    this.onSelectBlock = this.onSelectBlock.bind(this);
-    this.onDeleteBlock = this.onDeleteBlock.bind(this);
-    this.onAddBlock = this.onAddBlock.bind(this);
-    this.onMoveBlock = this.onMoveBlock.bind(this);
-    this.onSubmit = this.onSubmit.bind(this);
-    this.onFocusPreviousBlock = this.onFocusPreviousBlock.bind(this);
-    this.onFocusNextBlock = this.onFocusNextBlock.bind(this);
-    this.handleKeyDown = this.handleKeyDown.bind(this);
+    return state;
+  }
 
-    // We use these as instance fields, to be initialized in the render() meth
-    // from the context provider
-    this.contextData = null;
-    this.setContextData = null;
+  /**
+   * Component did update
+   * @method componentDidUpdate
+   * @param {Object} prevProps Previous properties
+   * @returns {undefined}
+   */
+  componentDidUpdate(prevProps) {
+    if (this.props.formData !== prevProps.formData) {
+      const newState = this.getInitialState(this.props);
+      this.setContextData(newState); // .then(() => this.setState(newState));;
+    }
   }
 
   /**

--- a/src/components/manage/Form/Form.jsx
+++ b/src/components/manage/Form/Form.jsx
@@ -232,7 +232,7 @@ class Form extends Component {
    * @returns {undefined}
    */
   onChangeField(id, value) {
-    this.setContextData({
+    return this.setContextData({
       formData: {
         ...this.contextData.formData,
         // We need to catch also when the value equals false this fixes #888
@@ -254,7 +254,7 @@ class Form extends Component {
    */
   onChangeBlock(id, value) {
     const blocksFieldname = getBlocksFieldname(this.contextData.formData);
-    this.setContextData({
+    return this.setContextData({
       formData: {
         ...this.contextData.formData,
         [blocksFieldname]: {
@@ -281,7 +281,7 @@ class Form extends Component {
     const index =
       this.contextData.formData[blocksLayoutFieldname].items.indexOf(id) + 1;
 
-    this.setContextData({
+    return this.setContextData({
       formData: {
         ...this.contextData.formData,
         [blocksFieldname]: {
@@ -314,7 +314,7 @@ class Form extends Component {
    * @returns {undefined}
    */
   onSelectBlock(id) {
-    this.setContextData({
+    return this.setContextData({
       selected: id,
     });
   }
@@ -332,7 +332,7 @@ class Form extends Component {
       this.contextData.formData,
     );
 
-    this.setContextData({
+    return this.setContextData({
       formData: {
         ...this.contextData.formData,
         [blocksLayoutFieldname]: {
@@ -448,7 +448,7 @@ class Form extends Component {
       }),
     );
     if (keys(errors).length > 0) {
-      this.setContextData({
+      return this.setContextData({
         errors,
       });
     } else {
@@ -460,7 +460,7 @@ class Form extends Component {
         this.props.onSubmit(this.contextData.formData);
       }
       if (this.props.resetAfterSubmit) {
-        this.setContextData({
+        return this.setContextData({
           formData: this.props.formData,
         });
       }
@@ -498,7 +498,7 @@ class Form extends Component {
       this.contextData.formData,
     );
 
-    this.setContextData({
+    return this.setContextData({
       formData: {
         ...this.contextData.formData,
         [blocksLayoutFieldname]: {
@@ -534,7 +534,7 @@ class Form extends Component {
     const newindex = currentIndex - 1;
     blockNode.blur();
 
-    this.onSelectBlock(
+    return this.onSelectBlock(
       this.contextData.formData[blocksLayoutFieldname].items[newindex],
     );
   }
@@ -559,13 +559,15 @@ class Form extends Component {
       this.contextData.formData[blocksLayoutFieldname].items.length - 1
     ) {
       // We are already at the bottom block don't do anything
-      return;
+      return new Promise((resolve) => {
+        resolve();
+      });
     }
 
     const newindex = currentIndex + 1;
     blockNode.blur();
 
-    this.onSelectBlock(
+    return this.onSelectBlock(
       this.contextData.formData[blocksLayoutFieldname].items[newindex],
     );
   }
@@ -643,7 +645,7 @@ class Form extends Component {
     this.setState({
       placeholderProps: {},
     });
-    this.setContextData({
+    return this.setContextData({
       formData: {
         ...this.contextData.formData,
         [blocksLayoutFieldname]: {

--- a/src/components/manage/Form/Form.jsx
+++ b/src/components/manage/Form/Form.jsx
@@ -239,7 +239,7 @@ class Form extends Component {
    * @returns {undefined}
    */
   componentDidUpdate(prevProps) {
-    if (this.props.formData !== prevProps.formData) {
+    if (this.props.formData?.['@id'] !== prevProps.formData?.['@id']) {
       const newState = this.getInitialState(this.props);
       this.setContextData(newState); // .then(() => this.setState(newState));;
     }

--- a/src/components/manage/Form/FormContext.jsx
+++ b/src/components/manage/Form/FormContext.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+export const FormStateContext = React.createContext();
+
+export const FormStateProvider = (props) => {
+  const { initialValue } = props;
+  const [contextData, setContextData] = React.useState(initialValue);
+
+  const logger = (val) => {
+    setContextData((data) => ({ ...data, ...val }));
+  };
+
+  return (
+    <FormStateContext.Provider value={{ contextData, setContextData: logger }}>
+      {props.children}
+    </FormStateContext.Provider>
+  );
+};
+
+export const useFormStateContext = () => {
+  const context = React.useContext(FormStateContext);
+
+  if (!context) {
+    throw new Error(
+      `The \`useFormStateContext\` hook must be used inside the <FormStateProvider> component's context.`,
+    );
+  }
+
+  return context;
+};

--- a/src/components/manage/Form/FormContext.jsx
+++ b/src/components/manage/Form/FormContext.jsx
@@ -2,20 +2,40 @@ import React from 'react';
 
 export const FormStateContext = React.createContext();
 
-export const FormStateProvider = (props) => {
-  const { initialValue } = props;
-  const [contextData, setContextData] = React.useState(initialValue);
+export class FormStateProvider extends React.Component {
+  constructor(props) {
+    super(props);
+    const { initialValue } = this.props;
+    this.state = { contextData: initialValue };
+  }
 
-  const logger = (val) => {
-    setContextData((data) => ({ ...data, ...val }));
+  setContextData = (value) => {
+    return new Promise((resolve, reject) => {
+      this.setState((state) => {
+        return {
+          ...state,
+          contextData: {
+            ...(state.contextData || {}),
+            ...value,
+          },
+        };
+      }, resolve);
+    });
   };
 
-  return (
-    <FormStateContext.Provider value={{ contextData, setContextData: logger }}>
-      {props.children}
-    </FormStateContext.Provider>
-  );
-};
+  render() {
+    const { contextData } = this.state;
+    // console.log('title in provider', contextData.formData.title);
+
+    return (
+      <FormStateContext.Provider
+        value={{ contextData, setContextData: this.setContextData }}
+      >
+        {this.props.children}
+      </FormStateContext.Provider>
+    );
+  }
+}
 
 export const useFormStateContext = () => {
   const context = React.useContext(FormStateContext);


### PR DESCRIPTION
**What is this?**

At its base, this PR separates the internal state of Form.jsx into its own component and exposes it as a context to any of its children or grandchildren.

**What are the benefits?**

- Performance: the `properties` doesn't need to be passed to the EditBlocks anymore, so each edit block won't re-render when other blocks are changed.
- It enables intra-form communication (via the form global state) for edit widgets. Blocks are being passed `properties={formData}` but widgets don't have that
- It enables form state mutation from any of the form components

**What can we do with it?**

I have multiple uses and it enables some advanced scenarios. For example:

- Inter-widgets communication. I have a widget where I can set "ElasticSearch Hostname" and the next widget is a dropdown with a list with the indexes on that ES Server. That means that the second widget needs to be able to read the values from the first widget (so that it knows which server to query for index values). I've used [a similar idea](https://github.com/eea/volto-searchkit/blob/599deced62f69bd041c488cfa90c03d937b840de/src/components/Widgets/SelectField.jsx#L27) in the volto-searchkit prototype.
- "Batch" editing of blocks. Right now the `on*Block`  methods don't use promises, so it's not easily possible to ensure order of execution or state integrity, so I'm forced to wrap mutation calls in setTimeout, which seems to ensure a sort of "synchronicity" in multiple setState calls. See [this](https://github.com/eea/volto-slate/blob/387129e652740da45d424b590e0b64ca6b864cb1/src/utils/volto-blocks.js#L70) as a counter-example of the workarounds that are needed.

**Is this a breaking change?**

Not really. I haven't removed yet the [properties being passed to EditBlock](https://github.com/plone/volto/blob/0542851a68ff73f519a9e97cc06e2c41420d76a2/src/components/manage/Form/Form.jsx#L777), but I'd like to do that. Removing it would improve the performance of the edit form, as blocks wouldn't have to re-render when one of them is changed (unless they specifically watch the context formData). I've changed all the Volto blocks that needed any change, so that we are prepared to remove that passed `properties` parameter. I don't know if there's any other blocks "out there" that depend on the "properties" passed to them. 

All of this is quite cleanly implemented and the advanced behavior is "opt-in". Child components need to use `useFormStateContext()` or `static contextType = FormStateContext` to get access to the ancestor form's internal state/setState.

My intention is to further build, as next PRs::

- promisify the form state change
- wrap the other form implementation (ModalForm, InlineForm) in the FormStateContext provider
- Explain all this in documentation