### PR TITLE
Fix bug in select widget handling of choices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Allow select widget to reset when the incoming props change. The react-select widget has its own internal state, so if you initialise the widget without choices, then populate the choices, it wouldn't properly show the default value @tiberiuichim
+
 ### Internal
 
 ## 8.0.1 (2020-09-22)

--- a/src/components/manage/Widgets/SelectWidget.jsx
+++ b/src/components/manage/Widgets/SelectWidget.jsx
@@ -270,6 +270,7 @@ class SelectWidget extends Component {
         ) : (
           <Select
             id={`field-${id}`}
+            key={this.props.choices}
             name={id}
             isDisabled={this.props.isDisabled}
             className="react-select-container"


### PR DESCRIPTION
Allow select widget to reset when the incoming props change. The react-select widget has its own internal state, so if you initialise the widget without choices, then populate the choices, it wouldn't properly show the default value (which is the value that's saved as the field value).

I've only done this for the react-select Select Widget, I haven't tested with the async widget.