### PR TITLE
Vertical form tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Feature
 
+- Render form with vertical tabs, setting the property `verticalFormTabs` in config.js @giuliaghisini
+
 ### Bugfix
 
 ### Internal

--- a/src/components/manage/Form/Form.jsx
+++ b/src/components/manage/Form/Form.jsx
@@ -879,6 +879,7 @@ class Form extends Component {
           method="post"
           onSubmit={this.onSubmit}
           error={keys(this.state.errors).length > 0}
+          className={settings.verticalFormTabs ? 'vertical-form' : ''}
         >
           <Segment.Group raised>
             {schema && schema.fieldsets.length > 1 && (

--- a/src/components/manage/Form/Form.jsx
+++ b/src/components/manage/Form/Form.jsx
@@ -882,39 +882,48 @@ class Form extends Component {
         >
           <Segment.Group raised>
             {schema && schema.fieldsets.length > 1 && (
-              <Tab
-                menu={{
-                  secondary: true,
-                  pointing: true,
-                  attached: true,
-                  tabular: true,
-                  className: 'formtabs',
-                }}
-                panes={map(schema.fieldsets, (item) => ({
-                  menuItem: item.title,
-                  render: () => [
-                    this.props.title && (
-                      <Segment secondary attached key={this.props.title}>
-                        {this.props.title}
-                      </Segment>
-                    ),
-                    ...map(item.fields, (field, index) => (
-                      <Field
-                        {...schema.properties[field]}
-                        id={field}
-                        formData={this.state.formData}
-                        fieldSet={item.title.toLowerCase()}
-                        focus={index === 0}
-                        value={this.state.formData[field]}
-                        required={schema.required.indexOf(field) !== -1}
-                        onChange={this.onChangeField}
-                        key={field}
-                        error={this.state.errors[field]}
-                      />
-                    )),
-                  ],
-                }))}
-              />
+              <>
+                {settings.verticalFormTabs && this.props.title && (
+                  <Segment secondary attached key={this.props.title}>
+                    {this.props.title}
+                  </Segment>
+                )}
+                <Tab
+                  menu={{
+                    secondary: true,
+                    pointing: true,
+                    attached: true,
+                    tabular: true,
+                    className: 'formtabs',
+                    vertical: settings.verticalFormTabs,
+                  }}
+                  grid={{ paneWidth: 9, tabWidth: 3, stackable: true }}
+                  panes={map(schema.fieldsets, (item) => ({
+                    menuItem: item.title,
+                    render: () => [
+                      !settings.verticalFormTabs && this.props.title && (
+                        <Segment secondary attached key={this.props.title}>
+                          {this.props.title}
+                        </Segment>
+                      ),
+                      ...map(item.fields, (field, index) => (
+                        <Field
+                          {...schema.properties[field]}
+                          id={field}
+                          formData={this.state.formData}
+                          fieldSet={item.title.toLowerCase()}
+                          focus={index === 0}
+                          value={this.state.formData[field]}
+                          required={schema.required.indexOf(field) !== -1}
+                          onChange={this.onChangeField}
+                          key={field}
+                          error={this.state.errors[field]}
+                        />
+                      )),
+                    ],
+                  }))}
+                />
+              </>
             )}
             {schema && schema.fieldsets.length === 1 && (
               <Segment>

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -73,7 +73,7 @@ let config = {
     expressMiddleware: [],
     timezone: 'UTC',
     defaultBlockType: 'text',
-    verticalFormTabs: true,
+    verticalFormTabs: false,
   },
   widgets: {
     ...widgetMapping,

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -73,6 +73,7 @@ let config = {
     expressMiddleware: [],
     timezone: 'UTC',
     defaultBlockType: 'text',
+    verticalFormTabs: true,
   },
   widgets: {
     ...widgetMapping,

--- a/theme/themes/pastanaga/extras/main.less
+++ b/theme/themes/pastanaga/extras/main.less
@@ -327,6 +327,14 @@ button {
   flex-direction: column;
 }
 
+.vertical-form {
+  .ui.grid.stackable {
+    .stretched.nine.wide.column {
+      align-self: start;
+    }
+  }
+}
+
 // Deprecated as per https://github.com/plone/volto/issues/1265
 // @import 'utils';
 @import 'toolbar';


### PR DESCRIPTION
By default, forms are displayed with horizontal tab at the top.
If you have a content type with a lot of tab, the horizontal arrangement fails to contain them all.
You could define, in config.js to display form tab as a vertical list in all your project, changing the variabile `verticalFormTabs` to true. 
<img width="1168" alt="Schermata 2020-09-04 alle 10 31 45" src="https://user-images.githubusercontent.com/51911425/92219129-6ed44200-ee9a-11ea-8eb6-a260b2babafd.png">
