### PR TITLE
Universallink: keep target of internal link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- UniversalLink: Respect target of internal link. @ksuess
+
 ### Internal
 
 ## 12.14.2 (2021-05-10)

--- a/src/components/manage/UniversalLink/UniversalLink.jsx
+++ b/src/components/manage/UniversalLink/UniversalLink.jsx
@@ -59,7 +59,7 @@ const UniversalLink = ({
   ) : (
     <Link
       to={flattenToAppURL(url)}
-      target={openLinkInNewTab ?? false ? '_blank' : null}
+      target={openLinkInNewTab ?? false ? openLinkInNewTab : null}
       title={title}
       className={className}
       {...props}


### PR DESCRIPTION
if target='_self' this should not be overridden by '_blank'

fixes https://github.com/plone/volto/issues/2434