### PR TITLE
Refactoring FileWidget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Internal
 
+- Refactoring FileWidget @iFlameing
+
 ## 8.9.1 (2020-11-06)
 
 ### Bugfix

--- a/src/components/manage/Preferences/__snapshots__/PersonalInformation.test.jsx.snap
+++ b/src/components/manage/Preferences/__snapshots__/PersonalInformation.test.jsx.snap
@@ -180,20 +180,24 @@ exports[`PersonalInformation renders a personal information component 1`] = `
                   </div>
                   <label
                     className="label-file-widget-input"
-                    htmlFor="field-portrait"
                   >
                     Choose a File/Image
                   </label>
-                  <div
-                    className="ui input file-widget-input"
-                  >
-                    <input
-                      id="field-portrait"
-                      name="portrait"
-                      onChange={[Function]}
-                      type="file"
-                    />
-                  </div>
+                  <input
+                    autoComplete="off"
+                    id="field-portrait"
+                    multiple={true}
+                    name="portrait"
+                    onChange={[Function]}
+                    onClick={[Function]}
+                    style={
+                      Object {
+                        "display": "none",
+                      }
+                    }
+                    tabIndex={-1}
+                    type="file"
+                  />
                 </div>
                 <div
                   className="field-file-name"
@@ -572,20 +576,24 @@ exports[`PersonalInformation renders a personal information component embedded i
                   </div>
                   <label
                     className="label-file-widget-input"
-                    htmlFor="field-portrait"
                   >
                     Choose a File/Image
                   </label>
-                  <div
-                    className="ui input file-widget-input"
-                  >
-                    <input
-                      id="field-portrait"
-                      name="portrait"
-                      onChange={[Function]}
-                      type="file"
-                    />
-                  </div>
+                  <input
+                    autoComplete="off"
+                    id="field-portrait"
+                    multiple={true}
+                    name="portrait"
+                    onChange={[Function]}
+                    onClick={[Function]}
+                    style={
+                      Object {
+                        "display": "none",
+                      }
+                    }
+                    tabIndex={-1}
+                    type="file"
+                  />
                 </div>
                 <div
                   className="field-file-name"

--- a/src/components/manage/Widgets/__snapshots__/FileWidget.test.jsx.snap
+++ b/src/components/manage/Widgets/__snapshots__/FileWidget.test.jsx.snap
@@ -51,20 +51,24 @@ Array [
             </div>
             <label
               className="label-file-widget-input"
-              htmlFor="field-my-field"
             >
               Choose a File/Image
             </label>
-            <div
-              className="ui input file-widget-input"
-            >
-              <input
-                id="field-my-field"
-                name="my-field"
-                onChange={[Function]}
-                type="file"
-              />
-            </div>
+            <input
+              autoComplete="off"
+              id="field-my-field"
+              multiple={true}
+              name="my-field"
+              onChange={[Function]}
+              onClick={[Function]}
+              style={
+                Object {
+                  "display": "none",
+                }
+              }
+              tabIndex={-1}
+              type="file"
+            />
           </div>
           <div
             className="field-file-name"

--- a/theme/themes/pastanaga/extras/main.less
+++ b/theme/themes/pastanaga/extras/main.less
@@ -374,15 +374,13 @@ button {
 
 .dropzone-placeholder {
   width: 100%;
-  height: 60px;
+  padding: 20px;
   border: 2px dashed #c7d5d8;
   margin-top: 20px;
 }
 
 .dropzone-text {
   height: 100%;
-  line-height: 60px;
-  overflow-y: scroll;
   text-align: center;
 }
 

--- a/theme/themes/pastanaga/extras/main.less
+++ b/theme/themes/pastanaga/extras/main.less
@@ -361,10 +361,6 @@ button {
   margin-top: 20px;
 }
 
-.ui.input.file-widget-input {
-  display: none;
-}
-
 .label-file-widget-input {
   display: inline-block;
   padding: 7px 10px;
@@ -386,6 +382,7 @@ button {
 .dropzone-text {
   height: 100%;
   line-height: 60px;
+  overflow-y: scroll;
   text-align: center;
 }
 


### PR DESCRIPTION
@sneridagh I found out that in react-dropzone if we don't provide onChange to input it will use onDrop handler for request. So, I remove the onChange handler for the input. I also found that we are using semantic input which might don't work for some case. And also react-dropzone uses browser Input tag. I have just deleted the unnecessary code.