### PR TITLE
fixed bug in render lists in draftjs, when there's some styles inside…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 8.5.4 (unreleased)
 
+- fixed bug in render lists in draftjs, when there's some styles inside list-item (links or bold text ecc..) @giuliaghisini
+
 ### Breaking
 
 ### Feature
@@ -57,7 +59,7 @@
 ### Bugfix
 
 - Errors catched by the default error handler are sent to sentry @zotya
-- Fixed a problem what occured when RAZZLE_SENTRY_DSN was missing but the other RAZZLE_SENTRY_* variables were set @zotya
+- Fixed a problem what occured when RAZZLE*SENTRY_DSN was missing but the other RAZZLE_SENTRY*\* variables were set @zotya
 
 ### Internal
 

--- a/src/config/RichTextEditor/ToHTML.jsx
+++ b/src/config/RichTextEditor/ToHTML.jsx
@@ -80,19 +80,25 @@ const splitSoftLinesOfLists = (children) =>
   children.map((child, index) => {
     return (
       <li key={index}>
-        {child[1].map((subchild) => {
-          if (typeof subchild === 'string') {
-            const last = subchild.split('\n').length - 1;
-            return subchild.split('\n').map((item, index) => (
-              <React.Fragment key={index}>
-                {item}
-                {index !== last && <br />}
-              </React.Fragment>
-            ));
-          } else {
-            return subchild;
-          }
-        })}
+        {Array.isArray(child[1]) ? (
+          <>
+            {child[1].map((subchild) => {
+              if (typeof subchild === 'string') {
+                const last = subchild.split('\n').length - 1;
+                return subchild.split('\n').map((item, index) => (
+                  <React.Fragment key={index}>
+                    {item}
+                    {index !== last && <br />}
+                  </React.Fragment>
+                ));
+              } else {
+                return subchild;
+              }
+            })}
+          </>
+        ) : (
+          child[1]
+        )}
       </li>
     );
   });


### PR DESCRIPTION
… list-item (links or bold text ecc..)

Before this fix, if you create a text-block, create list inside text block, add some styles or link to an element, a error was thrown.
For example:

- [Link1](http://www.google.it)
- [Link2](http://www.google.it)
- Text **bold**

Fixed this. 