### PR TITLE
Fix SidebarPortal min-height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugfix
 
 - fixed italian translations for block 'Maps" @giuliaghisini
+- fixed SidebarPortal min-height @avoinea
 
 ### Internal
 

--- a/src/components/manage/Sidebar/SidebarPortal.jsx
+++ b/src/components/manage/Sidebar/SidebarPortal.jsx
@@ -18,9 +18,9 @@ const SidebarPortal = ({ children, selected, tab = 'sidebar-properties' }) => {
     <>
       {selected && (
         <Portal node={isClient && document.getElementById(tab)}>
-          <div role="form" style={{ height: '100%' }}>
+          <div role="form" style={{ minHeight: '100%' }}>
             <div
-              style={{ height: '100%' }}
+              style={{ minHeight: '100%' }}
               role="presentation"
               onClick={(e) => {
                 e.stopPropagation();

--- a/src/components/manage/Sidebar/__snapshots__/SidebarPortal.test.jsx.snap
+++ b/src/components/manage/Sidebar/__snapshots__/SidebarPortal.test.jsx.snap
@@ -11,7 +11,7 @@ exports[`sidebar portal is rendered when the block is selected 1`] = `
       role="form"
       style={
         Object {
-          "height": "100%",
+          "minHeight": "100%",
         }
       }
     >
@@ -21,7 +21,7 @@ exports[`sidebar portal is rendered when the block is selected 1`] = `
         role="presentation"
         style={
           Object {
-            "height": "100%",
+            "minHeight": "100%",
           }
         }
       >


### PR DESCRIPTION
Fixes the following visual bug when the sidebar content is higher than the screen height:

![min-height](https://user-images.githubusercontent.com/323385/112212356-88b25800-8c25-11eb-8667-41d5117cfd47.png)
