### PR TITLE
New toast - make `toast` a component, to allow addons to configurate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Feature
 
 - A new component was added, `BlockChooserButton`, it encapsulate the logic of show/hiding the `BlockChooser` @tiberiuichim
+- make `toast` a component, to allow addons to configurate it and keep the same existing toast implementations
 
 ### Bugfix
 

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -102,6 +102,7 @@ export PersonalTools from '@plone/volto/components/manage/Toolbar/PersonalTools'
 export More from '@plone/volto/components/manage/Toolbar/More';
 export Types from '@plone/volto/components/manage/Toolbar/Types';
 export Toast from '@plone/volto/components/manage/Toast/Toast';
+export toast from '@plone/volto/components/manage/Toast/toastComponent/toast';
 export ManageTranslations from '@plone/volto/components/manage/Multilingual/ManageTranslations';
 
 // Potentially could ve removed from index, since they are internal components and

--- a/src/components/manage/Actions/Actions.jsx
+++ b/src/components/manage/Actions/Actions.jsx
@@ -9,12 +9,11 @@ import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { Dropdown, Icon } from 'semantic-ui-react';
-import { toast } from 'react-toastify';
 import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
 
 import { cut, copy, copyContent, moveContent } from '@plone/volto/actions';
 import { getBaseUrl } from '@plone/volto/helpers';
