### PR TITLE
fix redirects for Link objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bugfix
 
+- Fix redirection for Link objects. @cekk
 ### Internal
 
 ## 10.4.3 (2020-12-15)

--- a/src/components/theme/View/LinkView.jsx
+++ b/src/components/theme/View/LinkView.jsx
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 import { isInternalURL } from '@plone/volto/helpers';
 import { Link } from 'react-router-dom';
 import { Container } from 'semantic-ui-react';
+import { flattenToAppURL } from '@plone/volto/helpers';
 
 /**
  * View container class.
@@ -46,26 +47,11 @@ class LinkView extends Component {
    */
   UNSAFE_componentWillMount() {
     if (!this.props.token) {
-      if (isInternalURL(this.props.content.remoteUrl)) {
-        this.props.history.replace(this.props.content.remoteUrl);
+      const { remoteUrl } = this.props.content;
+      if (isInternalURL(remoteUrl)) {
+        this.props.history.replace(flattenToAppURL(remoteUrl));
       } else if (!__SERVER__) {
-        window.location.href = this.props.content.remoteUrl;
-      }
-    }
-  }
-
-  /**
-   * Component will receive props
-   * @method componentWillReceiveProps
-   * @param {Object} nextProps Next properties
-   * @returns {undefined}
-   */
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    if (!this.props.token) {
-      if (isInternalURL(this.props.content.remoteUrl)) {
-        this.props.history.replace(this.props.content.remoteUrl);
-      } else if (!__SERVER__) {
-        window.location.href = this.props.content.remoteUrl;
+        window.location.href = flattenToAppURL(remoteUrl);
       }
     }
   }

--- a/src/server.jsx
+++ b/src/server.jsx
@@ -16,6 +16,7 @@ import { ChunkExtractor, ChunkExtractorManager } from '@loadable/server';
 import { createProxyMiddleware } from 'http-proxy-middleware';
 import { updateIntl } from 'react-intl-redux';
 import { resetServerContext } from 'react-beautiful-dnd';
+import { flattenToAppURL } from '@plone/volto/helpers';
 
 import routes from '~/routes';
 import { settings } from '~/config';
@@ -183,7 +184,7 @@ server
           );
 
           if (context.url) {
-            res.redirect(context.url);
+            res.redirect(flattenToAppURL(context.url));
           } else if (context.error_code) {
             res.set({
               'Cache-Control': 'no-cache',


### PR DESCRIPTION
These changes fixes the redirects for anonymous both accessing directly the Link object (the change in server.jsx) and navigating through it (with internal links, listing, contents view).

I removed _UNSAFE_componentWillReceiveProps_ because it seemed unused and generated recursion depth errors with _UNSAFE_componentWillMount_