### PR TITLE
Return 404 on SSR, when appropriate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Properly return 404 in server response, when appropriate @tiberiuichim
+
 ### Internal
 
 ## 8.5.3 (2020-10-22)

--- a/src/components/theme/App/App.jsx
+++ b/src/components/theme/App/App.jsx
@@ -142,7 +142,9 @@ class App extends Component {
                   stackTrace={this.state.errorInfo.componentStack}
                 />
               ) : (
-                renderRoutes(this.props.route.routes)
+                renderRoutes(this.props.route.routes, {
+                  serverStaticContext: this.props.staticContext,
+                })
               )}
             </main>
           </Segment>

--- a/src/components/theme/Error/Error.jsx
+++ b/src/components/theme/Error/Error.jsx
@@ -9,7 +9,8 @@ import { views } from '~/config';
  * @function Unauthorized
  * @returns {string} Markup of the unauthorized page.
  */
-const Error = ({ error }) => {
+const Error = (props) => {
+  const { error } = props;
   let FoundView;
   if (error.status === undefined) {
     // For some reason, while development and if CORS is in place and the
@@ -24,7 +25,7 @@ const Error = ({ error }) => {
   }
   return (
     <div id="view">
-      <FoundView />
+      <FoundView {...props} />
     </div>
   );
 };

--- a/src/components/theme/NotFound/NotFound.jsx
+++ b/src/components/theme/NotFound/NotFound.jsx
@@ -8,45 +8,54 @@ import { FormattedMessage } from 'react-intl';
 import { Link } from 'react-router-dom';
 import { Container } from 'semantic-ui-react';
 
+global.__SERVER__ = false; // eslint-disable-line no-underscore-dangle
+
 /**
  * Not found function.
  * @function NotFound
  * @returns {string} Markup of the not found page.
  */
-const NotFound = () => (
-  <Container className="view-wrapper">
-    <h1>
-      <FormattedMessage
-        id="This page does not seem to exist…"
-        defaultMessage="This page does not seem to exist…"
-      />
-    </h1>
-    <p className="description">
-      <FormattedMessage
-        id="We apologize for the inconvenience, but the page you were trying to access is not at this address. You can use the links below to help you find what you are looking for."
-        defaultMessage="We apologize for the inconvenience, but the page you were trying to access is not at this address. You can use the links below to help you find what you are looking for."
-      />
-    </p>
-    <p>
-      <FormattedMessage
-        id="If you are certain you have the correct web address but are encountering an error, please contact the {site_admin}."
-        defaultMessage="If you are certain you have the correct web address but are encountering an error, please contact the {site_admin}."
-        values={{
-          site_admin: (
-            <Link to="/contact-form">
-              <FormattedMessage
-                id="Site Administration"
-                defaultMessage="Site Administration"
-              />
-            </Link>
-          ),
-        }}
-      />
-    </p>
-    <p>
-      <FormattedMessage id="Thank you." defaultMessage="Thank you." />
-    </p>
-  </Container>
-);
+const NotFound = (props) => {
+  if (__SERVER__ && props.serverStaticContext) {
+    const { serverStaticContext } = props;
+    serverStaticContext.is404 = true;
+    serverStaticContext.error = props.error;
+  }
+  return (
+    <Container className="view-wrapper">
+      <h1>
+        <FormattedMessage
+          id="This page does not seem to exist…"
+          defaultMessage="This page does not seem to exist…"
+        />
+      </h1>
+      <p className="description">
+        <FormattedMessage
+          id="We apologize for the inconvenience, but the page you were trying to access is not at this address. You can use the links below to help you find what you are looking for."
+          defaultMessage="We apologize for the inconvenience, but the page you were trying to access is not at this address. You can use the links below to help you find what you are looking for."
+        />
+      </p>
+      <p>
+        <FormattedMessage
+          id="If you are certain you have the correct web address but are encountering an error, please contact the {site_admin}."
+          defaultMessage="If you are certain you have the correct web address but are encountering an error, please contact the {site_admin}."
+          values={{
+            site_admin: (
+              <Link to="/contact-form">
+                <FormattedMessage
+                  id="Site Administration"
+                  defaultMessage="Site Administration"
+                />
+              </Link>
+            ),
+          }}
+        />
+      </p>
+      <p>
+        <FormattedMessage id="Thank you." defaultMessage="Thank you." />
+      </p>
+    </Container>
+  );
+};
 
 export default NotFound;

--- a/src/components/theme/NotFound/NotFound.server.test.jsx
+++ b/src/components/theme/NotFound/NotFound.server.test.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import configureStore from 'redux-mock-store';
+import { Provider } from 'react-intl-redux';
+import { MemoryRouter } from 'react-router-dom';
+
+import NotFound from './NotFound';
+
+global.__SERVER__ = true; // eslint-disable-line no-underscore-dangle
+
+const mockStore = configureStore();
+
+describe('NotFound', () => {
+  it('renders a not found component', () => {
+    const store = mockStore({
+      intl: {
+        locale: 'en',
+        messages: {},
+      },
+    });
+    const component = renderer.create(
+      <Provider store={store}>
+        <MemoryRouter>
+          <NotFound />
+        </MemoryRouter>
+      </Provider>,
+    );
+    const json = component.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+});

--- a/src/components/theme/NotFound/__snapshots__/NotFound.server.test.jsx.snap
+++ b/src/components/theme/NotFound/__snapshots__/NotFound.server.test.jsx.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NotFound renders a not found component 1`] = `
+<div
+  className="ui container view-wrapper"
+>
+  <h1>
+    This page does not seem to exist…
+  </h1>
+  <p
+    className="description"
+  >
+    We apologize for the inconvenience, but the page you were trying to access is not at this address. You can use the links below to help you find what you are looking for.
+  </p>
+  <p>
+    If you are certain you have the correct web address but are encountering an error, please contact the 
+    <a
+      href="/contact-form"
+      onClick={[Function]}
+    >
+      Site Administration
+    </a>
+    .
+  </p>
+  <p>
+    Thank you.
+  </p>
+</div>
+`;

--- a/src/components/theme/View/View.jsx
+++ b/src/components/theme/View/View.jsx
@@ -211,7 +211,7 @@ class View extends Component {
       }
       return (
         <div id="view">
-          <FoundView />
+          <FoundView {...this.props} />
         </div>
       );
     }

--- a/src/server.jsx
+++ b/src/server.jsx
@@ -16,6 +16,7 @@ import { ChunkExtractor, ChunkExtractorManager } from '@loadable/server';
 import { createProxyMiddleware } from 'http-proxy-middleware';
 import { updateIntl } from 'react-intl-redux';
 import { resetServerContext } from 'react-beautiful-dnd';
+import NotFoundView from '@plone/volto/components/theme/NotFound/NotFound';
 
 import routes from '~/routes';
 import { settings } from '~/config';
@@ -174,6 +175,25 @@ server
 
           if (context.url) {
             res.redirect(context.url);
+          } else if (context.is404) {
+            const error = context.error || {};
+            const errorPage = (
+              <Provider store={store}>
+                <StaticRouter context={{}} location={req.url}>
+                  <NotFoundView message={error.message} />
+                </StaticRouter>
+              </Provider>
+            );
+            res.set({
+              'Cache-Control': 'public, max-age=60, no-transform',
+            });
+
+            // Displays error in console
+            console.error(error);
+
+            res
+              .status(404)
+              .send(`<!doctype html> ${renderToString(errorPage)}`);
           } else {
             res.status(200).send(
               `<!doctype html>


### PR DESCRIPTION
Caveat: I haven't changed the 404 component and I've tried to reuse the DefaultView wrapper around it, to show the "site", but that does not work well because there's too much stuff missing. I think we should change the 404 component to include a link to the website root.

![Screenshot 2020-10-23 060437](https://user-images.githubusercontent.com/141568/96951726-ccc5f300-14f5-11eb-9aaf-933562a6cc9e.png)

I think we might want to handle the other error pages like this, 404 is priority right now for me.