### PR TITLE
On mutating block, don't create placeholder block if already exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- On mutating a block, don't create extra placeholder block if such block already exists @tiberiuichim
+
 ### Internal
 
 ## 7.8.3 (2020-08-21)

--- a/src/components/manage/Form/Form.jsx
+++ b/src/components/manage/Form/Form.jsx
@@ -277,12 +277,30 @@ class Form extends Component {
    * @returns {undefined}
    */
   onMutateBlock(id, value) {
-    const idTrailingBlock = uuid();
     const blocksFieldname = getBlocksFieldname(this.state.formData);
     const blocksLayoutFieldname = getBlocksLayoutFieldname(this.state.formData);
     const index =
       this.state.formData[blocksLayoutFieldname].items.indexOf(id) + 1;
 
+    // Test if block at index is already a placeholder (trailing) block
+    const trailId = this.state.formData[blocksLayoutFieldname].items[index];
+    if (trailId) {
+      const block = this.state.formData[blocksFieldname][trailId];
+      if (!blockHasValue(block)) {
+        this.setState({
+          formData: {
+            ...this.state.formData,
+            [blocksFieldname]: {
+              ...this.state.formData[blocksFieldname],
+              [id]: value || null,
+            },
+          },
+        });
+        return;
+      }
+    }
+
+    const idTrailingBlock = uuid();
     this.setState({
       formData: {
         ...this.state.formData,


### PR DESCRIPTION
How to reproduce, before & after:

- Create two empty text blocks, one after the other
- In the first text block, change the type to "image"
- Before this PR, you'd now have three blocks: image block + two empty text blocks
- After this PR, you now have two blocks: image block + empty text block

It needs a Cypress test, but I can't run Cypress right now.