### PR TITLE
refactor: extract parseDateTime from DatetimeWidget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Improve the blocks engine by adding a detector for clicking outside in the `BlocksForm` @sneridagh
 - Include a pluggable architecture for pluggable render-time insertions (similar to <Portal>) @tiberiuichim
+- Add parseDateTime helper from DatetimeWidget to handle timezones @nzambello
 
 ### Bugfix
 

--- a/src/components/manage/Widgets/DatetimeWidget.jsx
+++ b/src/components/manage/Widgets/DatetimeWidget.jsx
@@ -10,6 +10,7 @@ import { SingleDatePicker } from 'react-dates';
 import TimePicker from 'rc-time-picker';
 import cx from 'classnames';
 import { Icon, FormFieldWrapper } from '@plone/volto/components';
+import { parseDateTime } from '@plone/volto/helpers';
 import leftKey from '@plone/volto/icons/left-key.svg';
 import rightKey from '@plone/volto/icons/right-key.svg';
 import clearSVG from '@plone/volto/icons/clear.svg';
@@ -79,21 +80,8 @@ class DatetimeWidget extends Component {
    */
   constructor(props) {
     super(props);
-    //  Used to set a server timezone or UTC as default
-    moment.defineLocale(
-      this.props.intl.locale,
-      moment.localeData(this.props.intl.locale)._config,
-    ); // copy locale to moment-timezone
-    let datetime = null;
 
-    if (this.props.value) {
-      // check if datetime has timezone, otherwise assumes it's UTC
-      datetime = this.props.value.match(/T(.)*(-|\+|Z)/g)
-        ? // Since we assume UTC everywhere, then transform to local (momentjs default)
-          moment(this.props.value)
-        : // This might happen in old Plone versions dates
-          moment(`${this.props.value}Z`);
-    }
+    let datetime = parseDateTime(this.props.intl.locale, this.props.value);
 
     this.state = {
       focused: false,

--- a/src/helpers/Utils/Utils.js
+++ b/src/helpers/Utils/Utils.js
@@ -1,5 +1,6 @@
 import { isEqual, isObject, transform } from 'lodash';
 import React from 'react';
+import moment from 'moment/min/moment-with-locales';
 
 /**
  * Deep diff between two object, using lodash
@@ -139,4 +140,32 @@ export const getColor = (name) => {
     namedColors[name] = namedColor;
   }
   return namedColor;
+};
+
+/**
+ * Fixes TimeZones issues on moment date objects
+ * Parses a DateTime and sets correct moment locale
+ * @param {string} locale Current locale
+ * @param {string} value DateTime string
+ * @param {string} format Date format of choice
+ * @returns {Object|string} Moment object or sting if format is set
+ */
+export const parseDateTime = (locale, value, format) => {
+  //  Used to set a server timezone or UTC as default
+  moment.defineLocale(locale, moment.localeData(locale)._config); // copy locale to moment-timezone
+  let datetime = null;
+
+  if (value) {
+    // check if datetime has timezone, otherwise assumes it's UTC
+    datetime = value.match(/T(.)*(-|\+|Z)/g)
+      ? // Since we assume UTC everywhere, then transform to local (momentjs default)
+        moment(value)
+      : // This might happen in old Plone versions dates
+        moment(`${value}Z`);
+  }
+
+  if (format && datetime) {
+    return datetime.format(format);
+  }
+  return datetime;
 };

--- a/src/helpers/Utils/Utils.js
+++ b/src/helpers/Utils/Utils.js
@@ -148,7 +148,7 @@ export const getColor = (name) => {
  * @param {string} locale Current locale
  * @param {string} value DateTime string
  * @param {string} format Date format of choice
- * @returns {Object|string} Moment object or sting if format is set
+ * @returns {Object|string} Moment object or string if format is set
  */
 export const parseDateTime = (locale, value, format) => {
   //  Used to set a server timezone or UTC as default

--- a/src/helpers/Utils/Utils.js
+++ b/src/helpers/Utils/Utils.js
@@ -1,6 +1,6 @@
 import { isEqual, isObject, transform } from 'lodash';
 import React from 'react';
-import moment from 'moment/min/moment-with-locales';
+import moment from 'moment';
 
 /**
  * Deep diff between two object, using lodash

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -68,6 +68,7 @@ export {
   safeWrapper,
   applyConfig,
   withServerErrorCode,
+  parseDateTime,
 } from '@plone/volto/helpers/Utils/Utils';
 export { messages } from './MessageLabels/MessageLabels';
 export { asyncConnect } from './AsyncConnect';


### PR DESCRIPTION
Extract parseDateTime helper from DatetimeWidget

So now we have a reusable (I had this need) helper from what we did for the widget:
- Fixes TimeZones issues on moment date objects
- Parses a DateTime and sets correct moment locale 