### PR TITLE
Fix changelog for recurrence widget entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Feature
 
+- Added recurrence widget @giuliaghisini
+
 ### Bugfix
 
 ### Internal
@@ -100,12 +102,6 @@
 ### Feature
 
 - Added default Export for the QuerystringWidget for the ListingBlock @steffenri
-
-### Breaking
-
-### Feature
-
-- Added recurrence widget @giuliaghisini
 
 ### Bugfix
 


### PR DESCRIPTION
The entry for the recurrence widget is gone under 6.5.0 release in the changelog, but that’s not correct