### PR TITLE
build(make): Various minor Makefile cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Internal
 
+- Various minor `Makefile` cleanup @rpatterson
+
 ## 13.1.2 (2021-05-26)
 
 ### Internal

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,17 @@
+# Volto development
+
+### Defensive settings for make:
+#     https://tech.davis-hansson.com/p/make/
+SHELL:=bash
+.ONESHELL:
+.SHELLFLAGS:=-xeu -o pipefail -O inherit_errexit -c
+.SILENT:
+.DELETE_ON_ERROR:
+MAKEFLAGS+=--warn-undefined-variables
+MAKEFLAGS+=--no-builtin-rules
+
+# Recipe snippets for reuse
+
 # We like colors
 # From: https://coderwall.com/p/izxssa/colored-makefile-for-golang-projects
 RED=`tput setaf 1`

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,10 @@ docs-build:
 start-frontend: dist
 	yarn start:prod
 
+.PHONY: start-backend
+start-backend: ## Start Plone Backend
+	$(MAKE) -C "./api/" start
+
 .PHONY: start-backend-docker
 start-backend-docker:
 	docker run -it --rm --name=plone -p 8080:8080 -e SITE=Plone -e ADDONS="kitconcept.volto" -e ZCML="kitconcept.volto.cors" plone
@@ -85,6 +89,25 @@ start-backend-docker:
 .PHONY: start-backend-docker-guillotina
 start-backend-docker-guillotina:
 	docker-compose -f g-api/docker-compose.yml up -d
+
+.PHONY: start-test
+start-test: ## Start Test
+	@echo "$(GREEN)==> Start Test$(RESET)"
+	yarn cypress:open
+
+.PHONY: start-test-all
+start-test-all: ## Start Test
+	@echo "$(GREEN)==> Start Test$(RESET)"
+	yarn ci:cypress:run
+
+.PHONY: start-test-frontend
+start-test-frontend: ## Start Test Volto Frontend
+	@echo "$(GREEN)==> Start Test Volto Frontend$(RESET)"
+	RAZZLE_API_PATH=http://localhost:55001/plone yarn build && NODE_ENV=production node build/server.js
+
+.PHONY: start-test-backend
+start-test-backend: ## Start Test Plone Backend
+	$(MAKE) -C "./api/" start-test
 
 .PHONY: stop-backend-docker-guillotina
 stop-backend-docker-guillotina:
@@ -110,26 +133,3 @@ test-acceptance-guillotina:
 clean:
 	$(MAKE) -C "./api/" clean
 	rm -rf node_modules
-
-.PHONY: start-backend
-start-backend: ## Start Plone Backend
-	$(MAKE) -C "./api/" start
-
-.PHONY: start-test-backend
-start-test-backend: ## Start Test Plone Backend
-	$(MAKE) -C "./api/" start-test
-
-.PHONY: start-test-frontend
-start-test-frontend: ## Start Test Volto Frontend
-	@echo "$(GREEN)==> Start Test Volto Frontend$(RESET)"
-	RAZZLE_API_PATH=http://localhost:55001/plone yarn build && NODE_ENV=production node build/server.js
-
-.PHONY: start-test
-start-test: ## Start Test
-	@echo "$(GREEN)==> Start Test$(RESET)"
-	yarn cypress:open
-
-.PHONY: start-test-all
-start-test-all: ## Start Test
-	@echo "$(GREEN)==> Start Test$(RESET)"
-	yarn ci:cypress:run

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ SHELL:=bash
 MAKEFLAGS+=--warn-undefined-variables
 MAKEFLAGS+=--no-builtin-rules
 
+# Project settings
+
+INSTANCE_PORT=8080
+
 # Recipe snippets for reuse
 
 # We like colors
@@ -46,14 +50,6 @@ build-frontend:
 
 .PHONY: build-backend
 build-backend:  ## Build Plone 5.2
