### PR TITLE
How to use an addon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Internal
 
+- Docs: Review of "How to use and addon" @ksuess
+
 ## 7.8.2 (2020-08-18)
 
 ### Bugfix

--- a/docs/source/customizing/add-ons.md
+++ b/docs/source/customizing/add-ons.md
@@ -27,7 +27,6 @@ and in `package.json`:
 ```json
   "scripts": {
     "develop": "missdev --config=jsconfig.json --output=addons",
-    ...
   }
 ```
 
@@ -102,14 +101,12 @@ resolve them, so in `package.json`:
 
 ```json hl_lines="6"
   "jest": {
-    ...
     "moduleNameMapper": {
       "@plone/volto/(.*)$": "<rootDir>/node_modules/@plone/volto/src/$1",
       "@package/(.*)$": "<rootDir>/src/$1",
       "@plone/my-volto-addon/(.*)$": "<rootDir>/src/addons/@plone/my-volto-addon/src/$1",
       "~/(.*)$": "<rootDir>/src/$1"
     },
-    ...
 ```
 
 ### .eslintrc
@@ -146,7 +143,7 @@ their configuration, so they may offer additional configuration functions,
 which you can load by overloading the addon name in the ``addons`` package.json
 key, like so:
 
-```js
+```json
 {
   "name": "my-nice-volto-project",
   ...
@@ -154,7 +151,6 @@ key, like so:
     "acme-volto-foo-addon:loadOptionalBlocks,overrideSomeDefaultBlock",
     "volto-ga"
   ],
-  ...
 }
 ```
 
@@ -212,12 +208,10 @@ package names, like:
 ```json
 {
   "name": "my-nice-volto-project",
-  ...
   "addons": [
     "acme-volto-foo-addon",
     "volto-ga"
   ],
-  ...
 }
 ```
 
@@ -251,9 +245,7 @@ export default function applyConfig(config) {
 
 ```json
 {
-  ...
   "main": "src/index.js",
-  ...
 }
 ```
 

--- a/docs/source/customizing/add-ons.md
+++ b/docs/source/customizing/add-ons.md
@@ -3,7 +3,7 @@
 There are several advanced scenarios where we might want to have more control
 and flexibility beyond using the plain Volto project to build a site.
 
-### Addon packages
+## Addon packages
 
 We can build Volto add-on products and make them available as published
 packages (from public/private npm repositories), or as checkouts from git

--- a/docs/source/customizing/add-ons.md
+++ b/docs/source/customizing/add-ons.md
@@ -1,9 +1,9 @@
-# Add-on packages
+# Volto addons
 
 There are several advanced scenarios where we might want to have more control
 and flexibility beyond using the plain Volto project to build a site.
 
-## Use add-on products
+### Addon packages
 
 We can build Volto add-on products and make them available as published
 packages (from public/private npm repositories), or as checkouts from git
@@ -12,92 +12,11 @@ repositories using `mrs-developer` helper package.
 We can use them to easily reuse components across projects, like custom blocks,
 views, widgets, or any other Volto or React artifact.
 
-### Loading an addon configuration
-
-As a convenience, an addon can export configuration functions that can mutate,
-in-place, the overall ``~/config`` registry. An addon can export multiple
-configurations methods, making it possible to selectively choose which specific
-addon functionality you want to load.
-
-In your Volto project's ``package.json`` you can allow the addon to alter the
-global configuration by adding, in the ``addons`` key, a list of volto addon
-package names, like:
-
-```
-{
-  "name": "my-nice-volto-project",
-  ...
-  "addons": [
-    "volto-example-addon",
-    "volto-ga"
-  ],
-  ...
-}
-```
-
-!!! info
-  If you're an addon developer, you should export, in your package main,
-  a function with the signature ``config => config``. So it should take the
-  ``global`` configuration object and return it, possibly mutated or changed.
-
-Some addons might choose to allow the Volto project to selectively load some of
-their configuration, so they may offer additional configuration functions,
-which you can load by overloading the addon name in the ``addons`` package.json
-key, like so:
-
-```js
-{
-  "name": "my-nice-volto-project",
-  ...
-  "addons": [
-    "volto-example-addon:loadOptionalBlocks,overrideSomeDefaultBlock",
-    "volto-ga"
-  ],
-  ...
-}
-```
-
-!!! info
-  The additional comma-separated names should be exported from the addon
-  package's ``index.js``. The main configuration function should be exported as
-  the default. An addon's default configuration method will always be loaded.
-
-If for some reason, you want to manually load the addon, you could always do,
-in your project's ``config.js`` module:
-
-```js
-import loadExampleAddon, { enableOptionalBlocks } from 'volto-example-addon';
-import * as voltoConfig from '@plone/volto/config';
-
-const config = enableOptionalBlocks(loadExampleAddon(voltoConfig));
-
-export blocks = {
-  ...config.blocks,
-}
-...
-```
-
-### Mrs. Developer
-
-Eric Brehault ported this amazing Python tool, which provides a way to pull
-a package from git and set it up as a dependency for the current project
-codebase.
-
-https://www.npmjs.com/package/mrs-developer
-
-By doing this, you can develop both the project and the add-on product as if they
-were both part of the current codebase. Once the add-on development is done,
-you can publish the package to an npm repository.
-
-Volto is also capable of using aliases for your (unreleased) package, so that once
-you've released it, you don't need to change import paths, since you can use the
-final ones from the very beginning.
 
 
+## Configuring a Volto project to use a Volto addon
 
-## Configuring a Volto project to use a Volto add-on product
-
-### Add mr-developer dependency and related script
+### Add mrs-developer dependency and related script
 
 ```
 $ yarn add mrs-developer
