### PR TITLE
VocabularyTermsWidget option translations for config.settings.supportedLanguages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Feature
 
+- VocabularyTermsWidget option with translations for config.settings.supportedLanguages @ksuess
+
 ### Bugfix
 
 ### Internal

--- a/src/components/manage/Widgets/VocabularyTermsWidget.jsx
+++ b/src/components/manage/Widgets/VocabularyTermsWidget.jsx
@@ -2,27 +2,40 @@
  * VocabularyTermsWidget
  * @module components/manage/Widgets/VocabularyTermsWidget
  * Widget for dict field
- * with value_type TextLine field
+ *   - with value_type TextLine field
+ *   - or value_type Dict field for translations
  *
  * values are editable
  * keys are generated
- * Purpose: Use this widget for a dict field (of controlpanel), that acts as a source of a vocabulary for a Choice field.
- * Vocabulary terms should change over time only in title (corresponding dictionary value), not value (corresponding dictionary key), as vocabulary term values are stored on content type instances.
+ * Purpose: Use this widget for a dict field (of controlpanel),
+ * that acts as a source of a vocabulary for a Choice field.
+ * Vocabulary terms should change over time only in title (corresponding dictionary value), not value (corresponding dictionary key),
+ * as vocabulary term values are stored on content type instances.
+ *
+ * The widget has two versions depending if you apply it (widget='vocabularyterms') to a plone.schema Dict field
+ *   - with value_type TextLine field
+ *   - or value_type Dict field for translations
+ * The latter provides fields for all config.settings.supportedLanguages
+ *
+ * See storybook for a demo.
  */
 
 import React from 'react';
 import { useDispatch } from 'react-redux';
-import { keys } from 'lodash';
+import { keys, values } from 'lodash';
 import { defineMessages, useIntl } from 'react-intl';
 import { v4 as uuid } from 'uuid';
 
-import { Button, Grid, Input, Segment } from 'semantic-ui-react';
+import { Button, Divider, Grid, Input, Segment } from 'semantic-ui-react';
 
-import { FormFieldWrapper, Icon } from '@plone/volto/components';
+import { FormFieldWrapper, Icon, ObjectWidget } from '@plone/volto/components';
+import { langmap } from '@plone/volto/helpers';
 
 import deleteSVG from '@plone/volto/icons/delete.svg';
 import addSVG from '@plone/volto/icons/add.svg';
 import clearSVG from '@plone/volto/icons/clear.svg';
