### PR TITLE
fix secondary button behaving as type submit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Bugfix
 
 - German translation: aria-label of '/contents' button : "Inhalte" not "Inhaltsverzeichnis" @ksuess
+- Fix secondary button behaving as type submit @nileshgulia1
 
 ### Internal
 

--- a/src/components/manage/Form/Form.jsx
+++ b/src/components/manage/Form/Form.jsx
@@ -3,7 +3,7 @@
  * @module components/manage/Form/Form
  */
 
-import { EditBlock, Field, Icon } from '@plone/volto/components';
+import { EditBlock, Field, Icon, Toast } from '@plone/volto/components';
 import {
   blockHasValue,
   difference,
@@ -42,6 +42,7 @@ import {
   Tab,
 } from 'semantic-ui-react';
 import { v4 as uuid } from 'uuid';
+import { toast } from 'react-toastify';
 import { BlocksToolbar } from '@plone/volto/components';
 import { settings } from '~/config';
 
@@ -537,10 +538,19 @@ class Form extends Component {
         errors,
         schema: this.props.schema,
       });
-      this.setState({
-        errors,
-        activeIndex,
-      });
+      this.setState(
+        {
+          errors,
+          activeIndex,
+        },
+        () => {
+          Object.keys(errors).forEach((err) =>
+            toast.error(
+              <Toast error title={err} content={errors[err].join(', ')} />,
+            ),
+          );
+        },
+      );
     } else {
       // Get only the values that have been modified (Edit forms), send all in case that
       // it's an add form
@@ -1114,6 +1124,7 @@ class Form extends Component {
                   <Button
                     basic
                     secondary
+                    type="button"
                     aria-label={this.props.intl.formatMessage(messages.cancel)}
                     title={this.props.intl.formatMessage(messages.cancel)}
                     floated="right"

--- a/src/components/manage/Form/Form.jsx
+++ b/src/components/manage/Form/Form.jsx
@@ -3,7 +3,7 @@
  * @module components/manage/Form/Form
  */
 
-import { EditBlock, Field, Icon, Toast } from '@plone/volto/components';
+import { EditBlock, Field, Icon } from '@plone/volto/components';
 import {
   blockHasValue,
   difference,
@@ -42,7 +42,6 @@ import {
   Tab,
 } from 'semantic-ui-react';
 import { v4 as uuid } from 'uuid';
-import { toast } from 'react-toastify';
 import { BlocksToolbar } from '@plone/volto/components';
 import { settings } from '~/config';
 
@@ -538,19 +537,10 @@ class Form extends Component {
         errors,
         schema: this.props.schema,
       });
-      this.setState(
-        {
-          errors,
-          activeIndex,
-        },
-        () => {
-          Object.keys(errors).forEach((err) =>
-            toast.error(
-              <Toast error title={err} content={errors[err].join(', ')} />,
-            ),
-          );
-        },
-      );
+      this.setState({
+        errors,
+        activeIndex,
+      });
     } else {
       // Get only the values that have been modified (Edit forms), send all in case that
       // it's an add form

--- a/src/components/manage/Form/__snapshots__/Form.test.jsx.snap
+++ b/src/components/manage/Form/__snapshots__/Form.test.jsx.snap
@@ -53,6 +53,7 @@ exports[`Form renders a form component 1`] = `
           className="ui basic secondary right floated button"
           onClick={[Function]}
           title="Cancel"
+          type="button"
         >
           <svg
             className="icon circled"

--- a/src/components/manage/Preferences/__snapshots__/ChangePassword.test.jsx.snap
+++ b/src/components/manage/Preferences/__snapshots__/ChangePassword.test.jsx.snap
@@ -228,6 +228,7 @@ exports[`ChangePassword renders a change password component 1`] = `
             className="ui basic secondary right floated button"
             onClick={[Function]}
             title="Cancel"
+            type="button"
           >
             <svg
               className="icon circled"

--- a/src/components/manage/Preferences/__snapshots__/PersonalInformation.test.jsx.snap
+++ b/src/components/manage/Preferences/__snapshots__/PersonalInformation.test.jsx.snap
@@ -365,6 +365,7 @@ exports[`PersonalInformation renders a personal information component 1`] = `
           className="ui basic secondary right floated button"
           onClick={[Function]}
           title="Cancel"
+          type="button"
         >
           <svg
             className="icon circled"
@@ -756,6 +757,7 @@ exports[`PersonalInformation renders a personal information component embedded i
           className="ui basic secondary right floated button"
           onClick={[Function]}
           title="Cancel"
+          type="button"
         >
           <svg
             className="icon circled"

--- a/src/components/manage/Preferences/__snapshots__/PersonalPreferences.test.jsx.snap
+++ b/src/components/manage/Preferences/__snapshots__/PersonalPreferences.test.jsx.snap
@@ -143,6 +143,7 @@ exports[`PersonalPreferences renders a personal preferences component 1`] = `
             aria-label="Cancel"
             class="ui basic secondary right floated button"
             title="Cancel"
+            type="button"
           >
             <svg
               class="icon circled"

--- a/src/components/theme/ContactForm/__snapshots__/ContactForm.test.jsx.snap
+++ b/src/components/theme/ContactForm/__snapshots__/ContactForm.test.jsx.snap
@@ -257,6 +257,7 @@ exports[`Contact form renders a contact form 1`] = `
               className="ui basic secondary right floated button"
               onClick={[Function]}
               title="Cancel"
+              type="button"
             >
               <svg
                 className="icon circled"
@@ -548,6 +549,7 @@ exports[`Contact form renders a contact form with error message 1`] = `
               className="ui basic secondary right floated button"
               onClick={[Function]}
               title="Cancel"
+              type="button"
             >
               <svg
                 className="icon circled"

--- a/src/components/theme/PasswordReset/__snapshots__/RequestPasswordReset.test.jsx.snap
+++ b/src/components/theme/PasswordReset/__snapshots__/RequestPasswordReset.test.jsx.snap
@@ -119,6 +119,7 @@ exports[`RequestPasswordReset renders a RequestPasswordReset component 1`] = `
               className="ui basic secondary right floated button"
               onClick={[Function]}
               title="Cancel"
+              type="button"
             >
               <svg
                 className="icon circled"


### PR DESCRIPTION
related to #2181 
In `Form.jsx` we do validation checks and show toast in case there're errors. At the same time we let semantic-ui Form handle  these errors and render them inside the Form itself. Can we just rely on one of the two? or move the validation errors on bottom and remove the toast completely. what do you think @sneridagh @giuliaghisini ?