### PR TITLE
Revert "Run gha in fork (pull_requests event) too"

### DIFF
--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -1,5 +1,5 @@
 name: Code Analysis Check
-on: [push, pull_request]
+on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/core-sandbox.yml
+++ b/.github/workflows/core-sandbox.yml
@@ -1,5 +1,5 @@
 name: Core Sandbox Tests
-on: [push, pull_request]
+on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -1,5 +1,5 @@
 name: Core Main Tests
-on: [push, pull_request]
+on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/generator.yml
+++ b/.github/workflows/generator.yml
@@ -1,5 +1,5 @@
 name: Project Generator Tests
-on: [push, pull_request]
+on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/guillotina.yml
+++ b/.github/workflows/guillotina.yml
@@ -1,5 +1,5 @@
 name: Guillotina Backend Tests
-on: [push, pull_request]
+on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/multilingual.yml
+++ b/.github/workflows/multilingual.yml
@@ -1,5 +1,5 @@
 name: Multilingual Tests
-on: [push, pull_request]
+on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Reverts plone/volto#2450

It duplicates the jobs, which we definitely we don't want. It seems that the cause might be that the user of the forked repo should also enable the actions in the forked repo. It seems it's a security feature...

Let's see if GH improves that in the future...

More info:
https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=&ved=2ahUKEwjg8-bUucnwAhWDyYUKHcOEDWsQFjAAegQICBAD&url=https%3A%2F%2Fgithub.community%2Ft%2Fduplicate-checks-on-push-and-pull-request-simultaneous-event%2F18012&usg=AOvVaw1xyHSNiVbuGLFMggxrArHm

https://github.community/t/run-a-github-action-on-pull-request-for-pr-opened-from-a-forked-repo/16054