### PR TITLE
Removed unnecessary set-cookies for the removal of the authentication cookie when the user is not logged in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Feature
 
+- Removed unnecessary set-cookies for the removal of the authentication cookie when the user is not logged in @mamico
+
 ### Bugfix
 
 - Prevent form submit when clicking on BlockChooserButton @giuliaghisini

--- a/src/helpers/AuthToken/AuthToken.js
+++ b/src/helpers/AuthToken/AuthToken.js
@@ -49,7 +49,9 @@ export function persistAuthToken(store) {
 
     if (previousValue !== currentValue || initial) {
       if (!currentValue) {
-        cookie.remove('auth_token', { path: '/' });
+        if (previousValue) {
+          cookie.remove('auth_token', { path: '/' });
+        }
       } else {
         cookie.save('auth_token', currentValue, {
           path: '/',


### PR DESCRIPTION
I saw that every anonymous request currently has a Set-Cookie to expire  token_auth, but it's unnecessary and make hard to manage any kind of caching.

p.s. anyone that has a better experience with jest than me, please improve my test....