### PR TITLE
Improved object browser with manual input field

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -3,6 +3,8 @@ import { StaticRouter } from 'react-router-dom';
 import { IntlProvider } from 'react-intl';
 import enMessages from '~/../locales/en.json';
 
+import '../test-setup-config';
+
 import '~/theme';
 
 export const parameters = {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Fix storybook initial config registry setup @sneridagh
+
 ### Internal
 
 ## 12.2.0 (2021-03-03)

--- a/docs/source/blocks/editcomponent.md
+++ b/docs/source/blocks/editcomponent.md
@@ -223,6 +223,13 @@ You can select the attributes from the object (coming from the metadata brain fr
 @search endpoint used in the browser) using the `selectedItemAttrs` prop as shown in the
 last example.
 
+#### allowedExternal
+
+You can allow users to type manually an URL (internal or external). Once validated, it
+will tokenize the value. As a feature, you can paste an internal URL (eg. the user copy
+the URL from the browser, and paste it in the widget) and will be converted to a
+tokenized value, as if it was selected via the Object Browser widget.
+
 #### ObjectBrowserWidgetMode()
 
 Returns the component widget with _mode_ passed as argument.

--- a/src/components/manage/Sidebar/ObjectBrowserBody.jsx
+++ b/src/components/manage/Sidebar/ObjectBrowserBody.jsx
@@ -263,13 +263,13 @@ class ObjectBrowserBody extends Component {
     } else if (mode === 'image') {
       onChangeBlock(block, {
         ...data,
-        url: item.getURL,
+        url: flattenToAppURL(item.getURL),
         alt: title,
       });
     } else if (mode === 'link') {
       onChangeBlock(block, {
         ...data,
-        href: url,
+        href: flattenToAppURL(url),
       });
     }
     updateState(mode);

--- a/src/components/manage/Widgets/ObjectBrowserWidget.jsx
+++ b/src/components/manage/Widgets/ObjectBrowserWidget.jsx
@@ -104,14 +104,15 @@ export class ObjectBrowserWidgetComponent extends Component {
       <Popup
         key={flattenToAppURL(href)}
         content={
-          <>
+          <div style={{ display: 'flex' }}>
             {isInternalURL(href) ? (
               <Icon name={homeSVG} size="18px" />
             ) : (
               <Icon name={blankSVG} size="18px" />
             )}
+            &nbsp;
             {flattenToAppURL(href)}
-          </>
+          </div>
         }
         trigger={
           <Label>
@@ -339,16 +340,18 @@ export class ObjectBrowserWidgetComponent extends Component {
                 {this.props.intl.formatMessage(messages.placeholder)}
               </div>
             )}
-            {items.length === 0 && this.props.mode !== 'multiple' && (
-              <input
-                onKeyDown={this.onKeyDownManualLink}
-                onChange={this.onManualLinkInput}
-                value={this.state.manualLinkInput}
-                placeholder={this.props.intl.formatMessage(
-                  messages.placeholder,
-                )}
-              />
-            )}
+            {this.props.allowExternals &&
+              items.length === 0 &&
+              this.props.mode !== 'multiple' && (
+                <input
+                  onKeyDown={this.onKeyDownManualLink}
+                  onChange={this.onManualLinkInput}
+                  value={this.state.manualLinkInput}
+                  placeholder={this.props.intl.formatMessage(
+                    messages.placeholder,
+                  )}
+                />
+              )}
           </div>
           {this.state.manualLinkInput && isEmpty(items) && (
             <Button.Group>

--- a/src/components/manage/Widgets/ObjectBrowserWidget.jsx
+++ b/src/components/manage/Widgets/ObjectBrowserWidget.jsx
@@ -6,17 +6,27 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { compose } from 'redux';
-import { remove } from 'lodash';
-
+import { isEmpty, remove } from 'lodash';
+import { connect } from 'react-redux';
 import { Label, Popup, Button } from 'semantic-ui-react';
-import { flattenToAppURL } from '@plone/volto/helpers';
+import {
+  flattenToAppURL,
+  isInternalURL,
+  isUrl,
+  normalizeUrl,
+  removeProtocol,
+} from '@plone/volto/helpers/Url/Url';
+import { searchContent } from '@plone/volto/actions/search/search';
 import withObjectBrowser from '@plone/volto/components/manage/Sidebar/ObjectBrowser';
 import { defineMessages, injectIntl } from 'react-intl';
 import Icon from '@plone/volto/components/theme/Icon/Icon';
 import FormFieldWrapper from '@plone/volto/components/manage/Widgets/FormFieldWrapper';
+
 import navTreeSVG from '@plone/volto/icons/nav.svg';
 import clearSVG from '@plone/volto/icons/clear.svg';
 import homeSVG from '@plone/volto/icons/home.svg';
+import aheadSVG from '@plone/volto/icons/ahead.svg';
+import blankSVG from '@plone/volto/icons/blank.svg';
 
 const messages = defineMessages({
   placeholder: {
@@ -42,7 +52,7 @@ const messages = defineMessages({
  * @class ObjectBrowserWidget
  * @extends Component
  */
-class ObjectBrowserWidget extends Component {
+export class ObjectBrowserWidgetComponent extends Component {
   /**
    * Property types.
    * @property {Object} propTypes Property types.
@@ -76,19 +86,29 @@ class ObjectBrowserWidget extends Component {
     mode: 'multiple',
   };
 
+  state = {
+    manualLinkInput: '',
+    validURL: false,
+  };
+
   constructor(props) {
     super(props);
     this.selectedItemsRef = React.createRef();
     this.placeholderRef = React.createRef();
   }
   renderLabel(item) {
+    const href = item['@id'];
     return (
       <Popup
-        key={flattenToAppURL(item['@id'])}
+        key={flattenToAppURL(href)}
         content={
           <>
-            <Icon name={homeSVG} size="18px" />
-            {flattenToAppURL(item['@id'])}
+            {isInternalURL(href) ? (
+              <Icon name={homeSVG} size="18px" />
+            ) : (
+              <Icon name={blankSVG} size="18px" />
+            )}
+            {flattenToAppURL(href)}
           </>
         }
         trigger={
@@ -167,6 +187,74 @@ class ObjectBrowserWidget extends Component {
     }
   };
 
+  onManualLinkInput = (e) => {
+    this.setState({ manualLinkInput: e.target.value });
+    if (this.validateManualLink(e.target.value)) {
+      this.setState({ validURL: true });
+    } else {
+      this.setState({ validURL: false });
+    }
+  };
+
+  validateManualLink = (url) => {
+    if (this.props.allowExternals) {
+      return isUrl(url);
+    } else {
+      return isInternalURL(url);
+    }
+  };
+
+  onSubmitManualLink = () => {
+    if (this.validateManualLink(this.state.manualLinkInput)) {
+      if (isInternalURL(this.state.manualLinkInput)) {
+        // convert it into an internal on if possible
+        this.props
+          .searchContent(
+            '/',
+            {
+              'path.query': flattenToAppURL(this.state.manualLinkInput),
+              sort_on: 'getObjPositionInParent',
+              metadata_fields: '_all',
+              b_size: 1000,
+            },
+            `${this.props.block}-${this.props.mode}`,
+          )
+          .then((resp) => {
+            if (resp.items?.length > 0) {
+              this.onChange(resp.items[0]);
+            } else {
+              this.props.onChange(this.props.id, [
+                {
+                  '@id': normalizeUrl(this.state.manualLinkInput),
+                  title: removeProtocol(this.state.manualLinkInput),
+                },
+              ]);
+            }
+          });
+      } else {
+        this.props.onChange(this.props.id, [
+          {
+            '@id': normalizeUrl(this.state.manualLinkInput),
+            title: removeProtocol(this.state.manualLinkInput),
+          },
+        ]);
+      }
+      this.setState({ validURL: true, manualLinkInput: '' });
+    }
+  };
+
+  onKeyDownManualLink = (e) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      e.stopPropagation();
+      this.onSubmitManualLink();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      e.stopPropagation();
+      // TODO: Do something on ESC key
+    }
+  };
+
   showObjectBrowser = (ev) => {
     ev.preventDefault();
     this.props.openObjectBrowser({
@@ -230,7 +318,9 @@ class ObjectBrowserWidget extends Component {
       >
         <div
           className="objectbrowser-field"
-          aria-labelledby={`fieldset-${fieldSet}-field-label-${id}`}
+          aria-labelledby={`fieldset-${
+            fieldSet || 'default'
+          }-field-label-${id}`}
         >
           <div
             className="selected-values"
@@ -242,23 +332,56 @@ class ObjectBrowserWidget extends Component {
           >
             {items.map((item) => this.renderLabel(item))}
 
-            {items.length === 0 && (
+            {items.length === 0 && this.props.mode === 'multiple' && (
               <div className="placeholder" ref={this.placeholderRef}>
                 {this.props.intl.formatMessage(messages.placeholder)}
               </div>
             )}
-          </div>
-
-          <Button
-            aria-label={this.props.intl.formatMessage(
-              messages.openObjectBrowser,
+            {items.length === 0 && this.props.mode !== 'multiple' && (
+              <input
+                onKeyDown={this.onKeyDownManualLink}
+                onChange={this.onManualLinkInput}
+                value={this.state.manualLinkInput}
+              />
             )}
-            onClick={iconAction}
-            className="action"
-            disabled={isDisabled}
-          >
-            <Icon name={icon} size="18px" />
-          </Button>
+          </div>
+          {this.state.manualLinkInput && isEmpty(items) && (
+            <Button.Group>
+              <Button
+                basic
+                className="cancel"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  this.setState({ manualLinkInput: '' });
+                }}
+              >
+                <Icon name={clearSVG} size="18px" color="#e40166" />
+              </Button>
+              <Button
+                basic
+                primary
+                disabled={!this.state.validURL}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  this.onSubmitManualLink();
+                }}
+              >
+                <Icon name={aheadSVG} size="18px" />
+              </Button>
+            </Button.Group>
+          )}
+          {!this.state.manualLinkInput && (
+            <Button
+              aria-label={this.props.intl.formatMessage(
+                messages.openObjectBrowser,
+              )}
+              onClick={iconAction}
+              className="action"
+              disabled={isDisabled}
+            >
+              <Icon name={icon} size="18px" />
+            </Button>
+          )}
         </div>
       </FormFieldWrapper>
     );
@@ -269,6 +392,11 @@ const ObjectBrowserWidgetMode = (mode) =>
   compose(
     injectIntl,
     withObjectBrowser,
-  )((props) => <ObjectBrowserWidget {...props} mode={mode} />);
+    connect(null, { searchContent }),
+  )((props) => <ObjectBrowserWidgetComponent {...props} mode={mode} />);
 export { ObjectBrowserWidgetMode };
-export default compose(injectIntl, withObjectBrowser)(ObjectBrowserWidget);
+export default compose(
+  injectIntl,
+  withObjectBrowser,
+  connect(null, { searchContent }),
+)(ObjectBrowserWidgetComponent);

--- a/src/components/manage/Widgets/ObjectBrowserWidget.jsx
+++ b/src/components/manage/Widgets/ObjectBrowserWidget.jsx
@@ -71,6 +71,7 @@ export class ObjectBrowserWidgetComponent extends Component {
     ]),
     onChange: PropTypes.func.isRequired,
     openObjectBrowser: PropTypes.func.isRequired,
+    allowedExternal: PropTypes.bool,
   };
 
   /**
@@ -84,6 +85,7 @@ export class ObjectBrowserWidgetComponent extends Component {
     error: [],
     value: [],
     mode: 'multiple',
+    allowedExternal: false,
   };
 
   state = {

--- a/src/components/manage/Widgets/ObjectBrowserWidget.jsx
+++ b/src/components/manage/Widgets/ObjectBrowserWidget.jsx
@@ -342,6 +342,9 @@ export class ObjectBrowserWidgetComponent extends Component {
                 onKeyDown={this.onKeyDownManualLink}
                 onChange={this.onManualLinkInput}
                 value={this.state.manualLinkInput}
+                placeholder={this.props.intl.formatMessage(
+                  messages.placeholder,
+                )}
               />
             )}
           </div>

--- a/src/components/manage/Widgets/ObjectBrowserWidget.stories.js
+++ b/src/components/manage/Widgets/ObjectBrowserWidget.stories.js
@@ -1,0 +1,256 @@
+import ObjectBrowserWidgetDefault, {
+  ObjectBrowserWidgetComponent as OBC,
+} from './ObjectBrowserWidget';
+import Wrapper from '@plone/volto/storybook';
+import React from 'react';
+import { injectIntl } from 'react-intl';
+import UniversalLink from '@plone/volto/components/manage/UniversalLink/UniversalLink';
+
+const search = {
+  items: [
+    {
+      '@id': '/front-page',
+      '@type': 'Document',
+      CreationDate: '2019-08-19T10:13:54+02:00',
+      Creator: 'admin',
+      Date: '2019-08-19T10:13:54+02:00',
+      Description: 'Congratulations! You have successfully installed Plone.',
+      EffectiveDate: 'None',
+      ExpirationDate: 'None',
+      ModificationDate: '2019-08-19T10:13:54+02:00',
+      Subject: [],
+      Title: 'Welcome to Plone',
+      Type: 'Page',
+      UID: 'd4eea28b0d53439389f6f0d647de37f7',
+      author_name: null,
+      cmf_uid: 1,
+      commentators: [],
+      created: '2019-08-19T08:13:54+00:00',
+      description: 'Congratulations! You have successfully installed Plone.',
+      effective: '1969-12-30T22:00:00+00:00',
+      end: null,
+      exclude_from_nav: false,
+      expires: '2499-12-30T22:00:00+00:00',
+      getId: 'front-page',
+      getObjSize: '4.6 KB',
+      getPath: '/Plone/front-page',
+      getRemoteUrl: null,
+      getURL: 'http://localhost:8080/Plone/front-page',
+      id: 'front-page',
+      in_response_to: null,
+      is_folderish: false,
+      last_comment_date: null,
+      listCreators: ['admin'],
+      location: null,
+      meta_type: 'Dexterity Item',
+      mime_type: 'text/plain',
+      modified: '2019-08-19T08:13:54+00:00',
+      portal_type: 'Document',
+      review_state: 'published',
+      start: null,
+      sync_uid: null,
+      title: 'Welcome to Plone',
+      total_comments: 0,
+    },
+    {
+      '@id': '/news',
+      '@type': 'Folder',
+      CreationDate: '2019-08-19T10:13:54+02:00',
+      Creator: 'admin',
+      Date: '2019-08-19T10:13:54+02:00',
+      Description: 'Site News',
+      EffectiveDate: 'None',
+      ExpirationDate: 'None',
+      ModificationDate: '2019-08-19T10:13:54+02:00',
+      Subject: [],
+      Title: 'News',
+      Type: 'Folder',
+      UID: 'e5e494af671d4764a6ca417ab9c2348a',
+      author_name: null,
+      cmf_uid: null,
+      commentators: [],
+      created: '2019-08-19T08:13:54+00:00',
+      description: 'Site News',
+      effective: '1969-12-30T22:00:00+00:00',
+      end: null,
+      exclude_from_nav: false,
+      expires: '2499-12-30T22:00:00+00:00',
+      getId: 'news',
+      getObjSize: '0 KB',
+      getPath: '/Plone/news',
+      getRemoteUrl: null,
+      getURL: 'http://localhost:8080/Plone/news',
+      id: 'news',
+      in_response_to: null,
+      is_folderish: true,
+      last_comment_date: null,
+      listCreators: ['admin'],
+      location: null,
+      meta_type: 'Dexterity Container',
+      mime_type: 'text/plain',
+      modified: '2019-08-19T08:13:54+00:00',
+      portal_type: 'Folder',
+      review_state: 'published',
+      start: null,
+      sync_uid: null,
+      title: 'News',
+      total_comments: 0,
+    },
+  ],
+};
+
+const customStore = {
+  search: {
+    subrequests: {
+      'testBlock-multiple': search,
+      'testBlock-link': search,
+    },
+  },
+  userSession: { token: '1234' },
+  intl: {
+    locale: 'en',
+    messages: {},
+  },
+};
+
+const ObjectBrowserWidgetComponent = (args) => {
+  const IntlWrappedComponent = injectIntl(OBC);
+  return (
+    <Wrapper>
+      <style dangerouslySetInnerHTML={{ __html: style }}></style>
+      <IntlWrappedComponent {...args} search={search} />
+    </Wrapper>
+  );
+};
+
+const ObjectBrowserWidget = (args) => {
+  const [value, setValue] = React.useState([]);
+  const onChange = (block, value) => setValue(value);
+
+  return (
+    <Wrapper
+      location={{ pathname: '/folder2/folder21/doc212' }}
+      customStore={customStore}
+    >
+      <style dangerouslySetInnerHTML={{ __html: style }}></style>
+      <ObjectBrowserWidgetDefault
+        {...args}
+        id="objectBrowser"
+        title="Object Browser"
+        block="testBlock"
+        value={value}
+        onChange={onChange}
+      />
+      {value?.length > 0 && (
+        <div style={{ marginTop: '40px' }}>
+          <UniversalLink item={value[0]}>{value[0]['@id']}</UniversalLink>
+        </div>
+      )}
+    </Wrapper>
+  );
+};
+
+export default {
+  title: 'Object Browser',
+  component: OBC,
+  decorators: [
+    (Story) => (
+      <div style={{ width: '400px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+  // subcomponents: { ArgsTable },
+};
+
+export const Renderer = () => <ObjectBrowserWidgetComponent search={search} />;
+
+export const Connected = () => <ObjectBrowserWidget />;
+export const SingleElement = () => <ObjectBrowserWidget mode="link" />;
+
+const style = `
+.list .content .list a {
+  padding-left: 2rem !important;
+}
+
+.in_path {
+  font-weight: bold !important;
+}
+
+.list .content .list {
+  padding-top: 0!important;
+  padding-bottom: 0!important;
+
+  border-top: 1px solid #eee;
+  border-bottom: 1px solid #eee;
+}
+
+.context-navigation {
+  margin-right: 1rem;;
+  background     : white;
+  padding        : 0;
+  max-width      : 210px;
+  box-shadow     : 0px 0px 12px rgba(0, 0, 0, 0.2);
+  list-style-type: none;
+  border-radius  : 4px;
+  overflow       : hidden;
+}
+
+@media(max-width: 1200px) {
+  .context-navigation {
+    /* margin-right: 0; */
+    margin-top: 2rem;
+    box-shadow: none;
+    max-width: 200px;
+    margin: 2rem auto;
+  }
+}
+
+.context-navigation .item a {
+  padding    : .6rem 1rem;
+  font-size  : 1rem;
+  font-weight: 500;
+  display    : block;
+  position: relative;
+  color: #444;
+  font-weight: 400;
+}
+
+@media (min-width: 1200px) and (max-width: 1500px) {
+  .context-navigation .item a {
+    font-size: .9rem;
+  }
+}
+
+.context-navigation .item a:hover {
+  background: #cc4400 !important;
+  color     : white !important;
+}
+
+.context-navigation-header {
+  color      : #333;
+  font-size  : 16px;
+  font-weight: 500;
+  padding    : 1rem;
+  box-shadow : 0px 4px 19px rgba(0, 0, 1, 0.07);
+  border-bottom: 3px solid #cc4400;
+}
+.context-navigation-header a {
+  color: #444;
+    font-size: 1.3rem;
+    font-weight: 100;
+}
+
+.context-navigation .active-indicator {
+    position: absolute;
+    right: 0;
+    top: 50%;
+    transform: translateY(-50%);
+    color: #cc4400;
+    font-weight: bold;
+}
+
+.context-navigation .item a:hover .active-indicator {
+  color     : white !important;
+}
+`;

--- a/src/components/manage/Widgets/__snapshots__/ObjectBrowserWidget.test.jsx.snap
+++ b/src/components/manage/Widgets/__snapshots__/ObjectBrowserWidget.test.jsx.snap
@@ -44,6 +44,7 @@ exports[`renders a objectBrowser widget component 1`] = `
               No items selected
             </div>
           </div>
+          
           <button
             aria-label="Open object browser"
             className="ui button action"

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -2,7 +2,7 @@
  * Config.
  * @module config
  */
-
+import { parse as parseUrl } from 'url';
 import { defaultWidget, widgetMapping } from './Widgets';
 import {
   layoutViews,
@@ -45,6 +45,23 @@ const apiPath =
     ? `http://${host}:${port}/api`
     : 'http://localhost:8080/Plone');
 
+const getServerURL = (url) => {
+  if (!url) return;
+  const apiPathURL = parseUrl(url);
+  return `${apiPathURL.protocol}//${apiPathURL.hostname}:${apiPathURL.port}`;
+};
+
+// Sensible defaults for publicURL
+// if RAZZLE_PUBLIC_URL is present, use it
+// if in DEV, use the host/port combination by default
+// if in PROD, assume it's RAZZLE_API_PATH server name (no /api or alikes) or fallback
+// to DEV settings if RAZZLE_API_PATH is not present
+const publicURL =
+  process.env.RAZZLE_PUBLIC_URL ||
+  (__DEVELOPMENT__
+    ? `http://${host}:${port}`
+    : getServerURL(process.env.RAZZLE_API_PATH) || `http://${host}:${port}`);
+
 const serverConfig =
   typeof __SERVER__ !== 'undefined' && __SERVER__
     ? require('./server').default
@@ -54,6 +71,8 @@ let config = {
   settings: {
     host,
     port,
+    // The URL Volto is going to be served (see sensible defaults above)
+    publicURL,
     // Internal proxy to bypass CORS *while developing*. Not intended for production use.
     // In production, the proxy is disabled, make sure you specify an apiPath that does
     // not require CORS to work.

--- a/src/helpers/Url/Url.js
+++ b/src/helpers/Url/Url.js
@@ -4,6 +4,8 @@
  */
 
 import { last, memoize } from 'lodash';
+import urlRegex from './urlRegex';
+import prependHttp from 'prepend-http';
 import config from '@plone/volto/registry';
 
 /**
@@ -92,7 +94,10 @@ export function flattenToAppURL(url) {
   const { settings } = config;
   return (
     url &&
-    url.replace(settings.internalApiPath, '').replace(settings.apiPath, '')
+    url
+      .replace(settings.internalApiPath, '')
+      .replace(settings.apiPath, '')
+      .replace(settings.publicURL, '')
   );
 }
 
@@ -155,10 +160,29 @@ export function addAppURL(url) {
 export function isInternalURL(url) {
   const { settings } = config;
   return (
+    url.indexOf(settings.publicURL) !== -1 ||
     url.indexOf(settings.internalApiPath) !== -1 ||
     url.indexOf(settings.apiPath) !== -1 ||
     url.charAt(0) === '/' ||
     url.charAt(0) === '.' ||
     url.startsWith('#')
   );
+}
+
+/**
+ * Check if it's a valid url
+ * @method isUrl
+ * @param {string} url URL of the object
+ * @returns {boolean} True if is a valid url
+ */
+export function isUrl(url) {
+  return urlRegex().test(url);
+}
+
+export function normalizeUrl(url) {
+  return prependHttp(url);
+}
+
+export function removeProtocol(url) {
+  return url.replace('https://', '').replace('http://', '');
 }

--- a/src/helpers/Url/Url.js
+++ b/src/helpers/Url/Url.js
@@ -179,10 +179,22 @@ export function isUrl(url) {
   return urlRegex().test(url);
 }
 
+/**
+ * Normalize URL, adds protocol (if required eg. user has not entered the protocol)
+ * @method normalizeUrl
+ * @param {string} url URL of the object
+ * @returns {boolean} URL with the protocol
+ */
 export function normalizeUrl(url) {
   return prependHttp(url);
 }
 
+/**
+ * Removes protocol from URL (for display)
+ * @method removeProtocol
+ * @param {string} url URL of the object
+ * @returns {string} URL without the protocol part
+ */
 export function removeProtocol(url) {
   return url.replace('https://', '').replace('http://', '');
 }

--- a/src/helpers/Url/Url.test.js
+++ b/src/helpers/Url/Url.test.js
@@ -7,6 +7,9 @@ import {
   getView,
   isCmsUi,
   isInternalURL,
+  isUrl,
+  normalizeUrl,
+  removeProtocol,
 } from './Url';
 
 const { settings } = config;
@@ -107,8 +110,16 @@ describe('Url', () => {
     });
   });
   describe('isInternalURL', () => {
-    it('tells if an URL is internal or not', () => {
+    it('tells if an URL from API is internal or not', () => {
       const href = `${settings.apiPath}/foo/bar`;
+      expect(isInternalURL(href)).toBe(true);
+    });
+    it('tells if an URL from APP is internal or not', () => {
+      const href = `${settings.publicURL}`;
+      expect(isInternalURL(href)).toBe(true);
+    });
+    it('tells if an URL from APP is internal or not 2', () => {
+      const href = `${settings.publicURL}/foo/bar`;
       expect(isInternalURL(href)).toBe(true);
     });
     it('tells if an URL is internal or not, with settings.internalApiPath', () => {
@@ -129,6 +140,44 @@ describe('Url', () => {
     it('tells if an URL is internal if a relative path', () => {
       const href = './../';
       expect(isInternalURL(href)).toBe(true);
+    });
+  });
+  describe('isUrl', () => {
+    it('isUrl test', () => {
+      const href = `www.example.com`;
+      expect(isUrl(href)).toBe(true);
+    });
+    it('isUrl test 2', () => {
+      const href = `www.example.com/foo/bar`;
+      expect(isUrl(href)).toBe(true);
+    });
+    it('isUrl test 3', () => {
+      const href = `https://www.example.com/foo/bar`;
+      expect(isUrl(href)).toBe(true);
+    });
+    it('isUrl test 4', () => {
+      const href = `https://www`;
+      expect(isUrl(href)).toBe(false);
+    });
+    it('isUrl test 5', () => {
+      const href = `www.e`;
+      expect(isUrl(href)).toBe(false);
+    });
+  });
+  describe('normalizeUrl', () => {
+    it('normalizeUrl test', () => {
+      const href = `www.example.com`;
+      expect(normalizeUrl(href)).toBe('http://www.example.com');
+    });
+  });
+  describe('removeProtocol', () => {
+    it('removeProtocol test https', () => {
+      const href = `https://www.example.com`;
+      expect(removeProtocol(href)).toBe('www.example.com');
+    });
+    it('removeProtocol test http', () => {
+      const href = `http://www.example.com`;
+      expect(removeProtocol(href)).toBe('www.example.com');
     });
   });
 });

--- a/src/helpers/Url/urlRegex.js
+++ b/src/helpers/Url/urlRegex.js
@@ -1,0 +1,54 @@
+/* eslint-disable  arrow-body-style */
+/* eslint-disable  no-confusing-arrow */
+import tlds from 'tlds';
+
+const v4 =
+  '(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])(?:\\.(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])){3}';
+const v6seg = '[0-9a-fA-F]{1,4}';
+const v6 = `
+(
+(?:${v6seg}:){7}(?:${v6seg}|:)|                                // 1:2:3:4:5:6:7::  1:2:3:4:5:6:7:8
+(?:${v6seg}:){6}(?:${v4}|:${v6seg}|:)|                         // 1:2:3:4:5:6::    1:2:3:4:5:6::8   1:2:3:4:5:6::8  1:2:3:4:5:6::1.2.3.4
+(?:${v6seg}:){5}(?::${v4}|(:${v6seg}){1,2}|:)|                 // 1:2:3:4:5::      1:2:3:4:5::7:8   1:2:3:4:5::8    1:2:3:4:5::7:1.2.3.4
+(?:${v6seg}:){4}(?:(:${v6seg}){0,1}:${v4}|(:${v6seg}){1,3}|:)| // 1:2:3:4::        1:2:3:4::6:7:8   1:2:3:4::8      1:2:3:4::6:7:1.2.3.4
+(?:${v6seg}:){3}(?:(:${v6seg}){0,2}:${v4}|(:${v6seg}){1,4}|:)| // 1:2:3::          1:2:3::5:6:7:8   1:2:3::8        1:2:3::5:6:7:1.2.3.4
+(?:${v6seg}:){2}(?:(:${v6seg}){0,3}:${v4}|(:${v6seg}){1,5}|:)| // 1:2::            1:2::4:5:6:7:8   1:2::8          1:2::4:5:6:7:1.2.3.4
+(?:${v6seg}:){1}(?:(:${v6seg}){0,4}:${v4}|(:${v6seg}){1,6}|:)| // 1::              1::3:4:5:6:7:8   1::8            1::3:4:5:6:7:1.2.3.4
+(?::((?::${v6seg}){0,5}:${v4}|(?::${v6seg}){1,7}|:))           // ::2:3:4:5:6:7:8  ::2:3:4:5:6:7:8  ::8             ::1.2.3.4
+)(%[0-9a-zA-Z]{1,})?                                           // %eth0            %1
+`
+  .replace(/\s*\/\/.*$/gm, '')
+  .replace(/\n/g, '')
+  .trim();
+
+const ipRegex = (opts) =>
+  opts && opts.exact
+    ? new RegExp(`(?:^${v4}$)|(?:^${v6}$)`)
+    : new RegExp(`(?:${v4})|(?:${v6})`, 'g');
+
+ipRegex.v4 = (opts) =>
+  opts && opts.exact ? new RegExp(`^${v4}$`) : new RegExp(v4, 'g');
+ipRegex.v6 = (opts) =>
+  opts && opts.exact ? new RegExp(`^${v6}$`) : new RegExp(v6, 'g');
+
+export default (_opts) => {
+  const opts = Object.assign({ strict: true }, _opts);
+  const protocol = `(?:(?:[a-z]+:)?//)${opts.strict ? '' : '?'}`;
+  const auth = '(?:\\S+(?::\\S*)?@)?';
+  const ip = ipRegex.v4().source;
+  const host = '(?:(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+)';
+  const domain =
+    '(?:\\.(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+)*';
+  const tld = `(?:\\.${
+    opts.strict
+      ? '(?:[a-z\\u00a1-\\uffff]{2,})'
+      : `(?:${tlds.sort((a, b) => b.length - a.length).join('|')})`
+  })\\.?`;
+  const port = '(?::\\d{2,5})?';
+  const path = '(?:[/?#][^\\s"]*)?';
+  const regex = `(?:${protocol}|www\\.)${auth}(?:localhost|${ip}|${host}${domain}${tld})${port}${path}`;
+
+  return opts.exact
+    ? new RegExp(`(?:^${regex}$)`, 'i')
+    : new RegExp(regex, 'ig');
+};

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -22,6 +22,9 @@ export {
   getView,
   isCmsUi,
   getId,
+  isUrl,
+  normalizeUrl,
+  removeProtocol,
 } from '@plone/volto/helpers/Url/Url';
 export { generateSitemap } from '@plone/volto/helpers/Sitemap/Sitemap';
 export { generateRobots } from '@plone/volto/helpers/Robots/Robots';

--- a/theme/themes/pastanaga/extras/objectbrowser-widget.less
+++ b/theme/themes/pastanaga/extras/objectbrowser-widget.less
@@ -5,6 +5,8 @@
 
   .selected-values {
     display: flex;
+
+    overflow: hidden;
     flex: 1 1 auto;
     flex-wrap: wrap;
     align-items: center;
@@ -13,7 +15,10 @@
     margin-right: 1.5em;
 
     .ui.label {
+      overflow: hidden;
       margin: 0.3em;
+      text-overflow: ellipsis;
+      white-space: nowrap;
     }
   }
 
@@ -25,5 +30,9 @@
 
   .placeholder {
     color: #878f93;
+  }
+
+  input {
+    border: none !important;
   }
 }


### PR DESCRIPTION
WIP

- [x] allow manual input for URLs, tokeniser detector for internal ones, only for non-"multiple" widgets (eg. relation fields)
- [x] new helpers for making that possible - isInternalURL
- [x] new config setting for indicating the URL the app is deployed on (`publicURL`) so we can determine even in SSR isInternalURLs
- [x] new prop `allowedExternal` for the widget, if we do not want the widget to allow external links
- [x] tests for the new helpers required
- [x] documentation for the new `allowedExternal` prop
- [ ] cypress tests for it
- [ ] add icon for external and internal in the token?
- [x] fix icon in the popup

I wonder if we would like to reuse this in other scenarios, like the link chooser in the text block editor... we could refactor it to make it happen...

(sound on) 😄 

https://user-images.githubusercontent.com/486927/110161342-82cb1300-7ded-11eb-9b35-ee47d45ccf07.mov

