### PR TITLE
added explicit information about src/config.js to internal API proxy docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
 - Add "Humboldt Labor" to show cases.
 - Updated "Volto in Production" list @alecghica
 
+### Docs
+
+- Explicitly mention `src/config` in the "Internal proxy to API" documentation @pigeonflight
+
 ## 12.2.0 (2021-03-03)
 
 ### Feature

--- a/docs/source/configuration/internalproxy.md
+++ b/docs/source/configuration/internalproxy.md
@@ -2,7 +2,7 @@
 
 While in development, Volto has an internal proxy to the backend API enabled by default.
 It provides a better developer experience out of the box, so the developer doesn't has to
-deal with [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) and can focus in
+deal with [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) and can focus on
 develop/test drive/demo Volto.
 
 ## Configuration
@@ -25,7 +25,9 @@ Here are some examples.
 
 ### Redefining the proxy target
 
-You can redefine the local proxy target by using the `RAZZLE_DEV_PROXY_API_PATH` or `devProxyToApiPath` in the configuration object.
+You can redefine the local proxy target by using the `RAZZLE_DEV_PROXY_API_PATH` or `devProxyToApiPath` in the configuration object (`src/config.js`).
+
+For example, if the path to your Plone site is `http://localhost:8081/mysite`, add the following to the bottom of the `src/config.js` file:
 
 ```js
 export const settings = {
@@ -54,6 +56,9 @@ or use the environment variable:
 RAZZLE_API_PATH=http://localhost:8081/mysite yarn start
 ```
 
+!!! tip
+    To view the existing configuration, add console.log(config) to the `applyConfig` function. This dumps the existing config to your browser console.
+    
 ### Advanced usage
 
 It's possible to define the proxy target more accuratelly using the `RAZZLE_PROXY_REWRITE_TARGET` environment variable, or the `proxyRewriteTarget` setting in the configuration object.


### PR DESCRIPTION
The internal API proxy  documentation now includes more information about src/config.js and
a tip on using console.log(config) to view configuration settings.