### PR TITLE
Fix sort order: using 'ascending' and 'descending'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Bugfix
 
+- Fix sort_order restapi call, works on action for existing listing blocks
+  and in ListingData saving correctly new ones @nzambello
+
 ### Internal
 
 ## 13.0.0-alpha.1 (2021-05-03)
@@ -29,7 +32,7 @@
   `RAZZLE_API_PATH` in build time. See documentation for more information. @sneridagh
 - Deprecate Node 10 since it's out of LTS since April 30th, 2021 @sneridagh
 - Remove the "inverted" option in Table Block since it was useless with the current CSS
-  set. Better naming of options and labels in table block (English). Updating the i18n messages for the used translations is advisable, but not required.  @iFlameing
+  set. Better naming of options and labels in table block (English). Updating the i18n messages for the used translations is advisable, but not required. @iFlameing
 - Get rid of the font icons in the control panels overview @sneridagh
 
 For a complete list of actions to follow, please read the upgrade guide

--- a/src/actions/querystringsearch/querystringsearch.js
+++ b/src/actions/querystringsearch/querystringsearch.js
@@ -24,7 +24,7 @@ export function getQueryStringResults(path, data, subrequest, page) {
 
   // fixes https://github.com/plone/volto/issues/2397
   if (requestData?.sort_order !== null) {
-    if (typeof requestData.sort_order === "boolean") {
+    if (typeof requestData.sort_order === 'boolean') {
       requestData.sort_order = requestData.sort_order
         ? 'descending'
         : 'ascending';

--- a/src/actions/querystringsearch/querystringsearch.js
+++ b/src/actions/querystringsearch/querystringsearch.js
@@ -24,7 +24,7 @@ export function getQueryStringResults(path, data, subrequest, page) {
 
   // fixes https://github.com/plone/volto/issues/2397
   if (requestData?.sort_order !== null) {
-    if (requestData.sort_order === true || requestData.sort_order === false) {
+    if (typeof requestData.sort_order === "boolean") {
       requestData.sort_order = requestData.sort_order
         ? 'descending'
         : 'ascending';

--- a/src/actions/querystringsearch/querystringsearch.js
+++ b/src/actions/querystringsearch/querystringsearch.js
@@ -9,9 +9,10 @@ import config from '@plone/volto/registry';
  */
 export function getQueryStringResults(path, data, subrequest, page) {
   const { settings } = config;
-  // fixes https://github.com/plone/volto/issues/1059
 
+  // fixes https://github.com/plone/volto/issues/1059
   let requestData = JSON.parse(JSON.stringify(data));
+
   if (data?.depth != null) {
     delete requestData.depth;
     requestData.query.forEach((q) => {
@@ -19,6 +20,15 @@ export function getQueryStringResults(path, data, subrequest, page) {
         q.v += '::' + data.depth;
       }
     });
+  }
+
+  // fixes https://github.com/plone/volto/issues/2397
+  if (requestData?.sort_order !== null) {
+    if (requestData.sort_order === true || requestData.sort_order === false) {
+      requestData.sort_order = requestData.sort_order
+        ? 'descending'
+        : 'ascending';
+    }
   }
 
   return {

--- a/src/actions/querystringsearch/querystringsearch.test.js
+++ b/src/actions/querystringsearch/querystringsearch.test.js
@@ -55,4 +55,22 @@ describe('querystringsearch action', () => {
       '/folder1/folder2/object1/@querystring-search',
     );
   });
+  it('should create an action to get the querystring results fixing sort_order', () => {
+    const data = {
+      query: [
+        {
+          i: 'portal_type',
+          o: 'plone.app.querystring.operation.selection.any',
+          v: ['Document'],
+        },
+      ],
+      sort_order: true,
+    };
+    const action = getQueryStringResults('', data);
+
+    expect(action.type).toEqual(GET_QUERYSTRING_RESULTS);
+    expect(action.request.op).toEqual('post');
+    expect(action.request.path).toEqual('/@querystring-search');
+    expect(action.request.data.sort_order).toEqual('descending');
+  });
 });

--- a/src/components/manage/Blocks/Listing/ListingData.jsx
+++ b/src/components/manage/Blocks/Listing/ListingData.jsx
@@ -162,11 +162,11 @@ const ListingData = ({
         <CheckboxWidget
           id="listingblock-sort-on-reverse"
           title={intl.formatMessage(messages.reversedOrder)}
-          value={data.sort_order ? data.sort_order : false}
+          value={data.sort_order === 'descending' || data.sort_order === true}
           onChange={(name, value) => {
             onChangeBlock(block, {
               ...data,
-              sort_order: value,
+              sort_order: value ? 'descending' : 'ascending',
             });
           }}
         />


### PR DESCRIPTION
Fixes: #2397

Now listing blocks can order items with "reverse" using latest plone.restapi's rules.

Using a listing block ordered by title, in Edit mode when selecting "Reverse order" you can see contents with titles starting with Z or W, while finding the ones starting with A or B deselecting "Reverse order".

This PR uses two approaches:
- fix in the action which prevents us to migrate blocks to fix it, working with existing listing blocks
- ListingData saves correctly new blocks
  