### PR TITLE
Modify Default and Summary templates to render the LinkMore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Modify Default and Summary templates to render the LinkMore @ionlizarazu
+
 ### Internal
 
 ## 13.0.1 (2021-05-18)

--- a/src/components/manage/Blocks/Listing/DefaultTemplate.jsx
+++ b/src/components/manage/Blocks/Listing/DefaultTemplate.jsx
@@ -5,18 +5,18 @@ import { flattenToAppURL } from '@plone/volto/helpers';
 
 import { isInternalURL } from '@plone/volto/helpers/Url/Url';
 
-const DefaultTemplate = ({ items, linkMore, isEditMode }) => {
+const DefaultTemplate = ({ items, linkTitle, linkHref, isEditMode }) => {
   let link = null;
-  let href = linkMore?.href || '';
+  let href = linkHref?.[0]?.['@id'] || '';
 
   if (isInternalURL(href)) {
     link = (
       <ConditionalLink to={flattenToAppURL(href)} condition={!isEditMode}>
-        {linkMore?.title || href}
+        {linkTitle || href}
       </ConditionalLink>
     );
   } else if (href) {
-    link = <a href={href}>{linkMore?.title || href}</a>;
+    link = <a href={href}>{linkTitle || href}</a>;
   }
 
   return (

--- a/src/components/manage/Blocks/Listing/SummaryTemplate.jsx
+++ b/src/components/manage/Blocks/Listing/SummaryTemplate.jsx
@@ -7,18 +7,18 @@ import config from '@plone/volto/registry';
 import DefaultImageSVG from '@plone/volto/components/manage/Blocks/Listing/default-image.svg';
 import { isInternalURL } from '@plone/volto/helpers/Url/Url';
 
-const SummaryTemplate = ({ items, linkMore, isEditMode }) => {
+const SummaryTemplate = ({ items, linkTitle, linkHref, isEditMode }) => {
   let link = null;
-  let href = linkMore?.href || '';
+  let href = linkHref?.[0]?.['@id'] || '';
 
   if (isInternalURL(href)) {
     link = (
       <ConditionalLink to={flattenToAppURL(href)} condition={!isEditMode}>
-        {linkMore?.title || href}
+        {linkTitle || href}
       </ConditionalLink>
     );
   } else if (href) {
-    link = <a href={href}>{linkMore?.title || href}</a>;
+    link = <a href={href}>{linkTitle || href}</a>;
   }
 
   const { settings } = config;


### PR DESCRIPTION
The listing block Default and Summary templates doesn't render the LinkMore information with the new configurations.

I modify them to make it work. 

Before changes:
![listing block link more not working](https://user-images.githubusercontent.com/5443301/118804476-06e94e80-b8a5-11eb-939a-d132943aa3ea.gif)

After changes:
![listing block link more working](https://user-images.githubusercontent.com/5443301/118804515-149ed400-b8a5-11eb-9520-abe89ecc42fd.gif)
