### PR TITLE
Use params prop in api middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Feature
 
 ### Bugfix
+- Use params prop in api middleware @giuliaghisini
 
 ### Internal
 

--- a/src/middleware/api.js
+++ b/src/middleware/api.js
@@ -121,6 +121,7 @@ export default (api) => ({ dispatch, getState }) => (next) => (action) => {
                 data: item.data,
                 type: item.type,
                 headers: item.headers,
+                params: request.params,
               }).then((reqres) => {
                 return [...acc, reqres];
               });
@@ -132,6 +133,7 @@ export default (api) => ({ dispatch, getState }) => (next) => (action) => {
                 data: item.data,
                 type: item.type,
                 headers: item.headers,
+                params: request.params,
               }),
             ),
           )
@@ -139,6 +141,7 @@ export default (api) => ({ dispatch, getState }) => (next) => (action) => {
           data: request.data,
           type: request.type,
           headers: request.headers,
+          params: request.params,
         });
     actionPromise.then(
       (result) => {


### PR DESCRIPTION
Passed 'params' prop into api Middleware to be available and used in Api.js helper