-import { ContentsRenameModal, Toast } from '@plone/volto/components';
+import { ContentsRenameModal, Toast, toast } from '@plone/volto/components';
 
 const messages = defineMessages({
   cut: {

--- a/src/components/manage/Add/Add.jsx
+++ b/src/components/manage/Add/Add.jsx
@@ -16,7 +16,6 @@ import { DragDropContext } from 'react-dnd';
 import HTML5Backend from 'react-dnd-html5-backend';
 import { v4 as uuid } from 'uuid';
 import qs from 'query-string';
-import { toast } from 'react-toastify';
 
 import { createContent, getSchema } from '@plone/volto/actions';
 import {
@@ -25,6 +24,7 @@ import {
   Toolbar,
   Sidebar,
   Toast,
+  toast,
   TranslationObject,
 } from '@plone/volto/components';
 import {

--- a/src/components/manage/Controlpanels/ContentType.jsx
+++ b/src/components/manage/Controlpanels/ContentType.jsx
@@ -11,9 +11,15 @@ import { getParentUrl } from '@plone/volto/helpers';
 import { Portal } from 'react-portal';
 import { Button, Header } from 'semantic-ui-react';
 import { defineMessages, injectIntl } from 'react-intl';
-import { toast } from 'react-toastify';
 import { last, nth, join } from 'lodash';
-import { Error, Form, Icon, Toolbar, Toast } from '@plone/volto/components';
+import {
+  Error,
+  Form,
+  Icon,
+  Toolbar,
+  Toast,
+  toast,
+} from '@plone/volto/components';
 import { getControlpanel, updateControlpanel } from '@plone/volto/actions';
 
 import saveSVG from '@plone/volto/icons/save.svg';

--- a/src/components/manage/Controlpanels/ContentTypeLayout.jsx
+++ b/src/components/manage/Controlpanels/ContentTypeLayout.jsx
@@ -16,7 +16,6 @@ import {
 } from '@plone/volto/helpers';
 import { Portal } from 'react-portal';
 import { Button, Segment } from 'semantic-ui-react';
-import { toast } from 'react-toastify';
 import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
 import { nth, join } from 'lodash';
 import {
@@ -26,6 +25,7 @@ import {
   Toolbar,
   Sidebar,
   Toast,
+  toast,
 } from '@plone/volto/components';
 import {
   getSchema,

--- a/src/components/manage/Controlpanels/ContentTypeSchema.jsx
+++ b/src/components/manage/Controlpanels/ContentTypeSchema.jsx
@@ -6,7 +6,14 @@
 import { getSchema, putSchema } from '@plone/volto/actions';
 import { getParentUrl } from '@plone/volto/helpers';
 import { nth } from 'lodash';
-import { Error, Form, Icon, Toast, Toolbar } from '@plone/volto/components';
+import {
+  Error,
+  Form,
+  Icon,
+  Toast,
+  toast,
+  Toolbar,
+} from '@plone/volto/components';
 import clearSVG from '@plone/volto/icons/clear.svg';
 import saveSVG from '@plone/volto/icons/save.svg';
 import PropTypes from 'prop-types';
@@ -14,7 +21,6 @@ import React, { Component } from 'react';
 import { defineMessages, injectIntl } from 'react-intl';
 import { Portal } from 'react-portal';
 import { connect } from 'react-redux';
-import { toast } from 'react-toastify';
 import { compose } from 'redux';
 import { Button, Header } from 'semantic-ui-react';
 

--- a/src/components/manage/Controlpanels/ContentTypes.jsx
+++ b/src/components/manage/Controlpanels/ContentTypes.jsx
@@ -12,7 +12,6 @@ import { getParentUrl } from '@plone/volto/helpers';
 import { Portal } from 'react-portal';
 import { last } from 'lodash';
 import { Confirm, Container, Table, Button, Header } from 'semantic-ui-react';
-import { toast } from 'react-toastify';
 import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
 import {
   Error,
@@ -20,6 +19,7 @@ import {
   ModalForm,
   Toolbar,
   Toast,
+  toast,
   ContentTypesActions,
 } from '@plone/volto/components';
 import {

--- a/src/components/manage/Controlpanels/Controlpanel.jsx
+++ b/src/components/manage/Controlpanels/Controlpanel.jsx
@@ -12,9 +12,8 @@ import { Helmet } from '@plone/volto/helpers';
 import { Portal } from 'react-portal';
 import { Button, Container } from 'semantic-ui-react';
 import { defineMessages, injectIntl } from 'react-intl';
-import { toast } from 'react-toastify';
 
-import { Form, Icon, Toolbar, Toast } from '@plone/volto/components';
+import { Form, Icon, Toolbar, Toast, toast } from '@plone/volto/components';
 import { updateControlpanel, getControlpanel } from '@plone/volto/actions';
 
 import saveSVG from '@plone/volto/icons/save.svg';

--- a/src/components/manage/Controlpanels/UsersControlpanel.jsx
+++ b/src/components/manage/Controlpanels/UsersControlpanel.jsx
@@ -18,6 +18,7 @@ import {
   Icon,
   ModalForm,
   Toast,
+  toast,
   Toolbar,
   UsersControlpanelGroups,
   UsersControlpanelUser,
@@ -32,7 +33,6 @@ import { FormattedMessage, injectIntl } from 'react-intl';
 import { Portal } from 'react-portal';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
-import { toast } from 'react-toastify';
 import { bindActionCreators, compose } from 'redux';
 import {
   Button,

--- a/src/components/manage/Edit/Edit.jsx
+++ b/src/components/manage/Edit/Edit.jsx
@@ -14,7 +14,6 @@ import { Button, Grid, Menu } from 'semantic-ui-react';
 import { Portal } from 'react-portal';
 import qs from 'query-string';
 import { find } from 'lodash';
-import { toast } from 'react-toastify';
 
 import {
   Forbidden,
@@ -22,6 +21,7 @@ import {
   Icon,
   Sidebar,
   Toast,
+  toast,
   Toolbar,
   Unauthorized,
   CompareLanguages,

--- a/src/components/manage/Form/Form.jsx
+++ b/src/components/manage/Form/Form.jsx
@@ -3,7 +3,14 @@
  * @module components/manage/Form/Form
  */
 
-import { BlocksForm, Field, Icon, Toast } from '@plone/volto/components';
+import {
+  BlocksForm,
+  Field,
+  Icon,
+  Toast,
+  BlocksToolbar,
+  toast,
+} from '@plone/volto/components';
 import {
   difference,
   FormValidation,
@@ -37,8 +44,6 @@ import {
   Tab,
 } from 'semantic-ui-react';
 import { v4 as uuid } from 'uuid';
-import { toast } from 'react-toastify';
-import { BlocksToolbar } from '@plone/volto/components';
 import config from '@plone/volto/registry';
 
 /**

--- a/src/components/manage/Multilingual/ManageTranslations.jsx
+++ b/src/components/manage/Multilingual/ManageTranslations.jsx
@@ -4,7 +4,7 @@ import { Helmet } from '@plone/volto/helpers';
 import { flattenToAppURL, getBaseUrl, langmap } from '@plone/volto/helpers';
 import { reduce } from 'lodash';
 import { Link, useLocation } from 'react-router-dom';
-import { Icon, Toast, Toolbar } from '@plone/volto/components';
+import { Icon, Toast, toast, Toolbar } from '@plone/volto/components';
 import config from '@plone/volto/registry';
 
 import withObjectBrowser from '@plone/volto/components/manage/Sidebar/ObjectBrowser';
@@ -16,7 +16,6 @@ import {
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 import { useSelector, useDispatch } from 'react-redux';
 import { Portal } from 'react-portal';
-import { toast } from 'react-toastify';
 
 import addSVG from '@plone/volto/icons/add.svg';
 import backSVG from '@plone/volto/icons/back.svg';

--- a/src/components/manage/Preferences/ChangePassword.jsx
+++ b/src/components/manage/Preferences/ChangePassword.jsx
@@ -13,9 +13,8 @@ import { Portal } from 'react-portal';
 import { defineMessages, injectIntl } from 'react-intl';
 import { Container } from 'semantic-ui-react';
 import jwtDecode from 'jwt-decode';
-import { toast } from 'react-toastify';
 
-import { Form, Icon, Toast, Toolbar } from '@plone/volto/components';
+import { Form, Icon, Toast, toast, Toolbar } from '@plone/volto/components';
 import { updatePassword } from '@plone/volto/actions';
 import { getBaseUrl } from '@plone/volto/helpers';
 

--- a/src/components/manage/Preferences/PersonalInformation.jsx
+++ b/src/components/manage/Preferences/PersonalInformation.jsx
@@ -9,9 +9,8 @@ import { connect } from 'react-redux';
 import { compose } from 'redux';
 import { defineMessages, injectIntl } from 'react-intl';
 import jwtDecode from 'jwt-decode';
-import { toast } from 'react-toastify';
 
-import { Form, Toast } from '@plone/volto/components';
+import { Form, Toast, toast } from '@plone/volto/components';
 import { getUser, updateUser } from '@plone/volto/actions';
 
 const messages = defineMessages({

--- a/src/components/manage/Preferences/PersonalPreferences.jsx
+++ b/src/components/manage/Preferences/PersonalPreferences.jsx
@@ -10,9 +10,8 @@ import { compose } from 'redux';
 import { map, keys } from 'lodash';
 import cookie from 'react-cookie';
 import { defineMessages, injectIntl } from 'react-intl';
-import { toast } from 'react-toastify';
 
-import { Form, Toast } from '@plone/volto/components';
+import { Form, Toast, toast } from '@plone/volto/components';
 import languages from '@plone/volto/constants/Languages';
 import { changeLanguage } from '@plone/volto/actions';
 import { normalizeLanguageName } from '@plone/volto/helpers';

--- a/src/components/manage/Sharing/Sharing.jsx
+++ b/src/components/manage/Sharing/Sharing.jsx
@@ -25,8 +25,7 @@ import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
 
 import { updateSharing, getSharing } from '@plone/volto/actions';
 import { getBaseUrl } from '@plone/volto/helpers';
-import { Icon, Toolbar, Toast } from '@plone/volto/components';
-import { toast } from 'react-toastify';
+import { Icon, Toolbar, Toast, toast } from '@plone/volto/components';
 
 import aheadSVG from '@plone/volto/icons/ahead.svg';
 import clearSVG from '@plone/volto/icons/clear.svg';

--- a/src/components/manage/Toast/toastComponent/toast.js
+++ b/src/components/manage/Toast/toastComponent/toast.js
@@ -1,0 +1,23 @@
+import { toast as toastify } from 'react-toastify';
+import config from '@plone/volto/registry';
+
+const toast = {
+  error: (message, opts) =>
+    toastify.error(message, config.settings.toastConfig || opts),
+  success: (message, opts) =>
+    toastify.success(message, config.settings.toastConfig || opts),
+  info: (message, opts) =>
+    toastify.info(message, config.settings.toastConfig || opts),
+  warn: (message, opts) =>
+    toastify.warn(message, config.settings.toastConfig || opts),
+  dismiss: (toastId) => toastify.dismiss(toastId),
+  isActive: (toastId) => toastify.isActive(toastId),
+  update: (toastId, opts) =>
+    toastify.update(toastId, config.settings.toastConfig || opts),
+  clearWaitingQueue: (opts) =>
+    toastify.clearWaitingQueue(config.settings.toastConfig || opts),
+  done: (toastId) => toastify.done(toastId),
+  configure: (opts) => toastify.configure(config.settings.toastConfig || opts),
+};
+
+export default toast;

--- a/src/components/manage/Toast/toastComponent/toast.test.js
+++ b/src/components/manage/Toast/toastComponent/toast.test.js
@@ -1,0 +1,27 @@
+import toastMock from './toast';
+
+test('toast has my desired features', () => {
+  expect(toastMock).toHaveProperty('error');
+  expect(toastMock).toHaveProperty('success');
+  expect(toastMock).toHaveProperty('info');
+  expect(toastMock).toHaveProperty('warn');
+  expect(toastMock).toHaveProperty('dismiss');
+  expect(toastMock).toHaveProperty('isActive');
+  expect(toastMock).toHaveProperty('update');
+  expect(toastMock).toHaveProperty('clearWaitingQueue');
+  expect(toastMock).toHaveProperty('done');
+  expect(toastMock).toHaveProperty('configure');
+});
+
+test('toast function takes 2 arguments', () => {
+  expect(toastMock.error.length).toEqual(2);
+  expect(toastMock.success.length).toEqual(2);
+  expect(toastMock.info.length).toEqual(2);
+  expect(toastMock.warn.length).toEqual(2);
+  expect(toastMock.dismiss.length).toEqual(1);
+  expect(toastMock.isActive.length).toEqual(1);
+  expect(toastMock.update.length).toEqual(2);
+  expect(toastMock.clearWaitingQueue.length).toEqual(1);
+  expect(toastMock.done.length).toEqual(1);
+  expect(toastMock.configure.length).toEqual(1);
+});

--- a/src/components/manage/Workflow/Workflow.jsx
+++ b/src/components/manage/Workflow/Workflow.jsx
@@ -8,10 +8,9 @@ import PropTypes from 'prop-types';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { uniqBy } from 'lodash';
-import { toast } from 'react-toastify';
 import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
 import getWorkflowMapping from '@plone/volto/constants/Workflows';
-import { Icon, Toast } from '@plone/volto/components';
+import { Icon, Toast, toast } from '@plone/volto/components';
 import { flattenToAppURL } from '@plone/volto/helpers';
 
 import { injectLazyLibs } from '@plone/volto/helpers/Loadable/Loadable';

--- a/src/components/theme/ContactForm/ContactForm.jsx
+++ b/src/components/theme/ContactForm/ContactForm.jsx
@@ -12,9 +12,8 @@ import { Portal } from 'react-portal';
 import { Container, Message, Icon } from 'semantic-ui-react';
 import { defineMessages, injectIntl } from 'react-intl';
 import { Link, withRouter } from 'react-router-dom';
-import { toast } from 'react-toastify';
 
-import { Form, Toolbar, Toast } from '@plone/volto/components';
+import { Form, Toolbar, Toast, toast } from '@plone/volto/components';
 import { emailNotification } from '@plone/volto/actions';
 import { getBaseUrl } from '@plone/volto/helpers';
 

--- a/src/components/theme/Login/Login.jsx
+++ b/src/components/theme/Login/Login.jsx
@@ -21,10 +21,8 @@ import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
 import qs from 'query-string';
 import { withRouter } from 'react-router-dom';
 
-import { Icon } from '@plone/volto/components';
 import { getNavigation, login } from '@plone/volto/actions';
-import { toast } from 'react-toastify';
-import { Toast } from '@plone/volto/components';
+import { Icon, Toast, toast } from '@plone/volto/components';
 
 import aheadSVG from '@plone/volto/icons/ahead.svg';
 import clearSVG from '@plone/volto/icons/clear.svg';

--- a/src/components/theme/Register/Register.jsx
+++ b/src/components/theme/Register/Register.jsx
@@ -10,9 +10,8 @@ import { compose } from 'redux';
 import { defineMessages, injectIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router-dom';
-import { toast } from 'react-toastify';
 
-import { Form, Toast } from '@plone/volto/components';
+import { Form, Toast, toast } from '@plone/volto/components';
 import { createUser } from '@plone/volto/actions';
 
 const messages = defineMessages({

--- a/theme/themes/pastanaga/extras/main.less
+++ b/theme/themes/pastanaga/extras/main.less
@@ -311,25 +311,22 @@ button {
       font-weight: 300;
     }
   }
+}
 
-  .toast-dismiss-action {
-  }
+.Toastify__toast--info {
+  background: #aee2f2;
+}
 
-  .Toastify__toast--info {
-    background: #aee2f2;
-  }
+.Toastify__toast--error {
+  background: #f5c1c1;
+}
 
-  .Toastify__toast--error {
-    background: #f5c1c1;
-  }
+.Toastify__toast--success {
+  background: #c9eab1;
+}
 
-  .Toastify__toast--success {
-    background: #c9eab1;
-  }
-
-  .Toastify__toast--warning {
-    background: #f3e2ab;
-  }
+.Toastify__toast--warning {
+  background: #f3e2ab;
 }
 
 .users-control-panel .table {


### PR DESCRIPTION
Make `toast` a component, to allow addons to configurate it and keep the same existing toast implementations