### PR TITLE
Fix bug in auto select sidebar tab by block, on mount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugfix
 
 - Japanese translation updated @terapyon
+- Fix regression in setting selected sidebar tab by blocks @tiberiuichim
 
 ### Internal
 

--- a/src/components/manage/Blocks/Block/Edit.jsx
+++ b/src/components/manage/Blocks/Block/Edit.jsx
@@ -81,7 +81,7 @@ class Edit extends Component {
     }
     const tab = this.props.manage
       ? 1
-      : blocks.blocksConfig?.[type]?.sidebarBar || 0;
+      : blocks.blocksConfig?.[type]?.sidebarTab || 0;
     if (this.props.selected) {
       this.props.setSidebarTab(tab);
     }


### PR DESCRIPTION
Appears to be a regression somewhere.