### PR TITLE
This fixes addons in Volto itself

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["./babel"]
-}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Update plone/volto Docker image to use latest yo generator and support ADDONS env @avoinea
 - Add `docker-compose.yml` to the repo for quick demoing @sneridagh
+- Fixed babel config when loading addons (in testing mode) @sneridagh
 
 ## 12.4.0 (2021-03-25)
 

--- a/__tests__/create-addons-loader.test.js
+++ b/__tests__/create-addons-loader.test.js
@@ -130,6 +130,7 @@ function transpile(fpath) {
   const code = fs.readFileSync(fpath, 'utf-8');
   // console.log('original code', code);
   const output = transform(code, {
+    root: '../',
     plugins: ['@babel/plugin-transform-modules-commonjs'],
   });
   fs.writeFileSync(fpath, output.code);

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,1 @@
+module.exports = require('./babel');

--- a/razzle.config.js
+++ b/razzle.config.js
@@ -201,6 +201,16 @@ const defaultModify = ({
     addonsAsExternals = registry.addonNames.map((addon) => new RegExp(addon));
   }
 
+  if (process.env.RAZZLE_TESTING_ADDONS) {
+    testingAddons.forEach((addon) => {
+      const p = fs.realpathSync(registry.packages[addon].modulePath);
+      if (include.indexOf(p) === -1) {
+        include.push(p);
+      }
+      addonsAsExternals = registry.addonNames.map((addon) => new RegExp(addon));
+    });
+  }
+
   config.externals =
     target === 'node'
       ? [


### PR DESCRIPTION
by using the root config using the nowadays accepted naming for the babel config:

https://babeljs.io/docs/en/config-files#project-wide-configuration

Projects are already using it.

Also, updated the adding the nodeExternals for testing addons