### PR TITLE
Use querystring prop in ListingBody

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Making placeholder image of video block to take 100% width when it is right or left aligned @iFlameing
 - Showing clear icon when title is too long in objectbrowser selected items in multiple mode @iFlameing
+- Use querystring prop in ListingBody @giuliaghisini
 
 ### Internal
 

--- a/src/components/manage/Blocks/Listing/ListingData.jsx
+++ b/src/components/manage/Blocks/Listing/ListingData.jsx
@@ -17,9 +17,6 @@ const ListingData = (props) => {
         onChangeBlock(block, {
           ...data,
           [id]: value,
-          // // For backwards compat, we keep the content of the querystring widget spreaded
-          // // but we also keep the data in the place it belongs, for future deprecation
-          // ...(id === 'querystring' && { ...value }),
         });
       }}
       formData={data}

--- a/src/components/manage/Blocks/Listing/ListingData.jsx
+++ b/src/components/manage/Blocks/Listing/ListingData.jsx
@@ -17,9 +17,9 @@ const ListingData = (props) => {
         onChangeBlock(block, {
           ...data,
           [id]: value,
-          // For backwards compat, we keep the content of the querystring widget spreaded
-          // but we also keep the data in the place it belongs, for future deprecation
-          ...(id === 'querystring' && { ...value }),
+          // // For backwards compat, we keep the content of the querystring widget spreaded
+          // // but we also keep the data in the place it belongs, for future deprecation
+          // ...(id === 'querystring' && { ...value }),
         });
       }}
       formData={data}


### PR DESCRIPTION
New blocks schema adds **querystring** prop to listing block data, but it was not considered in listing body. 
Added compatibility for new block schema and  backwards compatibility