### PR TITLE
Fix leaking input CSS in the link widget in draftjs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Fix leaking input CSS in the link widget in draftjs @sneridagh
+
 ### Internal
 
 - Move Guillotina CI job to GH actions @sneridagh

--- a/src/components/manage/AnchorPlugin/components/LinkButton/AddLinkForm.jsx
+++ b/src/components/manage/AnchorPlugin/components/LinkButton/AddLinkForm.jsx
@@ -272,7 +272,7 @@ class AddLinkForm extends Component {
                       this.clear();
                     }}
                   >
-                    <Icon name={clearSVG} size="30px" />
+                    <Icon name={clearSVG} size="24px" />
                   </Button>
                 </Button.Group>
               ) : (
@@ -308,7 +308,7 @@ class AddLinkForm extends Component {
                     this.onSubmit();
                   }}
                 >
-                  <Icon name={aheadSVG} size="30px" />
+                  <Icon name={aheadSVG} size="24px" />
                 </Button>
               </Button.Group>
             </div>

--- a/theme/themes/pastanaga/extras/blocks.less
+++ b/theme/themes/pastanaga/extras/blocks.less
@@ -602,6 +602,11 @@ body.has-toolbar.has-sidebar-collapsed .ui.wrapper > .ui.inner.block.full {
 }
 
 .link-form-container {
+  .inline.field .wrapper {
+    min-height: initial;
+    border-bottom: none;
+  }
+
   button {
     padding: 0;
     border: 0;


### PR DESCRIPTION
<img width="481" alt="image" src="https://user-images.githubusercontent.com/486927/99059990-a567c080-259f-11eb-9fd3-911bf0e8600d.png">
