### PR TITLE
enabled no-folderish CT to be translated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- enabled no-folderish CT to be translated @giuliaghisini
+ 
 ### Internal
 
 ## 7.12.0 (2020-09-04)

--- a/src/components/manage/Toolbar/Toolbar.jsx
+++ b/src/components/manage/Toolbar/Toolbar.jsx
@@ -13,7 +13,7 @@ import { doesNodeContainClick } from 'semantic-ui-react/dist/commonjs/lib';
 import cookie from 'react-cookie';
 import { filter, find } from 'lodash';
 import cx from 'classnames';
-
+import { settings } from '~/config';
 import More from '@plone/volto/components/manage/Toolbar/More';
 import PersonalTools from '@plone/volto/components/manage/Toolbar/PersonalTools';
 import Types from '@plone/volto/components/manage/Toolbar/Types';
@@ -420,8 +420,10 @@ class Toolbar extends Component {
                         </Link>
                       )}
                     {this.props.content &&
-                      this.props.content.is_folderish &&
-                      this.props.types.length > 0 && (
+                      ((this.props.content.is_folderish &&
+                        this.props.types.length > 0) ||
+                        (settings.isMultilingual &&
+                          this.props.content['@components'].translations)) && (
                         <button
                           className="add"
                           aria-label={this.props.intl.formatMessage(

--- a/src/components/manage/Toolbar/Types.jsx
+++ b/src/components/manage/Toolbar/Types.jsx
@@ -8,40 +8,45 @@ import { flattenToAppURL } from '@plone/volto/helpers';
 import { settings } from '~/config';
 
 const Types = ({ types, pathname, content, currentLanguage }) => {
-  return types.length > 0 ? (
+  return types.length > 0 ||
+    (settings.isMultilingual && content['@components'].translations) ? (
     <div className="menu-more pastanaga-menu">
-      <header>
-        <FormattedMessage id="Add Content" defaultMessage="Add Content…" />
-      </header>
-      <div className="pastanaga-menu-list">
-        <ul>
-          {map(filter(types), (item) => {
-            // Strip the type for the item we want to add
-            const contentTypeToAdd = item['@id'].split('@types/')[1];
-            // If we are in the root or in /contents, we need to strip the preceeding / and /contents
-            const currentPath = pathname
-              .replace(/\/contents$/, '')
-              .replace(/\/$/, '');
-            // Finally build the route URL
-            const addContentTypeRoute = `${currentPath}/add?type=${contentTypeToAdd}`;
-            return (
-              <li key={item['@id']}>
-                <Link
-                  to={addContentTypeRoute}
-                  id={`toolbar-add-${item['@id']
-                    .split('@types/')[1]
-                    .toLowerCase()
-                    .replace(' ', '-')}`}
-                  className="item"
-                  key={item.title}
-                >
-                  <FormattedMessage id={item.title} />
-                </Link>
-              </li>
-            );
-          })}
-        </ul>
-      </div>
+      {types.length > 0 && (
+        <>
+          <header>
+            <FormattedMessage id="Add Content" defaultMessage="Add Content…" />
+          </header>
+          <div className="pastanaga-menu-list">
+            <ul>
+              {map(filter(types), (item) => {
+                // Strip the type for the item we want to add
+                const contentTypeToAdd = item['@id'].split('@types/')[1];
+                // If we are in the root or in /contents, we need to strip the preceeding / and /contents
+                const currentPath = pathname
+                  .replace(/\/contents$/, '')
+                  .replace(/\/$/, '');
+                // Finally build the route URL
+                const addContentTypeRoute = `${currentPath}/add?type=${contentTypeToAdd}`;
+                return (
+                  <li key={item['@id']}>
+                    <Link
+                      to={addContentTypeRoute}
+                      id={`toolbar-add-${item['@id']
+                        .split('@types/')[1]
+                        .toLowerCase()
+                        .replace(' ', '-')}`}
+                      className="item"
+                      key={item.title}
+                    >
+                      <FormattedMessage id={item.title} />
+                    </Link>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        </>
+      )}
       {settings.isMultilingual &&
         content['@components'].translations &&
         (() => {


### PR DESCRIPTION
This pr shows the 'add' button on the toolbar, if a content type is not folderish and multilingual is enabled, to enable ct translations. 