### PR TITLE
Fix Sentry tags and extra via settings.sentryOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Fix Sentry tags and extra via settings.sentryOptions @avoinea
+
 ### Internal
 
 ## 9.0.0 (2020-11-15)

--- a/src/sentry.js
+++ b/src/sentry.js
@@ -72,6 +72,12 @@ const initSentry = (Sentry) => {
       });
     }
     Sentry.init(sentry_options);
+    if (sentry_options?.tags) {
+      Sentry.setTags(sentry_options.tags);
+    }
+    if (sentry_options?.extras) {
+      Sentry.setExtras(sentry_options.extras);
+    }
 
     if (sentry_config?.SENTRY_CONFIG !== undefined) {
       if (sentry_config?.SENTRY_CONFIG?.tags !== undefined) {


### PR DESCRIPTION
Fix #1986 to also `setTags` and `setExtra` via `~config` settings.sentryOptions