### PR TITLE
Let toolbar buttons and menues be restrictable to route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking
 
-- Add a new config registry, the `toolbar`. You should migrate your project's `config.js` to export the `toolbar` registry. @tiberiuichim @ksuess
+- Add a new config registry, the `toolbar`. You should migrate your projects `config.js` to export the `toolbar` registry. @tiberiuichim @ksuess
 
 ### Feature
 

--- a/docs/source/recipes/toolbar.md
+++ b/docs/source/recipes/toolbar.md
@@ -15,18 +15,24 @@ diff, control-panel.
 
 ## Customization
 
-To add a new button to the toolbar, insert it in your configuration scripts:
+To add a new button to the toolbar, insert it in your configuration script:
 
-
+```jsx
 import {ButtonA, ButtonB} from './components';
 
 const applyConfig = (config) => {
   config.toolbar.activities.view.top.push(ButtonA)
-  config.toolbar.activities.view.bottom.push(ButtonB)
+  config.toolbar.activities.view.bottom.push({
+    match: '/documentation',
+    component: ButtonB,
+  })
   return config;
 };
 
 export default applyConfig;
+```
+
+ButtonB shows up only on /documentation.
 
 To insert new actions to the More component menu, use the `defaultMoreActions`
 key:
@@ -83,3 +89,34 @@ const applyConfig = (config) => {
 }
 
 export default applyConfig;
+```
+
+Same dropdown menu as above but restricted to route '/documentation':
+
+```jsx
+import { DropdownWithButton } from '@plone/volto/components/manage/Toolbar/Dropdown';
+
+const applyConfig = (config) => {
+  config.toolbar.activities.someActivity.top.push({
+    match: '/documentation',
+    component: (props) => (
+      <DropdownWithButton
+        {...props}
+        name="add-something"
+        title="Add something"
+        icon={<Icon name={addSVG} size="30px" />}
+        headerActions={
+          <button aria-label={'Add'} onClick={() => {}} tabIndex={0}>
+            <Icon name={addSVG} size="30px" />
+          </button>
+        }
+      >
+        <div>Hello!</div>
+      </DropdownWithButton>
+    ),
+});
+  return config;
+}
+
+export default applyConfig;
+```

--- a/docs/source/recipes/toolbar.md
+++ b/docs/source/recipes/toolbar.md
@@ -21,9 +21,16 @@ To add a new button to the toolbar, insert it in your configuration script:
 import {ButtonA, ButtonB} from './components';
 
 const applyConfig = (config) => {
-  config.toolbar.activities.view.top.push(ButtonA)
+  config.toolbar.activities.view.top.push({
+    match: {
+      path: '/',
+    },
+    component: ButtonA,
+  })
   config.toolbar.activities.view.bottom.push({
-    match: '/documentation',
+    match: {
+      path: '/documentation',
+    },
     component: ButtonB,
   })
   return config;
@@ -40,26 +47,48 @@ key:
 ```jsx
 import {MyAction}  from './components';
 
-export default function (config) {
+const applyConfig = (config) => {
   config.toolbar.defaultMoreActions.push(MyAction);
 
   return config;
-}
+};
+
+export default applyConfig;
 ```
 
 It's also possible to configure the "default view actions", which are, by
 default, defined as:
 
-```
+```jsx
 const defaultViewActions = [
-  EditButton,
-  ContentsButton,
-  AddButton,
-  moreMenu(defaultMoreActions),
+  {
+    match: {
+      path: '/',
+    },
+    component: EditButton,
+  },
+  {
+    match: {
+      path: '/',
+    },
+    component: ContentsButton,
+  },
+  {
+    match: {
+      path: '/',
+    },
+    component: AddButton,
+  },
+  {
+    match: {
+      path: '/',
+    },
+    component: moreMenu(defaultMoreActions),
+  },
 ];
 ```
 
-This is exposed as `config.toolbar.defaultViewActions`.
+They are exposed as `config.toolbar.defaultViewActions`.
 
 ### Dropdown menus
 
