### PR TITLE
Support for Github addon --template

### DIFF
--- a/packages/generator-volto/CHANGELOG.md
+++ b/packages/generator-volto/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Support for Github addon `--template` @avoinea
+
 ### Changes
 
 ## 4.1.0 (2021-03-26)

--- a/packages/generator-volto/README.md
+++ b/packages/generator-volto/README.md
@@ -91,14 +91,16 @@ Usage:
   yo @plone/volto:addon [<addonName>] [options]
 
 Options:
-  -h,   --help          # Print the generator's options and usage
-        --skip-cache    # Do not remember prompt answers             Default: false
-        --skip-install  # Do not automatically install dependencies  Default: false
-        --interactive   # Enable/disable interactive prompt          Default: true
+  -h,   --help           # Print the generator's options and usage
+        --skip-cache     # Do not remember prompt answers                            Default: false
+        --skip-install   # Do not automatically install dependencies                 Default: false
+        --force-install  # Fail on install dependencies error                        Default: false
+        --ask-answered   # Show prompts for already configured options               Default: false
+        --interactive    # Enable/disable interactive prompt                         Default: true
+        --template       # Use github repo template, e.g.: eea/volto-addon-template
 
 Arguments:
-  addonName  # Addon name, e.g.: @corp/volto-custom-block  Type: String  Required: false
-
+  addonName  # Addon name, e.g.: @plone-collective/volto-custom-block  Type: String  Required: false
 ```
 
 ### Start Volto with `yarn start`

--- a/packages/generator-volto/__tests__/addon.js
+++ b/packages/generator-volto/__tests__/addon.js
@@ -1,0 +1,22 @@
+const path = require('path');
+const assert = require('yeoman-assert');
+const helpers = require('yeoman-test');
+
+describe('generator-create-volto-app:addon', () => {
+  beforeAll(() => {
+    return helpers
+      .run(path.join(__dirname, '../generators/addon'))
+      .withPrompts({
+        addonName: 'test-volto-addon',
+      });
+  });
+
+  it('creates files', () => {
+    assert.file([
+      'src/addons/test-volto-addon/package.json',
+      'src/addons/test-volto-addon/.gitignore',
+      'src/addons/test-volto-addon/src/index.js',
+      'src/addons/test-volto-addon/src/i18n.js',
+    ]);
+  });
+});

--- a/packages/generator-volto/generators/addon/index.js
+++ b/packages/generator-volto/generators/addon/index.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const Generator = require('yeoman-generator');
+const utils = require('./utils');
 
 const currentDir = path.basename(process.cwd());
 
@@ -15,6 +16,11 @@ module.exports = class extends Generator {
       type: Boolean,
       desc: 'Enable/disable interactive prompt',
       default: true,
+    });
+    this.option('template', {
+      type: String,
+      desc: 'Use github repo template, e.g.: eea/volto-addon-template',
+      default: '',
     });
 
     this.args = args;
@@ -42,6 +48,7 @@ Run "npm install -g @plone/generator-volto" to update.`,
       addonName: '',
       name: '',
       scope: '',
+      template: '',
     };
     let props;
 
@@ -71,6 +78,11 @@ Run "npm install -g @plone/generator-volto" to update.`,
     } else {
       this.globals.name = this.globals.addonName;
     }
+
+    // Template
+    if (this.opts.template) {
+      this.globals.template = this.opts.template;
+    }
   }
 
   writing() {
@@ -78,20 +90,27 @@ Run "npm install -g @plone/generator-volto" to update.`,
       currentDir === this.globals.name
         ? '.'
         : './src/addons/' + this.globals.name;
-    this.fs.copyTpl(
-      this.templatePath('package.json.tpl'),
-      this.destinationPath(base, 'package.json'),
-      this.globals,
-    );
+    if (this.globals.template) {
+      utils.githubTpl(
+        this.globals.template,
+        this.destinationPath(base),
+        this.globals,
+      );
+    } else {
+      this.fs.copyTpl(
+        this.templatePath('package.json.tpl'),
+        this.destinationPath(base, 'package.json'),
+        this.globals,
+      );
 
-    this.fs.copy(this.templatePath(), this.destinationPath(base), {
-      globOptions: {
-        ignore: ['**/*.tpl', '**/*~'],
-        dot: true,
-      },
-    });
-
-    this.fs.delete(this.destinationPath(base, 'package.json.tpl'));
+      this.fs.copy(this.templatePath(), this.destinationPath(base), {
+        globOptions: {
+          ignore: ['**/*.tpl', '**/*~'],
+          dot: true,
+        },
+      });
+      this.fs.delete(this.destinationPath(base, 'package.json.tpl'));
+    }
   }
 
   install() {}

--- a/packages/generator-volto/generators/addon/utils.js
+++ b/packages/generator-volto/generators/addon/utils.js
@@ -1,0 +1,56 @@
+const gitly = require('gitly');
+const ejs = require('ejs');
+const fs = require('fs');
+const path = require('path');
+
+/*
+ * Apply tplSettings on .tpl file
+ */
+const bootstrap = function (ofile, tplSettings) {
+  fs.readFile(ofile, 'utf8', function (err, data) {
+    if (err) {
+      // eslint-disable-next-line no-console
+      return console.error(err);
+    }
+    const result = ejs.render(data, { ...tplSettings });
+    fs.writeFile(ofile, result, 'utf8', function (err) {
+      if (err) {
+        // eslint-disable-next-line no-console
+        return console.error(err);
+      }
+    });
+    if (ofile.includes('.tpl')) {
+      const output = ofile.replace('.tpl', '');
+      fs.rename(ofile, output, (err) => {
+        if (err) {
+          // eslint-disable-next-line no-console
+          return console.error(err);
+        }
+      });
+    }
+  });
+};
+
+/*
+ * Get github template and apply tplSettings on .tpl files
+ */
+async function githubTpl(source, destination, tplSettings) {
+  await gitly.default(source, destination);
+  fs.readdir(destination, { withFileTypes: true }, (err, dirents) => {
+    if (err) {
+      // eslint-disable-next-line no-console
+      return console.error(err);
+    }
+    const files = dirents
+      .filter((dirent) => dirent.isFile())
+      .map((dirent) => dirent.name);
+    files.forEach(function (file) {
+      const file_path = path.join(destination, file);
+      bootstrap(file_path, tplSettings);
+    });
+  });
+}
+
+module.exports = {
+  githubTpl,
+};

