### PR TITLE
Increasing the clickable area of right-arrow in objectBrowser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking
 
 ### Feature
+- Increase clickable area of right-arrow in objectBrowser @iFlameing
 
 ### Bugfix
 

--- a/src/components/manage/Sidebar/ObjectBrowserNav.jsx
+++ b/src/components/manage/Sidebar/ObjectBrowserNav.jsx
@@ -97,25 +97,30 @@ const ObjectBrowserNav = ({
               />
             )}
             {item.is_folderish && (mode === 'link' || mode === 'multiple') && (
-              <Button.Group>
-                <Button
-                  basic
-                  icon
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    navigateTo(item['@id']);
-                  }}
-                  aria-label={`${intl.formatMessage(messages.browse)} ${
-                    item.id
-                  }`}
-                >
-                  <Icon
-                    className="right-arrow-icon"
-                    name={rightArrowSVG}
-                    size="24px"
-                  />
-                </Button>
-              </Button.Group>
+              <div
+                role="presentation"
+                className="right-arrow-link-mode"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  navigateTo(item['@id']);
+                }}
+              >
+                <Button.Group>
+                  <Button
+                    basic
+                    icon
+                    aria-label={`${intl.formatMessage(messages.browse)} ${
+                      item.id
+                    }`}
+                  >
+                    <Icon
+                      className="right-arrow-icon"
+                      name={rightArrowSVG}
+                      size="24px"
+                    />
+                  </Button>
+                </Button.Group>
+              </div>
             )}
           </li>
         ))}

--- a/theme/themes/pastanaga/extras/sidebar.less
+++ b/theme/themes/pastanaga/extras/sidebar.less
@@ -319,6 +319,12 @@
         background: #edf1f2;
       }
 
+      .right-arrow-link-mode {
+        display: flex;
+        width: 50px;
+        justify-content: flex-end;
+      }
+
       span {
         display: flex;
         align-items: center;


### PR DESCRIPTION
Now you don't have to be pixel perfect for clicking the right arrow in link mode.

Regarding vertical we can't do much because it is space between li.

@tisto screenshot

![Screenshot 2021-07-22 at 6 52 59 PM](https://user-images.githubusercontent.com/33936987/126648503-d1d9ed95-912b-474a-a1c8-f81c8ffc83de.png)
