### PR TITLE
Fix getBlocks helper when blocks_layout has no items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Fix getBlocks helper when blocks_layout has no `items` (default PloneSite with no volto homepage)
+
 ### Internal
 
 - Docs: Review of "How to use and addon" @ksuess

--- a/src/helpers/Blocks/Blocks.js
+++ b/src/helpers/Blocks/Blocks.js
@@ -75,8 +75,10 @@ export function blockHasValue(data) {
 export const getBlocks = (properties) => {
   const blocksFieldName = getBlocksFieldname(properties);
   const blocksLayoutFieldname = getBlocksLayoutFieldname(properties);
-  return properties[blocksLayoutFieldname].items.map((n) => [
-    n,
-    properties[blocksFieldName][n],
-  ]);
+  return (
+    properties[blocksLayoutFieldname]?.items?.map((n) => [
+      n,
+      properties[blocksFieldName][n],
+    ]) || []
+  );
 };

--- a/src/helpers/Blocks/Blocks.test.js
+++ b/src/helpers/Blocks/Blocks.test.js
@@ -119,6 +119,10 @@ describe('Blocks', () => {
   });
 
   describe('getBlock', () => {
+    it('returns empty when there is no block content and no items in layout', () => {
+      expect(getBlocks({ blocks: {}, blocks_layout: {} })).toStrictEqual([]);
+    });
+
     it('returns empty when there is no block content', () => {
       expect(
         getBlocks({ blocks: {}, blocks_layout: { items: [] } }),


### PR DESCRIPTION
If you don't install `kitconcept.volto` homepage on backend, the Plone site api returns: 
```
@id: "http://localhost:3000/api/"
@type: "Plone Site"
blocks: {}
blocks_layout: {}
description: ""
```
Thus, getBlocks will fail with:
```
Unhandled Rejection (TypeError): Cannot read property 'map' of undefined
```