### PR TITLE
Use Plone's language cookie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Use Plone `I18N_LANGUAGE` cookie instead of `language` @cekk
+
 ### Internal
 
 ## 7.11.3 (2020-08-28)

--- a/api/buildout.cfg
+++ b/api/buildout.cfg
@@ -1,36 +1,10 @@
 [buildout]
 extends =
     base.cfg
-    http://dist.plone.org/release/5.2.1/versions.cfg
+    http://dist.plone.org/release/5.2.2/versions.cfg
 
 find-links += http://dist.plone.org/thirdparty/
 versions=versions
 
 [versions]
 plone.restapi =
-
-# Fixes the modified time for regenerating the caches
-# => Remove once Plone 5.2.2 is released
-plone.namedfile = 5.3.0
-
-# Fixes show self on listing blocks
-# => Remove once Plone 5.2.2 is released
-Products.ZCatalog = 5.1
-
-# fixes iface adaptation problem: https://github.com/plone/plone.dexterity/issues/120
-# => Remove once Plone 5.2.2 is released
-plone.dexterity = 2.9.5
-# Fix: Catastrophic backtracking in regex allows Denial of Service
-# https://github.com/Pylons/waitress/security/advisories/GHSA-73m2-3pwg-5fgc
-# => Remove once Plone 5.2.2 is released
-waitress = 1.4.3
-
-# Remove when Plone 5.2.2 is out
-plone.app.contenttypes = 2.1.6
-plone.rest = 1.6.1
-
-# hotfixes
-Products.PloneHotfix20200121 = 1.0
-
-# compatibility with Python3.8
-lxml = 4.4.2

--- a/src/components/manage/Preferences/PersonalPreferences.jsx
+++ b/src/components/manage/Preferences/PersonalPreferences.jsx
@@ -83,7 +83,7 @@ class PersonalPreferences extends Component {
    * @returns {undefined}
    */
   onSubmit(data) {
-    cookie.save('lang', data.language || '', {
+    cookie.save('I18N_LANGUAGE', data.language || '', {
       expires: new Date((2 ** 31 - 1) * 1000),
       path: '/',
     });
@@ -125,7 +125,7 @@ class PersonalPreferences extends Component {
   render() {
     return (
       <Form
-        formData={{ language: cookie.load('lang') || '' }}
+        formData={{ language: cookie.load('I18N_LANGUAGE') || '' }}
         schema={{
           fieldsets: [
             {

--- a/src/components/theme/LanguageSelector/LanguageSelector.js
+++ b/src/components/theme/LanguageSelector/LanguageSelector.js
@@ -36,7 +36,7 @@ const LanguageSelector = (props) => {
   );
 
   function changeLanguage(language) {
-    cookie.save('lang', language, {
+    cookie.save('I18N_LANGUAGE', language, {
       expires: new Date((2 ** 31 - 1) * 1000),
       path: '/',
     });

--- a/src/components/theme/MultilingualRedirector/MultilingualRedirector.jsx
+++ b/src/components/theme/MultilingualRedirector/MultilingualRedirector.jsx
@@ -17,7 +17,8 @@ if (settings) {
 
 const MultilingualRedirector = (props) => {
   const { pathname, children } = props;
-  const currentLanguage = cookie.load('lang') || settings.defaultLanguage;
+  const currentLanguage =
+    cookie.load('I18N_LANGUAGE') || settings.defaultLanguage;
   const redirectToLanguage = settings.supportedLanguages.includes(
     currentLanguage,
   )

--- a/src/server.jsx
+++ b/src/server.jsx
@@ -84,7 +84,7 @@ server
     const browserdetect = detect(req.headers['user-agent']);
 
     const lang = new locale.Locales(
-      cookie.load('lang') ||
+      cookie.load('I18N_LANGUAGE') ||
         settings.defaultLanguage ||
         req.headers['accept-language'],
     )


### PR DESCRIPTION
Without using **I18N_LANGUAGE** cookie we have the problem that edit interface (the one that came from Plone api) and toolbar aren't in the right language in LanguageSelector component because Volto use a different cookie (**lang**).

I'm not a master in js tests so i don't know how to test this. If we need some tests, someone can help me?