### PR TITLE
Fix Jest testing environment. Changed to --env=jest-environment-jsdom-sixteen

### DIFF
--- a/packages/generator-volto/CHANGELOG.md
+++ b/packages/generator-volto/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changes
 
+- Fix Jest testing environment. Changed to `--env=jest-environment-jsdom-sixteen` @avoinea
+
 ## 4.3.0 (2021-04-28)
 
 ### Added

--- a/packages/generator-volto/generators/app/templates/package.json.tpl
+++ b/packages/generator-volto/generators/app/templates/package.json.tpl
@@ -9,7 +9,7 @@
     "omelette": "ln -sf node_modules/@plone/volto/ omelette",
     "patches": "/bin/bash patches/patchit.sh > /dev/null 2>&1 ||true",
     "build": "razzle build",
-    "test": "razzle test --env=jsdom --passWithNoTests",
+    "test": "razzle test --env=jest-environment-jsdom-sixteen --passWithNoTests",
     "start:prod": "NODE_ENV=production node build/server.js",
     "i18n": "NODE_ENV=production node node_modules/@plone/volto/src/i18n.js",
     "develop": "missdev --config=jsconfig.json --output=addons --fetch-https"


### PR DESCRIPTION
Fix errors like within Jest tests:

```
  ● TextBlockEdit › renders w/o errors

    TypeError: root.getSelection is not a function

    > const { asFragment } = render(
```