### PR TITLE
`focus` prop support for all widgets

### DIFF
--- a/src/components/manage/Form/Form.jsx
+++ b/src/components/manage/Form/Form.jsx
@@ -817,7 +817,7 @@ class Form extends Component {
                         <Field
                           {...schema.properties[field]}
                           id={field}
-                          focus={false}
+                          focus={index === 0}
                           value={this.state.formData[field]}
                           required={schema.required.indexOf(field) !== -1}
                           onChange={this.onChangeField}
@@ -902,7 +902,7 @@ class Form extends Component {
                     content={this.props.error.message}
                   />
                 )}
-                {map(schema.fieldsets[0].fields, (field) => (
+                {map(schema.fieldsets[0].fields, (field, index) => (
                   <Field
                     {...schema.properties[field]}
                     id={field}
@@ -910,6 +910,7 @@ class Form extends Component {
                     required={schema.required.indexOf(field) !== -1}
                     onChange={this.onChangeField}
                     key={field}
+                    focus={index === 0}
                     error={this.state.errors[field]}
                   />
                 ))}

--- a/src/components/manage/Widgets/SelectWidget.jsx
+++ b/src/components/manage/Widgets/SelectWidget.jsx
@@ -148,6 +148,7 @@ class SelectWidget extends Component {
     onDelete: PropTypes.func,
     itemsTotal: PropTypes.number,
     wrapped: PropTypes.bool,
+    focus: PropTypes.bool,
   };
 
   /**
@@ -170,6 +171,7 @@ class SelectWidget extends Component {
     value: null,
     onEdit: null,
     onDelete: null,
+    focus: false,
   };
 
   state = {
@@ -186,6 +188,9 @@ class SelectWidget extends Component {
   componentDidMount() {
     if (!this.props.choices && this.props.vocabBaseUrl) {
       this.props.getVocabulary(this.props.vocabBaseUrl);
+    }
+    if (this.props.focus && this.focusRef.current) {
+      this.focusRef.current.focus();
     }
   }
 
@@ -230,6 +235,12 @@ class SelectWidget extends Component {
     this.setState({ selectedOption });
     this.props.onChange(this.props.id, selectedOption.value);
   };
+
+  constructor(props) {
+    super(props);
+
+    this.focusRef = React.createRef();
+  }
 
   /**
    * Render method.
@@ -296,6 +307,7 @@ class SelectWidget extends Component {
         {this.props.vocabBaseUrl ? (
           <>
             <AsyncPaginate
+              // ref={this.focusRef}
               className="react-select-container"
               classNamePrefix="react-select"
               options={this.props.choices || []}
@@ -318,6 +330,9 @@ class SelectWidget extends Component {
           <Select
             id={`field-${id}`}
             name={id}
+            ref={(x, y) => {
+              this.focusRef = x;
+            }}
             disabled={onEdit !== null}
             className="react-select-container"
             classNamePrefix="react-select"

--- a/src/components/manage/Widgets/TextareaWidget.jsx
+++ b/src/components/manage/Widgets/TextareaWidget.jsx
@@ -3,7 +3,7 @@
  * @module components/manage/Widgets/TextareaWidget
  */
 
-import React, { useState } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { Icon, Label, TextArea } from 'semantic-ui-react';
 
@@ -61,6 +61,7 @@ const TextareaWidget = ({
   fieldSet,
   wrapped,
   placeholder,
+  focus,
 }) => {
   const [lengthError, setlengthError] = useState('');
 
@@ -107,6 +108,14 @@ const TextareaWidget = ({
     required: ['id', 'title'],
   };
 
+  const textAreaRef = useRef(null);
+
+  useEffect(() => {
+    if (focus) {
+      textAreaRef.current.focus();
+    }
+  }, [focus]);
+
   return (
     <FormFieldWrapper
       id={id}
@@ -139,6 +148,7 @@ const TextareaWidget = ({
       )}
       <TextArea
         id={`field-${id}`}
+        ref={textAreaRef}
         name={id}
         value={value || ''}
         disabled={onEdit !== null}

--- a/src/components/manage/Widgets/TokenWidget.jsx
+++ b/src/components/manage/Widgets/TokenWidget.jsx
@@ -70,6 +70,7 @@ class TokenWidget extends Component {
     onChange: PropTypes.func.isRequired,
     itemsTotal: PropTypes.number,
     wrapped: PropTypes.bool,
+    focus: PropTypes.bool,
   };
 
   /**
@@ -90,6 +91,7 @@ class TokenWidget extends Component {
     choices: [],
     loading: false,
     value: null,
+    focus: false,
   };
 
   /**
@@ -112,6 +114,7 @@ class TokenWidget extends Component {
         ? props.value.map((item) => ({ label: item, value: item }))
         : [],
     };
+    this.focusRef = React.createRef();
   }
 
   /**
@@ -121,6 +124,10 @@ class TokenWidget extends Component {
    */
   componentDidMount() {
     this.props.getVocabulary(this.vocabBaseUrl);
+
+    if (this.props.focus && this.focusRef.current) {
+      this.focusRef.current.focus();
+    }
   }
 
   /**
@@ -178,6 +185,7 @@ class TokenWidget extends Component {
         <AsyncCreatable>
           {({ default: AsyncCreatableSelect }) => (
             <AsyncCreatableSelect
+              ref={this.focusRef}
               className="react-select-container"
               classNamePrefix="react-select"
               defaultOptions={this.props.choices || []}

--- a/src/components/manage/Widgets/WysiwygWidget.jsx
+++ b/src/components/manage/Widgets/WysiwygWidget.jsx
@@ -119,6 +119,10 @@ class WysiwygWidget extends Component {
      * Wrapped form component
      */
     wrapped: PropTypes.bool,
+    /**
+     * Focus the field or not
+     */
+    focus: PropTypes.bool,
   };
 
   /**
@@ -138,6 +142,7 @@ class WysiwygWidget extends Component {
     onEdit: null,
     onDelete: null,
     onChange: null,
+    focus: false,
   };
 
   /**
@@ -199,6 +204,19 @@ class WysiwygWidget extends Component {
     };
 
     this.onChange = this.onChange.bind(this);
+
+    this.focusRef = React.createRef();
+  }
+
+  /**
+   * Component did mount lifecycle method
+   * @method componentDidMount
+   * @returns {undefined}
+   */
+  componentDidMount() {
+    if (this.props.focus) {
+      this.focusRef.current.focus();
+    }
   }
 
   /**
@@ -311,6 +329,7 @@ class WysiwygWidget extends Component {
                 blockRenderMap={settings.extendedBlockRenderMap}
                 blockStyleFn={settings.blockStyleFn}
                 customStyleMap={settings.customStyleMap}
+                ref={this.focusRef}
               />
               {this.props.onChange && <InlineToolbar />}
             </>


### PR DESCRIPTION
Attempting to solve #1652 (WIP).

1. Changes to Form so that it passes focus to all widgets;
2. Changes to all widgets so that they change their state to focused when receiving focus={true}.
- [x] TextareaWidget
- [x] WysiwygWidget
- [x] TextWidget
- [ ] TokenWidget
- [ ] SelectWidget
- etc.