### PR TITLE
Only externalize node built-ins

### DIFF
--- a/razzle.config.js
+++ b/razzle.config.js
@@ -251,23 +251,8 @@ const defaultModify = ({
     });
   }
 
-  config.externals =
-    target === 'node'
-      ? [
-          nodeExternals({
-            whitelist: [
-              dev ? 'webpack/hot/poll?300' : null,
-              /\.(eot|woff|woff2|ttf|otf)$/,
-              /\.(svg|png|jpg|jpeg|gif|ico)$/,
-              /\.(mp4|mp3|ogg|swf|webp)$/,
-              /\.(css|scss|sass|sss|less)$/,
-              // Add support for whitelist external (ie. node_modules npm published packages)
-              ...addonsAsExternals,
-              /^@plone\/volto/,
-            ].filter(Boolean),
-          }),
-        ]
-      : [];
+  config.externals = target === 'node' ? ['crypto', 'buffer'] : [];
+
   return config;
 };
 


### PR DESCRIPTION
The purpose of this PR is to make it possible to `yarn build` a production build then just copy the public + build folders on a server and be able to completely run Volto with just that.

With the changes here I was able to do that, but there's a strangeness in the `formidable` package that requires a patch.

To replicate:

- pull this PR
- apply formidable patch
- yarn build
- copy build + public folder to another location
- in that location, run `RAZZLE_API_PATH=http://localhost:8080/Plone NODE_ENV=production node build/server.js`