-	(cd api && python3 -m venv .)
-	(cd api && bin/pip install --upgrade pip)
-	(cd api && bin/pip install --upgrade wheel)
-	(cd api && bin/pip install -r requirements.txt)
-	(cd api && bin/buildout)
-
-.PHONY: build-backend-withport
-build-backend-withport:  ## Build Plone 5.2 in specific port
 	(cd api && python3 -m venv .)
 	(cd api && bin/pip install --upgrade pip)
 	(cd api && bin/pip install --upgrade wheel)

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,11 @@ docs-build:
 	(cd docs && ../bin/mkdocs build)
 	yarn build-storybook -o docs/build/storybook
 
+.PHONY: start
+# Run both the back-end and the front end
+start:
+	$(MAKE) -j 2 start-backend start-frontend
+
 .PHONY: start-frontend
 start-frontend: dist
 	yarn start:prod

--- a/Makefile
+++ b/Makefile
@@ -50,11 +50,7 @@ build-frontend:
 
 .PHONY: build-backend
 build-backend:  ## Build Plone 5.2
-	(cd api && python3 -m venv .)
-	(cd api && bin/pip install --upgrade pip)
-	(cd api && bin/pip install --upgrade wheel)
-	(cd api && bin/pip install -r requirements.txt)
-	(cd api && bin/buildout instance:http-address=$(INSTANCE_PORT))
+	$(MAKE) -C "./api/" build
 
 .PHONY: dist
 dist:
@@ -63,7 +59,7 @@ dist:
 
 .PHONY: test
 test:
-	(cd api && bin/test)
+	$(MAKE) -C "./api/" test
 
 .PHONY: docs-serve
 docs-serve:
@@ -104,7 +100,7 @@ test-acceptance-server-multilingual:
 
 .PHONY: test-acceptance-server-old
 test-acceptance-server-old:
-	ZSERVER_PORT=55001 CONFIGURE_PACKAGES=plone.app.contenttypes,plone.restapi,kitconcept.volto,kitconcept.volto.cors APPLY_PROFILES=plone.app.contenttypes:plone-content,plone.restapi:default,kitconcept.volto:default-homepage ./api/bin/robot-server plone.app.robotframework.testing.PLONE_ROBOT_TESTING
+	$(MAKE) -C "./api/" test-acceptance-server-old
 
 .PHONY: test-acceptance-guillotina
 test-acceptance-guillotina:
@@ -112,18 +108,16 @@ test-acceptance-guillotina:
 
 .PHONY: clean
 clean:
-	(cd api && rm -rf bin eggs develop-eggs include lib parts .installed.cfg .mr.developer.cfg)
+	$(MAKE) -C "./api/" clean
 	rm -rf node_modules
 
 .PHONY: start-backend
 start-backend: ## Start Plone Backend
-	@echo "$(GREEN)==> Start Plone Backend$(RESET)"
-	(cd api && PYTHONWARNINGS=ignore bin/instance fg)
+	$(MAKE) -C "./api/" start
 
 .PHONY: start-test-backend
 start-test-backend: ## Start Test Plone Backend
-	@echo "$(GREEN)==> Start Test Plone Backend$(RESET)"
-	ZSERVER_PORT=55001 CONFIGURE_PACKAGES=plone.app.contenttypes,plone.restapi,kitconcept.volto,kitconcept.volto.cors APPLY_PROFILES=plone.app.contenttypes:plone-content,plone.restapi:default,kitconcept.volto:default-homepage ./api/bin/robot-server plone.app.robotframework.testing.PLONE_ROBOT_TESTING
+	$(MAKE) -C "./api/" start-test
 
 .PHONY: start-test-frontend
 start-test-frontend: ## Start Test Volto Frontend

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@ GREEN=`tput setaf 2`
 RESET=`tput sgr0`
 YELLOW=`tput setaf 3`
 
+
+# Top-level targets
+
+.PHONY: all
 all: build
 
 # Add the following 'help' target to your Makefile
@@ -13,17 +17,20 @@ all: build
 help: ## This help message
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
+.PHONY: release
 release:
 	./node_modules/.bin/release-it
 
+.PHONY: build
 build:
 	make build-backend
 	make build-frontend
 
+.PHONY: build-frontend
 build-frontend:
 	yarn && RAZZLE_API_PATH=http://localhost:55001/plone yarn build
 
-.PHONY: Build Plone 5.2
+.PHONY: build-backend
 build-backend:  ## Build Plone 5.2
 	(cd api && python3 -m venv .)
 	(cd api && bin/pip install --upgrade pip)
