### PR TITLE
Fix runtimeConfig relative vs absolute import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Internal
 
 - Translation @ksuess
+- Fix runtimeConfig relative vs absolute import @avoinea
 
 ## 8.5.1-alpha.0 (2020-10-19)
 

--- a/src/helpers/Html/Html.jsx
+++ b/src/helpers/Html/Html.jsx
@@ -9,7 +9,7 @@ import { Helmet } from '@plone/volto/helpers';
 import serialize from 'serialize-javascript';
 import { join } from 'lodash';
 import { BodyClass } from '@plone/volto/helpers';
-import { runtimeConfig } from '../../runtime_config';
+import { runtimeConfig } from '@plone/volto/runtime_config';
 
 /**
  * Html class.


### PR DESCRIPTION
This will allow runtime_config customization via volto-project / addons