### PR TITLE
feat: set focus on search input in object browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Feature
 
+- Opening the search input in the object browser, it will get the focus @nzambello
+
 ### Bugfix
 
 ### Internal

--- a/cypress/tests/core/objectBrowser.js
+++ b/cypress/tests/core/objectBrowser.js
@@ -70,6 +70,6 @@ describe('Object Browser Tests', () => {
     cy.get('.ui.basic.icon.button.image').contains('Image').click();
     cy.get('.toolbar-inner button.ui.basic.icon.button').click();
     cy.findByLabelText('Search SVG').click();
-    cy.get('.ui.input.search').should('be.focused');
+    cy.get('.ui.input.search input').should('be.focused');
   });
 });

--- a/cypress/tests/core/objectBrowser.js
+++ b/cypress/tests/core/objectBrowser.js
@@ -63,4 +63,13 @@ describe('Object Browser Tests', () => {
       .should('have.attr', 'src')
       .and('eq', '/my-page-1/my-image/@@images/image');
   });
+
+  it('As editor I get focus on search box in sidebar when clicking on lens icon', () => {
+    cy.get('.block.inner.text .public-DraftEditor-content').click();
+    cy.get('.ui.basic.icon.button.block-add-button').click();
+    cy.get('.ui.basic.icon.button.image').contains('Image').click();
+    cy.get('.toolbar-inner button.ui.basic.icon.button').click();
+    cy.findByLabelText('Search SVG').click();
+    cy.get('.ui.input.search').should('eq', cy.focused());
+  });
 });

--- a/cypress/tests/core/objectBrowser.js
+++ b/cypress/tests/core/objectBrowser.js
@@ -70,6 +70,6 @@ describe('Object Browser Tests', () => {
     cy.get('.ui.basic.icon.button.image').contains('Image').click();
     cy.get('.toolbar-inner button.ui.basic.icon.button').click();
     cy.findByLabelText('Search SVG').click();
-    cy.get('.ui.input.search').should('eq', cy.focused());
+    cy.get('.ui.input.search').should('be.focused');
   });
 });

--- a/src/components/manage/Sidebar/ObjectBrowserBody.jsx
+++ b/src/components/manage/Sidebar/ObjectBrowserBody.jsx
@@ -125,6 +125,7 @@ class ObjectBrowserBody extends Component {
           : '',
       showSearchInput: false,
     };
+    this.searchInputRef = React.createRef();
   }
 
   /**
@@ -187,9 +188,14 @@ class ObjectBrowserBody extends Component {
   };
 
   toggleSearchInput = () =>
-    this.setState((prevState) => ({
-      showSearchInput: !prevState.showSearchInput,
-    }));
+    this.setState(
+      (prevState) => ({
+        showSearchInput: !prevState.showSearchInput,
+      }),
+      () => {
+        this.searchInputRef.current.focus();
+      },
+    );
 
   onSearch = (e) => {
     const text = flattenToAppURL(e.target.value);
@@ -364,6 +370,7 @@ class ObjectBrowserBody extends Component {
           {this.state.showSearchInput ? (
             <Input
               className="search"
+              ref={this.searchInputRef}
               onChange={this.onSearch}
               placeholder={this.props.intl.formatMessage(
                 messages.SearchInputPlaceholder,

--- a/src/components/manage/Sidebar/ObjectBrowserBody.jsx
+++ b/src/components/manage/Sidebar/ObjectBrowserBody.jsx
@@ -193,7 +193,7 @@ class ObjectBrowserBody extends Component {
         showSearchInput: !prevState.showSearchInput,
       }),
       () => {
-        this.searchInputRef.current.focus();
+        if (this.searchInputRef?.current) this.searchInputRef.current.focus();
       },
     );
 


### PR DESCRIPTION
To search for a content within the object browser, we currently have to click on the lens icon, then click on the input to type some text.
With this PR I'm setting the focus on the search input when opening it from the button.