### PR TITLE
image loading lazy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Feature
 
+- Lazy load image in blocks Image and HeroImage @mamico
+
 ### Bugfix
 
 - Fix redirection for Link objects. @cekk

--- a/src/components/manage/Blocks/HeroImageLeft/View.jsx
+++ b/src/components/manage/Blocks/HeroImageLeft/View.jsx
@@ -20,6 +20,7 @@ const View = ({ data }) => (
           src={`${flattenToAppURL(data.url)}/@@images/image`}
           alt=""
           className="hero-image"
+          loading="lazy"
         />
       )}
       <div className="hero-body">

--- a/src/components/manage/Blocks/HeroImageLeft/__snapshots__/View.test.jsx.snap
+++ b/src/components/manage/Blocks/HeroImageLeft/__snapshots__/View.test.jsx.snap
@@ -10,6 +10,7 @@ exports[`renders a view hero component 1`] = `
     <img
       alt=""
       className="hero-image"
+      loading="lazy"
       src="heroimage.jpg/@@images/image"
     />
     <div

--- a/src/components/manage/Blocks/Image/View.jsx
+++ b/src/components/manage/Blocks/Image/View.jsx
@@ -56,6 +56,7 @@ const View = ({ data, detached }) => (
                   : data.url
               }
               alt={data.alt || ''}
+              loading="lazy"
             />
           );
           if (data.href) {

--- a/src/components/manage/Blocks/Image/View.test.jsx
+++ b/src/components/manage/Blocks/Image/View.test.jsx
@@ -9,6 +9,7 @@ describe('Image View Component', () => {
     const { getByRole } = render(<View data={{ url: '/image.jpg' }} />);
     const img = getByRole('img');
     expect(img).toHaveAttribute('src', '/image.jpg/@@images/image');
+    expect(img).toHaveAttribute('loading', 'lazy');
   });
   test('renders a view image component with a local image with a link', () => {
     const { container, getByRole } = render(

--- a/src/components/theme/Footer/__snapshots__/Footer.test.jsx.snap
+++ b/src/components/theme/Footer/__snapshots__/Footer.test.jsx.snap
@@ -23,7 +23,7 @@ exports[`Footer renders a footer component 1`] = `
       >
         ©
       </abbr>
-       2000-2020 by the 
+       2000-2021 by the 
       <a
         className="item"
         href="http://plone.org/foundation"


### PR DESCRIPTION
add the loading=lazy attribute to the img tag for the Image and HeroImage blocks

* currently 73% browser support https://caniuse.com/loading-lazy-attr but no side effect for others
* no need to add 3rd-party javascript code https://web.dev/browser-level-image-lazy-loading
* improve performance and lighthouse score #2088 