### PR TITLE
Fix customization mechanism when paths end with a slash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Fix customization mechanism where customization paths end with `/` @tiberiuichim
+
 ### Internal
 
 ## 7.14.0 (2020-09-08)

--- a/__tests__/fixtures/test-volto-project/package.json
+++ b/__tests__/fixtures/test-volto-project/package.json
@@ -1,8 +1,12 @@
 {
   "name": "test-volto-project",
-  "addons": ["test-addon", "test-released-addon:extra", "test-released-source-addon"],
+  "addons": [
+    "test-addon",
+    "test-released-addon:extra",
+    "test-released-source-addon"
+  ],
   "customizationPaths": [
     "src/custom-addons",
-    "src/customizations"
+    "src/customizations/"
   ]
 }

--- a/addon-registry.js
+++ b/addon-registry.js
@@ -189,6 +189,9 @@ class AddonConfigurationRegistry {
       customizationPaths = ['src/customizations'];
     }
     customizationPaths.forEach((customizationPath) => {
+      customizationPath = customizationPath.endsWith('/')
+        ? customizationPath.slice(0, customizationPath.length - 1)
+        : customizationPath;
       const base = path.join(rootPath, customizationPath);
       const reg = [];
 


### PR DESCRIPTION
A regression bug introduced in #1706 meant that customization paths that end with a slash, like `src/customizations/`, no longer worked. This fixes it.