### PR TITLE
Fix reactSelectAsyncPaginate in ArrayWidget and SelectWidget, and fix…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Footer: Point to plone.org instead of plone.com @ericof
 
+- Fix reactSelectAsyncPaginate in ArrayWidget and SelectWidget, and fix required prop of SearchWidget. @giuliaghisini
 
 ## 13.12.0 (2021-08-20)
 

--- a/src/components/manage/Widgets/ArrayWidget.jsx
+++ b/src/components/manage/Widgets/ArrayWidget.jsx
@@ -207,7 +207,7 @@ class ArrayWidget extends Component {
   render() {
     const { selectedOption } = this.state;
     const CreatableSelect = this.props.reactSelectCreateable.default;
-    const AsyncPaginate = this.props.reactSelectAsyncPaginate.AsyncPaginate;
+    const AsyncPaginate = this.props.reactSelectAsyncPaginate.default;
 
     return (
       <FormFieldWrapper {...this.props}>

--- a/src/components/manage/Widgets/SelectWidget.jsx
+++ b/src/components/manage/Widgets/SelectWidget.jsx
@@ -214,7 +214,7 @@ class SelectWidget extends Component {
     // Make sure that both disabled and isDisabled (from the DX layout feat work)
     const disabled = this.props.disabled || this.props.isDisabled;
     const Select = this.props.reactSelect.default;
-    const AsyncPaginate = this.props.reactSelectAsyncPaginate.AsyncPaginate;
+    const AsyncPaginate = this.props.reactSelectAsyncPaginate.default;
 
     return (
       <FormFieldWrapper {...this.props}>

--- a/src/components/theme/SearchWidget/SearchWidget.jsx
+++ b/src/components/theme/SearchWidget/SearchWidget.jsx
@@ -36,7 +36,7 @@ class SearchWidget extends Component {
    * @static
    */
   static propTypes = {
-    pathname: PropTypes.string.isRequired,
+    pathname: PropTypes.string,
   };
 
   /**


### PR DESCRIPTION
… required prop of SearchWidget.

This fixes loading error in ArrayWidget and SelectWidget introduced with this merge: https://github.com/plone/volto/pull/2563/. 

It also fixes required prop 'pathname' in SearchWidget, because it's not always required 