@@ -31,56 +38,69 @@ build-backend:  ## Build Plone 5.2
 	(cd api && bin/pip install -r requirements.txt)
 	(cd api && bin/buildout)
 
-.PHONY: Build Plone 5.2 in specific port
-build-backend-withport:  ## Build Plone 5.2 with port
+.PHONY: build-backend-withport
+build-backend-withport:  ## Build Plone 5.2 in specific port
 	(cd api && python3 -m venv .)
 	(cd api && bin/pip install --upgrade pip)
 	(cd api && bin/pip install --upgrade wheel)
 	(cd api && bin/pip install -r requirements.txt)
 	(cd api && bin/buildout instance:http-address=$(INSTANCE_PORT))
 
+.PHONY: dist
 dist:
 	yarn
 	yarn build
 
+.PHONY: test
 test:
 	(cd api && bin/test)
 
+.PHONY: docs-serve
 docs-serve:
 	(cd docs && ../bin/mkdocs serve)
 
+.PHONY: docs-build
 docs-build:
-	# The build in netlify breaks because they have not installed ensurepip
-	# So we should continue using virtualenv
+# The build in netlify breaks because they have not installed ensurepip
+# So we should continue using virtualenv
 	virtualenv --python=python3 .
 	./bin/pip install -r requirements-docs.txt
 	(cd docs && ../bin/mkdocs build)
 	yarn build-storybook -o docs/build/storybook
 
+.PHONY: start-frontend
 start-frontend: dist
 	yarn start:prod
 
+.PHONY: start-backend-docker
 start-backend-docker:
 	docker run -it --rm --name=plone -p 8080:8080 -e SITE=Plone -e ADDONS="kitconcept.volto" -e ZCML="kitconcept.volto.cors" plone
 
+.PHONY: start-backend-docker-guillotina
 start-backend-docker-guillotina:
 	docker-compose -f g-api/docker-compose.yml up -d
 
+.PHONY: stop-backend-docker-guillotina
 stop-backend-docker-guillotina:
 	docker-compose -f g-api/docker-compose.yml down
 
+.PHONY: test-acceptance-server
 test-acceptance-server:
 	docker run -i --rm -e ZSERVER_HOST=0.0.0.0 -e ZSERVER_PORT=55001 -p 55001:55001 -e VERSIONS="plone.restapi=8.0.0" -e APPLY_PROFILES=plone.app.contenttypes:plone-content,plone.restapi:default,kitconcept.volto:default-homepage -e CONFIGURE_PACKAGES=plone.app.contenttypes,plone.restapi,kitconcept.volto,kitconcept.volto.cors -e ADDONS='plone.app.robotframework plone.app.contenttypes plone.restapi kitconcept.volto' plone ./bin/robot-server plone.app.robotframework.testing.PLONE_ROBOT_TESTING
 
+.PHONY: test-acceptance-server-multilingual
 test-acceptance-server-multilingual:
 	docker run -i --rm -e ZSERVER_HOST=0.0.0.0 -e ZSERVER_PORT=55001 -p 55001:55001 -e VERSIONS="plone.restapi=8.0.0" -e APPLY_PROFILES=plone.app.contenttypes:plone-content,plone.restapi:default,kitconcept.volto:multilingual -e CONFIGURE_PACKAGES=plone.app.contenttypes,plone.restapi,kitconcept.volto,kitconcept.volto.cors -e ADDONS='plone.app.robotframework plone.app.contenttypes plone.restapi kitconcept.volto' plone ./bin/robot-server plone.app.robotframework.testing.PLONE_ROBOT_TESTING
 
+.PHONY: test-acceptance-server-old
 test-acceptance-server-old:
 	ZSERVER_PORT=55001 CONFIGURE_PACKAGES=plone.app.contenttypes,plone.restapi,kitconcept.volto,kitconcept.volto.cors APPLY_PROFILES=plone.app.contenttypes:plone-content,plone.restapi:default,kitconcept.volto:default-homepage ./api/bin/robot-server plone.app.robotframework.testing.PLONE_ROBOT_TESTING
 