@@ -70,35 +99,10 @@ dropdown menus, use the `DropdownWithButton` component for that:
 import { DropdownWithButton } from '@plone/volto/components/manage/Toolbar/Dropdown';
 
 const applyConfig = (config) => {
-  config.toolbar.activities.someActivity.top.push((props) => (
-    <DropdownWithButton
-      {...props}
-      name="add-something"
-      title="Add something"
-      icon={<Icon name={addSVG} size="30px" />}
-      headerActions={
-        <button aria-label={'Add'} onClick={() => {}} tabIndex={0}>
-          <Icon name={addSVG} size="30px" />
-        </button>
-      }
-    >
-      <div>Hello!</div>
-    </DropdownWithButton>
-  ));
-  return config;
-}
-
-export default applyConfig;
-```
-
-Same dropdown menu as above but restricted to route '/documentation':
-
-```jsx
-import { DropdownWithButton } from '@plone/volto/components/manage/Toolbar/Dropdown';
-
-const applyConfig = (config) => {
   config.toolbar.activities.someActivity.top.push({
-    match: '/documentation',
+    match: {
+      path: '/',
+    },
     component: (props) => (
       <DropdownWithButton
         {...props}
@@ -115,6 +119,24 @@ const applyConfig = (config) => {
       </DropdownWithButton>
     ),
 });
+  return config;
+}
+
+export default applyConfig;
+```
+
+With a menu component living in /components:
+
+```jsx
+import { MenuA } from './components';
+
+const applyConfig = (config) => {
+  config.toolbar.activities.someActivity.top.push({
+    match: {
+      path: '/',
+    },
+    component: (props) => <MenuA {...props} />,
+  });
   return config;
 }
 

--- a/src/components/manage/Toolbar/Toolbar.jsx
+++ b/src/components/manage/Toolbar/Toolbar.jsx
@@ -310,28 +310,40 @@ export class BasicToolbarComponent extends Component {
             <div className="toolbar-body">
               <div className="toolbar-actions">
                 {this.props.inner}
-                {top.map((ActionComponent, index) => (
-                  <ActionComponent
-                    {...this.props}
-                    key={index}
-                    toggleMenu={this.toggleMenu}
-                    showMenu={this.state.showMenu}
-                    theToolbar={this.toolbarWindow}
-                    loadedComponentName={this.state.loadedComponentName}
-                  />
-                ))}
+                {top.map((ActionComponent, index) => {
+                  let Cmp = ActionComponent.hasOwnProperty('component')
+                    ? ActionComponent.component
+                    : ActionComponent;
+                  return !ActionComponent.hasOwnProperty('match') ||
+                    this.props.pathname === ActionComponent.match ? (
+                    <Cmp
+                      {...this.props}
+                      key={index}
+                      toggleMenu={this.toggleMenu}
+                      showMenu={this.state.showMenu}
+                      theToolbar={this.toolbarWindow}
+                      loadedComponentName={this.state.loadedComponentName}
+                    />
+                  ) : null;
+                })}
               </div>
               <div className="toolbar-bottom">
-                {bottom.map((BottomComponent, index) => (
-                  <BottomComponent
-                    {...this.props}
-                    key={index}
-                    toggleMenu={this.toggleMenu}
-                    showMenu={this.state.showMenu}
-                    theToolbar={this.toolbarWindow}
-                    loadedComponentName={this.state.loadedComponentName}
-                  />
-                ))}
+                {bottom.map((BottomComponent, index) => {
+                  let Cmp = BottomComponent.hasOwnProperty('component')
+                    ? BottomComponent.component
+                    : BottomComponent;
+                  return !BottomComponent.hasOwnProperty('match') ||
+                    this.props.pathname === BottomComponent.match ? (
+                    <Cmp
+                      {...this.props}
+                      key={index}
+                      toggleMenu={this.toggleMenu}
+                      showMenu={this.state.showMenu}
+                      theToolbar={this.toolbarWindow}
+                      loadedComponentName={this.state.loadedComponentName}
+                    />
+                  ) : null;
+                })}
               </div>
             </div>
             <div className="toolbar-handler">

--- a/src/components/manage/Toolbar/Toolbar.jsx
+++ b/src/components/manage/Toolbar/Toolbar.jsx
@@ -5,6 +5,7 @@
 
 import React, { Component } from 'react';
 import { defineMessages, injectIntl } from 'react-intl';
+import { matchPath } from 'react-router';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
@@ -18,6 +19,7 @@ import {
   setExpandedToolbar,
 } from '@plone/volto/actions';
 import { BodyClass, getBaseUrl } from '@plone/volto/helpers';
+import { Bottom } from '@plone/volto/components/manage/Toolbar/ToolbarComponents';
 
 import { toolbar } from '~/config';
 
@@ -311,12 +313,12 @@ export class BasicToolbarComponent extends Component {
               <div className="toolbar-actions">
                 {this.props.inner}
                 {top.map((ActionComponent, index) => {
-                  let Cmp = ActionComponent.hasOwnProperty('component')
-                    ? ActionComponent.component
-                    : ActionComponent;
-                  return !ActionComponent.hasOwnProperty('match') ||
-                    this.props.pathname === ActionComponent.match ? (
-                    <Cmp
+                  return matchPath(
+                    this.props.pathname,
+                    ActionComponent.match,
+                  ) ? (
+                    // eslint-disable-next-line react/jsx-pascal-case
+                    <ActionComponent.component
                       {...this.props}
                       key={index}
                       toggleMenu={this.toggleMenu}
@@ -328,22 +330,24 @@ export class BasicToolbarComponent extends Component {
                 })}
               </div>
               <div className="toolbar-bottom">
-                {bottom.map((BottomComponent, index) => {
-                  let Cmp = BottomComponent.hasOwnProperty('component')
-                    ? BottomComponent.component
-                    : BottomComponent;
-                  return !BottomComponent.hasOwnProperty('match') ||
-                    this.props.pathname === BottomComponent.match ? (
-                    <Cmp
-                      {...this.props}
-                      key={index}
-                      toggleMenu={this.toggleMenu}
-                      showMenu={this.state.showMenu}
-                      theToolbar={this.toolbarWindow}
-                      loadedComponentName={this.state.loadedComponentName}
-                    />
-                  ) : null;
-                })}
+                <Bottom {...this.props}>
+                  {bottom.map((BottomComponent, index) => {
+                    return matchPath(
+                      this.props.pathname,
+                      BottomComponent.match,
+                    ) ? (
+                      // eslint-disable-next-line react/jsx-pascal-case
+                      <BottomComponent.component
+                        {...this.props}
+                        key={index}
+                        toggleMenu={this.toggleMenu}
+                        showMenu={this.state.showMenu}
+                        theToolbar={this.toolbarWindow}
+                        loadedComponentName={this.state.loadedComponentName}
+                      />
+                    ) : null;
+                  })}
+                </Bottom>
               </div>
             </div>
             <div className="toolbar-handler">

--- a/src/components/manage/Toolbar/ToolbarComponents.jsx
+++ b/src/components/manage/Toolbar/ToolbarComponents.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 import { filter, find } from 'lodash';
+import { matchPath } from 'react-router';
 import { Link } from 'react-router-dom';
 import { defineMessages, injectIntl } from 'react-intl';
 
@@ -299,14 +300,10 @@ export const UserButton = (props) => (
 );
 
 export const Bottom = (props) => {
-  const { actionComponents = [] } = props;
   return (
     <>
       <img className="minipastanaga" src={pastanagaSmall} alt="" />
-      {!props.hideDefaultViewButtons &&
-        actionComponents.map((BottomComponent, index) => (
-          <BottomComponent {...props} key={index} />
-        ))}
+      {!props.hideDefaultViewButtons && props.children}
       <div className="divider" />
       <div className="pastanagalogo">
         <img src={pastanagalogo} alt="" />

--- a/src/config/toolbar.js
+++ b/src/config/toolbar.js
@@ -18,7 +18,6 @@ import {
   HistoryAction,
   SharingAction,
   ManageTranslations,
-  Bottom,
   UserButton,
 } from '@plone/volto/components/manage/Toolbar/ToolbarComponents';
 
@@ -58,10 +57,6 @@ const moreMenu = (actions) => {
   return (props) => <MoreButton actionComponents={actions} {...props} />;
 };
 
-export const bottom = (actions) => {
-  return (props) => <Bottom actionComponents={actions} {...props} />;
-};
-
 const defaultMoreActions = [
   WorkflowAction,
   DisplayAction,
@@ -70,12 +65,39 @@ const defaultMoreActions = [
   ManageTranslations,
 ];
 const defaultViewActions = [
-  EditButton,
-  ContentsButton,
-  AddButton,
-  moreMenu(defaultMoreActions),
+  {
+    match: {
+      path: '/',
+    },
+    component: EditButton,
+  },
+  {
+    match: {
+      path: '/',
+    },
+    component: ContentsButton,
+  },
+  {
+    match: {
+      path: '/',
+    },
+    component: AddButton,
+  },
+  {
+    match: {
+      path: '/',
+    },
+    component: moreMenu(defaultMoreActions),
+  },
 ];
-const defaultBottomActions = [UserButton];
+const defaultBottomActions = [
+  {
+    match: {
+      path: '/',
+    },
+    component: UserButton,
+  },
+];
 
 /**
  * Registered activities in volto:
@@ -89,11 +111,11 @@ const activities = {
   },
   view: {
     top: [...defaultViewActions],
-    bottom: [bottom(defaultBottomActions)],
+    bottom: [...defaultBottomActions],
   },
   contents: {
     top: [...defaultViewActions],
-    bottom: [bottom(defaultBottomActions)],
+    bottom: [...defaultBottomActions],
   },
 };
 


### PR DESCRIPTION
```
const applyConfig = (config) => {
  config.toolbar.activities.view.top.push(ButtonA)
  config.toolbar.activities.view.bottom.push({
    match: '/documentation',
    component: ButtonB,
  })
  return config;
};
```