### PR TITLE
feat: improve UniversalLink error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### Internal
 
 - Various minor `Makefile` cleanup @rpatterson
-- Improve error handling in UniversalLink @nzambell
+- Improve error handling in UniversalLink @nzambello
 
 ## 13.1.2 (2021-05-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Internal
 
 - Various minor `Makefile` cleanup @rpatterson
+- Improve error handling in UniversalLink @nzambell
 
 ## 13.1.2 (2021-05-26)
 

--- a/src/components/manage/UniversalLink/UniversalLink.jsx
+++ b/src/components/manage/UniversalLink/UniversalLink.jsx
@@ -25,7 +25,7 @@ const UniversalLink = ({
   let url = href;
   if (!href && item) {
     if (!item['@id']) {
-      /* eslint no-console: 0 */
+      // eslint-disable-next-line no-console
       console.error(
         'Invalid item passed to UniversalLink',
         item,

--- a/src/components/manage/UniversalLink/UniversalLink.jsx
+++ b/src/components/manage/UniversalLink/UniversalLink.jsx
@@ -32,7 +32,7 @@ const UniversalLink = ({
         props,
         children,
       );
-      url = '/';
+      url = '#';
     } else {
       url = flattenToAppURL(item['@id']);
       if (!token && item.remoteUrl) {

--- a/src/components/manage/UniversalLink/UniversalLink.jsx
+++ b/src/components/manage/UniversalLink/UniversalLink.jsx
@@ -32,7 +32,7 @@ const UniversalLink = ({
         props,
         children,
       );
-      url = '';
+      url = '/';
     } else {
       url = flattenToAppURL(item['@id']);
       if (!token && item.remoteUrl) {

--- a/src/components/manage/UniversalLink/UniversalLink.jsx
+++ b/src/components/manage/UniversalLink/UniversalLink.jsx
@@ -24,9 +24,20 @@ const UniversalLink = ({
 
   let url = href;
   if (!href && item) {
-    url = flattenToAppURL(item['@id']);
-    if (!token && item.remoteUrl) {
-      url = item.remoteUrl;
+    if (!item['@id']) {
+      /* eslint no-console: 0 */
+      console.error(
+        'Invalid item passed to UniversalLink',
+        item,
+        props,
+        children,
+      );
+      url = '';
+    } else {
+      url = flattenToAppURL(item['@id']);
+      if (!token && item.remoteUrl) {
+        url = item.remoteUrl;
+      }
     }
   }
 

--- a/src/components/manage/UniversalLink/UniversalLink.test.jsx
+++ b/src/components/manage/UniversalLink/UniversalLink.test.jsx
@@ -17,6 +17,8 @@ const store = mockStore({
   },
 });
 
+global.console.error = jest.fn();
+
 describe('UniversalLink', () => {
   it('renders a UniversalLink component with internal link', () => {
     const component = renderer.create(
@@ -120,5 +122,25 @@ describe('UniversalLink', () => {
     expect(getByTitle('Volto GitHub repository').getAttribute('target')).toBe(
       null,
     );
+  });
+
+  it('check UniversalLink does not break with error in item', () => {
+    const component = renderer.create(
+      <Provider store={store}>
+        <MemoryRouter>
+          <UniversalLink
+            item={{
+              error: 'Error while fetching content',
+              message: 'Something went wrong',
+            }}
+          >
+            <h1>Title</h1>
+          </UniversalLink>
+        </MemoryRouter>
+      </Provider>,
+    );
+    const json = component.toJSON();
+    expect(json).toMatchSnapshot();
+    expect(global.console.error).toHaveBeenCalled();
   });
 });

--- a/src/components/manage/UniversalLink/__snapshots__/UniversalLink.test.jsx.snap
+++ b/src/components/manage/UniversalLink/__snapshots__/UniversalLink.test.jsx.snap
@@ -3,9 +3,9 @@
 exports[`UniversalLink check UniversalLink does not break with error in item 1`] = `
 <a
   className={null}
-  href=""
-  rel="noopener noreferrer"
-  target="_blank"
+  href="/"
+  onClick={[Function]}
+  target={null}
   title={null}
 >
   <h1>

--- a/src/components/manage/UniversalLink/__snapshots__/UniversalLink.test.jsx.snap
+++ b/src/components/manage/UniversalLink/__snapshots__/UniversalLink.test.jsx.snap
@@ -1,5 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`UniversalLink check UniversalLink does not break with error in item 1`] = `
+<a
+  className={null}
+  href=""
+  rel="noopener noreferrer"
+  target="_blank"
+  title={null}
+>
+  <h1>
+    Title
+  </h1>
+</a>
+`;
+
 exports[`UniversalLink renders a UniversalLink component if no external(href) link passed 1`] = `
 <a
   className={null}


### PR DESCRIPTION
We caught some edge cases in which UniversalLink was getting an error object as item from cache service.
This avoids any error from a non-nullish object passed as item but still not a Plone content, printing an error (useful for sentry).