+.PHONY: test-acceptance-guillotina
 test-acceptance-guillotina:
 	docker-compose -f g-api/docker-compose.yml up > /dev/null
 
+.PHONY: clean
 clean:
 	(cd api && rm -rf bin eggs develop-eggs include lib parts .installed.cfg .mr.developer.cfg)
 	rm -rf node_modules
@@ -109,5 +129,3 @@ start-test: ## Start Test
 start-test-all: ## Start Test
 	@echo "$(GREEN)==> Start Test$(RESET)"
 	yarn ci:cypress:run
-
-.PHONY: all start test-acceptance

--- a/api/Makefile
+++ b/api/Makefile
@@ -1,0 +1,68 @@
+# Volto Plone API development
+
+### Defensive settings for make:
+#     https://tech.davis-hansson.com/p/make/
+SHELL:=bash
+.ONESHELL:
+.SHELLFLAGS:=-xeu -o pipefail -O inherit_errexit -c
+.SILENT:
+.DELETE_ON_ERROR:
+MAKEFLAGS+=--warn-undefined-variables
+MAKEFLAGS+=--no-builtin-rules
+
+# Project settings
+
+INSTANCE_PORT=8080
+
+# Recipe snippets for reuse
+
+# We like colors
+# From: https://coderwall.com/p/izxssa/colored-makefile-for-golang-projects
+RED=`tput setaf 1`
+GREEN=`tput setaf 2`
+RESET=`tput sgr0`
+YELLOW=`tput setaf 3`
+
+
+# Top-level targets
+
+.PHONY: all
+all: build
+
+# Add the following 'help' target to your Makefile
+# And add help text after each target name starting with '\#\#'
+.PHONY: help
+help: ## This help message
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+.PHONY: build
+build:  ## Build Plone 5.2
+	python3 -m venv .
+	bin/pip install --upgrade pip
+	bin/pip install --upgrade wheel
+	bin/pip install -r requirements.txt
+	bin/buildout
+	bin/buildout instance:http-address=$(INSTANCE_PORT)
+
+.PHONY: test
+test:
+	bin/test
+
+.PHONY: test-acceptance-server-old
+test-acceptance-server-old:
+	ZSERVER_PORT=55001 CONFIGURE_PACKAGES=plone.app.contenttypes,plone.restapi,kitconcept.volto,kitconcept.volto.cors APPLY_PROFILES=plone.app.contenttypes:plone-content,plone.restapi:default,kitconcept.volto:default-homepage ./bin/robot-server plone.app.robotframework.testing.PLONE_ROBOT_TESTING
+
+.PHONY: clean
+clean:
+	rm -rf bin eggs develop-eggs include lib parts .installed.cfg .mr.developer.cfg
+
+
+.PHONY: start
+start: ## Start Plone Backend
+	@echo "$(GREEN)==> Start Plone Backend$(RESET)"
+	PYTHONWARNINGS=ignore bin/instance fg
+
+.PHONY: start-test
+start-test: ## Start Test Plone Backend
+	@echo "$(GREEN)==> Start Test Plone Backend$(RESET)"
+	ZSERVER_PORT=55001 CONFIGURE_PACKAGES=plone.app.contenttypes,plone.restapi,kitconcept.volto,kitconcept.volto.cors APPLY_PROFILES=plone.app.contenttypes:plone-content,plone.restapi:default,kitconcept.volto:default-homepage ./bin/robot-server plone.app.robotframework.testing.PLONE_ROBOT_TESTING

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,22 @@
 version: '3.3'
 services:
-    plone:
-        ports:
-            - '8080:8080'
-        environment:
-            - SITE=Plone
-            - ADDONS=kitconcept.volto
-            - 'PROFILES=kitconcept.volto:default-homepage'
-        image: plone
-    frontend:
-        ports:
-            - '3000:3000'
-        image: 'plone/volto:slim'
-        # Use just 'plone/volto' image and set the env var in case you want to
-        # use any released Volto addons
-        # image: 'plone/volto'
-        # environment:
-        #     - INTERNAL_API_PATH=plone:8080/Plone
-        #     - ADDONS="volto-slate:asDefault"
+
+  plone:
+    ports:
+      - '8080:8080'
+    environment:
+      - SITE=Plone
+      - ADDONS=kitconcept.volto
+      - 'PROFILES=kitconcept.volto:default-homepage'
+    image: plone
+
+  frontend:
+    ports:
+      - '3000:3000'
+    image: 'plone/volto:slim'
+    # Use just 'plone/volto' image and set the env var in case you want to
+    # use any released Volto addons
+    # image: 'plone/volto'
+    # environment:
+    #   - INTERNAL_API_PATH=plone:8080/Plone
+    #   - ADDONS="volto-slate:asDefault"

