### PR TITLE
fix default value bug if default = true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Feature
 
 ### Bugfix
-
+- Fix default value for checkbox widget @alexbueckig
 ### Internal
 
 ## 12.6.1 (2021-04-06)

--- a/src/components/manage/Form/InlineForm.jsx
+++ b/src/components/manage/Form/InlineForm.jsx
@@ -94,7 +94,7 @@ const InlineForm = ({
               focus={index === focusIndex}
               value={
                 'default' in schema.properties[field]
-                  ? formData[field] || schema.properties[field].default
+                  ? formData[field] ?? schema.properties[field].default
                   : formData[field]
               }
               required={schema.required.indexOf(field) !== -1}


### PR DESCRIPTION
Using a default value of true for the checkbox widget using the InlineForm makes the widget unuseable since the logical operator always returns true for the comparison in the InlineForm.jsx line 97. Using nullish coalescing operator `??` instead of logical or `||` fixes the issue.