### PR TITLE
Image block: modified alt tag to not use image id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added Schema Editor within Dexterity Content-Types Controlpanel @rexalex @avoinea #1517
 - Added Blocks Layout Editor within Dexterity Content-Types Controlpanel @avoinea #1517
 - Added missing components for Email and Url widgets #1246 @rexalex
+- Use content title instead of image id in alt tag @nileshgulia1
 
 ### Bugfix
 

--- a/src/components/manage/Blocks/Image/Edit.jsx
+++ b/src/components/manage/Blocks/Image/Edit.jsx
@@ -89,7 +89,7 @@ class Edit extends Component {
       this.props.onChangeBlock(this.props.block, {
         ...this.props.data,
         url: nextProps.content['@id'],
-        alt: nextProps.content.title,
+        alt: nextProps.properties.title,
       });
     }
   }


### PR DESCRIPTION
Since we don't want to automatically set image-id as alt in image block ,we might use content title instead. #1503 