### PR TITLE
#2570 A11y form contrast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugfix
 
 - Fix InlineForm's understanding of missing default values @rexalex
+- change Form input:focus text color to black for a11y @ThomasKindermann
 
 ### Internal
 

--- a/theme/themes/pastanaga/collections/form.overrides
+++ b/theme/themes/pastanaga/collections/form.overrides
@@ -46,6 +46,7 @@
 
   &:focus {
     border-radius: 0;
+    color: @textColor;
   }
 }
 


### PR DESCRIPTION
Changed the input:focus text color from light grey to black for better A11y contrast.

#2570
#1505 