### PR TITLE
Disable change workflow for Image and Files in FolderContents view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugfix
 
 - Prevent form submit when clicking on BlockChooserButton @giuliaghisini
+- Disable change workflow for Image and Files in FolderContents view @giuliaghisini
 
 ### Internal
 

--- a/src/components/manage/Contents/Contents.jsx
+++ b/src/components/manage/Contents/Contents.jsx
@@ -265,6 +265,8 @@ const messages = defineMessages({
   },
 });
 
+const NO_WORKFLOW_STATE = ['Image', 'File'];
+
 /**
  * Contents class.
  * @class Contents
@@ -387,6 +389,7 @@ class Contents extends Component {
     this.orderTimeout = null;
     this.state = {
       selected: [],
+      workflowSelected: [],
       showDelete: false,
       showUpload: false,
       showRename: false,
@@ -506,6 +509,7 @@ class Contents extends Component {
   onDeselect(event, { value }) {
     this.setState({
       selected: pull(this.state.selected, value),
+      workflowSelected: pull(this.state.workflowSelected, value),
     });
   }
 
@@ -515,14 +519,21 @@ class Contents extends Component {
    * @param {object} event Event object
    * @returns {undefined}
    */
-  onSelect(event, id) {
+  onSelect(event, item) {
+    const id = item['@id'];
+
     if (indexOf(this.state.selected, id) === -1) {
       this.setState({
         selected: concat(this.state.selected, id),
+        workflowSelected:
+          NO_WORKFLOW_STATE.indexOf(item['@type']) < 0
+            ? concat(this.state.workflowSelected, id)
+            : this.state.workflowSelected,
       });
     } else {
       this.setState({
         selected: pull(this.state.selected, id),
+        workflowSelected: pull(this.state.workflowSelected, id),
       });
     }
   }
@@ -535,6 +546,12 @@ class Contents extends Component {
   onSelectAll() {
     this.setState({
       selected: map(this.state.items, (item) => item['@id']),
+      workflowSelected: map(
+        this.state.items.filter(
+          (item) => NO_WORKFLOW_STATE.indexOf(item['@type']) < 0,
+        ),
+        (item) => item['@id'],
+      ),
     });
   }
 
@@ -546,6 +563,7 @@ class Contents extends Component {
   onSelectNone() {
     this.setState({
       selected: [],
+      workflowSelected: [],
     });
   }
 
@@ -1135,7 +1153,7 @@ class Contents extends Component {
                       open={this.state.showWorkflow}
                       onCancel={this.onWorkflowCancel}
                       onOk={this.onWorkflowOk}
-                      items={this.state.selected}
+                      items={this.state.workflowSelected}
                     />
                   )}
                   <section id="content-core">

--- a/src/components/manage/Contents/ContentsItem.jsx
+++ b/src/components/manage/Contents/ContentsItem.jsx
@@ -110,7 +110,7 @@ export const ContentsItemComponent = ({
               icon
               basic
               aria-label="Unchecked"
-              onClick={(e) => onClick(e, item['@id'])}
+              onClick={(e) => onClick(e, item)}
             >
               <Icon
                 name={checkboxCheckedSVG}
@@ -124,7 +124,7 @@ export const ContentsItemComponent = ({
               icon
               basic
               aria-label="Checked"
-              onClick={(e) => onClick(e, item['@id'])}
+              onClick={(e) => onClick(e, item)}
             >
               <Icon
                 name={checkboxUncheckedSVG}


### PR DESCRIPTION
This is because in the manual selection of multiple items, or all items, if there is an image or a file (which do not have a workflow by their definition) it failed.