### PR TITLE
Fixed InlineForm boolean false value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Fixed InlineForm boolean false value @razvanMiu
+
 ### Internal
 
 ## 12.4.0 (2021-03-25)

--- a/src/components/manage/Form/InlineForm.jsx
+++ b/src/components/manage/Form/InlineForm.jsx
@@ -75,7 +75,11 @@ const InlineForm = ({
             id={field}
             fieldSet={defaultFieldset.title.toLowerCase()}
             focus={index === 0}
-            value={formData[field] || schema.properties[field].default}
+            value={
+              'default' in schema.properties[field]
+                ? formData[field] || schema.properties[field].default
+                : formData[field]
+            }
             required={schema.required.indexOf(field) !== -1}
             onChange={(id, value) => {
               onChangeField(id, value);
@@ -97,7 +101,11 @@ const InlineForm = ({
               <Field
                 {...schema.properties[field]}
                 id={field}
-                value={formData[field] || schema.properties[field].default}
+                value={
+                  'default' in schema.properties[field]
+                    ? formData[field] || schema.properties[field].default
+                    : formData[field]
+                }
                 required={schema.required.indexOf(field) !== -1}
                 onChange={(id, value) => {
                   onChangeField(id, value);

--- a/src/components/manage/Widgets/CheckboxWidget.jsx
+++ b/src/components/manage/Widgets/CheckboxWidget.jsx
@@ -17,18 +17,16 @@ import { FormFieldWrapper } from '@plone/volto/components';
  */
 const CheckboxWidget = (props) => {
   const { id, title, value, onChange, isDisabled } = props;
-  const [checked, setChecked] = React.useState(value || false);
 
   return (
     <FormFieldWrapper {...props} columns={1}>
       <div className="wrapper">
         <Checkbox
           name={`field-${id}`}
-          checked={checked}
+          checked={value}
           disabled={isDisabled}
           onChange={(event, { checked }) => {
             onChange(id, checked);
-            setChecked(checked);
           }}
           label={<label htmlFor={`field-${id}`}>{title}</label>}
         />

--- a/src/components/manage/Widgets/__snapshots__/CheckboxWidget.test.jsx.snap
+++ b/src/components/manage/Widgets/__snapshots__/CheckboxWidget.test.jsx.snap
@@ -24,7 +24,7 @@ exports[`renders a checkbox widget component 1`] = `
             onMouseUp={[Function]}
           >
             <input
-              checked={false}
+              checked={null}
               className="hidden"
               name="field-my-field"
               readOnly={true}


### PR DESCRIPTION
**Issue:** If you have a boolean type Field (CheckboxWidget) with no default value and `props.value = false` then this condition `formData[field] || schema.properties[field].default` from InlineForm will evaluate as `false || undefined` which is equal to `undefined` hence the CheckboxWidget value will be `undefined` and will create the issue from here https://github.com/plone/volto/pull/2296.
**Fix:** Use the `default` property only if `default` is a defined property otherwise use the value of the Field.