### PR TITLE
Add external routes blacklist

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -135,6 +135,18 @@ let config = {
     storeExtenders: [],
     showTags: true,
     controlPanelsIcons,
+    externalRoutes: [
+      // {
+      //   match: {
+      //     path: '/news',
+      //     exact: true,
+      //     strict: false,
+      //   },
+      //   url(payload) {
+      //     return payload.location.pathname;
+      //   },
+      // },
+    ],
     showSelfRegistration: false,
   },
   widgets: {

--- a/src/middleware/blacklistRoutes.js
+++ b/src/middleware/blacklistRoutes.js
@@ -1,0 +1,31 @@
+import config from '@plone/volto/registry';
+import { matchPath } from 'react-router';
+
+const blacklistRoutes = ({ dispatch, getState }) => (next) => (action) => {
+  if (typeof action === 'function') {
+    return next(action);
+  }
+
+  switch (action.type) {
+    case '@@router/LOCATION_CHANGE':
+      const { pathname } = action.payload.location;
+      const { externalRoutes = [] } = config.settings;
+
+      const route = externalRoutes.find((route) =>
+        matchPath(pathname, route.match),
+      );
+
+      if (!route) {
+        return next(action);
+      } else {
+        window.location.replace(
+          route.url ? route.url(action.payload) : pathname,
+        );
+      }
+      break;
+    default:
+      return next(action);
+  }
+};
+
+export default blacklistRoutes;

--- a/src/middleware/index.js
+++ b/src/middleware/index.js
@@ -6,3 +6,4 @@
 
 export api from '@plone/volto/middleware/api';
 export crashReporter from '@plone/volto/middleware/crashReporter';
+export blacklistRoutes from './blacklistRoutes';

--- a/src/store.js
+++ b/src/store.js
@@ -7,10 +7,11 @@ import { save, load } from 'redux-localstorage-simple';
 import config from '@plone/volto/registry';
 import reducers from '~/reducers';
 
-import { api, crashReporter } from '@plone/volto/middleware';
+import { api, crashReporter, blacklistRoutes } from '@plone/volto/middleware';
 
 const configureStore = (initialState, history, apiHelper) => {
   let stack = [
+    blacklistRoutes,
     routerMiddleware(history),
     crashReporter,
     thunk,


### PR DESCRIPTION
This is an alternate implementation for #2427

There's two advantages:

- being a router-based solution, it's more generic and doesn't trigger any extra traffic
- it provides a customizable way to build the destination link (because why not).

Thoughts, ideas? Should I pursue the rest of this PR? Is my method of replacing the URL ok? (`window.location.replace()`)