### PR TITLE
Fix cosmetic issue, wrong Add link generated in Contents page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Fix cosmetic issue, add links were not properly generated in Contents view not under the root. This didn't impact functionality as the content was properly created @tiberiuichim
+
 ### Internal
 
 ## 7.9.0 (2020-08-24)

--- a/src/components/manage/Toolbar/Types.jsx
+++ b/src/components/manage/Toolbar/Types.jsx
@@ -19,8 +19,9 @@ const Types = ({ types, pathname, content, currentLanguage }) => {
             // Strip the type for the item we want to add
             const contentTypeToAdd = item['@id'].split('@types/')[1];
             // If we are in the root or in /contents, we need to strip the preceeding / and /contents
-            const currentPath =
-              pathname === '/' || pathname === '/contents' ? '' : pathname;
+            const currentPath = pathname
+              .replace(/\/contents$/, '')
+              .replace(/\/$/, '');
             // Finally build the route URL
             const addContentTypeRoute = `${currentPath}/add?type=${contentTypeToAdd}`;
             return (


### PR DESCRIPTION
In folders not under the root, the add links were generated like https://volto.kitconcept.com/news2/contents/add?type=News%20Item