### PR TITLE
Fix content tags modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,13 @@
 
 ### Bugfix
 
+- Fix for Contents tag modal @nzambello
+
 ### Internal
 
 - Updated Brazilian Portuguese translations @ericof
-
 - Footer: Point to plone.org instead of plone.com @ericof
-
+- Array and token widget available as named widget @nzambello
 
 ## 13.12.0 (2021-08-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Feature
 
+- Contents shows also array indexes @nzambello
+
 ### Bugfix
 
 - Fix for Contents tag modal @nzambello

--- a/src/components/manage/Contents/ContentsItem.jsx
+++ b/src/components/manage/Contents/ContentsItem.jsx
@@ -202,6 +202,9 @@ export const ContentsItemComponent = ({
                 )}
               </span>
             )}
+            {index.type === 'array' && (
+              <span>{item[index.id]?.join(', ')}</span>
+            )}
           </Table.Cell>
         ))}
         <Table.Cell

--- a/src/components/manage/Contents/ContentsTagsModal.jsx
+++ b/src/components/manage/Contents/ContentsTagsModal.jsx
@@ -7,7 +7,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
-import { without, union, map } from 'lodash';
+import { map } from 'lodash';
 import { defineMessages, injectIntl } from 'react-intl';
 
 import { updateContent } from '@plone/volto/actions';
@@ -89,14 +89,17 @@ class ContentsTagsModal extends Component {
    * @param {Object} data Form data
    * @returns {undefined}
    */
-  onSubmit(data) {
+  onSubmit({ tags_to_add = [], tags_to_remove = [] }) {
     this.props.updateContent(
       map(this.props.items, (item) => item.url),
       map(this.props.items, (item) => ({
-        subjects: union(
-          without(item.subjects, ...data.tags_to_remove),
-          data.tags_to_add,
-        ),
+        subjects: [
+          ...new Set(
+            (item.subjects ?? [])
+              .filter((s) => !tags_to_remove.includes(s))
+              .concat(tags_to_add),
+          ),
+        ],
       })),
     );
   }
@@ -107,6 +110,10 @@ class ContentsTagsModal extends Component {
    * @returns {string} Markup for the component.
    */
   render() {
+    const currentSetTags = [
+      ...new Set(this.props.items.map((item) => item.subjects).flat()),
+    ];
+
     return (
       this.props.open && (
         <ModalForm
@@ -114,10 +121,6 @@ class ContentsTagsModal extends Component {
           onSubmit={this.onSubmit}
           onCancel={this.props.onCancel}
           title={this.props.intl.formatMessage(messages.tags)}
-          formData={{
-            tags_to_remove: [],
-            tags_to_add: [],
-          }}
           schema={{
             fieldsets: [
               {
@@ -130,10 +133,15 @@ class ContentsTagsModal extends Component {
               tags_to_remove: {
                 type: 'array',
                 title: this.props.intl.formatMessage(messages.tagsToRemove),
+                choices: currentSetTags.map((tag) => [tag, tag]),
               },
               tags_to_add: {
                 type: 'array',
+                widget: 'token',
                 title: this.props.intl.formatMessage(messages.tagsToAdd),
+                items: {
+                  vocabulary: { '@id': 'plone.app.vocabularies.Keywords' },
+                },
               },
             },
             required: [],

--- a/src/components/manage/Contents/ContentsTagsModal.jsx
+++ b/src/components/manage/Contents/ContentsTagsModal.jsx
@@ -132,6 +132,7 @@ class ContentsTagsModal extends Component {
             properties: {
               tags_to_remove: {
                 type: 'array',
+                widget: 'array',
                 title: this.props.intl.formatMessage(messages.tagsToRemove),
                 choices: currentSetTags.map((tag) => [tag, tag]),
               },

--- a/src/config/Widgets.jsx
+++ b/src/config/Widgets.jsx
@@ -56,6 +56,7 @@ export const widgetMapping = {
     align: AlignWidget,
     url: UrlWidget,
     email: EmailWidget,
+    array: ArrayWidget,
     token: TokenWidget,
     query: QueryWidget,
     query_sort_on: QuerySortOnWidget,

--- a/src/config/Widgets.jsx
+++ b/src/config/Widgets.jsx
@@ -56,6 +56,7 @@ export const widgetMapping = {
     align: AlignWidget,
     url: UrlWidget,
     email: EmailWidget,
+    token: TokenWidget,
     query: QueryWidget,
     query_sort_on: QuerySortOnWidget,
     querystring: QuerystringWidget,


### PR DESCRIPTION
Fixes: #2615 

Adds:

- `array` and `token` as named widgets in the config
   (this because I had conflicts in the widget retrieval due to choices attribute)

Fixes: 
- fixes correct behavior of the modal to change tags

Now you can correctly set or remove tags to one or more contents.
Retrieves Subject vocabulary to show options to set while you can also create a new one.
Shows contents' actual tags to remove.