### PR TITLE
fix: checkbox widget styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Fix checkbox widget styles @nzambello
+
 ### Internal
 
 ## 7.12.0 (2020-09-04)

--- a/theme/themes/pastanaga/elements/input.overrides
+++ b/theme/themes/pastanaga/elements/input.overrides
@@ -15,7 +15,7 @@
   }
 
   &.required .wrapper {
-    label[for]::after,
+    > label[for]::after,
     .ui.label::after {
       display: inline-block;
       width: 10px;


### PR DESCRIPTION
Fixes checkbox widget in forms:

Before:
![Screenshot_2020-09-04 Impostazioni Dropdown Menu](https://user-images.githubusercontent.com/21101435/92223663-13f21900-eea1-11ea-96d0-870de843ed25.png)

Now:
![Screenshot_2020-09-04 Impostazioni Dropdown Menu(1)](https://user-images.githubusercontent.com/21101435/92223715-253b2580-eea1-11ea-9df7-3df3120059df.png)
