### PR TITLE
Validate touched-only `required` fields in Forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,13 @@
 
 ### Bugfix
 
+- Validate `required` touched-only fields in Form everywhere @nileshgulia1
+
 ### Internal
 
 - Updated Brazilian Portuguese translations @ericof
 
 - Footer: Point to plone.org instead of plone.com @ericof
-
 
 ## 13.12.0 (2021-08-20)
 

--- a/src/components/manage/Form/Form.jsx
+++ b/src/components/manage/Form/Form.jsx
@@ -255,6 +255,7 @@ class Form extends Component {
         schema: this.props.schema,
         formData: this.state.formData,
         formatMessage: this.props.intl.formatMessage,
+        touchedField: { [id]: value },
       });
 
       this.setState({

--- a/src/components/manage/Form/ModalForm.jsx
+++ b/src/components/manage/Form/ModalForm.jsx
@@ -155,6 +155,7 @@ class ModalForm extends Component {
         schema: this.props.schema,
         formData: this.state.formData,
         formatMessage: this.props.intl.formatMessage,
+        touchedField: { [id]: value },
       });
 
       this.setState({

--- a/src/helpers/FormValidation/FormValidation.js
+++ b/src/helpers/FormValidation/FormValidation.js
@@ -1,4 +1,4 @@
-import { map, uniq, keys, isEmpty } from 'lodash';
+import { map, uniq, keys, intersection, isEmpty } from 'lodash';
 import { messages } from '../MessageLabels/MessageLabels';
 
 /**
@@ -183,7 +183,9 @@ const validateRequiredFields = (
   touchedField,
 ) => {
   const errors = {};
-  const fields = isEmpty(touchedField) ? schema.required : keys(touchedField);
+  const fields = isEmpty(touchedField)
+    ? schema.required
+    : intersection(schema.required, keys(touchedField));
   map(fields, (requiredField) => {
     const type = schema.properties[requiredField]?.type;
     const widget = schema.properties[requiredField]?.widget;

--- a/src/helpers/FormValidation/FormValidation.js
+++ b/src/helpers/FormValidation/FormValidation.js
@@ -1,4 +1,4 @@
-import { map, uniq } from 'lodash';
+import { map, uniq, keys, isEmpty } from 'lodash';
 import { messages } from '../MessageLabels/MessageLabels';
 
 /**
@@ -176,10 +176,15 @@ const hasUniqueItems = (field, fieldData, formatMessage) => {
  * If required fields are undefined, return list of errors
  * @returns {Object[string]} - list of errors
  */
-const validateRequiredFields = (schema, formData, formatMessage) => {
+const validateRequiredFields = (
+  schema,
+  formData,
+  formatMessage,
+  touchedField,
+) => {
   const errors = {};
-
-  map(schema.required, (requiredField) => {
+  const fields = isEmpty(touchedField) ? schema.required : keys(touchedField);
+  map(fields, (requiredField) => {
     const type = schema.properties[requiredField]?.type;
     const widget = schema.properties[requiredField]?.widget;
 
@@ -215,8 +220,18 @@ const validateRequiredFields = (schema, formData, formatMessage) => {
  * !!ONLY fields with data will be tested (those undefined are ignored here)
  * @returns {Object[string]} - list of errors
  */
-const validateFieldsPerFieldset = (schema, formData, formatMessage) => {
-  const errors = validateRequiredFields(schema, formData, formatMessage);
+const validateFieldsPerFieldset = (
+  schema,
+  formData,
+  formatMessage,
+  touchedField,
+) => {
+  const errors = validateRequiredFields(
+    schema,
+    formData,
+    formatMessage,
+    touchedField,
+  );
 
   map(schema.properties, (field, fieldId) => {
     const fieldWidgetType = field.widget || field.type;
@@ -327,8 +342,14 @@ class FormValidation {
     schema = { properties: {}, fieldsets: [], required: [] },
     formData = {},
     formatMessage = () => {},
+    touchedField = {},
   } = {}) {
-    return validateFieldsPerFieldset(schema, formData, formatMessage);
+    return validateFieldsPerFieldset(
+      schema,
+      formData,
+      formatMessage,
+      touchedField,
+    );
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/plone/volto/issues/2528
The problem with "required fields" validation is they are all validated in one go, unlike other widget specific validations.
This is only required to be applied on `onBlur` method leaving `onSubmit` logic intact.
Before:

https://user-images.githubusercontent.com/22280901/131368199-7adaa1c7-622c-4d3b-8ad1-e31ee2afcfc9.mov

After:


https://user-images.githubusercontent.com/22280901/131368260-58b0c99c-add6-40ed-8299-1e13571e8869.mov



