### PR TITLE
Fix QueryWidget styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,13 @@
 
 ### Bugfix
 
+- Fix QueryWidget styling @kreafox
+
 ### Internal
 
 - Updated Brazilian Portuguese translations @ericof
 
 - Footer: Point to plone.org instead of plone.com @ericof
-
 
 ## 13.12.0 (2021-08-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugfix
 
-- Fix QueryWidget styling @kreafox
+- Properly style QueryWidget when used standalone, outside of QuerystringWidget @kreafox
 
 ### Internal
 

--- a/src/components/manage/Widgets/QueryWidget.jsx
+++ b/src/components/manage/Widgets/QueryWidget.jsx
@@ -14,6 +14,7 @@ import { getQuerystring } from '@plone/volto/actions';
 import { Icon } from '@plone/volto/components';
 import { format, parse } from 'date-fns';
 import { injectLazyLibs } from '@plone/volto/helpers/Loadable/Loadable';
+import cx from 'classnames';
 
 import {
   Option,
@@ -260,7 +261,7 @@ class QuerystringWidget extends Component {
         inline
         required={required}
         error={error.length > 0}
-        className={description ? 'help' : ''}
+        className={cx('query-widget', description ? 'help' : '')}
         id={`${fieldSet || 'field'}-${id}`}
       >
         <Grid>

--- a/theme/themes/pastanaga/extras/widgets.less
+++ b/theme/themes/pastanaga/extras/widgets.less
@@ -92,7 +92,10 @@
 
 .querystring-widget {
   padding-bottom: 20px;
+}
 
+.querystring-widget,
+.query-widget {
   .simple-field-name {
     padding-top: 20px;
     padding-bottom: 10px;


### PR DESCRIPTION
Fixes QueryWidget styling if we want to use it standalone.

Before:
![query_string-before](https://user-images.githubusercontent.com/20109479/130934947-e54377fc-73de-461c-89e1-f3b82a4be0b0.png)

After:
![query_string-after](https://user-images.githubusercontent.com/20109479/130934986-a42ee0bf-cae6-449f-b0f4-0f0f157019d1.png)
