### PR TITLE
remove componentWillReceiveProps from Form again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 ### Bugfix
 
-- Fix issue introduced with #1732 that caused the image Block to completely wipe the edit page when a new image was uploaded.
+- Remove supposed fix to form.jsx again, as it apparently did not really fix anything but only broke stuff @jackahl
 
 ### Internal
 

--- a/src/components/manage/Form/Form.jsx
+++ b/src/components/manage/Form/Form.jsx
@@ -15,7 +15,6 @@ import {
   pickBy,
   uniq,
   without,
-  isEqual,
 } from 'lodash';
 import move from 'lodash-move';
 import isBoolean from 'lodash/isBoolean';
@@ -227,18 +226,6 @@ class Form extends Component {
    */
   componentDidMount() {
     this.setState({ isClient: true });
-  }
-
-  /**
-   * Component will receive props
-   * @method componentWillReceiveProps
-   * @param {Object} nextProps Next properties
-   * @returns {undefined}
-   */
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    if (isEqual(nextProps.formData, this.state.formData)) {
-      this.setState({ formData: nextProps.formData });
-    }
   }
 
   /**


### PR DESCRIPTION
The stuff this supposedly fixed wasn't even broken in the current volto build. So I removed it again.