### PR TITLE
Fix on form errors in block editor, not changing to metadata tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugfix
 
 - Fix /edit and /add nonContentRoutes to fix isCmsUi fn @giuliaghisini
+- Fix on form errors in block editor, not changing to metadata tab @sneridagh
 
 ### Internal
 

--- a/cypress/tests/core/metadata.js
+++ b/cypress/tests/core/metadata.js
@@ -36,4 +36,18 @@ describe('Add Content Tests', () => {
     cy.get('input#effective-date').should('have.value', '12/24/2050');
     cy.get('input#effective-time').should('have.value', '10:00 AM');
   });
+
+  it('As an editor, given a document with no title or a validation error when I save the sidebar tab switches to the metadata tab', function () {
+    cy.get('.block.inner.text .public-DraftEditor-content').click();
+    cy.get('.ui.basic.icon.button.block-add-button').click();
+    cy.get('.ui.basic.icon.button.image').contains('Image').click();
+    cy.get('#toolbar-save').click();
+
+    cy.findByRole('alert')
+      .get('.toast-inner-content')
+      .contains('Required input is missing');
+    cy.get('.sidebar-container .tabs-wrapper a.active.item').contains(
+      'Document',
+    );
+  });
 });

--- a/src/components/manage/Form/Form.jsx
+++ b/src/components/manage/Form/Form.jsx
@@ -28,6 +28,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { injectIntl } from 'react-intl';
 import { Portal } from 'react-portal';
+import { connect } from 'react-redux';
 import {
   Button,
   Container,
@@ -39,6 +40,8 @@ import {
 import { v4 as uuid } from 'uuid';
 import { toast } from 'react-toastify';
 import { BlocksToolbar } from '@plone/volto/components';
+import { setSidebarTab } from '@plone/volto/actions';
+import { compose } from 'redux';
 import config from '@plone/volto/registry';
 
 /**
@@ -422,6 +425,8 @@ class Form extends Component {
           );
         },
       );
+      // Changes the focus to the metadata tab in the sidebar if error
+      this.props.setSidebarTab(0);
     } else {
       // Get only the values that have been modified (Edit forms), send all in case that
       // it's an add form
@@ -735,4 +740,8 @@ class Form extends Component {
   }
 }
 
-export default injectIntl(Form, { forwardRef: true });
+const FormIntl = injectIntl(Form, { forwardRef: true });
+
+export default compose(
+  connect(null, { setSidebarTab }, null, { forwardRef: true }),
+)(FormIntl);


### PR DESCRIPTION
So I've found a way of solving the `forwardRef` with `injectIntl` and a `connect` altogether... at last.

and with it, an historic wish in the validation of the block editor.

https://user-images.githubusercontent.com/486927/133855445-93c44916-8bd7-4f53-a1fd-6d2c9796b977.mov



