### PR TITLE
Fix api plone.schema versions

### DIFF
--- a/api/buildout.cfg
+++ b/api/buildout.cfg
@@ -8,6 +8,8 @@ versions=versions
 
 [versions]
 plone.restapi =
+plone.schema = 1.2.1
+plone.schemaeditor = 3.0.1
 
 # Fixes the modified time for regenerating the caches
 # => Remove once Plone 5.2.2 is released


### PR DESCRIPTION
Travis started to complain about `plone.schema` version after plone.restapi release. e.g.: https://github.com/plone/volto/pull/1665/checks?check_run_id=1050165615