### PR TITLE
Make cypress test more resiliant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Avoid a bug in cypress tests caused by multi-block copy/paste @tiberiuichim
+
 ### Internal
 
 ## 10.9.1 (2021-01-14)

--- a/cypress/integration/blocks-copypaste.js
+++ b/cypress/integration/blocks-copypaste.js
@@ -1,6 +1,7 @@
 if (Cypress.env('API') !== 'guillotina') {
   describe('Blocks copy/paste', () => {
     beforeEach(() => {
+      cy.clearLocalStorage();
       cy.autologin();
       cy.createContent({
         contentType: 'Document',

--- a/cypress/integration/content.js
+++ b/cypress/integration/content.js
@@ -76,7 +76,7 @@ describe('Add Content Tests', () => {
         subjectType: 'input',
       });
     }
-    cy.get('#toolbar-save').click();
+    cy.get('#toolbar-save').focus().click();
 
     // then a new file should have been created
     if (Cypress.env('API') === 'guillotina') {

--- a/src/components/manage/Form/BlocksToolbar.jsx
+++ b/src/components/manage/Form/BlocksToolbar.jsx
@@ -36,7 +36,7 @@ export class BlocksToolbarComponent extends React.Component {
   loadFromStorage() {
     const clipboard = load({ states: ['blocksClipboard'] })?.blocksClipboard;
     if (!isEqual(clipboard, this.props.blocksClipboard))
-      this.props.setBlocksClipboard(clipboard);
+      this.props.setBlocksClipboard(clipboard || {});
   }
 
   componentDidMount() {


### PR DESCRIPTION
This fixes a problem with flashing errors in cypress due to multi-block copy/paste code.