### PR TITLE
Fix bundle analyzer plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 
 ### Bugfix
 
+- Fix `yarn analyze` command by packing our own version of
+  webpack-bundle-analyzer integration. It has a few differences in
+  configuration to the previous integration: it saves the bundle stats by
+  default and doesn't open an HTTP server. Check output of `yarn analyze`
+  command to identify the path to the `reports.html` file @tiberiuichim
+
 ### Internal
 
 ## 9.0.0 (2020-11-15)

--- a/razzle.config.js
+++ b/razzle.config.js
@@ -185,6 +185,7 @@ const defaultPlugins = [
   require('./webpack-less-plugin')({ registry }),
   require('./webpack-sentry-plugin'),
   require('./webpack-svg-plugin'),
+  require('./webpack-bundle-analyze-plugin'),
   require('./jest-extender-plugin'),
 ];
 

--- a/webpack-bundle-analyze-plugin.js
+++ b/webpack-bundle-analyze-plugin.js
@@ -1,0 +1,38 @@
+/**
+ * An adaptation of MIT licensed for Razzle ^3.3
+ * https://github.com/nimacsoft/razzle-plugin-bundle-analyzer
+ */
+
+const defaultOptions = {
+  concatenateModules: false,
+  analyzerHost: '0.0.0.0',
+  analyzerMode: 'static',
+  generateStatsFile: true,
+  statsFilename: 'stats.json',
+  reportFilename: 'reports.html',
+  openAnalyzer: false,
+};
+
+function modifyWebpackConfig({
+  env: { target, dev },
+  webpackConfig: config,
+  webpackObject,
+  options: { pluginOptions, razzleOptions, webpackOptions },
+}) {
+  const options = Object.assign({}, defaultOptions, pluginOptions);
+
+  if (process.env.BUNDLE_ANALYZE === 'true' && target === 'web') {
+    const { concatenateModules, ...bundleAnalyzerOptions } = options;
+
+    config.optimization.concatenateModules = concatenateModules;
+    config.plugins.push(
+      new (require('webpack-bundle-analyzer').BundleAnalyzerPlugin)(
+        bundleAnalyzerOptions,
+      ),
+    );
+  }
+
+  return config;
+}
+
+module.exports = { modifyWebpackConfig };


### PR DESCRIPTION
Fix `yarn analyze` command by packing our own version of
  webpack-bundle-analyzer integration. It has a few differences in
  configuration to the previous integration: it saves the bundle stats by
  default and doesn't open an HTTP server. Check output of `yarn analyze`
  command to identify the path to the `reports.html` file @tiberiuichim