### PR TITLE
Internal url blacklist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Feature
 
+- Add internal URL blacklist to avoid render custom routes in Volto @nzambello
+
 ### Bugfix
 
 - Translate 'All' label in Contents view pagination. @giuliaghisini

--- a/docs/source/configuration/settings-reference.md
+++ b/docs/source/configuration/settings-reference.md
@@ -186,10 +186,17 @@ config.settings.asyncPropsExtenders = [
 ### Internal URL blacklist
 
 If another application is published under the same top domain as Volto, you could have a route like `/abc` which should be not rendered by Volto.
-This can be achieved by a rule in the web server (Apache or Nginx) but when navigating client side, you may have references to that route so Volto is
-handling that as an internal URL but when fetching the content will break.
+This can be achieved by a rule in the reverse proxy (Apache or Nginx for example) but, when navigating client side, you may have references to that route so Volto is
+handling that as an internal URL and fetching the content will break.
 
 You can disable that path in `config.settings.internalUrlBlacklist` so it will be handled as an external link.
+
+```js
+config.settings.internalUrlBlacklist = [
+  '/external-subsite',
+  '/another-blacklisted-url',
+];
+```
 
 ## Server-specific serverConfig
 

--- a/docs/source/configuration/settings-reference.md
+++ b/docs/source/configuration/settings-reference.md
@@ -183,6 +183,14 @@ config.settings.asyncPropsExtenders = [
 
 ```
 
+### Internal URL blacklist
+
+If another application is published under the same top domain as Volto, you could have a route like `/abc` which should be not rendered by Volto.
+This can be achieved by a rule in the web server (Apache or Nginx) but when navigating client side, you may have references to that route so Volto is
+handling that as an internal URL but when fetching the content will break.
+
+You can disable that path in `config.settings.internalUrlBlacklist` so it will be handled as an external link.
+
 ## Server-specific serverConfig
 
 Settings that are relevant to the Express-powered Volto SSR server are stored

--- a/src/components/manage/UniversalLink/UniversalLink.jsx
+++ b/src/components/manage/UniversalLink/UniversalLink.jsx
@@ -32,24 +32,13 @@ const UniversalLink = ({
     }
   }
 
-  const isExternal = !isInternalURL(url);
-  const isDownload = (!isExternal && url.includes('@@download')) || download;
   const isBlacklisted = (config.settings.internalUrlBlacklist ?? []).includes(
     flattenToAppURL(url),
   );
+  const isExternal = !isInternalURL(url) || isBlacklisted;
+  const isDownload = (!isExternal && url.includes('@@download')) || download;
 
-  return isBlacklisted ? (
-    <a
-      href={url}
-      title={title}
-      target="_blank"
-      rel="noopener noreferrer"
-      className={className}
-      {...props}
-    >
-      {children}
-    </a>
-  ) : isExternal ? (
+  return isExternal ? (
     <a
       href={url}
       title={title}

--- a/src/components/manage/UniversalLink/UniversalLink.jsx
+++ b/src/components/manage/UniversalLink/UniversalLink.jsx
@@ -10,6 +10,8 @@ import { useSelector } from 'react-redux';
 import { flattenToAppURL, isInternalURL } from '@plone/volto/helpers/Url/Url';
 import URLUtils from '@plone/volto/components/manage/AnchorPlugin/utils/URLUtils';
 
+import config from '@plone/volto/registry';
+
 const UniversalLink = ({
   href,
   item,
@@ -32,8 +34,22 @@ const UniversalLink = ({
 
   const isExternal = !isInternalURL(url);
   const isDownload = (!isExternal && url.includes('@@download')) || download;
+  const isBlacklisted = (config.settings.internalUrlBlacklist ?? []).includes(
+    flattenToAppURL(url),
+  );
 
-  return isExternal ? (
+  return isBlacklisted ? (
+    <a
+      href={url}
+      title={title}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={className}
+      {...props}
+    >
+      {children}
+    </a>
+  ) : isExternal ? (
     <a
       href={url}
       title={title}

--- a/src/components/manage/UniversalLink/UniversalLink.test.jsx
+++ b/src/components/manage/UniversalLink/UniversalLink.test.jsx
@@ -6,6 +6,8 @@ import { render } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import UniversalLink from './UniversalLink';
 
+import config from '@plone/volto/registry';
+
 const mockStore = configureStore();
 const store = mockStore({
   userSession: {
@@ -101,6 +103,27 @@ describe('UniversalLink', () => {
 
     expect(getByTitle('Volto GitHub repository').getAttribute('target')).toBe(
       null,
+    );
+  });
+
+  it('check UniversalLink renders ext link for blacklisted urls', () => {
+    config.settings.internalUrlBlacklist = ['/external-app'];
+
+    const { getByTitle } = render(
+      <Provider store={store}>
+        <MemoryRouter>
+          <UniversalLink
+            href="http://localhost:3000/external-app"
+            title="Blacklisted route"
+          >
+            <h1>Title</h1>
+          </UniversalLink>
+        </MemoryRouter>
+      </Provider>,
+    );
+
+    expect(getByTitle('Blacklisted route').getAttribute('target')).toBe(
+      '_blank',
     );
   });
 });

--- a/src/config/NonContentRoutes.jsx
+++ b/src/config/NonContentRoutes.jsx
@@ -1,3 +1,5 @@
+import config from '@plone/volto/registry';
+
 // Non Content Routes/Views
 // You can include either RegEx or a string representing the ending of the
 // nonContentRoute eg. '/add' will match '/foo/bar/add'
@@ -27,4 +29,5 @@ export const nonContentRoutes = [
   '/password-reset',
   '/create-translation',
   '/manage-translations',
+  ...(config.settings?.internalUrlBlacklist || []),
 ];

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -136,6 +136,7 @@ let config = {
     showTags: true,
     controlPanelsIcons,
     showSelfRegistration: false,
+    internalUrlBlacklist: [], // URL to be considered as external
   },
   widgets: {
     ...widgetMapping,

--- a/src/routes.js
+++ b/src/routes.js
@@ -211,6 +211,12 @@ const routes = [
     path: '/',
     component: App,
     routes: [
+      // redirect to external links if path in blacklist
+      ...(config.settings?.internalUrlBlacklist || []).map((path) => ({
+        path,
+        exact: true,
+        component: NotFound,
+      })),
       // addon routes have a higher priority then default routes
       ...(config.addonRoutes || []),
       ...defaultRoutes,


### PR DESCRIPTION
Fixes: #2411 

If another application is published under the same top domain as Volto, you could have a route like `/abc` which should be not rendered by Volto.

This can be achieved by a rule in the web server (Apache or Nginx) but when navigating client side, you may have references to that route so Volto is handling that as an internal URL but when fetching the content will break.

You can disable that path in `config.settings.internalUrlBlacklist` so it will be handled as an external link.

That route won't be rendered by View but I'm showing NotFound, while being in nonContentRoutes I'm assuring that it will not break the View.
Using UniversalLink will render an external link which will consent Apache/ngnix to pass the call to the external application or whatever.