### PR TITLE
In listing blocks, scroll to start of listing block instead page start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Allow passing a schemaEnhancer to QuerystringWidget @tiberiuichim
 - Add internal URL blacklist to avoid render custom routes in Volto @nzambello
+- In listing blocks, scroll to start of listing block instead page start @giuliaghisini
 
 ### Bugfix
 

--- a/src/components/manage/Blocks/Listing/ListingBody.jsx
+++ b/src/components/manage/Blocks/Listing/ListingBody.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { createRef } from 'react';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import { Pagination } from 'semantic-ui-react';
 import { Icon } from '@plone/volto/components';
@@ -38,8 +38,10 @@ const ListingBody = withQuerystringResults((props) => {
       variation?.template ?? defaultVariation?.template ?? null;
   }
 
+  const listingRef = createRef();
+
   return listingItems?.length > 0 ? (
-    <>
+    <div ref={listingRef}>
       <ListingBodyTemplate
         items={listingItems}
         isEditMode={isEditMode}
@@ -51,7 +53,8 @@ const ListingBody = withQuerystringResults((props) => {
             activePage={currentPage}
             totalPages={totalPages}
             onPageChange={(e, { activePage }) => {
-              !isEditMode && window.scrollTo(0, 0);
+              !isEditMode &&
+                listingRef.current.scrollIntoView({ behavior: 'smooth' });
               onPaginationChange(e, { activePage });
             }}
             firstItem={null}
@@ -71,9 +74,9 @@ const ListingBody = withQuerystringResults((props) => {
           />
         </div>
       )}
-    </>
+    </div>
   ) : isEditMode ? (
-    <div className="listing message">
+    <div className="listing message" ref={listingRef}>
       {isFolderContentsListing && (
         <FormattedMessage
           id="No items found in this container."


### PR DESCRIPTION
Let's imagine we have 3 listing block in page, and each one has pagination. 
If we change page of the 3rd block, window page was scrolled to top and i had to manually scroll down to see results of second page. 
With this change, on listing page change, window is scrolled to the start of listing block.