### PR TITLE
Solved the issue 1695: console error in /contents view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Solved a browser console error in /contents view (#1695) @silviubogan
+
 ### Internal
 
 ## 7.3.0 (2020-07-26)

--- a/src/components/manage/Contents/Contents.jsx
+++ b/src/components/manage/Contents/Contents.jsx
@@ -978,7 +978,7 @@ class Contents extends Component {
                   }
                   onCancel={this.onDeleteCancel}
                   onConfirm={this.onDeleteOk}
-                  size="none"
+                  size="mini"
                 />
                 <ContentsUploadModal
                   open={this.state.showUpload}


### PR DESCRIPTION
Solved https://github.com/plone/volto/issues/1695.

`mini` was used from the context. There also is another issue that makes the modals be displayed with a wrong position (not centered, the problem seems to be in `modal.less`).