### PR TITLE
Increase maxResponseSize for superagent calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Fix redirection for Link objects. @cekk
 - Fix import order in server.jsx. @cekk @tiberiuichim
 - Make sentry config more resilient to edge cases (SPA, storybook) @sneridagh
-
+- Increase maxResponseSize for superagent calls. Now is 500mb (#2098) @cekk
 ### Internal
 
 - Translations german: Unauthorized, Login/Register @ksuess

--- a/docs/source/configuration/settings-reference.md
+++ b/docs/source/configuration/settings-reference.md
@@ -98,3 +98,14 @@ This list is still incomplete, contributions are welcomed!
 
     A list of reducer names that should use the browser's localstorage to
     persist their data.
+
+## maxResponseSize
+
+!!! block ""
+
+    The library that we use to get files and images from the backend (superagent) 
+    has a response size limit of 200 mb, so if you want to get a file bigger than 200 mb
+    from Plone, the SSR will throw an error.
+
+    You can edit this limit in the `settings` object setting a new value in bytes
+    (for example, to set 500 mb you need to write 5000000000).

--- a/src/components/theme/Footer/__snapshots__/Footer.test.jsx.snap
+++ b/src/components/theme/Footer/__snapshots__/Footer.test.jsx.snap
@@ -23,7 +23,7 @@ exports[`Footer renders a footer component 1`] = `
       >
         ©
       </abbr>
-       2000-2020 by the 
+       2000-2021 by the 
       <a
         className="item"
         href="http://plone.org/foundation"

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -88,6 +88,7 @@ let config = {
     },
     contentIcons: contentIcons,
     appExtras: [],
+    maxResponseSize: 2000000000, // This is superagent default (200 mb)
   },
   widgets: {
     ...widgetMapping,

--- a/src/helpers/Api/APIResourceWithAuth.js
+++ b/src/helpers/Api/APIResourceWithAuth.js
@@ -24,6 +24,7 @@ export const getAPIResourceWithAuth = (req) =>
     }
     const request = superagent
       .get(`${apiPath}${req.path}`)
+      .maxResponseSize(5000000000)
       .responseType('blob');
     const authToken = cookie.load('auth_token');
     if (authToken) {

--- a/src/helpers/Api/APIResourceWithAuth.js
+++ b/src/helpers/Api/APIResourceWithAuth.js
@@ -24,7 +24,7 @@ export const getAPIResourceWithAuth = (req) =>
     }
     const request = superagent
       .get(`${apiPath}${req.path}`)
-      .maxResponseSize(5000000000)
+      .maxResponseSize(settings.maxResponseSize)
       .responseType('blob');
     const authToken = cookie.load('auth_token');
     if (authToken) {


### PR DESCRIPTION
By default superagent drops responses larger than 200mb.
This leads to an error (aka infinite page loading because errors are not well managed..se #2099 ) if we want to download files > 200 mb from Plone.

I don't know if you limit file sizes on Plone usually, but we have several files > 200 mb.

With this change i changed the default limit to 500 mb but i don't know if it's a good idea setting it higher or not.