+
+import config from '@plone/volto/registry';
 
 const messages = defineMessages({
   title: {
@@ -57,9 +70,42 @@ const VocabularyTermsWidget = (props) => {
   const [toFocusId, setToFocusId] = React.useState('');
   const intl = useIntl();
 
-  const vocabularytokens = keys(value).sort((a, b) => {
-    return value[a].localeCompare(value[b]);
-  });
+  // sort terms by values
+  // sort terms with translations by defaultLanguage if provided by config
+  const defaultLanguage =
+    config.settings.defaultLanguage ?? config.settings.supportedLanguages[0];
+  const vocabularytokens =
+    props.value_type?.schema?.type === 'string'
+      ? keys(value).sort((a, b) => {
+          return value[a].localeCompare(value[b]);
+        })
+      : keys(value).sort((a, b) => {
+          return defaultLanguage
+            ? value[a][defaultLanguage]?.localeCompare(
+                value[b][defaultLanguage],
+              )
+            : values(value[a])[0].localeCompare(values(value[b])[0]);
+        });
+
+  const TermSchema = {
+    title: 'Translation of term',
+    fieldsets: [
+      {
+        id: 'default',
+        title: 'Email',
+        fields: config.settings.supportedLanguages,
+      },
+    ],
+    properties: Object.fromEntries(
+      config.settings.supportedLanguages.map((languageIdentifier) => [
+        languageIdentifier,
+        {
+          title: langmap[languageIdentifier]?.nativeName ?? languageIdentifier,
+        },
+      ]),
+    ),
+    required: [],
+  };
 
   React.useEffect(() => {
     const element = document.getElementById(toFocusId);
@@ -68,7 +114,28 @@ const VocabularyTermsWidget = (props) => {
 
   function onChangeFieldHandler(dictkey, fieldvalue) {
     onChange(id, { ...value, [dictkey]: fieldvalue });
-    setToFocusId(props.id + '-' + dictkey);
+    if (typeof fieldvalue === 'string') {
+      setToFocusId(props.id + '-' + dictkey);
+    }
+  }
+
+  function addTermHandler(e) {
+    e.preventDefault();
+    const newdictkey = uuid();
+    if (props.value_type?.schema?.type === 'string') {
+      onChange(id, {
+        ...value,
+        [newdictkey]: '',
+      });
+      setToFocusId(props.id + '-' + newdictkey);
+    } else {
+      onChange(id, {
+        ...value,
+        [newdictkey]: Object.fromEntries(
+          config.settings.supportedLanguages.map((el) => [el, '']),
+        ),
+      });
+    }
   }
 
   return (
@@ -80,13 +147,7 @@ const VocabularyTermsWidget = (props) => {
         <Button
           aria-label={intl.formatMessage(messages.termtitle)}
           onClick={(e) => {
-            e.preventDefault();
-            const newdictkey = uuid();
-            onChange(id, {
-              ...value,
-              [newdictkey]: '',
-            });
-            setToFocusId(props.id + '-' + newdictkey);
+            addTermHandler(e);
           }}
         >
           <Icon name={addSVG} size="18px" />
@@ -118,19 +179,34 @@ const VocabularyTermsWidget = (props) => {
                 </Button.Group>
               </Grid.Column>
               <Grid.Column width="10">
-                <Input
-                  id={`${props.id}-${dictkey}`}
-                  name={`${props.id}-${dictkey}`}
-                  type="text"
-                  placeholder={intl.formatMessage(messages.termtitlelabel)}
-                  required={true}
-                  value={value[dictkey]}
-                  onChange={(e, target) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    onChangeFieldHandler(dictkey, target.value);
-                  }}
-                />
+                {typeof value[dictkey] === 'string' ? (
+                  <Input
+                    id={`${props.id}-${dictkey}`}
+                    name={`${props.id}-${dictkey}`}
+                    type="text"
+                    placeholder={intl.formatMessage(messages.termtitlelabel)}
+                    required={true}
+                    value={value[dictkey]}
+                    onChange={(e, target) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      onChangeFieldHandler(dictkey, target.value);
+                    }}
+                  />
+                ) : (
+                  <>
+                    <ObjectWidget
+                      id={`${id}-${dictkey}`}
+                      onChange={(id, value) => {
+                        onChangeFieldHandler(dictkey, value);
+                      }}
+                      value={value[dictkey]}
+                      schema={TermSchema}
+                      title="Translation of term"
+                    />
+                    <Divider />
+                  </>
+                )}
               </Grid.Column>
               <Grid.Column width="1">
                 {value[dictkey]?.length > 0 && (

--- a/src/components/manage/Widgets/VocabularyTermsWidget.stories.js
+++ b/src/components/manage/Widgets/VocabularyTermsWidget.stories.js
@@ -1,4 +1,4 @@
-import VocabularyTermsWidgetDefault from './VocabularyTermsWidget';
+import VocabularyTermsWidget from './VocabularyTermsWidget';
 import Wrapper from '@plone/volto/storybook';
 import React from 'react';
 
@@ -10,8 +10,19 @@ const customStore = {
   },
 };
 
-const VocabularyTermsWidgetComponent = (args) => {
-  const [value, setValue] = React.useState({});
+const customStoreTranslations = {
+  userSession: { token: '1234' },
+  intl: {
+    locale: 'it',
+    messages: {},
+  },
+};
+
+const WrappedSimple = (args) => {
+  const [value, setValue] = React.useState({
+    '001': 'manual',
+    '002': 'questions & answers',
+  });
   const onChange = (block, value) => setValue(value);
 
   return (
@@ -20,9 +31,49 @@ const VocabularyTermsWidgetComponent = (args) => {
       customStore={customStore}
     >
       <div className="ui segment form attached">
-        <VocabularyTermsWidgetDefault
+        <VocabularyTermsWidget
           {...args}
-          id="Dictionary"
+          id="Simple"
+          title="Vocabulary terms"
+          block="testBlock"
+          value={value}
+          value_type={{
+            schema: {
+              type: 'string',
+            },
+          }}
+          onChange={onChange}
+        />
+        <pre>{JSON.stringify(value, null, 4)}</pre>
+      </div>
+    </Wrapper>
+  );
+};
+
+const WrappedTranslations = (args) => {
+  const [value, setValue] = React.useState({
+    '001': {
+      en: 'manual',
+      it: 'manuale',
+      de: 'Anleitung',
+    },
+    '002': {
+      en: 'questions & answers',
+      it: 'domande frequenti',
+      de: 'FAQs',
+    },
+  });
+  const onChange = (block, value) => setValue(value);
+
+  return (
+    <Wrapper
+      location={{ pathname: '/folder2/folder21/doc212' }}
+      customStore={customStoreTranslations}
+    >
+      <div className="ui segment form attached">
+        <VocabularyTermsWidget
+          {...args}
+          id="Translations"
           title="Vocabulary terms"
           block="testBlock"
           value={value}
@@ -35,8 +86,8 @@ const VocabularyTermsWidgetComponent = (args) => {
 };
 
 export default {
-  title: 'Widgets/VocabularyTermsWidget',
-  component: VocabularyTermsWidgetDefault,
+  title: 'Widgets/Vocabulary',
+  component: VocabularyTermsWidget,
   decorators: [
     (Story) => (
       <div className="ui segment form attached" style={{ width: '600px' }}>
@@ -46,4 +97,6 @@ export default {
   ],
 };
 
-export const VocabularyTermsWidget = () => <VocabularyTermsWidgetComponent />;
+export const Simple = () => <WrappedSimple />;
+
+export const Translations = () => <WrappedTranslations />;


### PR DESCRIPTION
The widget can now also act for editing vocabularies with translations. It takes config.settings.supportedLanguages to provide fields for eache language needed.

![VocabularyTermsWidget_translations](https://user-images.githubusercontent.com/1144737/124458708-967f8980-dd8d-11eb-9150-aa5167b09afe.png)


![VocabularyTermsWidget_simple](https://user-images.githubusercontent.com/1144737/124458732-a008f180-dd8d-11eb-89b9-edb0a16048b0.png)
