### PR TITLE
feat: add extendable asyncConnect entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Feature
 
+- Add `asyncConnectExtras` in `config` to extend the list of asyncConnect calls @nzambello
+
 ### Bugfix
 
 ### Internal

--- a/docs/source/configuration/settings-reference.md
+++ b/docs/source/configuration/settings-reference.md
@@ -148,6 +148,24 @@ This list is still incomplete, contributions are welcomed!
     lazy libraries (with `preloadLazyLibs`) or quickly load them with
     `injectLazyLibs`.
 
+### asyncConnect
+
+!!! block ""
+
+    A list of async actions to be dispatched with `asyncConnect` on the SSR.
+    See the [Redux guideline](../developer-guidelines/redux.md) for more details.
+
+    ```js
+    config.asyncConnectExtras = [
+      ...config.asyncConnectExtras,
+      {
+        key: 'dropdownMenuNavItems',
+        promise: ({ location, store: { dispatch } }) =>
+          __SERVER__ && dispatch(getDropdownMenuNavitems()),
+      },
+    ];
+    ```
+
 ## Server-specific serverConfig
 
 Settings that are relevant to the Express-powered Volto SSR server are stored

--- a/docs/source/developer-guidelines/redux.md
+++ b/docs/source/developer-guidelines/redux.md
@@ -57,6 +57,10 @@ backend and available as props.
     inspecting the content, so it is not possible to use asyncConnect in any
     view/layout component!
 
+Due to this, you can add entries to the list of action to be handled by
+`asyncConnect` extending `config.asyncConnectExtras` as referenced
+[here](../configuration/settings-reference.md#asyncConnect).
+
 Notice the `emailNotification` action being passed to `connect` in the above
 example. All action (which trigger global state updates) need to be passed as
 props by `connect`. You can't properly trigger an action unless you access it

--- a/src/components/theme/App/App.jsx
+++ b/src/components/theme/App/App.jsx
@@ -213,6 +213,7 @@ export default compose(
       promise: ({ location, store: { dispatch } }) =>
         __SERVER__ && dispatch(getWorkflow(getBaseUrl(location.pathname))),
     },
+    ...(config.asyncConnectExtras || []),
   ]),
   connect(
     (state, props) => ({

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -127,7 +127,7 @@ let config = {
     groupBlocksOrder,
     initialBlocks,
   },
-
+  asyncConnectExtras: [],
   addonRoutes: [],
   addonReducers: {},
 };
@@ -141,6 +141,7 @@ export const blocks = config.blocks;
 export const addonRoutes = [...config.addonRoutes];
 export const addonReducers = { ...config.addonReducers };
 export const appExtras = config.appExtras;
+export const asyncConnectExtras = [...config.asyncConnectExtras];
 
 ConfigRegistry.settings = settings;
 ConfigRegistry.blocks = blocks;
@@ -149,3 +150,4 @@ ConfigRegistry.widgets = widgets;
 ConfigRegistry.addonRoutes = addonRoutes;
 ConfigRegistry.addonReducers = addonReducers;
 ConfigRegistry.appExtras = appExtras;
+ConfigRegistry.asyncConnectExtras = asyncConnectExtras;

--- a/src/registry.js
+++ b/src/registry.js
@@ -72,6 +72,14 @@ class Config {
     this._data.appExtras = appExtras;
   }
 
+  get asyncConnectExtras() {
+    return this._data.asyncConnectExtras;
+  }
+
+  set asyncConnectExtras(asyncConnectExtras) {
+    this._data.asyncConnectExtras = asyncConnectExtras;
+  }
+
   get slots() {
     return this._data.slots;
   }


### PR DESCRIPTION
As referred in the [docs](https://github.com/plone/volto/blob/master/docs/source/developer-guidelines/redux.md) we cannot add actions to SSR handling if not in routes' components.
I added a new entry in config with an extendable list of these actions to be used in `asyncConnect` from App.jsx so addons or site projects can use it to improve performances and be more SEO compliant.