@@ -112,28 +31,32 @@ and in `package.json`:
   }
 ```
 
-we can configure `mrs-developer` to use any directory that you want. Here we are
+We can configure `mrs-developer` to use any directory that you want. Here we are
 telling it to create the directory `src/addons` and put the packages managed by
 `mrs-developer` inside.
-
-!!! note
-    You can use any name/directory in your project. We chose `addons` by convention for
-    all Volto add-ons.
 
 ### mrs.developer.json
 
 This is the configuration file that instructs `mrs-developer` from where it has
-to pull the packages. So, in `mrs.developer.json`:
+to pull the packages. So, create `mrs.developer.json` and add:
 
 ```json
 {
-  "plone.my-volto-addon": {
-      "package": "@plone/my-volto-addon",
-      "url": "git@github.com:plone/my-volto-addon.git",
+  "acme-volto-foo-addon": {
+      "package": "acme/volto-foo-addon",
+      "url": "git@github.com:acme/my-volto-addon.git",
       "path": "src"
   }
 }
 ```
+
+run 
+
+```bash
+yarn develop
+```
+
+You see the addon cloned to `src/addons/`.
 
 !!! warning
     `mrs-developer` does not support scopes (`@` or `/` in the key for the definition of the
@@ -149,14 +72,14 @@ If you want to know more about `mrs-developer` config options, please refer to
 
 ### jsconfig.json
 
-You can let `mrs-developer` create this file for you or create it manually.
+`mrs-developer` creates this file for you.
 
 ```json
 {
     "compilerOptions": {
         "paths": {
-            "@plone/my-volto-addon": [
-                "addons/@plone/my-volto-addon/src"
+            "acme-volto-foo-addon": [
+                "addons/acme-volto-foo-addon/src"
             ]
         },
         "baseUrl": "src"
@@ -195,7 +118,7 @@ Make sure to upgrade your project's `.eslintrc` to the `.eslintrc.js` version,
 according to the [Upgrade Guide](/upgrade-guide).
 
 
-## Loading addon configuration
+### Loading addon configuration
 
 As a convenience, an addon can export configuration functions that can mutate,
 in-place, the overall ``~/config`` registry. An addon can export multiple
@@ -206,22 +129,17 @@ In your Volto project's ``package.json`` you can allow the addon to alter the
 global configuration by adding, in the ``addons`` key, a list of volto addon
 package names, like:
 
-```
+```js
 {
   "name": "my-nice-volto-project",
   ...
   "addons": [
-    "volto-example-addon",
-    "volto-ga"
+    "acme-volto-foo-addon",
+    "collective-another-volto-addon"
   ],
   ...
 }
 ```
-
-!!! info
-  If you're an addon developer, you should export, in your package main,
-  a function with the signature ``config => config``. So it should take the
-  ``global`` configuration object and return it, possibly mutated or changed.
 
 Some addons might choose to allow the Volto project to selectively load some of
 their configuration, so they may offer additional configuration functions,
@@ -233,7 +151,7 @@ key, like so:
   "name": "my-nice-volto-project",
   ...
   "addons": [
-    "volto-example-addon:loadOptionalBlocks,overrideSomeDefaultBlock",
+    "acme-volto-foo-addon:loadOptionalBlocks,overrideSomeDefaultBlock",
     "volto-ga"
   ],
   ...
@@ -241,9 +159,9 @@ key, like so:
 ```
 
 !!! info
-  The additional comma-separated names should be exported from the addon
-  package's ``index.js``. The main configuration function should be exported as
-  the default. An addon's default configuration method will always be loaded.
+    The additional comma-separated names should be exported from the addon
+    package's ``index.js``. The main configuration function should be exported as
+    the default. An addon's default configuration method will always be loaded.
 
 If for some reason, you want to manually load the addon, you could always do,
 in your project's ``config.js`` module:
@@ -261,7 +179,7 @@ export blocks = {
 ```
 
 
-## Add several layers of customizations
+### Add several layers of customizations
 
 In `package.json` we can add more customization layers that will be added to the
 current ones. These will be added to the aliases list, with the last ones
@@ -277,3 +195,129 @@ Volto project.
 
 !!! tip
     Do not forget the `/` at the end of both
+
+
+
+## Creating addons
+
+As a convenience, an addon can export configuration functions that can mutate,
+in-place, the overall ``~/config`` registry. An addon can export multiple
+configurations methods, making it possible to selectively choose which specific
+addon functionality you want to load.
+
+In a Volto project's ``package.json`` you can allow the addon to alter the
+global configuration by adding, in the ``addons`` key, a list of volto addon
+package names, like:
+
+```json
+{
+  "name": "my-nice-volto-project",
+  ...
+  "addons": [
+    "acme-volto-foo-addon",
+    "volto-ga"
+  ],
+  ...
+}
+```
+
+### Providing addon configuration
+In your addons package main you provide a function with the signature ``config => config``. So it should take the ``global`` configuration object and return it, possibly mutated or changed.
+
+``index.js``
+
+```js
+export default function applyConfig(config) {
+  config.blocks.blocksConfig.faq_viewer = {
+    id: 'faq_viewer',
+    title: 'FAQ Viewer',
+    edit: FAQBlockEdit,
+    view: FAQBlockView,
+    icon: chartIcon,
+    group: 'common',
+    restricted: false,
+    mostUsed: true,
+    sidebarTab: 1,
+    security: {
+      addPermission: [],
+      view: [],
+    },
+  };
+  return config;
+}
+```
+
+``packages.json``
+
+```json
+{
+  ...
+  "main": "src/index.js",
+  ...
+}
+```
+
+### Providing multiple addon configurations
+
+Some addons might choose to allow the Volto project to selectively load some of
+their configuration, so they may offer additional configuration functions,
+which you can load by overloading the addon name in the ``addons`` package.json
+key, like so:
+
+```js
+{
+  "name": "my-nice-volto-project",
+  ...
+  "addons": [
+    "acme-volto-foo-addon:loadOptionalBlocks,overrideSomeDefaultBlock",
+    "volto-ga"
+  ],
+  ...
+}
+```
+
+The additional comma-separated names should be exported from the addon
+package's ``index.js``. The main configuration function should be exported as
+the default. An addon's default configuration method will always be loaded.
+
+``index.js``
+
+```js
+import applyConfig, {loadOptionalBlocks,overrideSomeDefaultBlock} from './config';
+
+export {loadOptionalBlocks,overrideSomeDefaultBlock};
+export default applyConfig;
+```
+
+### Manually loading addon
+
+If for some reason, you want to manually load the addon, you could always do,
+in your project's ``config.js`` module:
+
+```js
+import loadExampleAddon, { enableOptionalBlocks } from 'volto-example-addon';
+import * as voltoConfig from '@plone/volto/config';
+
+const config = enableOptionalBlocks(loadExampleAddon(voltoConfig));
+
+export blocks = {
+  ...config.blocks,
+}
+...
+```
+
+### Mrs. Developer
+
+Eric Brehault ported this amazing Python tool, which provides a way to pull
+a package from git and set it up as a dependency for the current project
+codebase.
+
+https://www.npmjs.com/package/mrs-developer
+
+By doing this, you can develop both the project and the add-on product as if they
+were both part of the current codebase. Once the add-on development is done,
+you can publish the package to an npm repository.
+
+Volto is also capable of using aliases for your (unreleased) package, so that once
+you've released it, you don't need to change import paths, since you can use the
+final ones from the very beginning.


### PR DESCRIPTION
- Clear separation of "Use of an addon" and "Creating an addon".
- Changed order to first "Use of an addon" then "Creating an addon".
