### PR TITLE
Allow multi-selecting a single block

### DIFF
--- a/src/components/manage/Blocks/Block/Edit.jsx
+++ b/src/components/manage/Blocks/Block/Edit.jsx
@@ -137,12 +137,13 @@ export class Edit extends Component {
             role="presentation"
             onClick={(e) => {
               const isMultipleSelection = e.shiftKey || e.ctrlKey || e.metaKey;
-              !this.props.selected &&
-                this.props.onSelectBlock(
-                  this.props.id,
-                  this.props.selected ? false : isMultipleSelection,
-                  e,
-                );
+              // !this.props.selected &&
+              this.props.onSelectBlock(
+                this.props.id,
+                isMultipleSelection,
+                // this.props.selected ? false : isMultipleSelection,
+                e,
+              );
             }}
             onKeyDown={
               !(blockHasOwnFocusManagement || disableNewBlocks)


### PR DESCRIPTION
Hold shit key down, click on an already selected block. The block should now trigger the "multi-selection" and the bottom toolbar should show up.