### PR TITLE
Add extendible AppExtras

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### Feature
 
+- Enhance `AppExtras` component to make it pluggable and lookup a new
+  `~/config` export, the `appExtras`. These are router-path filtered components
+  that are rendered inside the `AppExtras` component @tiberiuichim
+
 ### Bugfix
 
 ### Internal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@
 
 ### Feature
 
-- Enhance `AppExtras` component to make it pluggable and lookup a new
-  `~/config` export, the `appExtras`. These are router-path filtered components
-  that are rendered inside the `AppExtras` component @tiberiuichim
+- Enhance `AppExtras` component to make it pluggable through the
+  `config.settings.appExtras`. These are router-path filtered components that
+  are rendered inside the `AppExtras` component @tiberiuichim
 
 ### Bugfix
 

--- a/docs/source/recipes/appextras.md
+++ b/docs/source/recipes/appextras.md
@@ -8,11 +8,11 @@ component.
 ## How to use it
 
 You can either use it by overriding it via Component Shadowing by placing
-a custom `src/customizations/components/theme/AppExtras/AppExtras.jsx`.
+a custom `src/customizations/components/theme/AppExtras/AppExtras.jsx`...
 
-Or you can use the new export of `~/config`, the `appExtras`. This is a list of
-registrations, each registration is an object with `match` and `component`. The
-`match` key is for objects compatible with [react-router's
+Or you can use the new key of `config.settings`, the `appExtras`. This is
+a list of registrations, each registration is an object with `match` and
+`component`. The `match` key is for objects compatible with [react-router's
 matchPath](https://reactrouter.com/web/api/matchPath), so it can be either
 a simple string or a match object. Use the `component` to link the component to
 be used.
@@ -20,26 +20,29 @@ be used.
 For example:
 
 ``` jsx
-import { appExtras as defaultAppExtras } from '@plone/volto/config'
+import { settings as defaultSettings } from '@plone/volto/config'
 
-export appExtras = [
-  ...appExtras,
-  {
-    match: '',
-    component: GoogleAnalyticsPing
-  },
-  {
-    match: {
-      path: '/blogs',
-      exact: true,
+export settings = {
+  ...defaultSettings,
+  appExtras: [
+    ...defaultSettings.appExtras,
+    {
+      match: '',
+      component: GoogleAnalyticsPing
     },
-    component: WordClouds
-  },
-  {
-    path: '/blog/**/edit',
-    component: ExtraToolbarButton,
-  }
-]
+    {
+      match: {
+        path: '/blogs',
+        exact: true,
+      },
+      component: WordClouds
+    },
+    {
+      path: '/blog/**/edit',
+      component: ExtraToolbarButton,
+    }
+  ]
+}
 ```
 
 You can use this to render, for example, `<Portal>` components to be inserted

--- a/docs/source/recipes/appextras.md
+++ b/docs/source/recipes/appextras.md
@@ -11,11 +11,13 @@ You can either use it by overriding it via Component Shadowing by placing
 a custom `src/customizations/components/theme/AppExtras/AppExtras.jsx`...
 
 Or you can use the new key of `config.settings`, the `appExtras`. This is
-a list of registrations, each registration is an object with `match` and
-`component`. The `match` key is for objects compatible with [react-router's
+a list of registrations, each registration is an object with:
+
+- `match`: The `match` key is for objects compatible with [react-router's
 matchPath](https://reactrouter.com/web/api/matchPath), so it can be either
-a simple string or a match object. Use the `component` to link the component to
-be used.
+a simple string or a match object.
+- `component`. Use the `component` to link the component to be used.
+- `props`: Extra props to be inject to the actual component used.
 
 For example:
 

--- a/docs/source/recipes/appextras.md
+++ b/docs/source/recipes/appextras.md
@@ -31,6 +31,9 @@ export settings = {
     {
       match: '',
       component: GoogleAnalyticsPing
+      props: {
+        'google-tag': '123456'
+      }
     },
     {
       match: {

--- a/docs/source/recipes/appextras.md
+++ b/docs/source/recipes/appextras.md
@@ -1,9 +1,46 @@
 # AppExtras component
 
-The `AppExtras` component is a general use insertion point for things like analytics,
-general purpose code spanning the whole application or third party services code. Using
-it you can avoid to have to override `App.jsx` component.
+The `AppExtras` component is a general use insertion point for things like
+analytics, general purpose code spanning the whole application or third party
+services code. AppExtras component inserts will be rendered by the `App`
+component.
 
 ## How to use it
 
-You can use it by overriding it via Component Shadowing by placing a custom `src/customizations/components/theme/AppExtras/AppExtras.jsx`.
+You can either use it by overriding it via Component Shadowing by placing
+a custom `src/customizations/components/theme/AppExtras/AppExtras.jsx`.
+
+Or you can use the new export of `~/config`, the `appExtras`. This is a list of
+registrations, each registration is an object with `match` and `component`. The
+`match` key is for objects compatible with [react-router's
+matchPath](https://reactrouter.com/web/api/matchPath), so it can be either
+a simple string or a match object. Use the `component` to link the component to
+be used.
+
+For example:
+
+``` jsx
+import { appExtras as defaultAppExtras } from '@plone/volto/config'
+
+export appExtras = [
+  ...appExtras,
+  {
+    match: '',
+    component: GoogleAnalyticsPing
+  },
+  {
+    match: {
+      path: '/blogs',
+      exact: true,
+    },
+    component: WordClouds
+  },
+  {
+    path: '/blog/**/edit',
+    component: ExtraToolbarButton,
+  }
+]
+```
+
+You can use this to render, for example, `<Portal>` components to be inserted
+somewhere in the website.

--- a/src/components/theme/App/App.jsx
+++ b/src/components/theme/App/App.jsx
@@ -163,7 +163,7 @@ class App extends Component {
             />
           }
         />
-        <AppExtras />
+        <AppExtras {...this.props} />
       </Fragment>
     );
   }

--- a/src/components/theme/AppExtras/AppExtras.jsx
+++ b/src/components/theme/AppExtras/AppExtras.jsx
@@ -13,9 +13,11 @@ const AppExtras = (props) => {
     })
     .filter((reg) => reg);
 
-  return active.map(({ reg: { component }, match }, i) => {
+  return active.map(({ reg: { component, props: extraProps }, match }, i) => {
     const Insert = component;
-    return <Insert key={`appextra-${i}`} match={match} {...props} />;
+    return (
+      <Insert key={`appextra-${i}`} match={match} {...props} {...extraProps} />
+    );
   });
 };
 

--- a/src/components/theme/AppExtras/AppExtras.jsx
+++ b/src/components/theme/AppExtras/AppExtras.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { matchPath } from 'react-router';
 
-import * as config from '~/config';
+import { settings } from '~/config';
 
 const AppExtras = (props) => {
-  const { appExtras = [] } = config;
+  const { appExtras = [] } = settings;
   const { pathname } = props;
   const active = appExtras
     .map((reg) => {

--- a/src/components/theme/AppExtras/AppExtras.jsx
+++ b/src/components/theme/AppExtras/AppExtras.jsx
@@ -1,5 +1,22 @@
-const AppExtras = () => {
-  return null;
+import React from 'react';
+import { matchPath } from 'react-router';
+
+import * as config from '~/config';
+
+const AppExtras = (props) => {
+  const { appExtras = [] } = config;
+  const { pathname } = props;
+  const active = appExtras
+    .map((reg) => {
+      const match = matchPath(pathname, reg.match);
+      return match ? { reg, match } : null;
+    })
+    .filter((reg) => reg);
+
+  return active.map(({ reg: { component }, match }, i) => {
+    const Insert = component;
+    return <Insert key={`appextra-${i}`} match={match} {...props} />;
+  });
 };
 
 export default AppExtras;

--- a/src/components/theme/AppExtras/AppExtras.test.jsx
+++ b/src/components/theme/AppExtras/AppExtras.test.jsx
@@ -3,45 +3,46 @@ import renderer from 'react-test-renderer';
 import AppExtras from './AppExtras';
 
 jest.mock('~/config', () => ({
-  settings: {},
   views: {},
-  appExtras: [
-    {
-      match: {
-        path: '',
+  settings: {
+    appExtras: [
+      {
+        match: {
+          path: '',
+        },
+        component: jest.fn((props) => (
+          <div className="everywhere">{props.pathname}</div>
+        )),
       },
-      component: jest.fn((props) => (
-        <div className="everywhere">{props.pathname}</div>
-      )),
-    },
-    {
-      match: {
-        path: '/all-blogs/*',
+      {
+        match: {
+          path: '/all-blogs/*',
+        },
+        component: jest.fn((props) => <div className="blog-listing" />),
       },
-      component: jest.fn((props) => <div className="blog-listing" />),
-    },
-    {
-      match: {
-        path: '/blog/edit',
+      {
+        match: {
+          path: '/blog/edit',
+        },
+        component: jest.fn((props) => <div className="blog-edit" />),
       },
-      component: jest.fn((props) => <div className="blog-edit" />),
-    },
-    {
-      match: {
-        path: '/blog',
-        exact: true,
+      {
+        match: {
+          path: '/blog',
+          exact: true,
+        },
+        component: jest.fn((props) => (
+          <div className="blog-view">{JSON.stringify(props.match)}</div>
+        )),
       },
-      component: jest.fn((props) => (
-        <div className="blog-view">{JSON.stringify(props.match)}</div>
-      )),
-    },
-    {
-      match: '/something',
-      component: jest.fn((props) => (
-        <div className="something">{JSON.stringify(props.match)}</div>
-      )),
-    },
-  ],
+      {
+        match: '/something',
+        component: jest.fn((props) => (
+          <div className="something">{JSON.stringify(props.match)}</div>
+        )),
+      },
+    ],
+  },
 }));
 
 describe('AppExtras', () => {

--- a/src/components/theme/AppExtras/AppExtras.test.jsx
+++ b/src/components/theme/AppExtras/AppExtras.test.jsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import AppExtras from './AppExtras';
+
+jest.mock('~/config', () => ({
+  settings: {},
+  views: {},
+  appExtras: [
+    {
+      match: {
+        path: '',
+      },
+      component: jest.fn((props) => (
+        <div className="everywhere">{props.pathname}</div>
+      )),
+    },
+    {
+      match: {
+        path: '/all-blogs/*',
+      },
+      component: jest.fn((props) => <div className="blog-listing" />),
+    },
+    {
+      match: {
+        path: '/blog/edit',
+      },
+      component: jest.fn((props) => <div className="blog-edit" />),
+    },
+    {
+      match: {
+        path: '/blog',
+        exact: true,
+      },
+      component: jest.fn((props) => (
+        <div className="blog-view">{JSON.stringify(props.match)}</div>
+      )),
+    },
+    {
+      match: '/something',
+      component: jest.fn((props) => (
+        <div className="something">{JSON.stringify(props.match)}</div>
+      )),
+    },
+  ],
+}));
+
+describe('AppExtras', () => {
+  it('renders one app extras registered on empty string', () => {
+    const component = renderer.create(<AppExtras pathname="/"></AppExtras>);
+    const json = component.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('renders 2 app extras on specific path /blog/edit', () => {
+    const component = renderer.create(
+      <AppExtras pathname="/blog/edit"></AppExtras>,
+    );
+    const json = component.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('renders other 2 app extras on exact path /blog', () => {
+    const component = renderer.create(<AppExtras pathname="/blog"></AppExtras>);
+    const json = component.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('can take string path as match', () => {
+    const component = renderer.create(
+      <AppExtras pathname="/something"></AppExtras>,
+    );
+    const json = component.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+});

--- a/src/components/theme/AppExtras/AppExtras.test.jsx
+++ b/src/components/theme/AppExtras/AppExtras.test.jsx
@@ -18,7 +18,13 @@ jest.mock('~/config', () => ({
         match: {
           path: '/all-blogs/*',
         },
-        component: jest.fn((props) => <div className="blog-listing" />),
+        component: jest.fn((props) => (
+          <div className="blog-listing" one={props.one} three={props.three} />
+        )),
+        props: {
+          one: 'two',
+          three: 'four',
+        },
       },
       {
         match: {
@@ -69,6 +75,14 @@ describe('AppExtras', () => {
   it('can take string path as match', () => {
     const component = renderer.create(
       <AppExtras pathname="/something"></AppExtras>,
+    );
+    const json = component.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('can take string extra parameters to be used from the actual component', () => {
+    const component = renderer.create(
+      <AppExtras pathname="/all-blogs/1"></AppExtras>,
     );
     const json = component.toJSON();
     expect(json).toMatchSnapshot();

--- a/src/components/theme/AppExtras/__snapshots__/AppExtras.test.jsx.snap
+++ b/src/components/theme/AppExtras/__snapshots__/AppExtras.test.jsx.snap
@@ -1,5 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`AppExtras can take string extra parameters to be used from the actual component 1`] = `
+Array [
+  <div
+    className="everywhere"
+  >
+    /all-blogs/1
+  </div>,
+  <div
+    className="blog-listing"
+    one="two"
+    three="four"
+  />,
+]
+`;
+
 exports[`AppExtras can take string path as match 1`] = `
 Array [
   <div

--- a/src/components/theme/AppExtras/__snapshots__/AppExtras.test.jsx.snap
+++ b/src/components/theme/AppExtras/__snapshots__/AppExtras.test.jsx.snap
@@ -1,0 +1,52 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AppExtras can take string path as match 1`] = `
+Array [
+  <div
+    className="everywhere"
+  >
+    /something
+  </div>,
+  <div
+    className="something"
+  >
+    {"path":"/something","url":"/something","isExact":true,"params":{}}
+  </div>,
+]
+`;
+
+exports[`AppExtras renders 2 app extras on specific path /blog/edit 1`] = `
+Array [
+  <div
+    className="everywhere"
+  >
+    /blog/edit
+  </div>,
+  <div
+    className="blog-edit"
+  />,
+]
+`;
+
+exports[`AppExtras renders one app extras registered on empty string 1`] = `
+<div
+  className="everywhere"
+>
+  /
+</div>
+`;
+
+exports[`AppExtras renders other 2 app extras on exact path /blog 1`] = `
+Array [
+  <div
+    className="everywhere"
+  >
+    /blog
+  </div>,
+  <div
+    className="blog-view"
+  >
+    {"path":"/blog","url":"/blog","isExact":true,"params":{}}
+  </div>,
+]
+`;

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -101,6 +101,7 @@ let config = {
 
   addonRoutes: [],
   addonReducers: {},
+  appExtras: [],
 };
 
 config = applyAddonConfiguration(config);
@@ -111,3 +112,4 @@ export const views = config.views;
 export const blocks = config.blocks;
 export const addonRoutes = [...config.addonRoutes];
 export const addonReducers = { ...config.addonReducers };
+export const appExtras = config.appExtras;


### PR DESCRIPTION
# AppExtras component

The `AppExtras` component is a general use insertion point for things like
analytics, general purpose code spanning the whole application or third party
services code. AppExtras component inserts will be rendered by the `App`
component.

## How to use it

You can either use it by overriding it via Component Shadowing by placing
a custom `src/customizations/components/theme/AppExtras/AppExtras.jsx`...

Or you can use the new key of `config.settings`, the `appExtras`. This is
a list of registrations, each registration is an object with:

- `match`: The `match` key is for objects compatible with [react-router's
matchPath](https://reactrouter.com/web/api/matchPath), so it can be either
a simple string or a match object.
- `component`. Use the `component` to link the component to be used.
- `props`: Extra props to be inject to the actual component used.

For example:

``` jsx
import { settings as defaultSettings } from '@plone/volto/config'

export settings = {
  ...defaultSettings,
  appExtras: [
    ...defaultSettings.appExtras,
    {
      match: '',
      component: GoogleAnalyticsPing
      props: {
        'google-tag': '123456'
      }
    },
    {
      match: {
        path: '/blogs',
        exact: true,
      },
      component: WordClouds
    },
    {
      path: '/blog/**/edit',
      component: ExtraToolbarButton,
    }
  ]
}
```

You can use this to render, for example, `<Portal>` components to be inserted
somewhere in the website.
