### PR TITLE
Test if content exists in ListingBody, for addon Dropdownmenu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Test if content exists in ListingBody, for addon Dropdownmenu @giuliaghisini
+
 ### Internal
 
 ## 8.2.3 (2020-10-07)

--- a/src/components/manage/Blocks/Listing/ListingBody.jsx
+++ b/src/components/manage/Blocks/Listing/ListingBody.jsx
@@ -46,7 +46,7 @@ const ListingBody = ({ data, properties, intl, path, isEditMode }) => {
     /* eslint-disable react-hooks/exhaustive-deps */
   }, [data]);
 
-  const folderItems = content.is_folderish ? content.items : [];
+  const folderItems = content?.is_folderish ? content.items : [];
 
   const loadingQuery =
     data?.query?.length > 0 && querystringResults?.[data.block]?.loading;
@@ -97,7 +97,7 @@ const ListingBody = ({ data, properties, intl, path, isEditMode }) => {
             {...data}
           />
           {data?.query?.length === 0 &&
-            content.items_total > settings.defaultPageSize && (
+            content?.items_total > settings.defaultPageSize && (
               <div className="pagination-wrapper">
                 <Pagination
                   activePage={currentPage}


### PR DESCRIPTION
When you use addon dropdownmenu, you can add some blocks into a dropdown menu. 
If you add some blocks and you try to access a non published content in private mode, an error is thrown because ListingBody expects a content to check if there's some items inside. 

With this fix, ListingBody could work without 'content'