### PR TITLE
Remove unused pathname parameter from Blocks/Listing/View.jsx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Fix the Listing block with criteria to render correctly on a non-multilingual homepage. @ionlizarazu
+
 ### Internal
 
 - Only log changes to po (`poToJson`) if running as a script @sneridagh

--- a/src/components/manage/Blocks/Listing/View.jsx
+++ b/src/components/manage/Blocks/Listing/View.jsx
@@ -6,11 +6,11 @@ import { withBlockExtensions } from '@plone/volto/helpers';
 import { ListingBlockBody as ListingBody } from '@plone/volto/components';
 
 const View = (props) => {
-  const { data, path, pathname } = props;
+  const { data, path } = props;
 
   return (
     <div className={cx('block listing', data.variation)}>
-      <ListingBody {...props} path={path || pathname} />
+      <ListingBody {...props} path={path} />
     </div>
   );
 };


### PR DESCRIPTION
The Listing block with criteria is not rendering correctly on a non-multilingual homepage.
the Listing View.jsx component supposedly receives a `pathname` [line 9](https://github.com/plone/volto/blob/bd1201a4f918c3e2d47c0360b3b3734a3c8aec0f/src/components/manage/Blocks/Listing/View.jsx#L9) parameter, but it never comes and everytime is _undefined_. See [DefaultView](https://github.com/plone/volto/blob/bd1201a4f918c3e2d47c0360b3b3734a3c8aec0f/src/components/theme/View/DefaultView.jsx#L46) and [RenderBlocks](https://github.com/plone/volto/blob/bd1201a4f918c3e2d47c0360b3b3734a3c8aec0f/src/components/theme/View/RenderBlocks.jsx#L32) parameters.
Being pathname _undefined_, if the path parameter value is an empty string (it is at root/homepage) ListingBody component is called with `path = undefined` at [line 13](https://github.com/plone/volto/blob/bd1201a4f918c3e2d47c0360b3b3734a3c8aec0f/src/components/manage/Blocks/Listing/View.jsx#L13).
If any criteria is defined, the getQueryStringResults action is called with a undefined path, that becomes into a error.

Here the visual example:
![listing block not rendering](https://user-images.githubusercontent.com/5443301/118156881-281bec00-b41a-11eb-88fc-5ba841b9802a.gif)

In this commit I removed pathname parameter from the View.jsx, because it has never any data.