--- a/packages/generator-volto/Makefile
+++ b/packages/generator-volto/Makefile
@@ -1,3 +1,8 @@
+
+
+# Top-level targets
+
+.PHONY: all
 all: build-backend
 
 .PHONY: Build Plone 5.2
@@ -7,10 +12,10 @@ build-backend:  ## Build Plone 5.2
 	(cd api && bin/pip install -r requirements.txt)
 	(cd api && bin/buildout)
 
+.PHONY: test-acceptance-server
 test-acceptance-server:
 	ZSERVER_PORT=55001 CONFIGURE_PACKAGES=plone.app.contenttypes,plone.restapi,kitconcept.volto,kitconcept.volto.cors APPLY_PROFILES=plone.app.contenttypes:plone-content,plone.restapi:default,kitconcept.volto:default ./api/bin/robot-server plone.app.robotframework.testing.PLONE_ROBOT_TESTING
 
+.PHONY: test-acceptance-guillotina
 test-acceptance-guillotina:
 	docker-compose -f g-api/docker-compose.yml up > /dev/null
-
-.PHONY: all test-acceptance

--- a/packages/generator-volto/Makefile
+++ b/packages/generator-volto/Makefile
@@ -1,3 +1,14 @@
+# Yeoman Volto App Generator development
+
+### Defensive settings for make:
+#     https://tech.davis-hansson.com/p/make/
+SHELL:=bash
+.ONESHELL:
+.SHELLFLAGS:=-xeu -o pipefail -O inherit_errexit -c
+.SILENT:
+.DELETE_ON_ERROR:
+MAKEFLAGS+=--warn-undefined-variables
+MAKEFLAGS+=--no-builtin-rules
 
 
 # Top-level targets

--- a/packages/generator-volto/generators/addon/templates/Makefile
+++ b/packages/generator-volto/generators/addon/templates/Makefile
@@ -1,7 +1,21 @@
-SHELL=/bin/bash
+# Yeoman Volto App development
+
+### Defensive settings for make:
+#     https://tech.davis-hansson.com/p/make/
+SHELL:=bash
+.ONESHELL:
+.SHELLFLAGS:=-xeu -o pipefail -O inherit_errexit -c
+.SILENT:
+.DELETE_ON_ERROR:
+MAKEFLAGS+=--warn-undefined-variables
+MAKEFLAGS+=--no-builtin-rules
+
+# Project settings
 
 DIR=$(shell basename $$(pwd))
 ADDON ?= "<%= addonName %>"
+
+# Recipe snippets for reuse
 
 # We like colors
 # From: https://coderwall.com/p/izxssa/colored-makefile-for-golang-projects

--- a/packages/generator-volto/generators/addon/templates/Makefile
+++ b/packages/generator-volto/generators/addon/templates/Makefile
@@ -10,6 +10,10 @@ GREEN=`tput setaf 2`
 RESET=`tput sgr0`
 YELLOW=`tput setaf 3`
 
+
+# Top-level targets
+
+.PHONY: project
 project:
 	npm install -g yo
 	npm install -g @plone/generator-volto
@@ -22,6 +26,7 @@ project:
 	@echo "$(GREEN)Volto project is ready!$(RESET)"
 	@echo "$(RED)Now run: cd project && yarn start$(RESET)"
 
+.PHONY: all
 all: project
 
 .PHONY: start-test-backend


### PR DESCRIPTION
Just some minor cleanup of the various `./**Makefile` files I ran across while setting
up a test bed for unifying ZMI login and JWT login.  There some tiny bits of opinion but
most of it is best practices, shouldn't interfere with existing developer workflows, and
so I hope will be uncontroversial.