### PR TITLE
Make CheckboxWidget behave as a controlled input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - fixed italian translations for block 'Maps" @giuliaghisini
 - fixed SidebarPortal min-height @avoinea
+- fixed CheckboxWidget state @razvanMiu
 
 ### Internal
 

--- a/src/components/manage/Widgets/CheckboxWidget.jsx
+++ b/src/components/manage/Widgets/CheckboxWidget.jsx
@@ -17,15 +17,19 @@ import { FormFieldWrapper } from '@plone/volto/components';
  */
 const CheckboxWidget = (props) => {
   const { id, title, value, onChange, isDisabled } = props;
+  const [checked, setChecked] = React.useState(value || false);
 
   return (
     <FormFieldWrapper {...props} columns={1}>
       <div className="wrapper">
         <Checkbox
           name={`field-${id}`}
-          checked={value}
+          checked={checked}
           disabled={isDisabled}
-          onChange={(event, { checked }) => onChange(id, checked)}
+          onChange={(event, { checked }) => {
+            onChange(id, checked);
+            setChecked(checked);
+          }}
           label={<label htmlFor={`field-${id}`}>{title}</label>}
         />
       </div>

--- a/src/components/manage/Widgets/__snapshots__/CheckboxWidget.test.jsx.snap
+++ b/src/components/manage/Widgets/__snapshots__/CheckboxWidget.test.jsx.snap
@@ -24,7 +24,7 @@ exports[`renders a checkbox widget component 1`] = `
             onMouseUp={[Function]}
           >
             <input
-              checked={null}
+              checked={false}
               className="hidden"
               name="field-my-field"
               readOnly={true}


### PR DESCRIPTION
_Before_
![before-gif](https://user-images.githubusercontent.com/24816111/112493241-ab11b600-8d8a-11eb-9ee7-b5c28f91b8b4.gif)

**Issue:** 
If the value of a checkbox is set to `true` going back to it and changing its value, the checkbox will remain checked even though the value is false.
Also a warning is popping out stating that the input needs to be either controlled or uncontrolled.

![Screenshot_2021-03-25_15-02-16](https://user-images.githubusercontent.com/24816111/112495021-2e7fd700-8d8c-11eb-900a-ac5929bc2337.png)

**Fix:**
Use a controlled input by defining a state which takes the value of `props.value` on mount or `false` by default.

_After_
![after-gif](https://user-images.githubusercontent.com/24816111/112495618-bb2a9500-8d8c-11eb-8240-4dca7d81d947.gif)
