### PR TITLE
Set default value selected for variation in listing block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Making placeholder image of video block to take 100% width when it is right or left aligned @iFlameing
 - Showing clear icon when title is too long in objectbrowser selected items in multiple mode @iFlameing
+- Set default value selected for variation in listing block @giuliaghisini
 
 ### Internal
 

--- a/src/components/manage/Widgets/SelectWidget.jsx
+++ b/src/components/manage/Widgets/SelectWidget.jsx
@@ -305,7 +305,10 @@ class SelectWidget extends Component {
             styles={customSelectStyles}
             theme={selectTheme}
             components={{ DropdownIndicator, Option }}
-            defaultValue={getDefaultValues(choices, value)}
+            defaultValue={getDefaultValues(
+              choices,
+              value || this.props.defaultValue,
+            )}
             onChange={(data) => {
               let dataValue = [];
               if (Array.isArray(data)) {

--- a/src/helpers/Extensions/withBlockSchemaEnhancer.js
+++ b/src/helpers/Extensions/withBlockSchemaEnhancer.js
@@ -51,6 +51,9 @@ export const addExtensionFieldToSchema = ({
       _({ id, defaultMessage: title }),
     ]),
     noValueOption: false,
+    defaultValue: hasDefaultExtension
+      ? items?.find((item) => item.isDefault).id
+      : null,
   };
 
   return schema;


### PR DESCRIPTION
Before this fix, when you creating a listing block, variation field was empty in sidebar, even though a default option was set. 

Now, when you create a new listing block, in sidebar default option is selected for field 'variation'