### PR TITLE
Showing clear icon when title is too long in objectbrowser selected i…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugfix
 
 - Making placeholder image of video block to take 100% width when it is right or left aligned @iFlameing
+- Showing clear icon when title is too long in objectbrowser selected items in multiple mode @iFlameing
 
 ### Internal
 

--- a/src/components/manage/Widgets/ObjectBrowserWidget.jsx
+++ b/src/components/manage/Widgets/ObjectBrowserWidget.jsx
@@ -117,18 +117,20 @@ export class ObjectBrowserWidgetComponent extends Component {
         }
         trigger={
           <Label>
-            {item.title}
-            {this.props.mode === 'multiple' && (
-              <Icon
-                name={clearSVG}
-                size="12px"
-                className="right"
-                onClick={(event) => {
-                  event.preventDefault();
-                  this.removeItem(item);
-                }}
-              />
-            )}
+            <div className="item-title">{item.title}</div>
+            <div>
+              {this.props.mode === 'multiple' && (
+                <Icon
+                  name={clearSVG}
+                  size="12px"
+                  className="right"
+                  onClick={(event) => {
+                    event.preventDefault();
+                    this.removeItem(item);
+                  }}
+                />
+              )}
+            </div>
           </Label>
         }
       />

--- a/theme/themes/pastanaga/extras/objectbrowser-widget.less
+++ b/theme/themes/pastanaga/extras/objectbrowser-widget.less
@@ -15,10 +15,15 @@
     margin-right: 1.5em;
 
     .ui.label {
+      display: flex;
       overflow: hidden;
       margin: 0.3em;
-      text-overflow: ellipsis;
-      white-space: nowrap;
+
+      .item-title {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
     }
   }
 


### PR DESCRIPTION
…tems in multiple mode.

@sneridagh If we have large title for a page like `Alokkumarsingh23456` and then try to add this page in related items then the clear button is hidden. This pr fixes it.

<img width="1440" alt="Screenshot 2021-06-07 at 6 41 27 PM" src="https://user-images.githubusercontent.com/33936987/121023891-55fa1380-c7c1-11eb-9c57-8a218717797c.png">
