### PR TITLE
Add toast error message when delete is not permitted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugfix
 
 - Prevent form submit when clicking on BlockChooserButton @giuliaghisini
+- Show toast error when trying to delete item and it's not permitted @danielamormocea
 
 ### Internal
 

--- a/src/components/manage/Contents/Contents.jsx
+++ b/src/components/manage/Contents/Contents.jsx
@@ -119,6 +119,10 @@ const messages = defineMessages({
     id: 'Do you really want to delete the following items?',
     defaultMessage: 'Do you really want to delete the following items?',
   },
+  deleteError: {
+    id: 'The object could not be deleted.',
+    defaultMessage: 'The object could not be deleted.',
+  },
   loading: {
     id: 'loading',
     defaultMessage: 'Loading',
@@ -485,6 +489,20 @@ class Contents extends Component {
         />,
       );
     }
+
+    if (
+      this.props.deleteRequest.loading &&
+      nextProps.deleteRequest.error
+    ) {
+      this.props.toastify.toast.error(
+        <Toast
+          error
+          title={this.props.intl.formatMessage(messages.deleteError)}
+          content={this.props.intl.formatMessage(messages.deleteError)}
+        />,
+      );
+    }
+
     if (this.props.orderRequest.loading && nextProps.orderRequest.loaded) {
       this.props.toastify.toast.success(
         <Toast

--- a/src/components/manage/Contents/Contents.jsx
+++ b/src/components/manage/Contents/Contents.jsx
@@ -120,8 +120,8 @@ const messages = defineMessages({
     defaultMessage: 'Do you really want to delete the following items?',
   },
   deleteError: {
-    id: 'The object could not be deleted.',
-    defaultMessage: 'The object could not be deleted.',
+    id: 'The item could not be deleted.',
+    defaultMessage: 'The item could not be deleted.',
   },
   loading: {
     id: 'loading',


### PR DESCRIPTION
When you try to delete something from contents and the page returns 401, there is no UI feedback. Added toast to make the operation visible.