--- a/packages/generator-volto/package.json
+++ b/packages/generator-volto/package.json
@@ -110,6 +110,7 @@
     "eslint-config-standard": "^16.0.2",
     "execa": "0.6.3",
     "fs-extra": "3.0.0",
+    "gitly": "2.0.3",
     "mkdirp-then": "1.2.0",
     "ms": "1.0.0",
     "mz": "2.6.0",

--- a/packages/generator-volto/yarn.lock
+++ b/packages/generator-volto/yarn.lock
@@ -999,6 +999,13 @@ axios@^0.18.0:
     follow-redirects "1.5.10"
     is-buffer "^2.0.2"
 
+axios@^0.21.1:
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
+  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
+  dependencies:
+    follow-redirects "^1.10.0"
+
 babel-jest@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-24.9.0.tgz#3fc327cb8467b89d14d7bc70e315104a783ccd54"
@@ -1308,6 +1315,11 @@ chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
+
+chownr@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
+  integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
 
 ci-info@^2.0.0:
   version "2.0.0"
@@ -2496,6 +2508,11 @@ follow-redirects@1.5.10:
   dependencies:
     debug "=3.1.0"
 
+follow-redirects@^1.10.0:
+  version "1.13.3"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.3.tgz#e5598ad50174c1bc4e872301e82ac2cd97f90267"
+  integrity sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA==
+
 for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -2539,6 +2556,13 @@ fs-extra@3.0.0:
     graceful-fs "^4.1.2"
     jsonfile "^3.0.0"
     universalify "^0.1.0"
+
+fs-minipass@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-2.1.0.tgz#7f5036fdbf12c63c169190cbe4199c852271f9fb"
+  integrity sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==
+  dependencies:
+    minipass "^3.0.0"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -2663,6 +2687,14 @@ github-username@^4.0.0:
   integrity sha1-y+KABBiDIG2kISrp5LXxacML9Bc=
   dependencies:
     gh-got "^6.0.0"
+
+gitly@2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/gitly/-/gitly-2.0.3.tgz#6da28a32fd6f4b96838d251cb2941d2644627310"
+  integrity sha512-xpbBJ4IZJbLXmggispcRlppo9hsYI90lxzYuLPEYQ4FaOG5j+o1K1823MD54KFIyMgBzS5lnlInvXgEibG2uuA==
+  dependencies:
+    axios "^0.21.1"
+    tar "^6.1.0"
 
 glob-parent@^3.1.0:
   version "3.1.0"
@@ -4585,6 +4617,21 @@ minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
+minipass@^3.0.0:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.1.3.tgz#7d42ff1f39635482e15f9cdb53184deebd5815fd"
+  integrity sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==
+  dependencies:
+    yallist "^4.0.0"
+
+minizlib@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-2.1.2.tgz#e90d3466ba209b932451508a11ce3d3632145931"
+  integrity sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==
+  dependencies:
+    minipass "^3.0.0"
+    yallist "^4.0.0"
+
 mixin-deep@^1.2.0:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.2.tgz#1120b43dc359a785dce65b55b82e257ccf479566"
@@ -4608,7 +4655,7 @@ mkdirp@^0.5.0, mkdirp@^0.5.1:
   dependencies:
     minimist "^1.2.5"
 
-mkdirp@^1.0.0:
+mkdirp@^1.0.0, mkdirp@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
@@ -6353,6 +6400,18 @@ table@^5.2.3:
     lodash "^4.17.14"
     slice-ansi "^2.1.0"
     string-width "^3.0.0"
+
+tar@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.0.tgz#d1724e9bcc04b977b18d5c573b333a2207229a83"
+  integrity sha512-DUCttfhsnLCjwoDoFcI+B2iJgYa93vBnDUATYEeRx6sntCTdN01VnqsIuTlALXla/LWooNg0yEGeB+Y8WdFxGA==
+  dependencies:
+    chownr "^2.0.0"
+    fs-minipass "^2.0.0"
+    minipass "^3.0.0"
+    minizlib "^2.1.1"
+    mkdirp "^1.0.3"
+    yallist "^4.0.0"
 
 term-size@^2.1.0:
   version "2.2.0"


### PR DESCRIPTION
# Add support for github addon `--template`

```
yo @plone/volto:addon --template eea/volto-addon-template @plone-collective/volto-test-addon
```

## Try it:

### Setup
```
git clone https://github.com/plone/volto.git
cd volto/packages/generator-volto
git checkout remote-addon-template
npm link
```

### Generate new project

```
yo @plone/volto my-volto-project --skip-install 
cd my-volto-project
```

### Generate new add-on based on remote template

```
yo @plone/volto:addon --template=eea/volto-addon-template @eeacms/volto-foo-bar
cd src/addons/volto-foo-bar
```

See github template example: [volto-addon-template](https://github.com/eea/volto-addon-template)
