### PR TITLE
Sidebar on small mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - temporarly removed linkDetectionPlugin for draftjs (for some conflicts with AnchorPlugin) @giuliaghisini
 - German translation: aria-label of '/contents' button : "Inhalte" not "Inhaltsverzeichnis" @ksuess
+- Make sidebar-collapsed visible on small mobile. @giuliaghisini
 
 ### Internal
 

--- a/theme/themes/pastanaga/extras/sidebar.less
+++ b/theme/themes/pastanaga/extras/sidebar.less
@@ -105,6 +105,15 @@
     }
   }
 
+  @media (max-width: 400px) {
+    width: 100vw;
+    max-width: 375px;
+
+    &.collapsed {
+      right: calc(-100vw + 20px);
+    }
+  }
+
   .ui.raised.segments {
     display: flex;
     height: 100%;


### PR DESCRIPTION
When you are on small mobile device (f.e. iPhone 5/SE) collapsed sidebar is not visibile and you cannot use it. 

This fix, makes sidebar-collapsed visibile on small mobile devices.