### PR TITLE
Allow customization of piped resources from the backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Feature
 
 - Enabling support for the new active LTS NodeJS version 14. NodeJS 10 eol will happen on 2021-04-30 and Volto will update accordingly. More information on https://nodejs.org/en/about/releases @sneridagh
+- Add `settings.backendResourceMatch` to allow handling of backend resources similar to `@@images` or `@@download` @tiberiuichim
 
 ### Bugfix
 

--- a/docs/source/configuration/settings-reference.md
+++ b/docs/source/configuration/settings-reference.md
@@ -5,11 +5,29 @@ This is a summary of all the configuration options and what they control.
 !!! note
     This list is still incomplete, contributions are welcomed!
 
-# navDepth
+## navDepth
 
 Navigation levels depth used in the navigation endpoint calls. Increasing this is useful
 for implementing fat navigation menus. Defaults to `1`.
 
-# defaultBlockType
+## defaultBlockType
 
 The default block type in Volto is "text", which uses the current DraftJS-based implementation for the rich text editor. Future alternative rich text editors will need to use this setting and replace it with their block type. The block definition should also include the `blockHasValue` function, which is needed to activate the Block Chooser functionality. See this function signature in [Blocks > Settings](../blocks/settings.md).
+
+## backendResourceMatch
+
+The Volto Express server, by default, pipes some requests from the backend, for
+example image and file transfers, denoted by paths such as `@@images` or
+`@download`. This setting enables adding additional such paths. This is a list
+of "matchers", functions that receive the Express server request and return
+true if the request should be piped to the backend server.
+
+For example, if we'd like to pipe a request such as
+`http://localhost:8080/Plone/something/@@ics`, we'd write a matcher like:
+
+```jsx
+settings.backendResourceMatch = [
+  ...backendResourceMatch,
+  (request) => request.path.match(/(.*)\/@@ics/)
+]
+```

--- a/src/server.jsx
+++ b/src/server.jsx
@@ -70,6 +70,11 @@ if (__DEVELOPMENT__ && settings.devProxyToApiPath) {
 if ((settings.expressMiddleware || []).length)
   server.use('/', settings.expressMiddleware);
 
+const defaultResources = [
+  /(.*)\/@@images\/(.*)/,
+  /(.*)\/@@download\/(.*)/,
+].map((r) => (req) => req.path.match(r));
+
 /**
  * Returns true if the request should be piped from the backend.
  *
@@ -79,13 +84,12 @@ if ((settings.expressMiddleware || []).length)
  * @param {} request
  */
 function isBackendResource(request) {
-  const defaultResources = [/(.*)\/@@images\/(.*)/, /(.*)\/@@download\/(.*)/];
-  const toMatch = [
-    ...defaultResources.map((r) => (req) => req.path.match(r)),
-    ...(settings.backendResourceMatch || []),
-  ];
-
-  return toMatch.findIndex((m) => m(request)) > -1;
+  return (
+    [
+      ...defaultResources,
+      ...(settings.backendResourceMatch || []),
+    ].findIndex((m) => m(request)) > -1
+  );
 }
 
 server


### PR DESCRIPTION
Introduce `settings.backendResourceMatch`. This enables additional "backend pipes" that are treated similar to ``@@images`` and ``@@downloads``