### PR TITLE
Fix default target for links in text blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Bugfix
 
+- Fix default target for links in text blocks @giuliaghisini
+
 ### Internal
 
 ## 8.7.1 (2020-10-29)

--- a/src/config/RichTextEditor/ToHTML.jsx
+++ b/src/config/RichTextEditor/ToHTML.jsx
@@ -222,7 +222,7 @@ const blocks = {
 
 const LinkEntity = connect((state) => ({
   token: state.userSession.token,
-}))(({ token, key, url, target = '_blank', targetUrl, download, children }) => {
+}))(({ token, key, url, target, targetUrl, download, children }) => {
   const to = token ? url : targetUrl || url;
 
   return (


### PR DESCRIPTION
Removed default target for link in LinkEntity for text blocks, because was causing internal link to open in new tab.