### PR TITLE
Fix SelectWidget vocabulary load on second component mount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Fix SelectWidget vocabulary load on second component mount @avoinea #2655
+
 ### Internal
 
 ## 14.0.0-alpha.0 (2021-09-08)

--- a/src/components/manage/Widgets/ArrayWidget.jsx
+++ b/src/components/manage/Widgets/ArrayWidget.jsx
@@ -132,8 +132,8 @@ class ArrayWidget extends Component {
    */
   componentDidMount() {
     if (
-      !this.props.items?.choices &&
-      !this.props.choices &&
+      !this.props.items?.choices?.length &&
+      !this.props.choices?.length &&
       this.vocabBaseUrl
     ) {
       this.props.getVocabulary(this.vocabBaseUrl);

--- a/src/components/manage/Widgets/SelectWidget.jsx
+++ b/src/components/manage/Widgets/SelectWidget.jsx
@@ -155,7 +155,7 @@ class SelectWidget extends Component {
    * @returns {undefined}
    */
   componentDidMount() {
-    if (!this.props.choices && this.props.vocabBaseUrl) {
+    if (!this.props.choices?.length && this.props.vocabBaseUrl) {
       this.props.getVocabulary(this.props.vocabBaseUrl);
     }
   }


### PR DESCRIPTION
See #2655