### PR TITLE
Python3.9 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Internal
 
+- For python3.9 compatibility, install wheel package in build-backend targets @tiberiuichim
+
 ## 10.1.0 (2020-11-30)
 
 ### Feature

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ build-frontend:
 build-backend:  ## Build Plone 5.2
 	(cd api && python3 -m venv .)
 	(cd api && bin/pip install --upgrade pip)
+	(cd api && bin/pip install --upgrade wheel)
 	(cd api && bin/pip install -r requirements.txt)
 	(cd api && bin/buildout)
 
@@ -34,6 +35,7 @@ build-backend:  ## Build Plone 5.2
 build-backend-withport:  ## Build Plone 5.2 with port
 	(cd api && python3 -m venv .)
 	(cd api && bin/pip install --upgrade pip)
+	(cd api && bin/pip install --upgrade wheel)
 	(cd api && bin/pip install -r requirements.txt)
 	(cd api && bin/buildout instance:http-address=$(INSTANCE_PORT))
 

--- a/api/buildout.cfg
+++ b/api/buildout.cfg
@@ -80,3 +80,4 @@ robotframework-selenium2library =
 robotframework-seleniumlibrary =
 robotframework-webpack=
 selenium =
+feedparser =


### PR DESCRIPTION
For some reason the "wheel" package needs to be installed. At least on my system, ArchLinux up to date.