### PR TITLE
UniversalLink and ConditionalLink accepts also an item to link to.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Feature
 
 - Internationalization story for add-ons @sneridagh
+- UniversalLink and ConditionalLink accepts also an item to link to. If item is of @type Link, a direct link to remote url is generated if user is not logged. @giuliaghisini
 
 ### Bugfix
 

--- a/src/components/manage/Blocks/Listing/DefaultTemplate.jsx
+++ b/src/components/manage/Blocks/Listing/DefaultTemplate.jsx
@@ -24,10 +24,7 @@ const DefaultTemplate = ({ items, linkMore, isEditMode }) => {
       <div className="items">
         {items.map((item) => (
           <div className="listing-item" key={item['@id']}>
-            <ConditionalLink
-              to={flattenToAppURL(item['@id'])}
-              condition={!isEditMode}
-            >
+            <ConditionalLink item={item} condition={!isEditMode}>
               <div className="listing-body">
                 <h4>{item.title ? item.title : item.id}</h4>
                 <p>{item.description}</p>

--- a/src/components/manage/Blocks/Listing/SummaryTemplate.jsx
+++ b/src/components/manage/Blocks/Listing/SummaryTemplate.jsx
@@ -26,10 +26,7 @@ const SummaryTemplate = ({ items, linkMore, isEditMode }) => {
       <div className="items">
         {items.map((item) => (
           <div className="listing-item" key={item['@id']}>
-            <ConditionalLink
-              to={flattenToAppURL(item['@id'])}
-              condition={!isEditMode}
-            >
+            <ConditionalLink item={item} condition={!isEditMode}>
               {!item[settings.listingPreviewImageField] && (
                 <img src={DefaultImageSVG} alt="" />
               )}

--- a/src/components/manage/ConditionalLink/ConditionalLink.jsx
+++ b/src/components/manage/ConditionalLink/ConditionalLink.jsx
@@ -2,10 +2,10 @@ import React from 'react';
 import { UniversalLink } from '@plone/volto/components';
 import PropTypes from 'prop-types';
 
-const ConditionalLink = ({ condition, to, ...props }) => {
+const ConditionalLink = ({ condition, to, item, ...props }) => {
   if (condition) {
     return (
-      <UniversalLink href={to} {...props}>
+      <UniversalLink href={to} item={item} {...props}>
         {props.children}
       </UniversalLink>
     );
@@ -17,6 +17,10 @@ const ConditionalLink = ({ condition, to, ...props }) => {
 ConditionalLink.propTypes = {
   condition: PropTypes.bool,
   to: PropTypes.string,
+  item: PropTypes.shape({
+    '@id': PropTypes.string,
+    remoteUrl: PropTypes.string, //of plone @type 'Link'
+  }),
   children: PropTypes.node,
 };
 

--- a/src/components/manage/UniversalLink/UniversalLink.jsx
+++ b/src/components/manage/UniversalLink/UniversalLink.jsx
@@ -18,7 +18,6 @@ const UniversalLink = ({
   children,
   className = null,
   title = null,
-  link = null,
   ...props
 }) => {
   const token = useSelector((state) => state.userSession?.token);

--- a/src/components/manage/UniversalLink/UniversalLink.jsx
+++ b/src/components/manage/UniversalLink/UniversalLink.jsx
@@ -64,7 +64,7 @@ const UniversalLink = ({
 };
 
 UniversalLink.propTypes = {
-  href: PropTypes.string.isRequired,
+  href: PropTypes.string,
   openLinkInNewTab: PropTypes.bool,
   download: PropTypes.bool,
   className: PropTypes.string,

--- a/src/components/manage/UniversalLink/UniversalLink.stories.mdx
+++ b/src/components/manage/UniversalLink/UniversalLink.stories.mdx
@@ -1,0 +1,64 @@
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
+import UniversalLinkComponent from './UniversalLink';
+import { injectIntl } from 'react-intl';
+import configureStore from 'redux-mock-store';
+import { Provider } from 'react-intl-redux';
+
+<Meta
+  title="UniversalLink"
+  argTypes={{
+    href: { control: 'text' },
+    item: { control: 'object' },
+    text: { control: 'text' },
+  }}
+  decorators={[
+    (Story) => (
+      <div style={{ width: '400px' }}>
+        <Story />
+      </div>
+    ),
+  ]}
+/>
+
+# UniversalLink
+
+Link to url or item
+
+export const UniversalLink = (args) => {
+  const mockStore = configureStore();
+  const store = mockStore({
+    userSession: {
+      token: null,
+    },
+    intl: {
+      locale: 'en',
+      messages: {},
+    },
+  });
+  return (
+    <Provider store={store}>
+      <UniversalLinkComponent
+        href="http://www.google.it"
+        item={{
+          '@id': 'localhost:3000/example-link-to-twitter',
+          remoteUrl: 'http://www.twitter.it',
+        }}
+        {...args}
+      >
+        {args.text || 'Example link to google'}
+      </UniversalLinkComponent>
+      <h4>Link to a generic object. Example code for 'item' prop:</h4>
+      <code> {`{'@id':'localhost:3000/test-page'}`}</code>
+      <h4>Link to a Link object. Example code for 'item' prop:</h4>
+      <code>
+        {`{'@id':'localhost:3000/example-link-to-twitter', 'remoteUrl':'http://www.twitter.it'}`}
+      </code>
+    </Provider>
+  );
+};
+
+<Story name="UniversalLink">{injectIntl(UniversalLink).bind({})}</Story>
+
+# Props
+
+<ArgsTable of={UniversalLinkComponent} />

--- a/src/components/manage/UniversalLink/UniversalLink.test.jsx
+++ b/src/components/manage/UniversalLink/UniversalLink.test.jsx
@@ -1,18 +1,32 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
+import { Provider } from 'react-intl-redux';
+import configureStore from 'redux-mock-store';
 import { render } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-
 import UniversalLink from './UniversalLink';
+
+const mockStore = configureStore();
+const store = mockStore({
+  userSession: {
+    token: null,
+  },
+  intl: {
+    locale: 'en',
+    messages: {},
+  },
+});
 
 describe('UniversalLink', () => {
   it('renders a UniversalLink component with internal link', () => {
     const component = renderer.create(
-      <MemoryRouter>
-        <UniversalLink href={'/en/welcome-to-volto'}>
-          <h1>Title</h1>
-        </UniversalLink>
-      </MemoryRouter>,
+      <Provider store={store}>
+        <MemoryRouter>
+          <UniversalLink href={'/en/welcome-to-volto'}>
+            <h1>Title</h1>
+          </UniversalLink>
+        </MemoryRouter>
+      </Provider>,
     );
     const json = component.toJSON();
     expect(json).toMatchSnapshot();
@@ -20,11 +34,13 @@ describe('UniversalLink', () => {
 
   it('renders a UniversalLink component with external link', () => {
     const component = renderer.create(
-      <MemoryRouter>
-        <UniversalLink href="https://github.com/plone/volto">
-          <h1>Title</h1>
-        </UniversalLink>
-      </MemoryRouter>,
+      <Provider store={store}>
+        <MemoryRouter>
+          <UniversalLink href="https://github.com/plone/volto">
+            <h1>Title</h1>
+          </UniversalLink>
+        </MemoryRouter>
+      </Provider>,
     );
     const json = component.toJSON();
     expect(json).toMatchSnapshot();
@@ -32,14 +48,16 @@ describe('UniversalLink', () => {
 
   it('check UniversalLink set rel attribute for ext links', () => {
     const { getByTitle } = render(
-      <MemoryRouter>
-        <UniversalLink
-          href="https://github.com/plone/volto"
-          title="Volto GitHub repository"
-        >
-          <h1>Title</h1>
-        </UniversalLink>
-      </MemoryRouter>,
+      <Provider store={store}>
+        <MemoryRouter>
+          <UniversalLink
+            href="https://github.com/plone/volto"
+            title="Volto GitHub repository"
+          >
+            <h1>Title</h1>
+          </UniversalLink>
+        </MemoryRouter>
+      </Provider>,
     );
 
     expect(getByTitle('Volto GitHub repository').getAttribute('rel')).toBe(
@@ -49,14 +67,16 @@ describe('UniversalLink', () => {
 
   it('check UniversalLink set target attribute for ext links', () => {
     const { getByTitle } = render(
-      <MemoryRouter>
-        <UniversalLink
-          href="https://github.com/plone/volto"
-          title="Volto GitHub repository"
-        >
-          <h1>Title</h1>
-        </UniversalLink>
-      </MemoryRouter>,
+      <Provider store={store}>
+        <MemoryRouter>
+          <UniversalLink
+            href="https://github.com/plone/volto"
+            title="Volto GitHub repository"
+          >
+            <h1>Title</h1>
+          </UniversalLink>
+        </MemoryRouter>
+      </Provider>,
     );
 
     expect(getByTitle('Volto GitHub repository').getAttribute('target')).toBe(
@@ -66,15 +86,17 @@ describe('UniversalLink', () => {
 
   it('check UniversalLink can unset target for ext links with prop', () => {
     const { getByTitle } = render(
-      <MemoryRouter>
-        <UniversalLink
-          href="https://github.com/plone/volto"
-          title="Volto GitHub repository"
-          openLinkInNewTab={false}
-        >
-          <h1>Title</h1>
-        </UniversalLink>
-      </MemoryRouter>,
+      <Provider store={store}>
+        <MemoryRouter>
+          <UniversalLink
+            href="https://github.com/plone/volto"
+            title="Volto GitHub repository"
+            openLinkInNewTab={false}
+          >
+            <h1>Title</h1>
+          </UniversalLink>
+        </MemoryRouter>
+      </Provider>,
     );
 
     expect(getByTitle('Volto GitHub repository').getAttribute('target')).toBe(


### PR DESCRIPTION
if item is of @type Link (has the remoteUrl property), a direct link to remoteUrl is generated if user is not logged.

This avoids the passage from the Link detail view page even when users are not authenticated. Especially when Link-type objects appears in listing blocks.