### PR TITLE
Proper EN i18n defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bugfix
 
+- Missing default messages from JSON EN language file @sneridagh
 - Fix /edit and /add nonContentRoutes to fix isCmsUi fn @giuliaghisini
 
 ### Internal

--- a/docs/source/upgrade-guide/index.md
+++ b/docs/source/upgrade-guide/index.md
@@ -15,6 +15,14 @@ This upgrade guide lists all breaking changes in Volto and explains the
 
 ## Upgrading to Volto 14.x.x
 
+### Update i18n configuration for addons
+
+Not a breaking change, but it's worth noticing that there was some i18n improvements, and
+in the case of addons, it should be updated with the version in the new generator. You'll
+find it in:
+
+https://github.com/plone/volto/blob/master/packages/generator-volto/generators/addon/templates/src/i18n.js
+
 ### Removal of old configuration system based on imports
 
 As announced in the deprecation notice in Volto 12 release, from Volto 14 on, the old

--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -27,22 +27,27 @@ msgstr ""
 "X-Is-Fallback-For: de-at de-li de-lu de-ch de-de\n"
 
 #: components/manage/Blocks/HTML/Edit
+# defaultMessage: <p>Add some HTML here</p>
 msgid "<p>Add some HTML here</p>"
 msgstr "<p>HTML hier einfügen</p>"
 
 #: components/theme/Footer/Footer
+# defaultMessage: Accessibility
 msgid "Accessibility"
 msgstr "Barrierefreiheit"
 
 #: components/theme/Register/Register
+# defaultMessage: Account Registration Completed
 msgid "Account Registration Completed"
 msgstr "Die Registrierung Ihres Zugangs wurde erfolgreich abgeschlossen."
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Account activation completed
 msgid "Account activation completed"
 msgstr "Passwort gesetzt."
 
 #: components/manage/Controlpanels/ModerateComments
+# defaultMessage: Action
 msgid "Action"
 msgstr "Aktion"
 
@@ -51,10 +56,12 @@ msgstr "Aktion"
 #: components/manage/Controlpanels/ContentTypes
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
+# defaultMessage: Actions
 msgid "Actions"
 msgstr "Aktionen"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Activate and deactivate add-ons in the lists below.
 msgid "Activate and deactivate"
 msgstr "Aktiviern und Deaktivieren"
 
@@ -62,86 +69,107 @@ msgstr "Aktiviern und Deaktivieren"
 #: components/manage/Toolbar/Toolbar
 #: components/manage/Widgets/SchemaWidget
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add
 msgid "Add"
 msgstr "Hinzufügen"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: To make new add-ons show up here, add them to your buildout configuration, run buildout, and restart the server process. For detailed instructions see
 msgid "Add Addons"
 msgstr "Add-on hinzufügen"
 
 #: components/manage/Toolbar/Types
+# defaultMessage: Add Content…
 msgid "Add Content"
 msgstr "Inhalte hinzufügen"
 
 #: components/manage/Toolbar/Types
+# defaultMessage: Add Translation…
 msgid "Add Translation…"
 msgstr "Übersetzung hinzufügen…"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add User
 msgid "Add User"
 msgstr "Benutzer hinzufügen"
 
 #: components/manage/Blocks/Description/Edit
+# defaultMessage: Add a description…
 msgid "Add a description…"
 msgstr "Beschreibung hinzufügen…"
 
 #: components/manage/BlockChooser/BlockChooserButton
+# defaultMessage: Add block
 msgid "Add block"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add block…
 msgid "Add block…"
 msgstr "Block hinzufügen"
 
 #: components/manage/Widgets/QueryWidget
+# defaultMessage: Add criteria
 msgid "Add criteria"
 msgstr "Kriterien hinzufügen"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Add date
 msgid "Add date"
 msgstr "Datum hinzufügen"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Add field
 msgid "Add field"
 msgstr "Feld hinzufügen"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Add fieldset
 msgid "Add fieldset"
 msgstr "Fieldset hinzufügen"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add group
 msgid "Add group"
 msgstr "Gruppe hinzufügen"
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Add new content type
 msgid "Add new content type"
 msgstr "Neuen Inhaltstypen hinzufügen"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add new group
 msgid "Add new group"
 msgstr "Neue Gruppe hinzufügen"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add new user
 msgid "Add new user"
 msgstr "Neuen Benutzer hinzufügen"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add to Groups
 msgid "Add to Groups"
 msgstr "Zu Gruppe hinzufügen"
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Add term
 msgid "Add vocabulary term"
 msgstr "Füge neuen Term hinzu"
 
 #: components/manage/Add/Add
+# defaultMessage: Add {type}
 msgid "Add {type}"
 msgstr "{type} hinzufügen"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Add-ons Settings
 msgid "Add-ons Settings"
 msgstr "Einstellungen Add-ons"
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: Additional date
 msgid "Additional date"
 msgstr "Zusätzliches Datum"
 
@@ -149,39 +177,48 @@ msgstr "Zusätzliches Datum"
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
 #: components/manage/Blocks/Maps/MapsSidebar
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Alignment
 msgid "Alignment"
 msgstr "Ausrichtung"
 
 #: components/manage/Contents/Contents
+# defaultMessage: All
 msgid "All"
 msgstr "Alle"
 
 #: components/theme/Search/Search
+# defaultMessage: Alphabetically
 msgid "Alphabetically"
 msgstr "alphabetisch"
 
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: Alt text
 msgid "Alt text"
 msgstr "Alternative Text"
 
 #: components/manage/Toolbar/More
+# defaultMessage: Apply working copy
 msgid "Apply working copy"
 msgstr "Arbeitskopie anwenden"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Are you sure you want to delete this field?
 msgid "Are you sure you want to delete this field?"
 msgstr "Sind Sie sicher, dass Sie dieses Feld löschen möchten?"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Are you sure you want to delete this fieldset including all fields?
 msgid "Are you sure you want to delete this fieldset including all fields?"
 msgstr "Sind Sie sicher, dass Sie dieses Fieldset löschen möchten?"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Ascending
 msgid "Ascending"
 msgstr "Aufsteigend"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Available
 msgid "Available"
 msgstr "Verfügbar"
 
@@ -206,48 +243,59 @@ msgstr "Verfügbar"
 #: components/manage/Toolbar/Toolbar
 #: components/theme/ContactForm/ContactForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Back
 msgid "Back"
 msgstr "Zurück"
 
 #: components/manage/Diff/Diff
+# defaultMessage: Base
 msgid "Base"
 msgstr "Basis"
 
 #: components/manage/Sidebar/Sidebar
+# defaultMessage: Block
 msgid "Block"
 msgstr "Block"
 
 #: components/theme/Login/Login
+# defaultMessage: Both email address and password are case sensitive, check that caps lock is not enabled.
 msgid "Both email address and password are case sensitive, check that caps lock is not enabled."
 msgstr "Sowohl E-Mail Adresse als auch Passwort unterscheiden zwischen Groß- und Kleinschreibung, stellen Sie sicher dass die Hochstelltaste nicht aktiviert ist."
 
 #: components/theme/Breadcrumbs/Breadcrumbs
+# defaultMessage: Breadcrumbs
 msgid "Breadcrumbs"
 msgstr "Brotkrumen"
 
 #: components/manage/Blocks/HeroImageLeft/Edit
 #: components/manage/Contents/ContentsUploadModal
 #: components/manage/Sidebar/ObjectBrowserNav
+# defaultMessage: Browse
 msgid "Browse"
 msgstr "Durchsuchen"
 
 #: components/manage/Blocks/Image/Edit
+# defaultMessage: Browse the site, drop an image, or type an URL
 msgid "Browse the site, drop an image, or type an URL"
 msgstr "Seite durchsuchen, Bild ablegen oder URL eingeben"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: By default, permissions from the container of this item are inherited. If you disable this, only the explicitly defined sharing permissions will be valid. In the overview, the symbol {inherited} indicates an inherited value. Similarly, the symbol {global} indicates a global role, which is managed by the site administrator.
 msgid "By default, permissions from the container of this item are inherited. If you disable this, only the explicitly defined sharing permissions will be valid. In the overview, the symbol {inherited} indicates an inherited value. Similarly, the symbol {global} indicates a global role, which is managed by the site administrator."
 msgstr "Standardmäßig werden die Berechtigungen von einem Ordner auf die in ihm befindlichen Artikel vererbt. Wenn Sie dies deaktivieren, sind nur die explizit definierten Zugriffsberechtigungen gültig. In der Übersicht zeigt das Symbol ${image_confirm_icon} einen ererbten Wert an. Das Symbol ${image_link_icon} zeigt eine globale Funktion an, die vom Administrator verwaltet wird."
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Cache Name
 msgid "Cache Name"
 msgstr "Cache Name"
 
 #: components/manage/Controlpanels/ContentTypeLayout
+# defaultMessage: Can not edit Layout for <strong>{type}</strong> content-type as it doesn't have support for <strong>Volto Blocks</strong> enabled
 msgid "Can not edit Layout for <strong>{type}</strong> content-type as it doesn't have support for <strong>Volto Blocks</strong> enabled"
 msgstr "Layout für <strong>{type}</strong> kann nicht verändert werden, da das <strong>Volto Blocks</strong>-Behavior nicht für diesen Inhaltstyp aktiviert ist"
 
 #: components/manage/Controlpanels/ContentTypeLayout
+# defaultMessage: Can not edit Layout for <strong>{type}</strong> content-type as the <strong>Blocks behavior</strong> is enabled and <strong>read-only</strong>
 msgid "Can not edit Layout for <strong>{type}</strong> content-type as the <strong>Blocks behavior</strong> is enabled and <strong>read-only</strong>"
 msgstr "Layout für <strong>{type}</strong> kann nicht verändert werden, da das <strong>Volto Blocks</strong>-Behavior auf nur-lesend gesetzt ist"
 
@@ -263,42 +311,51 @@ msgstr "Layout für <strong>{type}</strong> kann nicht verändert werden, da das
 #: components/manage/Sharing/Sharing
 #: components/theme/Login/Login
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Cancel
 msgid "Cancel"
 msgstr "Abbrechen"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Cell
 msgid "Cell"
 msgstr "Zelle"
 
 #: components/manage/Blocks/Image/ImageSizeWidget
 #: components/manage/Blocks/Maps/Edit
 #: components/manage/Sidebar/AlignBlock
+# defaultMessage: Center
 msgid "Center"
 msgstr "Mittig"
 
 #: components/manage/History/History
+# defaultMessage: Change Note
 msgid "Change Note"
 msgstr "Änderungsnotiz"
 
 #: components/manage/Preferences/ChangePassword
+# defaultMessage: Change Password
 msgid "Change Password"
 msgstr "Passwort ändern"
 
 #: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Change State
 msgid "Change State"
 msgstr "Arbeitsablauf-Status ändern"
 
 #: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Change workflow state recursively
 msgid "Change workflow state recursively"
 msgstr "Arbeitlauf-Status für alle Unterobjekte ebenfalls ändern"
 
 #: components/manage/Toolbar/More
+# defaultMessage: Changes applied
 msgid "Changes applied."
 msgstr "Änderungen durchgeführt."
 
 #: components/manage/Preferences/ChangePassword
 #: components/manage/Preferences/PersonalInformation
 #: components/manage/Preferences/PersonalPreferences
+# defaultMessage: Changes saved
 msgid "Changes saved"
 msgstr "Änderungen gespeichert"
 
@@ -306,192 +363,237 @@ msgstr "Änderungen gespeichert"
 #: components/manage/Controlpanels/ContentTypeLayout
 #: components/manage/Controlpanels/ContentTypeSchema
 #: components/manage/Controlpanels/Controlpanel
+# defaultMessage: Changes saved.
 msgid "Changes saved."
 msgstr "Änderungen gespeichert."
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Checkbox
 msgid "Checkbox"
 msgstr "Checkbox"
 
 #: components/manage/Widgets/SelectWidget
+# defaultMessage: Choices
 msgid "Choices"
 msgstr "Auswahlfeld"
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: Choose Image
 msgid "Choose Image"
 msgstr "Bild auswählen"
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: Choose Target
 msgid "Choose Target"
 msgstr "Ziel auswählen"
 
 #: components/manage/Widgets/FileWidget
+# defaultMessage: Choose a file
 msgid "Choose a file"
 msgstr "Datei auswählen"
 
 #: components/manage/Blocks/HTML/Edit
+# defaultMessage: Clear
 msgid "Clear"
 msgstr "Löschen"
 
 #: components/theme/View/ImageView
+# defaultMessage: Click to download full sized image
 msgid "Click to download full sized image"
 msgstr "Klicken um das Bild in der vollen Größe runterzuladen"
 
 #: components/manage/Widgets/SelectWidget
+# defaultMessage: Close
 msgid "Close"
 msgstr "Schließen"
 
 #: components/theme/Navigation/Navigation
+# defaultMessage: Close menu
 msgid "Close menu"
 msgstr "Menu schließen"
 
 #: components/manage/Blocks/HTML/Edit
+# defaultMessage: Code
 msgid "Code"
 msgstr "Code"
 
 #: components/manage/Widgets/ObjectListWidget
+# defaultMessage: Collapse item
 msgid "Collapse item"
 msgstr "Element einklappen"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Collection
 msgid "Collection"
 msgstr "Kollektion"
 
 #: components/manage/Controlpanels/ModerateComments
 #: components/theme/Comments/CommentEditModal
 #: components/theme/Comments/Comments
+# defaultMessage: Comment
 msgid "Comment"
 msgstr "Kommentar"
 
 #: components/manage/Controlpanels/ModerateComments
+# defaultMessage: Commenter
 msgid "Commenter"
 msgstr "Kommentarautor"
 
 #: components/theme/Comments/Comments
+# defaultMessage: Comments
 msgid "Comments"
 msgstr "Kommentare"
 
 #: components/manage/Diff/Diff
+# defaultMessage: Compare
 msgid "Compare"
 msgstr "Vergleichen"
 
 #: components/manage/Preferences/ChangePassword
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Confirm password
 msgid "Confirm password"
 msgstr "Passwort bestätigen"
 
 #: components/theme/ConnectionRefused/ConnectionRefused
+# defaultMessage: Connection refused
 msgid "Connection refused"
 msgstr "Verbindung abgelehnt"
 
 #: components/theme/Footer/Footer
+# defaultMessage: Contact
 msgid "Contact"
 msgstr "Kontakt"
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Contact form
 msgid "Contact form"
 msgstr "Kontaktformular"
 
 #: components/manage/Blocks/Listing/Edit
+# defaultMessage: Contained items
 msgid "Contained items"
 msgstr "Enthaltene Elemente"
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Content type created
 msgid "Content type created"
 msgstr "Inhaltstyp erstellt"
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Content type deleted
 msgid "Content type deleted"
 msgstr "Inhaltstyp gelöscht"
 
 #: components/manage/Contents/Contents
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Contents
 msgid "Contents"
 msgstr "Inhalte"
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Copy
 msgid "Copy"
 msgstr "Kopieren"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: undefined
 msgid "Copy blocks"
 msgstr "Blöcke kopieren"
 
 #: components/theme/Footer/Footer
+# defaultMessage: Copyright
 msgid "Copyright"
 msgstr "Urheberrecht"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Copyright statement or other rights information on this item.
 msgid "Copyright statement or other rights information on this item."
 msgstr "Informationen über die Urheber- und Nutzungsrechte an diesem Artikel."
 
 #: components/manage/Toolbar/More
+# defaultMessage: Create working copy
 msgid "Create working copy"
 msgstr "Arbeitskopie erstellen"
 
 #: components/manage/WorkingCopyToastsFactory/WorkingCopyToastsFactory
+# defaultMessage: Created by {creator} on {date}
 msgid "Created by {creator} on {date}"
 msgstr "Erstellt von {creator} am {date}"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Created on
 msgid "Created on"
 msgstr "Erstellt am"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Creator
 msgid "Creator"
 msgstr "Ersteller"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Creators
 msgid "Creators"
 msgstr "Ersteller"
 
 #: components/manage/Widgets/QuerystringWidget
 #: components/manage/Widgets/QueryWidget
+# defaultMessage: Criteria
 msgid "Criteria"
 msgstr "Kriterium"
 
 #: components/manage/Preferences/ChangePassword
+# defaultMessage: Current password
 msgid "Current password"
 msgstr "Aktuelles Passwort"
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Cut
 msgid "Cut"
 msgstr "Ausschneiden"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: undefined
 msgid "Cut blocks"
 msgstr "Blöcke ausschneiden"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Daily
 msgid "Daily"
 msgstr "Täglich"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Database Information
 msgid "Database Information"
 msgstr "Datenbankinformationen"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Database Location
 msgid "Database Location"
 msgstr "Speicheort Datenbank"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Database Size
 msgid "Database Size"
 msgstr "Größe Datenbank"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Database main
 msgid "Database main"
 msgstr "Datenbank"
 
 #: components/manage/Controlpanels/ModerateComments
 #: components/manage/Widgets/DatetimeWidget
+# defaultMessage: Date
 msgid "Date"
 msgstr "Datum"
 
 #: components/theme/Search/Search
+# defaultMessage: Date (newest first)
 msgid "Date (newest first)"
 msgstr "Datum (neustes zuerst)"
 
@@ -511,6 +613,7 @@ msgstr "Datum (neustes zuerst)"
 #: components/theme/PasswordReset/PasswordReset
 #: components/theme/PasswordReset/RequestPasswordReset
 #: components/theme/Register/Register
+# defaultMessage: Default
 msgid "Default"
 msgstr "Standard"
 
@@ -525,38 +628,47 @@ msgstr "Standard"
 #: components/manage/Widgets/ObjectBrowserWidget
 #: components/manage/Widgets/WysiwygWidget
 #: components/theme/Comments/Comments
+# defaultMessage: Delete
 msgid "Delete"
 msgstr "Löschen"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Delete Group
 msgid "Delete Group"
 msgstr "Gruppe löschen"
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Delete Type
 msgid "Delete Type"
 msgstr "Inhaltstype löschen"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Delete User
 msgid "Delete User"
 msgstr "Benutzer löschen"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: undefined
 msgid "Delete blocks"
 msgstr "Blöcke löschen"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Delete col
 msgid "Delete col"
 msgstr "Spalte löschen"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Delete row
 msgid "Delete row"
 msgstr "Zeile löschen"
 
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: Depth
 msgid "Depth"
 msgstr "Tiefe"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Descending
 msgid "Descending"
 msgstr "Absteigend"
 
@@ -567,72 +679,89 @@ msgstr "Absteigend"
 #: components/manage/Widgets/WysiwygWidget
 #: components/theme/View/TabularView
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Description
 msgid "Description"
 msgstr "Beschreibung"
 
 #: components/manage/Diff/Diff
+# defaultMessage: Diff
 msgid "Diff"
 msgstr "Unterschied"
 
 #: components/manage/Diff/Diff
+# defaultMessage: Difference between revision {one} and {two} of {title}
 msgid "Difference between revision {one} and {two} of {title}"
 msgstr "Unterschied zwischen Version {one} and {two} von {title}"
 
 #: components/theme/Footer/Footer
+# defaultMessage: Distributed under the {license}.
 msgid "Distributed under the {license}."
 msgstr "Lizensiert unter der {license}."
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Add border to inner columns
 msgid "Divide each row into separate cells"
 msgstr "Zeile in zwei separate Zellen aufteilen"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Do you really want to delete the following items?
 msgid "Do you really want to delete the following items?"
 msgstr "Möchten Sie den Artikel wirklich löschen?"
 
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
+# defaultMessage: Do you really want to delete the group {groupname}?
 msgid "Do you really want to delete the group {groupname}?"
 msgstr "Möchten Sie die Gruppe {groupname} wirklich löschen?"
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Do you really want to delete type {typename}?
 msgid "Do you really want to delete the type {typename}?"
 msgstr "Möchten Sie den Inhaltstyp {typename} wirklich löschen?"
 
 #: components/manage/Controlpanels/Users/UsersControlpanel
+# defaultMessage: Do you really want to delete the user {username}?
 msgid "Do you really want to delete the user {username}?"
 msgstr "Möchten Sie den Nutzer {username} wirklich löschen?"
 
 #: components/manage/Delete/Delete
+# defaultMessage: Do you really want to delete this item?
 msgid "Do you really want to delete this item?"
 msgstr "Möchten Sie den Artikel wirklich löschen?"
 
 #: components/manage/Multilingual/TranslationObject
 #: components/manage/Sidebar/Sidebar
+# defaultMessage: Document
 msgid "Document"
 msgstr "Seite"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Drag and drop files from your computer onto this area or click the “Browse” button.
 msgid "Drag and drop files from your computer onto this area or click the “Browse” button."
 msgstr "Ziehen Sie Dateien von Ihrem Computer auf diesen Bereich oder drücken Sie den “Durchsuchen”-Knopf."
 
 #: components/manage/Widgets/FileWidget
+# defaultMessage: Drop file here to replace the existing file
 msgid "Drop file here to replace the existing file"
 msgstr "Datei hier ablegen um die bestehende Datei zu ersetzen"
 
 #: components/manage/Widgets/FileWidget
+# defaultMessage: Drop file here to upload a new file
 msgid "Drop file here to upload a new file"
 msgstr "Datei hier ablegen um eine neue Datei hochzuladen"
 
 #: components/manage/Widgets/FileWidget
+# defaultMessage: Drop files here ...
 msgid "Drop files here ..."
 msgstr "Datei hier ablegen um die bestehende Datei zu ersetzen"
 
 #: components/manage/Preferences/PersonalInformation
 #: components/theme/Register/Register
+# defaultMessage: E-mail
 msgid "E-mail"
 msgstr "E-Mail"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: E-mail addresses do not match.
 msgid "E-mail addresses do not match."
 msgstr "E-Mail-Adressen stimmen nicht überein."
 
@@ -643,93 +772,115 @@ msgstr "E-Mail-Adressen stimmen nicht überein."
 #: components/manage/Widgets/FormFieldWrapper
 #: components/manage/Widgets/ObjectBrowserWidget
 #: components/theme/Comments/Comments
+# defaultMessage: Edit
 msgid "Edit"
 msgstr "Bearbeiten"
 
 #: components/theme/Comments/CommentEditModal
+# defaultMessage: Edit comment
 msgid "Edit comment"
 msgstr "Kommentar bearbeiten"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Edit field
 msgid "Edit field"
 msgstr "Feld bearbeiten"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Edit fieldset
 msgid "Edit fieldset"
 msgstr "Fieldset bearbeiten"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Edit recurrence
 msgid "Edit recurrence"
 msgstr "Wiederkehrende Einstellungen bearbeiten"
 
 #: components/manage/Form/InlineForm
+# defaultMessage: Edit values
 msgid "Edit values"
 msgstr "Werte bearbeiten"
 
 #: components/manage/Edit/Edit
+# defaultMessage: Edit {title}
 msgid "Edit {title}"
 msgstr "{title} bearbeiten"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Email
 msgid "Email"
 msgstr "E-Mail"
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Email sent
 msgid "Email sent"
 msgstr "E-Mail versendet"
 
 #: components/manage/Blocks/Maps/Edit
+# defaultMessage: Embed code error, please follow the instructions and try again.
 msgid "Embed code error, please follow the instructions and try again."
 msgstr "Fehler beim Einbinden des Google Maps Codes. Bitte lesen Sie die Anweisungen und stellen Sie sicher dass Sie den korrekten Code verwenden."
 
 #: components/manage/Blocks/Maps/View
+# defaultMessage: Embeded Google Maps
 msgid "Embeded Google Maps"
 msgstr "Eingebettete Google Maps Karte"
 
 #: components/manage/Widgets/ObjectListWidget
+# defaultMessage: Empty object list
 msgid "Empty object list"
 msgstr "Leere Liste von Elementen"
 
 #: components/manage/Controlpanels/ContentTypeLayout
+# defaultMessage: Enable editable Blocks
 msgid "Enable editable Blocks"
 msgstr "Aktiviere bearbeitbare Blocks"
 
 #: components/manage/Contents/Contents
+# defaultMessage: End Date
 msgid "End Date"
 msgstr "Enddatum"
 
 #: components/manage/AnchorPlugin/components/LinkButton/AddLinkForm
+# defaultMessage: Enter URL or select an item
 msgid "Enter URL or select an item"
 msgstr "URL eingeben oder Objekt auswählen"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Enter a username above to search or click 'Show All'
 msgid "Enter a username above to search or click 'Show All'"
 msgstr "Benutzername oben eingeben oder auf 'Alle anzeigen' klicken"
 
 #: components/theme/Register/Register
+# defaultMessage: Enter an email address. This will be your login name. We respect your privacy, and will not give the address away to any third parties or expose it anywhere.
 msgid "Enter an email address. This will be your login name. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr "Tragen Sie Ihre E-Mail-Adresse ein, mit der Sie sich künftig anmelden müssen. Wir respektieren den Datenschutz und werden die E-Mail-Adresse nicht an Dritte weitergeben und auch nirgends anzeigen."
 
 #: components/manage/Preferences/PersonalInformation
 #: components/theme/PasswordReset/PasswordReset
 #: components/theme/Register/Register
+# defaultMessage: Enter full name, e.g. John Smith.
 msgid "Enter full name, e.g. John Smith."
 msgstr "Tragen Sie bitte Ihren vollen Namen ein."
 
 #: components/manage/Blocks/Maps/Edit
+# defaultMessage: Enter map Embed Code
 msgid "Enter map Embed Code"
 msgstr "Karten-Einbettungscode eingeben"
 
 #: components/manage/Preferences/ChangePassword
+# defaultMessage: Enter your current password.
 msgid "Enter your current password."
 msgstr "Geben Sie Ihr aktuelles Passwort ein."
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Enter your email address for verification.
 msgid "Enter your email address for verification."
 msgstr "Tragen Sie zur Überprüfung Ihre E-Mail-Adresse ein."
 
 #: components/manage/Preferences/ChangePassword
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Enter your new password. Minimum 5 characters.
 msgid "Enter your new password. Minimum 5 characters."
 msgstr "Geben Sie ihr neues Passwort ein. Mindestens 5 Zeichen."
 
@@ -741,199 +892,245 @@ msgstr "Geben Sie ihr neues Passwort ein. Mindestens 5 Zeichen."
 #: components/theme/ContactForm/ContactForm
 #: components/theme/Login/Login
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Error
 msgid "Error"
 msgstr "Fehler"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Exclude from navigation
 msgid "Exclude from navigation"
 msgstr "Von der Navigation ausschließen"
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: Exclude this occurence
 msgid "Exclude this occurence"
 msgstr "Dieses Datum ausschließen"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Excluded from navigation
 msgid "Excluded from navigation"
 msgstr "Von Navigation ausgeschlossen"
 
 #: components/manage/Sidebar/Sidebar
+# defaultMessage: Expand sidebar
 msgid "Expand sidebar"
 msgstr "Sidebar vergrößern"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Expiration Date
 msgid "Expiration Date"
 msgstr "Ablaufdatum"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Expiration date
 msgid "Expiration date"
 msgstr "Ablaufdatum"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Expired
 msgid "Expired"
 msgstr "Abgelaufen"
 
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: External URL
 msgid "External URL"
 msgstr "Externe URL"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: File
 msgid "File"
 msgstr "Datei"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: File size
 msgid "File size"
 msgstr "Dateigröße"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Filename
 msgid "Filename"
 msgstr "Dateiname"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Filter…
 msgid "Filter…"
 msgstr "Filter…"
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: First
 msgid "First"
 msgstr "Erster Tag des Monats"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Fixed width columns
 msgid "Fixed width table cells"
 msgstr "Tabellen-Zellen mit fester Breite"
 
 #: components/manage/BlockChooser/BlockChooser
+# defaultMessage: Fold
 msgid "Fold"
 msgstr "Einklappen"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Folder
 msgid "Folder"
 msgstr "Ordner"
 
 #: components/theme/Forbidden/Forbidden
+# defaultMessage: Forbidden
 msgid "Forbidden"
 msgstr "Verboten"
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: Fourth
 msgid "Fourth"
 msgstr "Vierter"
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: From
 msgid "From"
 msgstr "E-Mail"
 
 #: components/manage/Blocks/Maps/Edit
 #: components/manage/Sidebar/AlignBlock
+# defaultMessage: Full
 msgid "Full"
 msgstr "Volle Breite"
 
 #: components/manage/Preferences/PersonalInformation
 #: components/theme/PasswordReset/PasswordReset
 #: components/theme/Register/Register
+# defaultMessage: Full Name
 msgid "Full Name"
 msgstr "Vor- und Nachname"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Fullname
 msgid "Fullname"
 msgstr "Name"
 
 #: components/theme/Footer/Footer
+# defaultMessage: GNU GPL license
 msgid "GNU GPL license"
 msgstr "GNU-GPL-Lizenz"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Global role
 msgid "Global role"
 msgstr "Globale Rolle"
 
 #: components/manage/Blocks/Maps/Edit
+# defaultMessage: Google Maps Embedded Block
 msgid "Google Maps Embedded Block"
 msgstr "Google Maps Block"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Group
 msgid "Group"
 msgstr "Gruppe"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Group created
 msgid "Group created"
 msgstr "Gruppe erstellt"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Group roles updated
 msgid "Group roles updated"
 msgstr ""
 
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Groupname
 msgid "Groupname"
 msgstr "Gruppenname"
 
 #: components/manage/Controlpanels/Controlpanels
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Groups
 msgid "Groups"
 msgstr "Gruppen"
 
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
+# defaultMessage: Groups are logical collections of users, such as departments and business units. Groups are not directly related to permissions on a global level, you normally use Roles for that - and let certain Groups have a particular role. The symbol{plone_svg}indicates a role inherited from membership in another group.
 msgid "Groups are logical collections of users, such as departments and business units. Groups are not directly related to permissions on a global level, you normally use Roles for that - and let certain Groups have a particular role. The symbol{plone_svg}indicates a role inherited from membership in another group."
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Header cell
 msgid "Header cell"
 msgstr "Kopfzeile"
 
 #: components/theme/Comments/Comments
+# defaultMessage: Hide Replies
 msgid "Hide Replies"
 msgstr "Antworten ausblenden"
 
 #: components/manage/History/History
 #: components/manage/Toolbar/More
+# defaultMessage: History
 msgid "History"
 msgstr "Historie"
 
 #: components/manage/History/History
+# defaultMessage: #
 msgid "History Version Number"
 msgstr ""
 
 #: components/manage/History/History
+# defaultMessage: History of {title}
 msgid "History of {title}"
 msgstr "Historie von {title}"
 
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsBreadcrumbs
 #: components/theme/Breadcrumbs/Breadcrumbs
+# defaultMessage: Home
 msgid "Home"
 msgstr "Startseite"
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: Home page
 msgid "Home page"
 msgstr "Homepage"
 
 #: components/manage/Contents/Contents
+# defaultMessage: ID
 msgid "ID"
 msgstr "ID"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: If selected, this item will not appear in the navigation tree
 msgid "If selected, this item will not appear in the navigation tree"
 msgstr "Bestimmt, ob der Artikel nicht in der Navigation auftauchen soll."
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: If this date is in the future, the content will not show up in listings and searches until this date.
 msgid "If this date is in the future, the content will not show up in listings and searches until this date."
 msgstr "Falls das Datum in der Zukunft liegt wird der Inhalt in Auflistungen und bei der Suche nicht auftauchen, bis zu dem Datum."
 
 #: components/manage/LockingToastsFactory/LockingToastsFactory
+# defaultMessage: If you are certain this user has abandoned the object, you may unlock the object. You will then be able to edit it.
 msgid "If you are certain this user has abandoned the object, you may unlock the object. You will then be able to edit it."
 msgstr ""
 
 #: components/theme/NotFound/NotFound
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: If you are certain you have the correct web address but are encountering an error, please contact the {site_admin}.
 msgid "If you are certain you have the correct web address but are encountering an error, please contact the {site_admin}."
 msgstr "Wenn Sie sicher sind, dass Sie die richtige Adresse eingegeben haben, kontaktieren Sie bitte den {site_admin}."
 
 #: components/manage/Blocks/HeroImageLeft/Edit
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: Image
 msgid "Image"
 msgstr "Bild"
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: Include this occurence
 msgid "Include this occurence"
 msgstr "Datum einbeziehen"
 
@@ -941,142 +1138,176 @@ msgstr "Datum einbeziehen"
 #: components/manage/Controlpanels/ContentTypeLayout
 #: components/manage/Controlpanels/ContentTypeSchema
 #: components/manage/Controlpanels/Controlpanel
+# defaultMessage: Info
 msgid "Info"
 msgstr "Information"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Inherit permissions from higher levels
 msgid "Inherit permissions from higher levels"
 msgstr "Berechtigungen von übergeordneten Ordnern übernehmen"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Inherited value
 msgid "Inherited value"
 msgstr "Geerbter Wert"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Insert col after
 msgid "Insert col after"
 msgstr "Spalte danach einfügen"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Insert col before
 msgid "Insert col before"
 msgstr "Spalte davor einfügen"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Insert row after
 msgid "Insert row after"
 msgstr "Zeile danach einfügen"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Insert row before
 msgid "Insert row before"
 msgstr "Zeile davor einfügen"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Install
 msgid "Install"
 msgstr "Installieren"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Installed
 msgid "Installed"
 msgstr "Installiert"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Installed version
 msgid "Installed version"
 msgstr "Installierte Version"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: days
 msgid "Interval Daily"
 msgstr "Täglich"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Month(s)
 msgid "Interval Monthly"
 msgstr "Monatlich"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: week(s)
 msgid "Interval Weekly"
 msgstr "Wöchentlich"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: year(s)
 msgid "Interval Yearly"
 msgstr "Jährliches Intervall"
 
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: Item batch size
 msgid "Item batch size"
 msgstr "Batch-Anzahl"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Item succesfully moved.
 msgid "Item succesfully moved."
 msgstr "Objekt wurde erfolgreich verschoben."
 
 #: components/manage/Contents/Contents
+# defaultMessage: Item(s) copied.
 msgid "Item(s) copied."
 msgstr "Objekt(e) kopiert."
 
 #: components/manage/Contents/Contents
+# defaultMessage: Item(s) cut.
 msgid "Item(s) cut."
 msgstr "Objekt(e) ausgeschnitten."
 
 #: components/manage/Contents/Contents
+# defaultMessage: Item(s) has been updated.
 msgid "Item(s) has been updated."
 msgstr "Objekt(e) wurde(n) aktualisiert"
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
+# defaultMessage: Item(s) pasted.
 msgid "Item(s) pasted."
 msgstr "Artikel eingefügt."
 
 #: components/manage/Contents/Contents
+# defaultMessage: Item(s) state has been updated.
 msgid "Item(s) state has been updated."
 msgstr "Der Status der Objekte wurde aktualisiert."
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Items
 msgid "Items"
 msgstr "Elemente"
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Items must be unique.
 msgid "Items must be unique."
 msgstr "Auswahl muss eindeutig sein."
 
 #: components/manage/Preferences/PersonalPreferences
+# defaultMessage: Language
 msgid "Language"
 msgstr "Sprache"
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: Last
 msgid "Last"
 msgstr "Letzter"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Last comment date
 msgid "Last comment date"
 msgstr "Letztes Kommentierdatum"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Last modified
 msgid "Last modified"
 msgstr "Letzte Änderung"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Latest version
 msgid "Latest version"
 msgstr "Letzte Version"
 
 #: components/manage/Controlpanels/ContentTypesActions
+# defaultMessage: Layout
 msgid "Layout"
 msgstr "Layout"
 
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: Lead Image
 msgid "Lead Image"
 msgstr "Lead-Bild"
 
 #: components/manage/Blocks/Image/ImageSizeWidget
 #: components/manage/Blocks/Maps/Edit
 #: components/manage/Sidebar/AlignBlock
+# defaultMessage: Left
 msgid "Left"
 msgstr "Links"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Link
 msgid "Link"
 msgstr "Link"
 
 #: components/manage/Blocks/Listing/schema
+# defaultMessage: Link more
 msgid "Link more"
 msgstr "'Mehr' Link"
 
 #: components/manage/Blocks/Listing/schema
+# defaultMessage: Link Title
 msgid "Link title"
 msgstr "Linktitel"
 
@@ -1085,212 +1316,262 @@ msgstr "Linktitel"
 #: components/manage/Blocks/Listing/schema
 #: components/manage/Blocks/Maps/MapsSidebar
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Link to
 msgid "Link to"
 msgstr "Link auf"
 
 #: components/manage/Multilingual/ManageTranslations
+# defaultMessage: Link translation for
 msgid "Link translation for"
 msgstr "Übersetzung verbinden"
 
 #: components/manage/Blocks/Listing/schema
+# defaultMessage: Listing
 msgid "Listing"
 msgstr "Auflistung"
 
 #: components/theme/Comments/Comments
+# defaultMessage: Load more...
 msgid "Load more"
 msgstr "Mehr laden"
 
 #: components/manage/Form/ModalForm
+# defaultMessage: Loading.
 msgid "Loading"
 msgstr "lädt"
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: Location
 msgid "Location"
 msgstr "Ort"
 
 #: components/theme/Login/Login
+# defaultMessage: Login
 msgid "Log In"
 msgstr "Anmelden"
 
 #: components/theme/Anontools/Anontools
 #: components/theme/Login/Login
+# defaultMessage: Log in
 msgid "Log in"
 msgstr "Anmelden"
 
 #: components/theme/Login/Login
+# defaultMessage: Login
 msgid "Login"
 msgstr "Einloggen"
 
 #: components/theme/Login/Login
+# defaultMessage: Login Failed
 msgid "Login Failed"
 msgstr "Login fehlgeschlagen"
 
 #: components/theme/Login/Login
+# defaultMessage: Login Name
 msgid "Login Name"
 msgstr "Benutzername"
 
 #: components/manage/Toolbar/PersonalTools
+# defaultMessage: Logout
 msgid "Logout"
 msgstr ""
 
 #: components/manage/Toolbar/More
+# defaultMessage: Made by {creator} on {date}. This is not a working copy anymore, but the main content.
 msgid "Made by {creator} on {date}. This is not a working copy anymore, but the main content."
 msgstr "Erstellt von {creator} am {date}. Diese Seite ist keine Arbeitskopie mehr sondern die Live-Seite."
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Reduce cell padding
 msgid "Make the table compact"
 msgstr "Tabelle kompakt darstellen"
 
 #: components/manage/Multilingual/ManageTranslations
 #: components/manage/Toolbar/More
+# defaultMessage: Manage Translations
 msgid "Manage Translations"
 msgstr "Übersetzungen verwalten"
 
 #: components/manage/Multilingual/ManageTranslations
+# defaultMessage: Manage translations for {title}
 msgid "Manage translations for {title}"
 msgstr "Übersetzungen für {} verwalten"
 
 #: components/manage/Blocks/Maps/MapsSidebar
+# defaultMessage: Map
 msgid "Map"
 msgstr "Karte"
 
 #: components/manage/Blocks/Maps/MapsSidebar
+# defaultMessage: Maps URL
 msgid "Maps URL"
 msgstr "Karten URL"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Maximum length is {len}.
 msgid "Maximum length is {len}."
 msgstr "Maximale Länge ist {len}."
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Maximum value is {len}.
 msgid "Maximum value is {len}."
 msgstr "Maximaler Wert ist {len}"
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Message
 msgid "Message"
 msgstr "Nachricht"
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Minimum length is {len}.
 msgid "Minimum length is {len}."
 msgstr "Minimale Länge ist {len}"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Minimum value is {len}.
 msgid "Minimum value is {len}."
 msgstr "Minimaler Wert ist {len}"
 
 #: components/manage/Controlpanels/Controlpanels
+# defaultMessage: Moderate Comments
 msgid "Moderate Comments"
 msgstr "Kommentare moderieren"
 
 #: components/manage/Controlpanels/ModerateComments
+# defaultMessage: Moderate comments
 msgid "Moderate comments"
 msgstr "Kommentare moderieren"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Monday and Friday
 msgid "Monday and Friday"
 msgstr "Montag und Freitag"
 
 #: components/manage/Widgets/RecurrenceWidget/ByMonthDayField
+# defaultMessage: Day
 msgid "Month day"
 msgstr "Tag des Monats"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Monthly
 msgid "Monthly"
 msgstr "Monatlich"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: More
 msgid "More"
 msgstr "Mehr"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Move to bottom of folder
 msgid "Move to bottom of folder"
 msgstr "Ans Ende verschieben"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Move to top of folder
 msgid "Move to top of folder"
 msgstr "An den Anfang verschieben"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: My email address is
 msgid "My email address is"
 msgstr "Meine E-Mail-Adresse lautet"
 
 #: components/manage/Sharing/Sharing
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Name
 msgid "Name"
 msgstr "Name"
 
 #: error
+# defaultMessage: Navigate back
 msgid "Navigate back"
 msgstr "Zurück navigieren"
 
 #: components/theme/Navigation/ContextNavigation
+# defaultMessage: Navigation
 msgid "Navigation"
 msgstr "Navigation"
 
 #: components/manage/Preferences/ChangePassword
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: New password
 msgid "New password"
 msgstr "Neues Passwort"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: News Item
 msgid "News Item"
 msgstr "Nachricht"
 
 #: components/manage/Contents/ContentsItem
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: No
 msgid "No"
 msgstr "Nein"
 
 #: components/manage/Blocks/Image/ImageSidebar
+# defaultMessage: No image selected
 msgid "No image selected"
 msgstr "Kein Bild ausgewählt"
 
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: No image set in Lead Image content field
 msgid "No image set in Lead Image content field"
 msgstr "Im Feld 'Lead-Bild' wurde kein Bild gesetzt."
 
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: No image set in image content field
 msgid "No image set in image content field"
 msgstr "Im Feld 'Bild' wurde kein Bild gesetzt"
 
 #: components/manage/Blocks/Listing/ListingBody
+# defaultMessage: No items found in this container.
 msgid "No items found in this container."
 msgstr "Keine Elemente gefunden"
 
 #: components/manage/Widgets/ObjectBrowserWidget
+# defaultMessage: No items selected
 msgid "No items selected"
 msgstr "Kein Element ausgewählt"
 
 #: components/manage/Blocks/Maps/MapsSidebar
+# defaultMessage: No map selected
 msgid "No map selected"
 msgstr "Keine Karte ausgewählt"
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: No occurences set
 msgid "No occurences set"
 msgstr "Kein Datum gesetzt"
 
 #: components/manage/Widgets/ArrayWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/TokenWidget
+# defaultMessage: No options
 msgid "No options"
 msgstr "Keine Option"
 
 #: components/theme/Search/Search
+# defaultMessage: No results found
 msgid "No results found"
 msgstr "Keine Ergebnisse gefunden"
 
 #: components/manage/Blocks/Listing/ListingBody
 #: components/manage/Widgets/ReferenceWidget
+# defaultMessage: No results found.
 msgid "No results found."
 msgstr "Keine Ergebnisse gefunden."
 
 #: components/manage/Widgets/QuerySortOnWidget
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: No selection
 msgid "No selection"
 msgstr "Keine Auswahl"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: This addon does not provide an uninstall profile.
 msgid "No uninstall profile"
 msgstr "Kein Deinstallationsprofil"
 
@@ -1298,39 +1579,48 @@ msgstr "Kein Deinstallationsprofil"
 #: components/manage/Widgets/ReferenceWidget
 #: components/manage/Widgets/SelectUtils
 #: components/manage/Widgets/SelectWidget
+# defaultMessage: No value
 msgid "No value"
 msgstr "Kein Wert"
 
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: No video selected
 msgid "No video selected"
 msgstr "Kein Video ausgewählt"
 
 #: components/manage/Workflow/Workflow
+# defaultMessage: No workflow
 msgid "No workflow"
 msgstr "Kein Workflow"
 
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsItem
+# defaultMessage: None
 msgid "None"
 msgstr "Nicht vorhanden"
 
 #: components/manage/Controlpanels/Users/UsersControlpanel
+# defaultMessage: Note that roles set here apply directly to a user. The symbol{plone_svg}indicates a role inherited from membership in a group.
 msgid "Note that roles set here apply directly to a user. The symbol{plone_svg}indicates a role inherited from membership in a group."
 msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Number of active objects
 msgid "Number of active objects"
 msgstr "Anzahl aktive Objekte"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Object Size
 msgid "Object Size"
 msgstr "Grösse"
 
 #: components/manage/Widgets/RecurrenceWidget/EndField
+# defaultMessage: occurrence(s)
 msgid "Occurences"
 msgstr "Vorkommen"
 
 #: components/manage/Delete/Delete
+# defaultMessage: Ok
 msgid "Ok"
 msgstr "OK"
 
@@ -1338,301 +1628,371 @@ msgstr "OK"
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
 #: components/manage/Blocks/Maps/MapsSidebar
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Open in a new tab
 msgid "Open in a new tab"
 msgstr "In neuem Browser-Tab öffnen"
 
 #: components/theme/Navigation/Navigation
+# defaultMessage: Open menu
 msgid "Open menu"
 msgstr "Menü öffnen"
 
 #: components/manage/Widgets/ObjectBrowserWidget
+# defaultMessage: Open object browser
 msgid "Open object browser"
 msgstr "Objekt-Browser öffnen"
 
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: Origin
 msgid "Origin"
 msgstr "Quelle"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Page
 msgid "Page"
 msgstr "Seite"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Parent fieldset
 msgid "Parent fieldset"
 msgstr "Eltern-Fieldset"
 
 #: components/theme/Login/Login
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Password
 msgid "Password"
 msgstr "Passwort"
 
 #: components/theme/PasswordReset/PasswordReset
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Password reset
 msgid "Password reset"
 msgstr "Passwort zurücksetzen"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Passwords do not match.
 msgid "Passwords do not match."
 msgstr "Die Passwörter stimmen nicht überein."
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
+# defaultMessage: Paste
 msgid "Paste"
 msgstr "Einfügen"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: undefined
 msgid "Paste blocks"
 msgstr "Blöcke einfügen"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Permissions have been updated successfully
 msgid "Permissions have been updated successfully"
 msgstr "Berechtigungen wurden erfolgreich aktualisiert"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Permissions updated
 msgid "Permissions updated"
 msgstr "Berechtigungen aktualisiert"
 
 #: components/manage/Preferences/PersonalInformation
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Personal Information
 msgid "Personal Information"
 msgstr "Persönliche Informationen"
 
 #: components/manage/Preferences/PersonalPreferences
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Personal Preferences
 msgid "Personal Preferences"
 msgstr "Meine Einstellungen"
 
 #: components/manage/Toolbar/More
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Personal tools
 msgid "Personal tools"
 msgstr "Persönliche Einstellungen"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Persons responsible for creating the content of this item. Please enter a list of user names, one per line. The principal creator should come first.
 msgid "Persons responsible for creating the content of this item. Please enter a list of user names, one per line. The principal creator should come first."
 msgstr "Eine Liste von Personen, die an der Erstellung dieses Artikels beteiligt waren. Bitte geben Sie einen Benutzernamen pro Zeile ein. Der Hauptverantwortliche sollte zuerst genannt werden."
 
 #: components/manage/Blocks/Video/Edit
+# defaultMessage: Please enter a valid URL by deleting the block and adding a new video block.
 msgid "Please enter a valid URL by deleting the block and adding a new video block."
 msgstr "Geben Sie eine gültige URL "
 
 #: components/manage/Blocks/Maps/Edit
+# defaultMessage: Please enter the Embed Code provided by Google Maps -> Share -> Embed map. It should contain the <iframe> code on it.
 msgid "Please enter the Embed Code provided by Google Maps -> Share -> Embed map. It should contain the <iframe> code on it."
 msgstr "Bitte geben sie den Einbettungscode von Google Maps ein. Klicken Sie auf 'Teilen' und dann 'Karte einbetten'. Der Code sollte ein '<iframe>'-Element enthalten."
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Please fill out the form below to set your password.
 msgid "Please fill out the form below to set your password."
 msgstr "Bitte füllen Sie das unten stehende Formular aus, um Ihr Passwort neu zu setzen."
 
 #: components/theme/Footer/Footer
+# defaultMessage: Plone Foundation
 msgid "Plone Foundation"
 msgstr "Plone Foundation"
 
 #: components/theme/Logo/Logo
+# defaultMessage: Plone Site
 msgid "Plone Site"
 msgstr "Website"
 
 #: components/theme/Footer/Footer
+# defaultMessage: Plone{reg} Open Source CMS/WCM
 msgid "Plone{reg} Open Source CMS/WCM"
 msgstr "Plone{reg} Open Source Content Management System"
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: Portrait
 msgid "Portrait"
 msgstr "Portrait"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Possible values (Enter allowed choices one per line).
 msgid "Possible values"
 msgstr "Mögliche Werte"
 
 #: components/theme/Footer/Footer
+# defaultMessage: Powered by Plone & Python
 msgid "Powered by Plone & Python"
 msgstr "Powered by Plone & Python"
 
 #: components/manage/Toolbar/PersonalTools
+# defaultMessage: Preferences
 msgid "Preferences"
 msgstr "Einstellungen"
 
 #: components/manage/Blocks/HTML/Edit
+# defaultMessage: Prettify your code
 msgid "Prettify your code"
 msgstr "Quellcode aufräumen"
 
 #: components/manage/Blocks/HTML/Edit
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Preview
 msgid "Preview"
 msgstr "Vorschau"
 
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Preview Image URL
 msgid "Preview Image URL"
 msgstr "URL Vorschaubild"
 
 #: components/manage/Toolbar/PersonalTools
+# defaultMessage: Profile
 msgid "Profile"
 msgstr "Profil"
 
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Properties
 msgid "Properties"
 msgstr "Eigenschaften"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Publication date
 msgid "Publication date"
 msgstr "Freigabedatum"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Publishing Date
 msgid "Publishing Date"
 msgstr "Freigabedatum"
 
 #: components/manage/Blocks/Listing/schema
+# defaultMessage: Query
 msgid "Query"
 msgstr "Anfrage"
 
 #: components/manage/Preferences/ChangePassword
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Re-enter the password. Make sure the passwords are identical.
 msgid "Re-enter the password. Make sure the passwords are identical."
 msgstr "Geben Sie das gleiche Passwort erneut ein."
 
 #: components/theme/Search/Search
 #: components/theme/View/SummaryView
+# defaultMessage: Read More…
 msgid "Read More…"
 msgstr "Mehr…"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Rearrange items by…
 msgid "Rearrange items by…"
 msgstr "Elemente sortieren nach…"
 
 #: components/manage/Widgets/RecurrenceWidget/EndField
+# defaultMessage: Ends
 msgid "Recurrence ends"
 msgstr "Ende des wiederkehrenden Vorkommens"
 
 #: components/manage/Widgets/RecurrenceWidget/EndField
+# defaultMessage: after
 msgid "Recurrence ends after"
 msgstr "Wiederkehrendes Vorkommen endet nach"
 
 #: components/manage/Widgets/RecurrenceWidget/EndField
+# defaultMessage: on
 msgid "Recurrence ends on"
 msgstr "Wiederkehrendes Vorkommen endet am"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Minimalistic table design
 msgid "Reduce complexity"
 msgstr "Komplexität reduzieren"
 
 #: components/theme/Anontools/Anontools
 #: components/theme/Login/Login
 #: components/theme/Register/Register
+# defaultMessage: Register
 msgid "Register"
 msgstr "Registrieren"
 
 #: components/theme/Register/Register
+# defaultMessage: Registration form
 msgid "Registration form"
 msgstr "Registrierungsformular"
 
 #: components/theme/Search/Search
+# defaultMessage: Relevance
 msgid "Relevance"
 msgstr "relevanz"
 
 #: components/manage/Widgets/ObjectListWidget
+# defaultMessage: Remove item
 msgid "Remove item"
 msgstr "Element entfernen"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Remove
 msgid "Remove recurrence"
 msgstr "Wiederkehrende Einstellung entfernen"
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Remove term
 msgid "Remove term"
 msgstr "Entferne Term"
 
 #: components/manage/Toolbar/More
+# defaultMessage: Remove working copy
 msgid "Remove working copy"
 msgstr "Arbeitskopie löschen"
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
+# defaultMessage: Rename
 msgid "Rename"
 msgstr "Umbenennen"
 
 #: components/manage/Contents/ContentsRenameModal
+# defaultMessage: Renaming items...
 msgid "Rename Items Loading Message"
 msgstr "Umbenennen-Modal lädt"
 
 #: components/manage/Contents/ContentsRenameModal
+# defaultMessage: Rename items
 msgid "Rename items"
 msgstr "Artikel umbenennen"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Repeat
 msgid "Repeat"
 msgstr "Wiederholen"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Repeat every
 msgid "Repeat every"
 msgstr "Wiederhole jeden"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Repeat on
 msgid "Repeat on"
 msgstr "Wiederhole am"
 
 #: components/manage/Widgets/FileWidget
+# defaultMessage: Replace existing file
 msgid "Replace existing file"
 msgstr "Bestehende Datei ersetzen"
 
 #: components/theme/Comments/Comments
+# defaultMessage: Reply
 msgid "Reply"
 msgstr "Antworten"
 
 #: components/manage/Widgets/SchemaWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/WysiwygWidget
+# defaultMessage: Required
 msgid "Required"
 msgstr "Notwendig"
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Required input is missing.
 msgid "Required input is missing."
 msgstr "Notwendige Eingabe fehlt."
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Reset title
 msgid "Reset term title"
 msgstr "Setze Titel zurück"
 
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: Results limit
 msgid "Results limit"
 msgstr "Anzahl der Ergebnisse einschränken"
 
 #: components/manage/Blocks/Listing/Edit
+# defaultMessage: Results preview
 msgid "Results preview"
 msgstr "Ergebnisvorschau"
 
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: Reversed order
 msgid "Reversed order"
 msgstr "Sortierreihenfolge umkehren"
 
 #: components/manage/History/History
+# defaultMessage: Revert to this revision
 msgid "Revert to this revision"
 msgstr "Die aktuelle Version durch diese ersetzen"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Review state
 msgid "Review state"
 msgstr "Arbeitsablauf"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Richtext
 msgid "Richtext"
 msgstr "Richtext"
 
 #: components/manage/Blocks/Image/ImageSizeWidget
 #: components/manage/Blocks/Maps/Edit
 #: components/manage/Sidebar/AlignBlock
+# defaultMessage: Right
 msgid "Right"
 msgstr "Rechte"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Rights
 msgid "Rights"
 msgstr "Rechte"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Roles
 msgid "Roles"
 msgstr "Rollen"
 
 #: components/manage/Contents/ContentsBreadcrumbs
+# defaultMessage: Root
 msgid "Root"
 msgstr "Wurzel"
 
@@ -1645,90 +2005,112 @@ msgstr "Wurzel"
 #: components/manage/Form/ModalForm
 #: components/manage/Sharing/Sharing
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Save
 msgid "Save"
 msgstr "Speichern"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Save
 msgid "Save recurrence"
 msgstr "Wiederkehrende Einstellung speichern"
 
 #: components/manage/Controlpanels/ContentTypesActions
+# defaultMessage: Schema
 msgid "Schema"
 msgstr "Schema"
 
 #: components/manage/Controlpanels/ContentTypeSchema
+# defaultMessage: Schema updates
 msgid "Schema updates"
 msgstr "Aktualisierungen Schema"
 
 #: components/theme/SearchWidget/SearchWidget
+# defaultMessage: Search
 msgid "Search"
 msgstr "Suche"
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: Search SVG
 msgid "Search SVG"
 msgstr "Suchen"
 
 #: components/theme/SearchWidget/SearchWidget
+# defaultMessage: Search Site
 msgid "Search Site"
 msgstr "Website durchsuchen"
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: Search content
 msgid "Search content"
 msgstr "Inhalte suchen"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Search for user or group
 msgid "Search for user or group"
 msgstr "Nach Benutzer oder Gruppe suchen"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Search group…
 msgid "Search group…"
 msgstr "Nach Gruppe suchen…"
 
 #: components/theme/Search/Search
+# defaultMessage: Search results
 msgid "Search results"
 msgstr "Suchergebnisse"
 
 #: components/theme/Search/Search
+# defaultMessage: Search results for {term}
 msgid "Search results for {term}"
 msgstr "Suchergebnisse für {term}"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Search users…
 msgid "Search users…"
 msgstr "Nach Nutzern suchen…"
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: Second
 msgid "Second"
 msgstr "Zweiter"
 
 #: components/manage/Sidebar/ObjectBrowserNav
+# defaultMessage: Select
 msgid "Select"
 msgstr "Auswählen"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Select a date to add to recurrence
 msgid "Select a date to add to recurrence"
 msgstr "Wählen Sie ein Datum um ein wiederkehrendes Datum einzustellen"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Select columns to show
 msgid "Select columns to show"
 msgstr "Anzuzeigende Spalten wählen"
 
 #: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Select the transition to be used for modifying the items state.
 msgid "Select the transition to be used for modifying the items state."
 msgstr "Arbeitsablauf-Status für Seite wählen."
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: Selected dates
 msgid "Selected dates"
 msgstr "Ausgewählte Daten"
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: Selected items
 msgid "Selected items"
 msgstr "Ausgewählte Objekte"
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: of
 msgid "Selected items - x of y"
 msgstr "Ausgewählte Objekte - x von y"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Selection
 msgid "Selection"
 msgstr "Auswahl"
 
@@ -1736,158 +2118,195 @@ msgstr "Auswahl"
 #: components/manage/Widgets/ArrayWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/TokenWidget
+# defaultMessage: Select…
 msgid "Select…"
 msgstr "Wähle…"
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Send
 msgid "Send"
 msgstr "Absenden"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Set my password
 msgid "Set my password"
 msgstr "Passwort neu setzen"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Set your password
 msgid "Set your password"
 msgstr "Setzen Sie Ihr Passwort"
 
 #: components/manage/Sidebar/Sidebar
+# defaultMessage: Settings
 msgid "Settings"
 msgstr "Einstellungen"
 
 #: components/manage/Sharing/Sharing
 #: components/manage/Toolbar/More
+# defaultMessage: Sharing
 msgid "Sharing"
 msgstr "Freigabe"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Sharing for {title}
 msgid "Sharing for {title}"
 msgstr "Freigabe für"
 
 #: components/manage/Widgets/SchemaWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/WysiwygWidget
+# defaultMessage: Short Name
 msgid "Short Name"
 msgstr "Kurzname"
 
 #: components/manage/Contents/ContentsRenameModal
+# defaultMessage: Short name
 msgid "Short name"
 msgstr "Kurzname"
 
 #: components/theme/Pagination/Pagination
+# defaultMessage: Show
 msgid "Show"
 msgstr "Zeige"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Show All
 msgid "Show All"
 msgstr "Alle anzeigen"
 
 #: components/theme/Comments/Comments
+# defaultMessage: Show Replies
 msgid "Show Replies"
 msgstr "Antworten anzeigen"
 
 #: components/manage/Widgets/ObjectListWidget
+# defaultMessage: Show item
 msgid "Show item"
 msgstr "Elemente anzeigen"
 
 #: components/manage/Sidebar/Sidebar
+# defaultMessage: Shrink sidebar
 msgid "Shrink sidebar"
 msgstr "Sidebar verkleinern"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Shrink toolbar
 msgid "Shrink toolbar"
 msgstr "Toolbar verkleinern"
 
 #: components/theme/Login/Login
+# defaultMessage: Sign in to start session
 msgid "Sign in to start session"
 msgstr "Loggen Sie sich ein"
 
 #: components/theme/Logo/Logo
+# defaultMessage: Site
 msgid "Site"
 msgstr "Website"
 
 #: components/theme/NotFound/NotFound
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: Site Administration
 msgid "Site Administration"
 msgstr "Website-Administrator"
 
 #: components/theme/Footer/Footer
+# defaultMessage: Site Map
 msgid "Site Map"
 msgstr "Übersicht"
 
 #: components/manage/Controlpanels/Controlpanels
 #: components/manage/Toolbar/PersonalTools
+# defaultMessage: Site Setup
 msgid "Site Setup"
 msgstr "Seiteneinstellungen"
 
 #: components/theme/Sitemap/Sitemap
+# defaultMessage: Sitemap
 msgid "Sitemap"
 msgstr "Sitemap"
 
 #: components/manage/Blocks/Image/ImageSidebar
+# defaultMessage: Size
 msgid "Size"
 msgstr "Größe"
 
 #: components/theme/View/ImageView
+# defaultMessage: Size: {size}
 msgid "Size: {size}"
 msgstr "Grösse: {size}"
 
 #: error
+# defaultMessage: Sorry, something went wrong with your request
 msgid "Sorry, something went wrong with your request"
 msgstr "Entschuldigung, ein Fehler ist beim Ausführen Ihrer Anfrage aufgetreten "
 
 #: components/theme/Search/Search
+# defaultMessage: Sort by:
 msgid "Sort By:"
 msgstr "Sortieren nach:"
 
 #: components/manage/Widgets/QuerySortOnWidget
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: Sort on
 msgid "Sort on"
 msgstr "Sortieren nach"
 
 #: components/manage/Blocks/HTML/Edit
+# defaultMessage: Source
 msgid "Source"
 msgstr "Quelle"
 
 #: components/manage/Blocks/Video/Edit
+# defaultMessage: Specify a youtube video or playlist url
 msgid "Specify a youtube video or playlist url"
 msgstr "Geben Sie ein YouTube-Video oder eine YouTube-Playlist URL ein"
 
 #: components/manage/Diff/Diff
+# defaultMessage: Split
 msgid "Split"
 msgstr "Aufsplitten"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Start Date
 msgid "Start Date"
 msgstr "Anfangsdatum"
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: Start of the recurrence
 msgid "Start of the recurrence"
 msgstr "Anfangsdatum des wiederkehrenden Termins"
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Start password reset
 msgid "Start password reset"
 msgstr "E-Mail anfordern"
 
 #: components/manage/Contents/Contents
 #: components/manage/Workflow/Workflow
 #: components/theme/View/TabularView
+# defaultMessage: State
 msgid "State"
 msgstr "Status"
 
 #: components/manage/Multilingual/CompareLanguages
+# defaultMessage: Stop compare
 msgid "Stop compare"
 msgstr "Vergleichsansicht verlassen"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: String
 msgid "String"
 msgstr "Text"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Alternate row background color
 msgid "Stripe alternate rows with color"
 msgstr "Zeilen abwechselnd einfärben"
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Subject
 msgid "Subject"
 msgstr "Betreff"
 
@@ -1901,43 +2320,53 @@ msgstr "Betreff"
 #: components/manage/Preferences/PersonalPreferences
 #: components/theme/ContactForm/ContactForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Success
 msgid "Success"
 msgstr "Erfolgreich"
 
 #: components/theme/LanguageSelector/LanguageSelector
+# defaultMessage: Switch to
 msgid "Switch to"
 msgstr "Wechseln zu"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Table
 msgid "Table"
 msgstr "Tabelle"
 
 #: components/manage/Blocks/ToC/View
+# defaultMessage: Table of Contents
 msgid "Table of Contents"
 msgstr "Inhaltsverzeichnis"
 
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsTagsModal
+# defaultMessage: Tags
 msgid "Tags"
 msgstr "Tags"
 
 #: components/manage/Contents/ContentsTagsModal
+# defaultMessage: Tags to add
 msgid "Tags to add"
 msgstr "Hinzuzufügende Tags"
 
 #: components/manage/Contents/ContentsTagsModal
+# defaultMessage: Tags to remove
 msgid "Tags to remove"
 msgstr "Zu entfernende Tags"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Target memory size per cache in bytes
 msgid "Target memory size per cache in bytes"
 msgstr "Ziel-Speichergröße pro Cache in Bytes"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Target number of objects in memory per cache
 msgid "Target number of objects in memory per cache"
 msgstr "Ziel-Anzahl von Objekten im Speicher pro Cache"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Text
 msgid "Text"
 msgstr "Text"
 
@@ -1945,87 +2374,108 @@ msgstr "Text"
 #: components/theme/CorsError/CorsError
 #: components/theme/NotFound/NotFound
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: Thank you.
 msgid "Thank you."
 msgstr "Vielen Dank."
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: The Database Manager allow you to view database status information
 msgid "The Database Manager allow you to view database status information"
 msgstr "Der Datenbank-Manager zeigt Ihnen Status-Informationen zu der Datenbank"
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: The URL for your external home page, if you have one.
 msgid "The URL for your external home page, if you have one."
 msgstr "Die URL Ihrer externen Homepage, sollten Sie eine besitzen."
 
 #: components/theme/ConnectionRefused/ConnectionRefused
+# defaultMessage: The backend is not responding, please check if you have started Plone, check your project's configuration object apiPath (or if you are using the internal proxy, devProxyToApiPath) or the RAZZLE_API_PATH Volto's environment variable.
 msgid "The backend is not responding, please check if you have started Plone, check your project's configuration object apiPath (or if you are using the internal proxy, devProxyToApiPath) or the RAZZLE_API_PATH Volto's environment variable."
 msgstr "Das Backend beantwortet die Anfrage nicht, prüfen Sie bitte ob Sie Plone gestartet haben. Prüfen Sie den apiPath Parameter Ihrer Projekt-Konfiguration oder die RAZZLE_API_PATH Umgebungsvariable."
 
 #: components/theme/CorsError/CorsError
+# defaultMessage: The backend is responding, but the CORS headers are not configured properly and the browser has denied the access to the backend resources.
 msgid "The backend is responding, but the CORS headers are not configured properly and the browser has denied the access to the backend resources."
 msgstr "Das Backend antwortet, allerdings sind ihre CORS HTTP Header nicht korrekt konfiguriert."
 
 #: components/theme/CorsError/CorsError
+# defaultMessage: The backend server of your website is not anwering, we apologize for the inconvenience. Please try to re-load the page and try again. If the problem persists please contact the site administrators.
 msgid "The backend server of your website is not anwering, we apologize for the inconvenience. Please try to re-load the page and try again. If the problem persists please contact the site administrators."
 msgstr "Der Server antwortet nicht, wir entschuldigen uns für die Unanehmlichkeiten. Bitte versuchen Sie die Seite neu zu laden. Falls das Problem weiterhin besteht kontaktieren Sie bitte den Seitenbetreiber."
 
 #: components/manage/Contents/Contents
+# defaultMessage: The item could not be deleted.
 msgid "The item could not be deleted."
 msgstr ""
 
 #: components/theme/Register/Register
+# defaultMessage: The registration process has been successful. Please check your e-mail inbox for information on how activate your account.
 msgid "The registration process has been successful. Please check your e-mail inbox for information on how activate your account."
 msgstr "Bitte prüfen Sie Ihr E-Mail Postfach. Sie sollten eine E-Mail erhalten haben mit Anweisungen, wie Sie Ihren Zugang aktivieren können."
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: The user portrait/avatar
 msgid "The user portrait/avatar"
 msgstr "Benutzer Portrait/Avatar"
 
 #: components/manage/Toolbar/More
+# defaultMessage: The working copy was discarded
 msgid "The working copy was discarded"
 msgstr "Die Arbeitskopie wurde verworfen"
 
 #: components/theme/Footer/Footer
+# defaultMessage: The {plonecms} is {copyright} 2000-{current_year} by the {plonefoundation} and friends.
 msgid "The {plonecms} is {copyright} 2000-{current_year} by the {plonefoundation} and friends."
 msgstr "{plonecms} {copyright} 2000-{current_year} {plonefoundation} und Freunde."
 
 #: components/theme/CorsError/CorsError
+# defaultMessage: There is a configuration problem on the backend
 msgid "There is a configuration problem on the backend"
 msgstr "Konfigurationsproblem im Backend"
 
 #: components/manage/Form/InlineForm
+# defaultMessage: There were some errors
 msgid "There were some errors"
 msgstr "Es sind Fehler"
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: There were some errors.
 msgid "There were some errors."
 msgstr "Es sind Fehler aufgetreten."
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: Third
 msgid "Third"
 msgstr "Dritter"
 
 #: components/manage/WorkingCopyToastsFactory/WorkingCopyToastsFactory
+# defaultMessage: This has an ongoing working copy in {title}
 msgid "This has an ongoing working copy in {title}"
 msgstr "Diese Seite hat eine Arbeitskopie unter {title}"
 
 #: components/manage/WorkingCopyToastsFactory/WorkingCopyToastsFactory
+# defaultMessage: This is a working copy of {title}
 msgid "This is a working copy of {title}"
 msgstr "Das ist eine Arbeitskopie von {title}"
 
 #: components/manage/LockingToastsFactory/LockingToastsFactory
+# defaultMessage: This item was locked by {creator} on {date}
 msgid "This item was locked by {creator} on {date}"
 msgstr ""
 
 #: components/manage/Contents/ContentsRenameModal
+# defaultMessage: This name will be displayed in the URL.
 msgid "This name will be displayed in the URL."
 msgstr "Dieser Name wird in der Adressleiste des Browsers angezeigt."
 
 #: components/theme/NotFound/NotFound
+# defaultMessage: This page does not seem to exist…
 msgid "This page does not seem to exist…"
 msgstr "Die Seite existiert leider nicht…"
 
 #: components/manage/Widgets/DatetimeWidget
+# defaultMessage: Time
 msgid "Time"
 msgstr "Zeit"
 
@@ -2038,714 +2488,889 @@ msgstr "Zeit"
 #: components/manage/Widgets/WysiwygWidget
 #: components/theme/View/TabularView
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Title
 msgid "Title"
 msgstr "Titel"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Total active and non-active objects
 msgid "Total active and non-active objects"
 msgstr "Anzahl aktive und nicht-aktive Objekte"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Total comments
 msgid "Total comments"
 msgstr "Anzahl Komentare"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Total number of objects in each cache
 msgid "Total number of objects in each cache"
 msgstr "Anzahl aller Objekte im Cache"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Total number of objects in memory from all caches
 msgid "Total number of objects in memory from all caches"
 msgstr "Anzahl aller Objekte im Speicher von allen Caches"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Total number of objects in the database
 msgid "Total number of objects in the database"
 msgstr "Anzahl aller Objekte in der Datenbank"
 
 #: components/manage/Add/Add
 #: components/manage/Toolbar/Types
+# defaultMessage: Translate to {lang}
 msgid "Translate to {lang}"
 msgstr "Auf {lang} übersetzen"
 
 #: components/manage/Multilingual/ManageTranslations
+# defaultMessage: Translation linked
 msgid "Translation linked"
 msgstr "Übersetzung verbunden"
 
 #: components/manage/Multilingual/ManageTranslations
+# defaultMessage: Translation linking removed
 msgid "Translation linking removed"
 msgstr "Verbindung zu Übersetzung gelöst"
 
 #: components/manage/Controlpanels/ContentTypes
 #: components/manage/Widgets/SchemaWidget
 #: components/theme/View/TabularView
+# defaultMessage: Type
 msgid "Type"
 msgstr "Typ"
 
 #: components/manage/Blocks/Video/Edit
+# defaultMessage: Type a Video (YouTube, Vimeo or mp4) URL
 msgid "Type a Video (YouTube, Vimeo or mp4) URL"
 msgstr "Geben Sie eine Video-URL (YouTube, Video oder MP4) ein"
 
 #: components/manage/Blocks/Text/Edit
+# defaultMessage: Type text…
 msgid "Type text…"
 msgstr "Text eingeben…"
 
 #: components/manage/Blocks/Title/Edit
+# defaultMessage: Type the title…
 msgid "Type the title…"
 msgstr "Titel eingeben…"
 
 #: components/manage/Contents/Contents
+# defaultMessage: UID
 msgid "UID"
 msgstr "UID"
 
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: Unauthorized
 msgid "Unauthorized"
 msgstr "Nicht autorisiert"
 
 #: components/manage/BlockChooser/BlockChooser
+# defaultMessage: Unfold
 msgid "Unfold"
 msgstr "Ausklappen"
 
 #: components/manage/Diff/Diff
+# defaultMessage: Unified
 msgid "Unified"
 msgstr "Vereinigt"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Uninstall
 msgid "Uninstall"
 msgstr "Deinstallieren"
 
 #: components/manage/Blocks/Block/Edit
 #: components/theme/View/DefaultView
 #: components/theme/View/RenderBlocks
+# defaultMessage: Unknown Block {block}
 msgid "Unknown Block"
 msgstr "Unbekannter Block"
 
 #: components/manage/Multilingual/ManageTranslations
+# defaultMessage: Unlink translation for
 msgid "Unlink translation for"
 msgstr "Verknüpfung der Übersetzung aufheben"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Unlock
 msgid "Unlock"
 msgstr ""
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Update
 msgid "Update"
 msgstr "Update"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Update installed addons
 msgid "Update installed addons"
 msgstr "Installierte Erweiterungen aktualisieren"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Update installed addons:
 msgid "Update installed addons:"
 msgstr "Installierte Erweiterungen:"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Updates available
 msgid "Updates available"
 msgstr "Verfügbare Erweiterungen"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Upload
 msgid "Upload"
 msgstr "Hochladen"
 
 #: components/manage/Blocks/LeadImage/Edit
+# defaultMessage: Upload a lead image in the 'Lead Image' content field.
 msgid "Upload a lead image in the 'Lead Image' content field."
 msgstr "Laden Sie ein Lead-Bild im Feld 'Lead-Bild' hoch."
 
 #: components/manage/Blocks/HeroImageLeft/Edit
+# defaultMessage: Upload a new image
 msgid "Upload a new image"
 msgstr "Neues Bild hochladen"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Upload files
 msgid "Upload files"
 msgstr "Datei hochladen"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Uploading files
 msgid "Uploading files"
 msgstr "Dateien hochladen"
 
 #: components/manage/Blocks/HeroImageLeft/Edit
+# defaultMessage: Uploading image
 msgid "Uploading image"
 msgstr "Bild hochladen"
 
 #: components/manage/Widgets/SchemaWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/WysiwygWidget
+# defaultMessage: Used for programmatic access to the fieldset.
 msgid "Used for programmatic access to the fieldset."
 msgstr "Wir für den programmierten Zugriff auf das Fieldset verwendet."
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: User
 msgid "User"
 msgstr "Benutzer"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: User created
 msgid "User created"
 msgstr "Benutzer erstellt"
 
 #: components/manage/Controlpanels/Users/UsersControlpanel
+# defaultMessage: User name
 msgid "User name"
 msgstr "Benutzername"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: User roles updated
 msgid "User roles updated"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Username
 msgid "Username"
 msgstr "Benutzername"
 
 #: components/manage/Controlpanels/Controlpanels
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Users
 msgid "Users"
 msgstr "Nutzer"
 
 #: components/manage/Controlpanels/Controlpanels
+# defaultMessage: Users and Groups
 msgid "Users and Groups"
 msgstr "Nutzer und Gruppen"
 
 #: helpers/Extensions/withBlockSchemaEnhancer
+# defaultMessage: Variation
 msgid "Variation"
 msgstr "Variante"
 
 #: components/manage/Controlpanels/Controlpanels
+# defaultMessage: Version Overview
 msgid "Version Overview"
 msgstr "Versionsübersicht"
 
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Video
 msgid "Video"
 msgstr "Video"
 
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Video URL
 msgid "Video URL"
 msgstr "Video URL"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: View
 msgid "View"
 msgstr "Anzeigen"
 
 #: components/manage/History/History
+# defaultMessage: View changes
 msgid "View changes"
 msgstr "Änderungen anzeigen"
 
 #: components/manage/History/History
+# defaultMessage: View this revision
 msgid "View this revision"
 msgstr "Diese revision ansehen"
 
 #: components/manage/Toolbar/More
+# defaultMessage: View working copy
 msgid "View working copy"
 msgstr "Arbeitskopie ansehen"
 
 #: components/manage/Display/Display
+# defaultMessage: View
 msgid "Viewmode"
 msgstr "Ansicht"
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Vocabulary term
 msgid "Vocabulary term"
 msgstr "Term"
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Title
 msgid "Vocabulary term title"
 msgstr "Termtitel"
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Vocabulary terms
 msgid "Vocabulary terms"
 msgstr "Terme"
 
 #: components/manage/Controlpanels/VersionOverview
+# defaultMessage: You are running in 'debug mode'. This mode is intended for sites that are under development. This allows many configuration changes to be immediately visible, but will make your site run more slowly. To turn off debug mode, stop the server, set 'debug-mode=off' in your buildout.cfg, re-run bin/buildout and then restart the server process.
 msgid "Warning Regarding debug mode"
 msgstr "Debug-Modus Warnung"
 
 #: components/theme/ConnectionRefused/ConnectionRefused
+# defaultMessage: We apologize for the inconvenience, but the backend of the site you are accessing is not available right now. Please, try again later.
 msgid "We apologize for the inconvenience, but the backend of the site you are accessing is not available right now. Please, try again later."
 msgstr "Entschuldigen Sie die Unanehmlichkeiten aber das Backend der Seite antwortet zur Zeit nicht."
 
 #: components/theme/NotFound/NotFound
+# defaultMessage: We apologize for the inconvenience, but the page you were trying to access is not at this address. You can use the links below to help you find what you are looking for.
 msgid "We apologize for the inconvenience, but the page you were trying to access is not at this address. You can use the links below to help you find what you are looking for."
 msgstr "Entschuldigung, aber die Webseite die Sie versucht haben zu erreichen ist hier nicht verfügbar. Bitte benutzen Sie die aufgeführten Verweise um zu finden was Sie gesucht haben."
 
 #: components/theme/Forbidden/Forbidden
+# defaultMessage: We apologize for the inconvenience, but you don't have permissions on this resource.
 msgid "We apologize for the inconvenience, but you don't have permissions on this resource."
 msgstr "Entschuldigen Sie die Unanehmlichkeiten, aber Sie besitzen nicht die erforderlichen Rechte um diese Seite anzuzeigen."
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: We will use this address if you need to recover your password
 msgid "We will use this address if you need to recover your password"
 msgstr "Wir verwenden diese E-Mail Adresse wenn wir Ihr Passwort wiederherstellen müssen"
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: The
 msgid "Weeek day of month"
 msgstr "Wochentag im Monat"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Weekday
 msgid "Weekday"
 msgstr "Wochentag"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Weekly
 msgid "Weekly"
 msgstr "wöchentlich"
 
 #: components/manage/History/History
+# defaultMessage: What
 msgid "What"
 msgstr "Was"
 
 #: components/manage/History/History
+# defaultMessage: When
 msgid "When"
 msgstr "Wann"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: When this date is reached, the content will nolonger be visible in listings and searches.
 msgid "When this date is reached, the content will nolonger be visible in listings and searches."
 msgstr "Wenn dieses Datum erreicht wird, wird der Inhalt nicht länger in Auflistungen und in der Suche auftauchen."
 
 #: components/manage/History/History
+# defaultMessage: Who
 msgid "Who"
 msgstr "Wer"
 
 #: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Updating workflow states...
 msgid "Workflow Change Loading Message"
 msgstr "Statuswechsel wird geladen"
 
 #: components/manage/Workflow/Workflow
+# defaultMessage: Workflow updated.
 msgid "Workflow updated."
 msgstr "Arbeitsablauf aktualisiert."
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Yearly
 msgid "Yearly"
 msgstr "jährlich"
 
 #: components/manage/Contents/ContentsItem
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Yes
 msgid "Yes"
 msgstr "Ja"
 
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: You are trying to access a protected resource, please {login} first.
 msgid "You are trying to access a protected resource, please {login} first."
 msgstr "Sie versuchen eine geschützte Seite aufzurufen, bitte zuerst {login}."
 
 #: components/theme/OutdatedBrowser/OutdatedBrowser
+# defaultMessage: You are using an outdated browser
 msgid "You are using an outdated browser"
 msgstr "Sie verwenden einen veralteten Browser"
 
 #: components/theme/Comments/Comments
+# defaultMessage: You can add a comment by filling out the form below. Plain text formatting.
 msgid "You can add a comment by filling out the form below. Plain text formatting."
 msgstr "Sie können einen Kommentar abgeben wenn Sie das untenstehende Formular ausfüllen. Plain-Text-Formatierung."
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: You can control who can view and edit your item using the list below.
 msgid "You can control who can view and edit your item using the list below."
 msgstr "Sie können mit der folgenden Liste bestimmen, wer Ihren Artikel sehen und bearbeiten kann."
 
 #: components/manage/Diff/Diff
+# defaultMessage: You can view the difference of the revisions below.
 msgid "You can view the difference of the revisions below."
 msgstr "Sie können die Unterschiede der verschiedenen Versionen unten sehen."
 
 #: components/manage/History/History
+# defaultMessage: You can view the history of your item below.
 msgid "You can view the history of your item below."
 msgstr "Sie können die Historie des Inhalts unten einsehen."
 
 #: components/manage/Contents/Contents
+# defaultMessage: You can't paste this content here
 msgid "You can't paste this content here"
 msgstr "Sie können diese(s) Objekt(e) hier nicht einfügen"
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Your email is required for reset your password.
 msgid "Your email is required for reset your password."
 msgstr "Ihre E-Mail Adresse ist notwendig um Ihr Passwort zurücksetzen zu können."
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: Your location - either city and country - or in a company setting, where your office is located.
 msgid "Your location - either city and country - or in a company setting, where your office is located."
 msgstr "Ihr Standort - entweder eine Stadt und ein Land - oder im Rahmen einer Firma, wo Ihr Büro ist."
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Your password has been set successfully. You may now {link} with your new password.
 msgid "Your password has been set successfully. You may now {link} with your new password."
 msgstr "Ihr Passwort wurde erfolgreich vergeben. Sie können sich jetzt mit Ihrem neuen Passwort {link}."
 
 #: components/manage/Preferences/PersonalPreferences
+# defaultMessage: Your preferred language
 msgid "Your preferred language"
 msgstr "Ihre bevorzugte Sprache"
 
 #: components/theme/Login/Login
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Forgot your password?
 msgid "box_forgot_password_option"
 msgstr "Passwort vergessen?"
 
 #: config/Blocks
+# defaultMessage: Common
 msgid "common"
 msgstr "Allgemein"
 
 #: components/manage/Multilingual/CompareLanguages
+# defaultMessage: Compare to language
 msgid "compare_to"
 msgstr "Vergleichen mit"
 
 #: components/manage/Blocks/Block/EditBlockWrapper
+# defaultMessage: delete
 msgid "delete"
 msgstr "Löschen"
 
 #: components/theme/OutdatedBrowser/OutdatedBrowser
+# defaultMessage: You are using {browsername} {browserversion} which is deprecated by its vendor. That means that it does not get security updates and it is not ready for current modern web features, which deteriorates the user experience. Please upgrade to a modern browser.
 msgid "deprecated_browser_notice_message"
 msgstr "Sie verwenden einen veralteten Browser. Wir empfehlen den Einsatz eines modernen Browsers wie Firefox, Chrome, Safari oder Windows Edge Chromium."
 
 #: config/Blocks
+# defaultMessage: Description
 msgid "description"
 msgstr "Beschreibung"
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: For security reasons, we store your password encrypted, and cannot mail it to you. If you would like to reset your password, fill out the form below and we will send you an email at the address you gave when you registered to start the process of resetting your password.
 msgid "description_lost_password"
 msgstr "Aus Sicherheitsgründen speichern wir Ihr Passwort verschlüsselt und können es Ihnen daher nicht per E-Mail schicken. Um ein neues Passwort zu erhalten, tragen Sie unten bitte Ihren Benutzernamen ein. Wir werden Ihnen daraufhin eine E-Mail schicken, in der das weitere Vorgehen beschrieben ist."
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Your password reset request has been mailed. It should arrive in your mailbox shortly. When you receive the message, visit the address it contains to reset your password.
 msgid "description_sent_password"
 msgstr "Der Link, um das Passwort neu zu setzen, wurde Ihnen zugesendet. Die E-Mail sollte in Kürze in Ihrem Postfach ankommen. Wenn Sie die Nachricht erhalten haben, klicken Sie auf den Link in der E-Mail, um zu der Webseite zu gelangen, wo Sie das Passwort neu setzen können."
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Draft
 msgid "draft"
 msgstr "Entwurf"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Input must be valid email (something@domain.com)
 msgid "email"
 msgstr "E-Mail"
 
 #: components/theme/View/EventView
+# defaultMessage: All dates
 msgid "event_alldates"
 msgstr "Alle Termine"
 
 #: components/theme/View/EventView
+# defaultMessage: Attendees
 msgid "event_attendees"
 msgstr "Teilnehmer"
 
 #: components/theme/View/EventView
+# defaultMessage: Contact Name
 msgid "event_contactname"
 msgstr "Kontaktname"
 
 #: components/theme/View/EventView
+# defaultMessage: Contact Phone
 msgid "event_contactphone"
 msgstr "Kontakttelefon"
 
 #: components/theme/View/EventView
+# defaultMessage: Website
 msgid "event_website"
 msgstr "Webseite"
 
 #: components/theme/View/EventView
+# defaultMessage: What
 msgid "event_what"
 msgstr "Was"
 
 #: components/theme/View/EventView
+# defaultMessage: When
 msgid "event_when"
 msgstr "Datum"
 
 #: components/theme/View/EventView
+# defaultMessage: Where
 msgid "event_where"
 msgstr "Ort"
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Password reset confirmation sent
 msgid "heading_sent_password"
 msgstr "Bestätigung für das Zurücksetzen des Passwortes wurde gesendet!"
 
 #: config/Blocks
+# defaultMessage: Hero
 msgid "hero"
 msgstr "Hero"
 
 #: config/Blocks
+# defaultMessage: HTML
 msgid "html"
 msgstr "HTML"
 
 #: config/Blocks
+# defaultMessage: Image
 msgid "image"
 msgstr "Bild"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Input must be integer
 msgid "integer"
 msgstr "Ganzzahl"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Intranet
 msgid "intranet"
 msgstr "Intranet"
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: My email address is
 msgid "label_my_email_address_is"
 msgstr "Meine E-Mail-Adresse lautet"
 
 #: config/Blocks
+# defaultMessage: Lead Image Field
 msgid "leadimage"
 msgstr "Lead-Bild"
 
 #: config/Blocks
+# defaultMessage: Listing
 msgid "listing"
 msgstr "Listing"
 
 #: components/manage/Blocks/Listing/ListingBody
 #: components/manage/Contents/Contents
+# defaultMessage: Loading
 msgid "loading"
 msgstr "laden"
 
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: log in
 msgid "log in"
 msgstr "Einloggen"
 
 #: config/Blocks
+# defaultMessage: Maps
 msgid "maps"
 msgstr "Karten"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Maximum Length
 msgid "maxLength"
 msgstr "Maximale Länge"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: End of the range (including the value itself)
 msgid "maximum"
 msgstr "Maximum"
 
 #: config/Blocks
+# defaultMessage: Media
 msgid "media"
 msgstr "Medien"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Minimum Length
 msgid "minLength"
 msgstr "Minimale Länge"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Start of the range
 msgid "minimum"
 msgstr "Minimum"
 
 #: config/Blocks
+# defaultMessage: Most used
 msgid "mostUsed"
 msgstr "Häufig genutzt"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: No workflow state
 msgid "no workflow state"
 msgstr "Kein Status gesetzt"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Input must be number
 msgid "number"
 msgstr "Zahl"
 
 #: components/manage/Widgets/RecurrenceWidget/ByMonthDayField
 #: components/manage/Widgets/RecurrenceWidget/ByYearField
+# defaultMessage: of the month
 msgid "of the month"
 msgstr "im Monat"
 
 #: error
+# defaultMessage: or try a different page.
 msgid "or try a different page."
 msgstr "versuchen Sie eine andere Seite."
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: others
 msgid "others"
 msgstr "andere"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Private
 msgid "private"
 msgstr "Privat"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Published
 msgid "published"
 msgstr "Veröffentlicht"
 
 #: components/manage/Widgets/QueryWidget
+# defaultMessage: Select…
 msgid "querystring-widget-select"
 msgstr "Select Auswahlfeld"
 
 #: components/theme/Search/Search
+# defaultMessage: results
 msgid "results found"
 msgstr "Ergebnisse gefunden"
 
 #: error
+# defaultMessage: return to the site root
 msgid "return to the site root"
 msgstr "Zur Startseite zurückkehren"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: and
 msgid "rrule_and"
 msgstr "Regel UND"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: (~approximate)
 msgid "rrule_approximate"
 msgstr "REGEL Annäherung"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: at
 msgid "rrule_at"
 msgstr "Regel AT"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: [month] [day], [year]
 msgid "rrule_dateFormat"
 msgstr "Regel Datumsformat"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: day
 msgid "rrule_day"
 msgstr "Regel Tag"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: days
 msgid "rrule_days"
 msgstr "Regel Tage"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: every
 msgid "rrule_every"
 msgstr "Regel Jeden"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: for
 msgid "rrule_for"
 msgstr "Regel für"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: hour
 msgid "rrule_hour"
 msgstr "Regel Stunde"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: hours
 msgid "rrule_hours"
 msgstr "Regel Stunden"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: in
 msgid "rrule_in"
 msgstr "Regel in"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: last
 msgid "rrule_last"
 msgstr "Regel letztes"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: minutes
 msgid "rrule_minutes"
 msgstr "Regel Minuten"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: month
 msgid "rrule_month"
 msgstr "Regel Monat"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: months
 msgid "rrule_months"
 msgstr "Regel Monate"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: nd
 msgid "rrule_nd"
 msgstr "Regel ND"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: on
 msgid "rrule_on"
 msgstr "Regel on"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: on the
 msgid "rrule_on the"
 msgstr "Regel on the"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: or
 msgid "rrule_or"
 msgstr "Regel oder"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: rd
 msgid "rrule_rd"
 msgstr "Regel rd"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: st
 msgid "rrule_st"
 msgstr "Regel st"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: th
 msgid "rrule_th"
 msgstr "Regel th"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: the
 msgid "rrule_the"
 msgstr "Regel the"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: time
 msgid "rrule_time"
 msgstr "Regel Zeit"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: times
 msgid "rrule_times"
 msgstr "Regel Zeiten"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: until
 msgid "rrule_until"
 msgstr "Regel bis"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: week
 msgid "rrule_week"
 msgstr "Regel Woche"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: weekday
 msgid "rrule_weekday"
 msgstr "Regel Wochentag"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: weekdays
 msgid "rrule_weekdays"
 msgstr "Regel Wochentage"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: weeks
 msgid "rrule_weeks"
 msgstr "Regel Wochen"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: year
 msgid "rrule_year"
 msgstr "Regel Jahr"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: years
 msgid "rrule_years"
 msgstr "Regel Jahre"
 
 #: components/theme/SkipLinks/SkipLinks
+# defaultMessage: Skip to footer
 msgid "skiplink-footer"
 msgstr "Footer überspringen"
 
 #: components/theme/SkipLinks/SkipLinks
+# defaultMessage: Skip to main content
 msgid "skiplink-main-content"
 msgstr "Hauptinhalt überspringen"
 
 #: components/theme/SkipLinks/SkipLinks
+# defaultMessage: Skip to navigation
 msgid "skiplink-navigation"
 msgstr "Navigation überspringen"
 
 #: components/manage/Contents/Contents
+# defaultMessage: sort
 msgid "sort"
 msgstr "sortieren"
 
 #: config/Blocks
+# defaultMessage: Table
 msgid "table"
 msgstr "Tabelle"
 
 #: config/Blocks
+# defaultMessage: Text
 msgid "text"
 msgstr "Text"
 
 #: config/Blocks
+# defaultMessage: Title
 msgid "title"
 msgstr "Titel"
 
 #: config/Blocks
+# defaultMessage: Table of Contents
 msgid "toc"
 msgstr "Inhaltsverzeichnis"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Input must be valid url (www.something.com or http(s)://www.something.com)
 msgid "url"
 msgstr "URL"
 
 #: components/manage/Toolbar/PersonalTools
+# defaultMessage: user avatar
 msgid "user avatar"
 msgstr "Nutzer Avatar"
 
 #: config/Blocks
+# defaultMessage: Video
 msgid "video"
 msgstr "Video"
 
 #: components/theme/View/EventView
+# defaultMessage: Visit external website
 msgid "visit_external_website"
 msgstr "Externe Webseite besuchen"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: {count, plural, one {Upload {count} file} other {Upload {count} files}}
 msgid "{count, plural, one {Upload {count} file} other {Upload {count} files}}"
 msgstr "Lade {count, plural, one {# Datei} other {# Dateien}} hoch"
 
 #: components/manage/Contents/Contents
+# defaultMessage: {count} selected
 msgid "{count} selected"
 msgstr "{count} ausgewählt"
 
 #: components/manage/Controlpanels/ContentType
+# defaultMessage: {id} Content Type
 msgid "{id} Content Type"
 msgstr "{id} Inhaltstyp"
 
 #: components/manage/Controlpanels/ContentTypeSchema
+# defaultMessage: {id} Schema
 msgid "{id} Schema"
 msgstr "{id} Schema"
 
 #: components/manage/Actions/Actions
+# defaultMessage: {title} copied.
 msgid "{title} copied."
 msgstr "{title} kopiert."
 
 #: components/manage/Actions/Actions
+# defaultMessage: {title} cut.
 msgid "{title} cut."
 msgstr "{title} ausgeschnitten."
 
 #: components/manage/Actions/Actions
+# defaultMessage: {title} has been deleted.
 msgid "{title} has been deleted."
 msgstr "{title} wurde gelöscht."

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -13,23 +13,23 @@ msgstr ""
 
 #: components/manage/Blocks/HTML/Edit
 msgid "<p>Add some HTML here</p>"
-msgstr "<p>Add some HTML here</p>"
+msgstr ""
 
 #: components/theme/Footer/Footer
 msgid "Accessibility"
-msgstr "Accessibility"
+msgstr ""
 
 #: components/theme/Register/Register
 msgid "Account Registration Completed"
-msgstr "Account Registration Completed"
+msgstr ""
 
 #: components/theme/PasswordReset/PasswordReset
 msgid "Account activation completed"
-msgstr "Account activation completed"
+msgstr ""
 
 #: components/manage/Controlpanels/ModerateComments
 msgid "Action"
-msgstr "Action"
+msgstr ""
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
@@ -37,138 +37,138 @@ msgstr "Action"
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 msgid "Actions"
-msgstr "Actions"
+msgstr ""
 
 #: components/manage/Controlpanels/AddonsControlpanel
 msgid "Activate and deactivate"
-msgstr "Activate and deactivate add-ons in the lists below."
+msgstr ""
 
 #: components/manage/Controlpanels/ContentTypes
 #: components/manage/Toolbar/Toolbar
 #: components/manage/Widgets/SchemaWidget
 #: helpers/MessageLabels/MessageLabels
 msgid "Add"
-msgstr "Add"
+msgstr ""
 
 #: components/manage/Controlpanels/AddonsControlpanel
 msgid "Add Addons"
-msgstr "To make new add-ons show up here, add them to your buildout configuration, run buildout, and restart the server process. For detailed instructions see"
+msgstr ""
 
 #: components/manage/Toolbar/Types
 msgid "Add Content"
-msgstr "Add Content…"
+msgstr ""
 
 #: components/manage/Toolbar/Types
 msgid "Add Translation…"
-msgstr "Add Translation…"
+msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
 msgid "Add User"
-msgstr "Add User"
+msgstr ""
 
 #: components/manage/Blocks/Description/Edit
 msgid "Add a description…"
-msgstr "Add a description…"
+msgstr ""
 
 #: components/manage/BlockChooser/BlockChooserButton
 msgid "Add block"
-msgstr "Add block"
+msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
 msgid "Add block…"
-msgstr "Add block…"
+msgstr ""
 
 #: components/manage/Widgets/QueryWidget
 msgid "Add criteria"
-msgstr "Add criteria"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
 msgid "Add date"
-msgstr "Add date"
+msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
 msgid "Add field"
-msgstr "Add field"
+msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
 msgid "Add fieldset"
-msgstr "Add fieldset"
+msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
 msgid "Add group"
-msgstr "Add group"
+msgstr ""
 
 #: components/manage/Controlpanels/ContentTypes
 msgid "Add new content type"
-msgstr "Add new content type"
+msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
 msgid "Add new group"
-msgstr "Add new group"
+msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
 msgid "Add new user"
-msgstr "Add new user"
+msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
 msgid "Add to Groups"
-msgstr "Add to Groups"
+msgstr ""
 
 #: components/manage/Widgets/VocabularyTermsWidget
 msgid "Add vocabulary term"
-msgstr "Add term"
+msgstr ""
 
 #: components/manage/Add/Add
 msgid "Add {type}"
-msgstr "Add {type}"
+msgstr ""
 
 #: components/manage/Controlpanels/AddonsControlpanel
 msgid "Add-ons Settings"
-msgstr "Add-ons Settings"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
 msgid "Additional date"
-msgstr "Additional date"
+msgstr ""
 
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
 #: components/manage/Blocks/Maps/MapsSidebar
 #: components/manage/Blocks/Video/VideoSidebar
 msgid "Alignment"
-msgstr "Alignment"
+msgstr ""
 
 #: components/manage/Contents/Contents
 msgid "All"
-msgstr "All"
+msgstr ""
 
 #: components/theme/Search/Search
 msgid "Alphabetically"
-msgstr "Alphabetically"
+msgstr ""
 
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
 msgid "Alt text"
-msgstr "Alt text"
+msgstr ""
 
 #: components/manage/Toolbar/More
 msgid "Apply working copy"
-msgstr "Apply working copy"
+msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
 msgid "Are you sure you want to delete this field?"
-msgstr "Are you sure you want to delete this field?"
+msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
 msgid "Are you sure you want to delete this fieldset including all fields?"
-msgstr "Are you sure you want to delete this fieldset including all fields?"
+msgstr ""
 
 #: components/manage/Contents/Contents
 msgid "Ascending"
-msgstr "Ascending"
+msgstr ""
 
 #: components/manage/Controlpanels/AddonsControlpanel
 msgid "Available"
-msgstr "Available"
+msgstr ""
 
 #: components/manage/Contents/Contents
 #: components/manage/Controlpanels/AddonsControlpanel
@@ -192,49 +192,49 @@ msgstr "Available"
 #: components/theme/ContactForm/ContactForm
 #: helpers/MessageLabels/MessageLabels
 msgid "Back"
-msgstr "Back"
+msgstr ""
 
 #: components/manage/Diff/Diff
 msgid "Base"
-msgstr "Base"
+msgstr ""
 
 #: components/manage/Sidebar/Sidebar
 msgid "Block"
-msgstr "Block"
+msgstr ""
 
 #: components/theme/Login/Login
 msgid "Both email address and password are case sensitive, check that caps lock is not enabled."
-msgstr "Both email address and password are case sensitive, check that caps lock is not enabled."
+msgstr ""
 
 #: components/theme/Breadcrumbs/Breadcrumbs
 msgid "Breadcrumbs"
-msgstr "Breadcrumbs"
+msgstr ""
 
 #: components/manage/Blocks/HeroImageLeft/Edit
 #: components/manage/Contents/ContentsUploadModal
 #: components/manage/Sidebar/ObjectBrowserNav
 msgid "Browse"
-msgstr "Browse"
+msgstr ""
 
 #: components/manage/Blocks/Image/Edit
 msgid "Browse the site, drop an image, or type an URL"
-msgstr "Browse the site, drop an image, or type an URL"
+msgstr ""
 
 #: components/manage/Sharing/Sharing
 msgid "By default, permissions from the container of this item are inherited. If you disable this, only the explicitly defined sharing permissions will be valid. In the overview, the symbol {inherited} indicates an inherited value. Similarly, the symbol {global} indicates a global role, which is managed by the site administrator."
-msgstr "By default, permissions from the container of this item are inherited. If you disable this, only the explicitly defined sharing permissions will be valid. In the overview, the symbol {inherited} indicates an inherited value. Similarly, the symbol {global} indicates a global role, which is managed by the site administrator."
+msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
 msgid "Cache Name"
-msgstr "Cache Name"
+msgstr ""
 
 #: components/manage/Controlpanels/ContentTypeLayout
 msgid "Can not edit Layout for <strong>{type}</strong> content-type as it doesn't have support for <strong>Volto Blocks</strong> enabled"
-msgstr "Can not edit Layout for <strong>{type}</strong> content-type as it doesn't have support for <strong>Volto Blocks</strong> enabled"
+msgstr ""
 
 #: components/manage/Controlpanels/ContentTypeLayout
 msgid "Can not edit Layout for <strong>{type}</strong> content-type as the <strong>Blocks behavior</strong> is enabled and <strong>read-only</strong>"
-msgstr "Can not edit Layout for <strong>{type}</strong> content-type as the <strong>Blocks behavior</strong> is enabled and <strong>read-only</strong>"
+msgstr ""
 
 #: components/manage/Add/Add
 #: components/manage/Contents/ContentsUploadModal
@@ -249,236 +249,236 @@ msgstr "Can not edit Layout for <strong>{type}</strong> content-type as the <str
 #: components/theme/Login/Login
 #: helpers/MessageLabels/MessageLabels
 msgid "Cancel"
-msgstr "Cancel"
+msgstr ""
 
 #: components/manage/Blocks/Table/Edit
 msgid "Cell"
-msgstr "Cell"
+msgstr ""
 
 #: components/manage/Blocks/Image/ImageSizeWidget
 #: components/manage/Blocks/Maps/Edit
 #: components/manage/Sidebar/AlignBlock
 msgid "Center"
-msgstr "Center"
+msgstr ""
 
 #: components/manage/History/History
 msgid "Change Note"
-msgstr "Change Note"
+msgstr ""
 
 #: components/manage/Preferences/ChangePassword
 msgid "Change Password"
-msgstr "Change Password"
+msgstr ""
 
 #: components/manage/Contents/ContentsWorkflowModal
 msgid "Change State"
-msgstr "Change State"
+msgstr ""
 
 #: components/manage/Contents/ContentsWorkflowModal
 msgid "Change workflow state recursively"
-msgstr "Change workflow state recursively"
+msgstr ""
 
 #: components/manage/Toolbar/More
 msgid "Changes applied."
-msgstr "Changes applied"
+msgstr ""
 
 #: components/manage/Preferences/ChangePassword
 #: components/manage/Preferences/PersonalInformation
 #: components/manage/Preferences/PersonalPreferences
 msgid "Changes saved"
-msgstr "Changes saved"
+msgstr ""
 
 #: components/manage/Controlpanels/ContentType
 #: components/manage/Controlpanels/ContentTypeLayout
 #: components/manage/Controlpanels/ContentTypeSchema
 #: components/manage/Controlpanels/Controlpanel
 msgid "Changes saved."
-msgstr "Changes saved."
+msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
 msgid "Checkbox"
-msgstr "Checkbox"
+msgstr ""
 
 #: components/manage/Widgets/SelectWidget
 msgid "Choices"
-msgstr "Choices"
+msgstr ""
 
 #: components/manage/Sidebar/ObjectBrowserBody
 msgid "Choose Image"
-msgstr "Choose Image"
+msgstr ""
 
 #: components/manage/Sidebar/ObjectBrowserBody
 msgid "Choose Target"
-msgstr "Choose Target"
+msgstr ""
 
 #: components/manage/Widgets/FileWidget
 msgid "Choose a file"
-msgstr "Choose a file"
+msgstr ""
 
 #: components/manage/Blocks/HTML/Edit
 msgid "Clear"
-msgstr "Clear"
+msgstr ""
 
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"
-msgstr "Click to download full sized image"
+msgstr ""
 
 #: components/manage/Widgets/SelectWidget
 msgid "Close"
-msgstr "Close"
+msgstr ""
 
 #: components/theme/Navigation/Navigation
 msgid "Close menu"
-msgstr "Close menu"
+msgstr ""
 
 #: components/manage/Blocks/HTML/Edit
 msgid "Code"
-msgstr "Code"
+msgstr ""
 
 #: components/manage/Widgets/ObjectListWidget
 msgid "Collapse item"
-msgstr "Collapse item"
+msgstr ""
 
 #: components/manage/Toolbar/Toolbar
 msgid "Collection"
-msgstr "Collection"
+msgstr ""
 
 #: components/manage/Controlpanels/ModerateComments
 #: components/theme/Comments/CommentEditModal
 #: components/theme/Comments/Comments
 msgid "Comment"
-msgstr "Comment"
+msgstr ""
 
 #: components/manage/Controlpanels/ModerateComments
 msgid "Commenter"
-msgstr "Commenter"
+msgstr ""
 
 #: components/theme/Comments/Comments
 msgid "Comments"
-msgstr "Comments"
+msgstr ""
 
 #: components/manage/Diff/Diff
 msgid "Compare"
-msgstr "Compare"
+msgstr ""
 
 #: components/manage/Preferences/ChangePassword
 #: components/theme/PasswordReset/PasswordReset
 msgid "Confirm password"
-msgstr "Confirm password"
+msgstr ""
 
 #: components/theme/ConnectionRefused/ConnectionRefused
 msgid "Connection refused"
-msgstr "Connection refused"
+msgstr ""
 
 #: components/theme/Footer/Footer
 msgid "Contact"
-msgstr "Contact"
+msgstr ""
 
 #: components/theme/ContactForm/ContactForm
 msgid "Contact form"
-msgstr "Contact form"
+msgstr ""
 
 #: components/manage/Blocks/Listing/Edit
 msgid "Contained items"
-msgstr "Contained items"
+msgstr ""
 
 #: components/manage/Controlpanels/ContentTypes
 msgid "Content type created"
-msgstr "Content type created"
+msgstr ""
 
 #: components/manage/Controlpanels/ContentTypes
 msgid "Content type deleted"
-msgstr "Content type deleted"
+msgstr ""
 
 #: components/manage/Contents/Contents
 #: components/manage/Toolbar/Toolbar
 msgid "Contents"
-msgstr "Contents"
+msgstr ""
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsItem
 msgid "Copy"
-msgstr "Copy"
+msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
 msgid "Copy blocks"
-msgstr "undefined"
+msgstr ""
 
 #: components/theme/Footer/Footer
 msgid "Copyright"
-msgstr "Copyright"
+msgstr ""
 
 #: components/manage/Contents/ContentsPropertiesModal
 msgid "Copyright statement or other rights information on this item."
-msgstr "Copyright statement or other rights information on this item."
+msgstr ""
 
 #: components/manage/Toolbar/More
 msgid "Create working copy"
-msgstr "Create working copy"
+msgstr ""
 
 #: components/manage/WorkingCopyToastsFactory/WorkingCopyToastsFactory
 msgid "Created by {creator} on {date}"
-msgstr "Created by {creator} on {date}"
+msgstr ""
 
 #: components/manage/Contents/Contents
 msgid "Created on"
-msgstr "Created on"
+msgstr ""
 
 #: components/manage/Contents/Contents
 msgid "Creator"
-msgstr "Creator"
+msgstr ""
 
 #: components/manage/Contents/ContentsPropertiesModal
 msgid "Creators"
-msgstr "Creators"
+msgstr ""
 
 #: components/manage/Widgets/QuerystringWidget
 #: components/manage/Widgets/QueryWidget
 msgid "Criteria"
-msgstr "Criteria"
+msgstr ""
 
 #: components/manage/Preferences/ChangePassword
 msgid "Current password"
-msgstr "Current password"
+msgstr ""
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsItem
 msgid "Cut"
-msgstr "Cut"
+msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
 msgid "Cut blocks"
-msgstr "undefined"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
 msgid "Daily"
-msgstr "Daily"
+msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
 msgid "Database Information"
-msgstr "Database Information"
+msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
 msgid "Database Location"
-msgstr "Database Location"
+msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
 msgid "Database Size"
-msgstr "Database Size"
+msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
 msgid "Database main"
-msgstr "Database main"
+msgstr ""
 
 #: components/manage/Controlpanels/ModerateComments
 #: components/manage/Widgets/DatetimeWidget
 msgid "Date"
-msgstr "Date"
+msgstr ""
 
 #: components/theme/Search/Search
 msgid "Date (newest first)"
-msgstr "Date (newest first)"
+msgstr ""
 
 #: components/manage/Contents/ContentsPropertiesModal
 #: components/manage/Contents/ContentsRenameModal
@@ -497,7 +497,7 @@ msgstr "Date (newest first)"
 #: components/theme/PasswordReset/RequestPasswordReset
 #: components/theme/Register/Register
 msgid "Default"
-msgstr "Default"
+msgstr ""
 
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsItem
@@ -511,39 +511,39 @@ msgstr "Default"
 #: components/manage/Widgets/WysiwygWidget
 #: components/theme/Comments/Comments
 msgid "Delete"
-msgstr "Delete"
+msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
 msgid "Delete Group"
-msgstr "Delete Group"
+msgstr ""
 
 #: components/manage/Controlpanels/ContentTypes
 msgid "Delete Type"
-msgstr "Delete Type"
+msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
 msgid "Delete User"
-msgstr "Delete User"
+msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
 msgid "Delete blocks"
-msgstr "undefined"
+msgstr ""
 
 #: components/manage/Blocks/Table/Edit
 msgid "Delete col"
-msgstr "Delete col"
+msgstr ""
 
 #: components/manage/Blocks/Table/Edit
 msgid "Delete row"
-msgstr "Delete row"
+msgstr ""
 
 #: components/manage/Widgets/QuerystringWidget
 msgid "Depth"
-msgstr "Depth"
+msgstr ""
 
 #: components/manage/Contents/Contents
 msgid "Descending"
-msgstr "Descending"
+msgstr ""
 
 #: components/manage/Blocks/HeroImageLeft/Edit
 #: components/manage/Controlpanels/ContentTypes
@@ -553,73 +553,73 @@ msgstr "Descending"
 #: components/theme/View/TabularView
 #: helpers/MessageLabels/MessageLabels
 msgid "Description"
-msgstr "Description"
+msgstr ""
 
 #: components/manage/Diff/Diff
 msgid "Diff"
-msgstr "Diff"
+msgstr ""
 
 #: components/manage/Diff/Diff
 msgid "Difference between revision {one} and {two} of {title}"
-msgstr "Difference between revision {one} and {two} of {title}"
+msgstr ""
 
 #: components/theme/Footer/Footer
 msgid "Distributed under the {license}."
-msgstr "Distributed under the {license}."
+msgstr ""
 
 #: components/manage/Blocks/Table/Edit
 msgid "Divide each row into separate cells"
-msgstr "Add border to inner columns"
+msgstr ""
 
 #: components/manage/Contents/Contents
 msgid "Do you really want to delete the following items?"
-msgstr "Do you really want to delete the following items?"
+msgstr ""
 
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 msgid "Do you really want to delete the group {groupname}?"
-msgstr "Do you really want to delete the group {groupname}?"
+msgstr ""
 
 #: components/manage/Controlpanels/ContentTypes
 msgid "Do you really want to delete the type {typename}?"
-msgstr "Do you really want to delete type {typename}?"
+msgstr ""
 
 #: components/manage/Controlpanels/Users/UsersControlpanel
 msgid "Do you really want to delete the user {username}?"
-msgstr "Do you really want to delete the user {username}?"
+msgstr ""
 
 #: components/manage/Delete/Delete
 msgid "Do you really want to delete this item?"
-msgstr "Do you really want to delete this item?"
+msgstr ""
 
 #: components/manage/Multilingual/TranslationObject
 #: components/manage/Sidebar/Sidebar
 msgid "Document"
-msgstr "Document"
+msgstr ""
 
 #: components/manage/Contents/ContentsUploadModal
 msgid "Drag and drop files from your computer onto this area or click the “Browse” button."
-msgstr "Drag and drop files from your computer onto this area or click the “Browse” button."
+msgstr ""
 
 #: components/manage/Widgets/FileWidget
 msgid "Drop file here to replace the existing file"
-msgstr "Drop file here to replace the existing file"
+msgstr ""
 
 #: components/manage/Widgets/FileWidget
 msgid "Drop file here to upload a new file"
-msgstr "Drop file here to upload a new file"
+msgstr ""
 
 #: components/manage/Widgets/FileWidget
 msgid "Drop files here ..."
-msgstr "Drop files here ..."
+msgstr ""
 
 #: components/manage/Preferences/PersonalInformation
 #: components/theme/Register/Register
 msgid "E-mail"
-msgstr "E-mail"
+msgstr ""
 
 #: components/theme/PasswordReset/PasswordReset
 msgid "E-mail addresses do not match."
-msgstr "E-mail addresses do not match."
+msgstr ""
 
 #: components/manage/Contents/ContentsItem
 #: components/manage/Controlpanels/ContentTypesActions
@@ -629,94 +629,94 @@ msgstr "E-mail addresses do not match."
 #: components/manage/Widgets/ObjectBrowserWidget
 #: components/theme/Comments/Comments
 msgid "Edit"
-msgstr "Edit"
+msgstr ""
 
 #: components/theme/Comments/CommentEditModal
 msgid "Edit comment"
-msgstr "Edit comment"
+msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
 msgid "Edit field"
-msgstr "Edit field"
+msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
 msgid "Edit fieldset"
-msgstr "Edit fieldset"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
 msgid "Edit recurrence"
-msgstr "Edit recurrence"
+msgstr ""
 
 #: components/manage/Form/InlineForm
 msgid "Edit values"
-msgstr "Edit values"
+msgstr ""
 
 #: components/manage/Edit/Edit
 msgid "Edit {title}"
-msgstr "Edit {title}"
+msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
 msgid "Email"
-msgstr "Email"
+msgstr ""
 
 #: components/theme/ContactForm/ContactForm
 msgid "Email sent"
-msgstr "Email sent"
+msgstr ""
 
 #: components/manage/Blocks/Maps/Edit
 msgid "Embed code error, please follow the instructions and try again."
-msgstr "Embed code error, please follow the instructions and try again."
+msgstr ""
 
 #: components/manage/Blocks/Maps/View
 msgid "Embeded Google Maps"
-msgstr "Embeded Google Maps"
+msgstr ""
 
 #: components/manage/Widgets/ObjectListWidget
 msgid "Empty object list"
-msgstr "Empty object list"
+msgstr ""
 
 #: components/manage/Controlpanels/ContentTypeLayout
 msgid "Enable editable Blocks"
-msgstr "Enable editable Blocks"
+msgstr ""
 
 #: components/manage/Contents/Contents
 msgid "End Date"
-msgstr "End Date"
+msgstr ""
 
 #: components/manage/AnchorPlugin/components/LinkButton/AddLinkForm
 msgid "Enter URL or select an item"
-msgstr "Enter URL or select an item"
+msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
 msgid "Enter a username above to search or click 'Show All'"
-msgstr "Enter a username above to search or click 'Show All'"
+msgstr ""
 
 #: components/theme/Register/Register
 msgid "Enter an email address. This will be your login name. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
-msgstr "Enter an email address. This will be your login name. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
+msgstr ""
 
 #: components/manage/Preferences/PersonalInformation
 #: components/theme/PasswordReset/PasswordReset
 #: components/theme/Register/Register
 msgid "Enter full name, e.g. John Smith."
-msgstr "Enter full name, e.g. John Smith."
+msgstr ""
 
 #: components/manage/Blocks/Maps/Edit
 msgid "Enter map Embed Code"
-msgstr "Enter map Embed Code"
+msgstr ""
 
 #: components/manage/Preferences/ChangePassword
 msgid "Enter your current password."
-msgstr "Enter your current password."
+msgstr ""
 
 #: components/theme/PasswordReset/PasswordReset
 msgid "Enter your email address for verification."
-msgstr "Enter your email address for verification."
+msgstr ""
 
 #: components/manage/Preferences/ChangePassword
 #: components/theme/PasswordReset/PasswordReset
 msgid "Enter your new password. Minimum 5 characters."
-msgstr "Enter your new password. Minimum 5 characters."
+msgstr ""
 
 #: components/manage/Add/Add
 #: components/manage/Controlpanels/ContentTypeSchema
@@ -727,343 +727,343 @@ msgstr "Enter your new password. Minimum 5 characters."
 #: components/theme/Login/Login
 #: helpers/MessageLabels/MessageLabels
 msgid "Error"
-msgstr "Error"
+msgstr ""
 
 #: components/manage/Contents/ContentsPropertiesModal
 msgid "Exclude from navigation"
-msgstr "Exclude from navigation"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
 msgid "Exclude this occurence"
-msgstr "Exclude this occurence"
+msgstr ""
 
 #: components/manage/Contents/Contents
 msgid "Excluded from navigation"
-msgstr "Excluded from navigation"
+msgstr ""
 
 #: components/manage/Sidebar/Sidebar
 msgid "Expand sidebar"
-msgstr "Expand sidebar"
+msgstr ""
 
 #: components/manage/Contents/ContentsPropertiesModal
 msgid "Expiration Date"
-msgstr "Expiration Date"
+msgstr ""
 
 #: components/manage/Contents/Contents
 msgid "Expiration date"
-msgstr "Expiration date"
+msgstr ""
 
 #: components/manage/Contents/ContentsItem
 msgid "Expired"
-msgstr "Expired"
+msgstr ""
 
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
 msgid "External URL"
-msgstr "External URL"
+msgstr ""
 
 #: components/manage/Toolbar/Toolbar
 msgid "File"
-msgstr "File"
+msgstr ""
 
 #: components/manage/Contents/ContentsUploadModal
 msgid "File size"
-msgstr "File size"
+msgstr ""
 
 #: components/manage/Contents/ContentsUploadModal
 msgid "Filename"
-msgstr "Filename"
+msgstr ""
 
 #: components/manage/Contents/Contents
 msgid "Filter…"
-msgstr "Filter…"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
 msgid "First"
-msgstr "First"
+msgstr ""
 
 #: components/manage/Blocks/Table/Edit
 msgid "Fixed width table cells"
-msgstr "Fixed width columns"
+msgstr ""
 
 #: components/manage/BlockChooser/BlockChooser
 msgid "Fold"
-msgstr "Fold"
+msgstr ""
 
 #: components/manage/Contents/Contents
 msgid "Folder"
-msgstr "Folder"
+msgstr ""
 
 #: components/theme/Forbidden/Forbidden
 msgid "Forbidden"
-msgstr "Forbidden"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
 msgid "Fourth"
-msgstr "Fourth"
+msgstr ""
 
 #: components/theme/ContactForm/ContactForm
 msgid "From"
-msgstr "From"
+msgstr ""
 
 #: components/manage/Blocks/Maps/Edit
 #: components/manage/Sidebar/AlignBlock
 msgid "Full"
-msgstr "Full"
+msgstr ""
 
 #: components/manage/Preferences/PersonalInformation
 #: components/theme/PasswordReset/PasswordReset
 #: components/theme/Register/Register
 msgid "Full Name"
-msgstr "Full Name"
+msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
 msgid "Fullname"
-msgstr "Fullname"
+msgstr ""
 
 #: components/theme/Footer/Footer
 msgid "GNU GPL license"
-msgstr "GNU GPL license"
+msgstr ""
 
 #: components/manage/Sharing/Sharing
 msgid "Global role"
-msgstr "Global role"
+msgstr ""
 
 #: components/manage/Blocks/Maps/Edit
 msgid "Google Maps Embedded Block"
-msgstr "Google Maps Embedded Block"
+msgstr ""
 
 #: components/manage/Sharing/Sharing
 msgid "Group"
-msgstr "Group"
+msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
 msgid "Group created"
-msgstr "Group created"
+msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
 msgid "Group roles updated"
-msgstr "Group roles updated"
+msgstr ""
 
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: helpers/MessageLabels/MessageLabels
 msgid "Groupname"
-msgstr "Groupname"
+msgstr ""
 
 #: components/manage/Controlpanels/Controlpanels
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: helpers/MessageLabels/MessageLabels
 msgid "Groups"
-msgstr "Groups"
+msgstr ""
 
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 msgid "Groups are logical collections of users, such as departments and business units. Groups are not directly related to permissions on a global level, you normally use Roles for that - and let certain Groups have a particular role. The symbol{plone_svg}indicates a role inherited from membership in another group."
-msgstr "Groups are logical collections of users, such as departments and business units. Groups are not directly related to permissions on a global level, you normally use Roles for that - and let certain Groups have a particular role. The symbol{plone_svg}indicates a role inherited from membership in another group."
+msgstr ""
 
 #: components/manage/Blocks/Table/Edit
 msgid "Header cell"
-msgstr "Header cell"
+msgstr ""
 
 #: components/theme/Comments/Comments
 msgid "Hide Replies"
-msgstr "Hide Replies"
+msgstr ""
 
 #: components/manage/History/History
 #: components/manage/Toolbar/More
 msgid "History"
-msgstr "History"
+msgstr ""
 
 #: components/manage/History/History
 msgid "History Version Number"
-msgstr "#"
+msgstr ""
 
 #: components/manage/History/History
 msgid "History of {title}"
-msgstr "History of {title}"
+msgstr ""
 
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsBreadcrumbs
 #: components/theme/Breadcrumbs/Breadcrumbs
 msgid "Home"
-msgstr "Home"
+msgstr ""
 
 #: components/manage/Preferences/PersonalInformation
 msgid "Home page"
-msgstr "Home page"
+msgstr ""
 
 #: components/manage/Contents/Contents
 msgid "ID"
-msgstr "ID"
+msgstr ""
 
 #: components/manage/Contents/ContentsPropertiesModal
 msgid "If selected, this item will not appear in the navigation tree"
-msgstr "If selected, this item will not appear in the navigation tree"
+msgstr ""
 
 #: components/manage/Contents/ContentsPropertiesModal
 msgid "If this date is in the future, the content will not show up in listings and searches until this date."
-msgstr "If this date is in the future, the content will not show up in listings and searches until this date."
+msgstr ""
 
 #: components/manage/LockingToastsFactory/LockingToastsFactory
 msgid "If you are certain this user has abandoned the object, you may unlock the object. You will then be able to edit it."
-msgstr "If you are certain this user has abandoned the object, you may unlock the object. You will then be able to edit it."
+msgstr ""
 
 #: components/theme/NotFound/NotFound
 #: components/theme/Unauthorized/Unauthorized
 msgid "If you are certain you have the correct web address but are encountering an error, please contact the {site_admin}."
-msgstr "If you are certain you have the correct web address but are encountering an error, please contact the {site_admin}."
+msgstr ""
 
 #: components/manage/Blocks/HeroImageLeft/Edit
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
 msgid "Image"
-msgstr "Image"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
 msgid "Include this occurence"
-msgstr "Include this occurence"
+msgstr ""
 
 #: components/manage/Controlpanels/ContentType
 #: components/manage/Controlpanels/ContentTypeLayout
 #: components/manage/Controlpanels/ContentTypeSchema
 #: components/manage/Controlpanels/Controlpanel
 msgid "Info"
-msgstr "Info"
+msgstr ""
 
 #: components/manage/Sharing/Sharing
 msgid "Inherit permissions from higher levels"
-msgstr "Inherit permissions from higher levels"
+msgstr ""
 
 #: components/manage/Sharing/Sharing
 msgid "Inherited value"
-msgstr "Inherited value"
+msgstr ""
 
 #: components/manage/Blocks/Table/Edit
 msgid "Insert col after"
-msgstr "Insert col after"
+msgstr ""
 
 #: components/manage/Blocks/Table/Edit
 msgid "Insert col before"
-msgstr "Insert col before"
+msgstr ""
 
 #: components/manage/Blocks/Table/Edit
 msgid "Insert row after"
-msgstr "Insert row after"
+msgstr ""
 
 #: components/manage/Blocks/Table/Edit
 msgid "Insert row before"
-msgstr "Insert row before"
+msgstr ""
 
 #: components/manage/Controlpanels/AddonsControlpanel
 msgid "Install"
-msgstr "Install"
+msgstr ""
 
 #: components/manage/Controlpanels/AddonsControlpanel
 msgid "Installed"
-msgstr "Installed"
+msgstr ""
 
 #: components/manage/Controlpanels/AddonsControlpanel
 msgid "Installed version"
-msgstr "Installed version"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
 msgid "Interval Daily"
-msgstr "days"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
 msgid "Interval Monthly"
-msgstr "Month(s)"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
 msgid "Interval Weekly"
-msgstr "week(s)"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
 msgid "Interval Yearly"
-msgstr "year(s)"
+msgstr ""
 
 #: components/manage/Widgets/QuerystringWidget
 msgid "Item batch size"
-msgstr "Item batch size"
+msgstr ""
 
 #: components/manage/Contents/Contents
 msgid "Item succesfully moved."
-msgstr "Item succesfully moved."
+msgstr ""
 
 #: components/manage/Contents/Contents
 msgid "Item(s) copied."
-msgstr "Item(s) copied."
+msgstr ""
 
 #: components/manage/Contents/Contents
 msgid "Item(s) cut."
-msgstr "Item(s) cut."
+msgstr ""
 
 #: components/manage/Contents/Contents
 msgid "Item(s) has been updated."
-msgstr "Item(s) has been updated."
+msgstr ""
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
 msgid "Item(s) pasted."
-msgstr "Item(s) pasted."
+msgstr ""
 
 #: components/manage/Contents/Contents
 msgid "Item(s) state has been updated."
-msgstr "Item(s) state has been updated."
+msgstr ""
 
 #: components/manage/Controlpanels/ContentTypes
 msgid "Items"
-msgstr "Items"
+msgstr ""
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
 msgid "Items must be unique."
-msgstr "Items must be unique."
+msgstr ""
 
 #: components/manage/Preferences/PersonalPreferences
 msgid "Language"
-msgstr "Language"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
 msgid "Last"
-msgstr "Last"
+msgstr ""
 
 #: components/manage/Contents/Contents
 msgid "Last comment date"
-msgstr "Last comment date"
+msgstr ""
 
 #: components/manage/Contents/ContentsUploadModal
 msgid "Last modified"
-msgstr "Last modified"
+msgstr ""
 
 #: components/manage/Controlpanels/AddonsControlpanel
 msgid "Latest version"
-msgstr "Latest version"
+msgstr ""
 
 #: components/manage/Controlpanels/ContentTypesActions
 msgid "Layout"
-msgstr "Layout"
+msgstr ""
 
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
 msgid "Lead Image"
-msgstr "Lead Image"
+msgstr ""
 
 #: components/manage/Blocks/Image/ImageSizeWidget
 #: components/manage/Blocks/Maps/Edit
 #: components/manage/Sidebar/AlignBlock
 msgid "Left"
-msgstr "Left"
+msgstr ""
 
 #: components/manage/Toolbar/Toolbar
 msgid "Link"
-msgstr "Link"
+msgstr ""
 
 #: components/manage/Blocks/Listing/schema
 msgid "Link more"
-msgstr "Link more"
+msgstr ""
 
 #: components/manage/Blocks/Listing/schema
 msgid "Link title"
-msgstr "Link Title"
+msgstr ""
 
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
@@ -1071,555 +1071,555 @@ msgstr "Link Title"
 #: components/manage/Blocks/Maps/MapsSidebar
 #: components/manage/Blocks/Video/VideoSidebar
 msgid "Link to"
-msgstr "Link to"
+msgstr ""
 
 #: components/manage/Multilingual/ManageTranslations
 msgid "Link translation for"
-msgstr "Link translation for"
+msgstr ""
 
 #: components/manage/Blocks/Listing/schema
 msgid "Listing"
-msgstr "Listing"
+msgstr ""
 
 #: components/theme/Comments/Comments
 msgid "Load more"
-msgstr "Load more..."
+msgstr ""
 
 #: components/manage/Form/ModalForm
 msgid "Loading"
-msgstr "Loading."
+msgstr ""
 
 #: components/manage/Preferences/PersonalInformation
 msgid "Location"
-msgstr "Location"
+msgstr ""
 
 #: components/theme/Login/Login
 msgid "Log In"
-msgstr "Login"
+msgstr ""
 
 #: components/theme/Anontools/Anontools
 #: components/theme/Login/Login
 msgid "Log in"
-msgstr "Log in"
+msgstr ""
 
 #: components/theme/Login/Login
 msgid "Login"
-msgstr "Login"
+msgstr ""
 
 #: components/theme/Login/Login
 msgid "Login Failed"
-msgstr "Login Failed"
+msgstr ""
 
 #: components/theme/Login/Login
 msgid "Login Name"
-msgstr "Login Name"
+msgstr ""
 
 #: components/manage/Toolbar/PersonalTools
 msgid "Logout"
-msgstr "Logout"
+msgstr ""
 
 #: components/manage/Toolbar/More
 msgid "Made by {creator} on {date}. This is not a working copy anymore, but the main content."
-msgstr "Made by {creator} on {date}. This is not a working copy anymore, but the main content."
+msgstr ""
 
 #: components/manage/Blocks/Table/Edit
 msgid "Make the table compact"
-msgstr "Reduce cell padding"
+msgstr ""
 
 #: components/manage/Multilingual/ManageTranslations
 #: components/manage/Toolbar/More
 msgid "Manage Translations"
-msgstr "Manage Translations"
+msgstr ""
 
 #: components/manage/Multilingual/ManageTranslations
 msgid "Manage translations for {title}"
-msgstr "Manage translations for {title}"
+msgstr ""
 
 #: components/manage/Blocks/Maps/MapsSidebar
 msgid "Map"
-msgstr "Map"
+msgstr ""
 
 #: components/manage/Blocks/Maps/MapsSidebar
 msgid "Maps URL"
-msgstr "Maps URL"
+msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
 msgid "Maximum length is {len}."
-msgstr "Maximum length is {len}."
+msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
 msgid "Maximum value is {len}."
-msgstr "Maximum value is {len}."
+msgstr ""
 
 #: components/theme/ContactForm/ContactForm
 msgid "Message"
-msgstr "Message"
+msgstr ""
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
 msgid "Minimum length is {len}."
-msgstr "Minimum length is {len}."
+msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
 msgid "Minimum value is {len}."
-msgstr "Minimum value is {len}."
+msgstr ""
 
 #: components/manage/Controlpanels/Controlpanels
 msgid "Moderate Comments"
-msgstr "Moderate Comments"
+msgstr ""
 
 #: components/manage/Controlpanels/ModerateComments
 msgid "Moderate comments"
-msgstr "Moderate comments"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
 msgid "Monday and Friday"
-msgstr "Monday and Friday"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/ByMonthDayField
 msgid "Month day"
-msgstr "Day"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
 msgid "Monthly"
-msgstr "Monthly"
+msgstr ""
 
 #: components/manage/Toolbar/Toolbar
 msgid "More"
-msgstr "More"
+msgstr ""
 
 #: components/manage/Contents/ContentsItem
 msgid "Move to bottom of folder"
-msgstr "Move to bottom of folder"
+msgstr ""
 
 #: components/manage/Contents/ContentsItem
 msgid "Move to top of folder"
-msgstr "Move to top of folder"
+msgstr ""
 
 #: components/theme/PasswordReset/PasswordReset
 msgid "My email address is"
-msgstr "My email address is"
+msgstr ""
 
 #: components/manage/Sharing/Sharing
 #: components/theme/ContactForm/ContactForm
 msgid "Name"
-msgstr "Name"
+msgstr ""
 
 #: error
 msgid "Navigate back"
-msgstr "Navigate back"
+msgstr ""
 
 #: components/theme/Navigation/ContextNavigation
 msgid "Navigation"
-msgstr "Navigation"
+msgstr ""
 
 #: components/manage/Preferences/ChangePassword
 #: components/theme/PasswordReset/PasswordReset
 msgid "New password"
-msgstr "New password"
+msgstr ""
 
 #: components/manage/Toolbar/Toolbar
 msgid "News Item"
-msgstr "News Item"
+msgstr ""
 
 #: components/manage/Contents/ContentsItem
 #: components/manage/Controlpanels/ContentTypes
 msgid "No"
-msgstr "No"
+msgstr ""
 
 #: components/manage/Blocks/Image/ImageSidebar
 msgid "No image selected"
-msgstr "No image selected"
+msgstr ""
 
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
 msgid "No image set in Lead Image content field"
-msgstr "No image set in Lead Image content field"
+msgstr ""
 
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
 msgid "No image set in image content field"
-msgstr "No image set in image content field"
+msgstr ""
 
 #: components/manage/Blocks/Listing/ListingBody
 msgid "No items found in this container."
-msgstr "No items found in this container."
+msgstr ""
 
 #: components/manage/Widgets/ObjectBrowserWidget
 msgid "No items selected"
-msgstr "No items selected"
+msgstr ""
 
 #: components/manage/Blocks/Maps/MapsSidebar
 msgid "No map selected"
-msgstr "No map selected"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
 msgid "No occurences set"
-msgstr "No occurences set"
+msgstr ""
 
 #: components/manage/Widgets/ArrayWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/TokenWidget
 msgid "No options"
-msgstr "No options"
+msgstr ""
 
 #: components/theme/Search/Search
 msgid "No results found"
-msgstr "No results found"
+msgstr ""
 
 #: components/manage/Blocks/Listing/ListingBody
 #: components/manage/Widgets/ReferenceWidget
 msgid "No results found."
-msgstr "No results found."
+msgstr ""
 
 #: components/manage/Widgets/QuerySortOnWidget
 #: components/manage/Widgets/QuerystringWidget
 msgid "No selection"
-msgstr "No selection"
+msgstr ""
 
 #: components/manage/Controlpanels/AddonsControlpanel
 msgid "No uninstall profile"
-msgstr "This addon does not provide an uninstall profile."
+msgstr ""
 
 #: components/manage/Widgets/ArrayWidget
 #: components/manage/Widgets/ReferenceWidget
 #: components/manage/Widgets/SelectUtils
 #: components/manage/Widgets/SelectWidget
 msgid "No value"
-msgstr "No value"
+msgstr ""
 
 #: components/manage/Blocks/Video/VideoSidebar
 msgid "No video selected"
-msgstr "No video selected"
+msgstr ""
 
 #: components/manage/Workflow/Workflow
 msgid "No workflow"
-msgstr "No workflow"
+msgstr ""
 
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsItem
 msgid "None"
-msgstr "None"
+msgstr ""
 
 #: components/manage/Controlpanels/Users/UsersControlpanel
 msgid "Note that roles set here apply directly to a user. The symbol{plone_svg}indicates a role inherited from membership in a group."
-msgstr "Note that roles set here apply directly to a user. The symbol{plone_svg}indicates a role inherited from membership in a group."
+msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
 msgid "Number of active objects"
-msgstr "Number of active objects"
+msgstr ""
 
 #: components/manage/Contents/Contents
 msgid "Object Size"
-msgstr "Object Size"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/EndField
 msgid "Occurences"
-msgstr "occurrence(s)"
+msgstr ""
 
 #: components/manage/Delete/Delete
 msgid "Ok"
-msgstr "Ok"
+msgstr ""
 
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
 #: components/manage/Blocks/Maps/MapsSidebar
 #: components/manage/Blocks/Video/VideoSidebar
 msgid "Open in a new tab"
-msgstr "Open in a new tab"
+msgstr ""
 
 #: components/theme/Navigation/Navigation
 msgid "Open menu"
-msgstr "Open menu"
+msgstr ""
 
 #: components/manage/Widgets/ObjectBrowserWidget
 msgid "Open object browser"
-msgstr "Open object browser"
+msgstr ""
 
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
 msgid "Origin"
-msgstr "Origin"
+msgstr ""
 
 #: components/manage/Toolbar/Toolbar
 msgid "Page"
-msgstr "Page"
+msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
 msgid "Parent fieldset"
-msgstr "Parent fieldset"
+msgstr ""
 
 #: components/theme/Login/Login
 #: helpers/MessageLabels/MessageLabels
 msgid "Password"
-msgstr "Password"
+msgstr ""
 
 #: components/theme/PasswordReset/PasswordReset
 #: components/theme/PasswordReset/RequestPasswordReset
 msgid "Password reset"
-msgstr "Password reset"
+msgstr ""
 
 #: components/theme/PasswordReset/PasswordReset
 msgid "Passwords do not match."
-msgstr "Passwords do not match."
+msgstr ""
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
 msgid "Paste"
-msgstr "Paste"
+msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
 msgid "Paste blocks"
-msgstr "undefined"
+msgstr ""
 
 #: components/manage/Sharing/Sharing
 msgid "Permissions have been updated successfully"
-msgstr "Permissions have been updated successfully"
+msgstr ""
 
 #: components/manage/Sharing/Sharing
 msgid "Permissions updated"
-msgstr "Permissions updated"
+msgstr ""
 
 #: components/manage/Preferences/PersonalInformation
 #: components/manage/Toolbar/Toolbar
 msgid "Personal Information"
-msgstr "Personal Information"
+msgstr ""
 
 #: components/manage/Preferences/PersonalPreferences
 #: components/manage/Toolbar/Toolbar
 msgid "Personal Preferences"
-msgstr "Personal Preferences"
+msgstr ""
 
 #: components/manage/Toolbar/More
 #: components/manage/Toolbar/Toolbar
 msgid "Personal tools"
-msgstr "Personal tools"
+msgstr ""
 
 #: components/manage/Contents/ContentsPropertiesModal
 msgid "Persons responsible for creating the content of this item. Please enter a list of user names, one per line. The principal creator should come first."
-msgstr "Persons responsible for creating the content of this item. Please enter a list of user names, one per line. The principal creator should come first."
+msgstr ""
 
 #: components/manage/Blocks/Video/Edit
 msgid "Please enter a valid URL by deleting the block and adding a new video block."
-msgstr "Please enter a valid URL by deleting the block and adding a new video block."
+msgstr ""
 
 #: components/manage/Blocks/Maps/Edit
 msgid "Please enter the Embed Code provided by Google Maps -> Share -> Embed map. It should contain the <iframe> code on it."
-msgstr "Please enter the Embed Code provided by Google Maps -> Share -> Embed map. It should contain the <iframe> code on it."
+msgstr ""
 
 #: components/theme/PasswordReset/PasswordReset
 msgid "Please fill out the form below to set your password."
-msgstr "Please fill out the form below to set your password."
+msgstr ""
 
 #: components/theme/Footer/Footer
 msgid "Plone Foundation"
-msgstr "Plone Foundation"
+msgstr ""
 
 #: components/theme/Logo/Logo
 msgid "Plone Site"
-msgstr "Plone Site"
+msgstr ""
 
 #: components/theme/Footer/Footer
 msgid "Plone{reg} Open Source CMS/WCM"
-msgstr "Plone{reg} Open Source CMS/WCM"
+msgstr ""
 
 #: components/manage/Preferences/PersonalInformation
 msgid "Portrait"
-msgstr "Portrait"
+msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
 msgid "Possible values"
-msgstr "Possible values (Enter allowed choices one per line)."
+msgstr ""
 
 #: components/theme/Footer/Footer
 msgid "Powered by Plone & Python"
-msgstr "Powered by Plone & Python"
+msgstr ""
 
 #: components/manage/Toolbar/PersonalTools
 msgid "Preferences"
-msgstr "Preferences"
+msgstr ""
 
 #: components/manage/Blocks/HTML/Edit
 msgid "Prettify your code"
-msgstr "Prettify your code"
+msgstr ""
 
 #: components/manage/Blocks/HTML/Edit
 #: components/manage/Contents/ContentsUploadModal
 msgid "Preview"
-msgstr "Preview"
+msgstr ""
 
 #: components/manage/Blocks/Video/VideoSidebar
 msgid "Preview Image URL"
-msgstr "Preview Image URL"
+msgstr ""
 
 #: components/manage/Toolbar/PersonalTools
 msgid "Profile"
-msgstr "Profile"
+msgstr ""
 
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsPropertiesModal
 msgid "Properties"
-msgstr "Properties"
+msgstr ""
 
 #: components/manage/Contents/Contents
 msgid "Publication date"
-msgstr "Publication date"
+msgstr ""
 
 #: components/manage/Contents/ContentsPropertiesModal
 msgid "Publishing Date"
-msgstr "Publishing Date"
+msgstr ""
 
 #: components/manage/Blocks/Listing/schema
 msgid "Query"
-msgstr "Query"
+msgstr ""
 
 #: components/manage/Preferences/ChangePassword
 #: components/theme/PasswordReset/PasswordReset
 msgid "Re-enter the password. Make sure the passwords are identical."
-msgstr "Re-enter the password. Make sure the passwords are identical."
+msgstr ""
 
 #: components/theme/Search/Search
 #: components/theme/View/SummaryView
 msgid "Read More…"
-msgstr "Read More…"
+msgstr ""
 
 #: components/manage/Contents/Contents
 msgid "Rearrange items by…"
-msgstr "Rearrange items by…"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/EndField
 msgid "Recurrence ends"
-msgstr "Ends"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/EndField
 msgid "Recurrence ends after"
-msgstr "after"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/EndField
 msgid "Recurrence ends on"
-msgstr "on"
+msgstr ""
 
 #: components/manage/Blocks/Table/Edit
 msgid "Reduce complexity"
-msgstr "Minimalistic table design"
+msgstr ""
 
 #: components/theme/Anontools/Anontools
 #: components/theme/Login/Login
 #: components/theme/Register/Register
 msgid "Register"
-msgstr "Register"
+msgstr ""
 
 #: components/theme/Register/Register
 msgid "Registration form"
-msgstr "Registration form"
+msgstr ""
 
 #: components/theme/Search/Search
 msgid "Relevance"
-msgstr "Relevance"
+msgstr ""
 
 #: components/manage/Widgets/ObjectListWidget
 msgid "Remove item"
-msgstr "Remove item"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
 msgid "Remove recurrence"
-msgstr "Remove"
+msgstr ""
 
 #: components/manage/Widgets/VocabularyTermsWidget
 msgid "Remove term"
-msgstr "Remove term"
+msgstr ""
 
 #: components/manage/Toolbar/More
 msgid "Remove working copy"
-msgstr "Remove working copy"
+msgstr ""
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
 msgid "Rename"
-msgstr "Rename"
+msgstr ""
 
 #: components/manage/Contents/ContentsRenameModal
 msgid "Rename Items Loading Message"
-msgstr "Renaming items..."
+msgstr ""
 
 #: components/manage/Contents/ContentsRenameModal
 msgid "Rename items"
-msgstr "Rename items"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
 msgid "Repeat"
-msgstr "Repeat"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
 msgid "Repeat every"
-msgstr "Repeat every"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
 msgid "Repeat on"
-msgstr "Repeat on"
+msgstr ""
 
 #: components/manage/Widgets/FileWidget
 msgid "Replace existing file"
-msgstr "Replace existing file"
+msgstr ""
 
 #: components/theme/Comments/Comments
 msgid "Reply"
-msgstr "Reply"
+msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/WysiwygWidget
 msgid "Required"
-msgstr "Required"
+msgstr ""
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
 msgid "Required input is missing."
-msgstr "Required input is missing."
+msgstr ""
 
 #: components/manage/Widgets/VocabularyTermsWidget
 msgid "Reset term title"
-msgstr "Reset title"
+msgstr ""
 
 #: components/manage/Widgets/QuerystringWidget
 msgid "Results limit"
-msgstr "Results limit"
+msgstr ""
 
 #: components/manage/Blocks/Listing/Edit
 msgid "Results preview"
-msgstr "Results preview"
+msgstr ""
 
 #: components/manage/Widgets/QuerystringWidget
 msgid "Reversed order"
-msgstr "Reversed order"
+msgstr ""
 
 #: components/manage/History/History
 msgid "Revert to this revision"
-msgstr "Revert to this revision"
+msgstr ""
 
 #: components/manage/Contents/Contents
 msgid "Review state"
-msgstr "Review state"
+msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
 msgid "Richtext"
-msgstr "Richtext"
+msgstr ""
 
 #: components/manage/Blocks/Image/ImageSizeWidget
 #: components/manage/Blocks/Maps/Edit
 #: components/manage/Sidebar/AlignBlock
 msgid "Right"
-msgstr "Right"
+msgstr ""
 
 #: components/manage/Contents/ContentsPropertiesModal
 msgid "Rights"
-msgstr "Rights"
+msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
 msgid "Roles"
-msgstr "Roles"
+msgstr ""
 
 #: components/manage/Contents/ContentsBreadcrumbs
 msgid "Root"
-msgstr "Root"
+msgstr ""
 
 #: components/manage/Add/Add
 #: components/manage/Controlpanels/ContentType
@@ -1631,250 +1631,250 @@ msgstr "Root"
 #: components/manage/Sharing/Sharing
 #: helpers/MessageLabels/MessageLabels
 msgid "Save"
-msgstr "Save"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
 msgid "Save recurrence"
-msgstr "Save"
+msgstr ""
 
 #: components/manage/Controlpanels/ContentTypesActions
 msgid "Schema"
-msgstr "Schema"
+msgstr ""
 
 #: components/manage/Controlpanels/ContentTypeSchema
 msgid "Schema updates"
-msgstr "Schema updates"
+msgstr ""
 
 #: components/theme/SearchWidget/SearchWidget
 msgid "Search"
-msgstr "Search"
+msgstr ""
 
 #: components/manage/Sidebar/ObjectBrowserBody
 msgid "Search SVG"
-msgstr "Search SVG"
+msgstr ""
 
 #: components/theme/SearchWidget/SearchWidget
 msgid "Search Site"
-msgstr "Search Site"
+msgstr ""
 
 #: components/manage/Sidebar/ObjectBrowserBody
 msgid "Search content"
-msgstr "Search content"
+msgstr ""
 
 #: components/manage/Sharing/Sharing
 msgid "Search for user or group"
-msgstr "Search for user or group"
+msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
 msgid "Search group…"
-msgstr "Search group…"
+msgstr ""
 
 #: components/theme/Search/Search
 msgid "Search results"
-msgstr "Search results"
+msgstr ""
 
 #: components/theme/Search/Search
 msgid "Search results for {term}"
-msgstr "Search results for {term}"
+msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
 msgid "Search users…"
-msgstr "Search users…"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
 msgid "Second"
-msgstr "Second"
+msgstr ""
 
 #: components/manage/Sidebar/ObjectBrowserNav
 msgid "Select"
-msgstr "Select"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
 msgid "Select a date to add to recurrence"
-msgstr "Select a date to add to recurrence"
+msgstr ""
 
 #: components/manage/Contents/Contents
 msgid "Select columns to show"
-msgstr "Select columns to show"
+msgstr ""
 
 #: components/manage/Contents/ContentsWorkflowModal
 msgid "Select the transition to be used for modifying the items state."
-msgstr "Select the transition to be used for modifying the items state."
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
 msgid "Selected dates"
-msgstr "Selected dates"
+msgstr ""
 
 #: components/manage/Sidebar/ObjectBrowserBody
 msgid "Selected items"
-msgstr "Selected items"
+msgstr ""
 
 #: components/manage/Sidebar/ObjectBrowserBody
 msgid "Selected items - x of y"
-msgstr "of"
+msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
 msgid "Selection"
-msgstr "Selection"
+msgstr ""
 
 #: components/manage/Contents/Contents
 #: components/manage/Widgets/ArrayWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/TokenWidget
 msgid "Select…"
-msgstr "Select…"
+msgstr ""
 
 #: components/theme/ContactForm/ContactForm
 msgid "Send"
-msgstr "Send"
+msgstr ""
 
 #: components/theme/PasswordReset/PasswordReset
 msgid "Set my password"
-msgstr "Set my password"
+msgstr ""
 
 #: components/theme/PasswordReset/PasswordReset
 msgid "Set your password"
-msgstr "Set your password"
+msgstr ""
 
 #: components/manage/Sidebar/Sidebar
 msgid "Settings"
-msgstr "Settings"
+msgstr ""
 
 #: components/manage/Sharing/Sharing
 #: components/manage/Toolbar/More
 msgid "Sharing"
-msgstr "Sharing"
+msgstr ""
 
 #: components/manage/Sharing/Sharing
 msgid "Sharing for {title}"
-msgstr "Sharing for {title}"
+msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/WysiwygWidget
 msgid "Short Name"
-msgstr "Short Name"
+msgstr ""
 
 #: components/manage/Contents/ContentsRenameModal
 msgid "Short name"
-msgstr "Short name"
+msgstr ""
 
 #: components/theme/Pagination/Pagination
 msgid "Show"
-msgstr "Show"
+msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
 msgid "Show All"
-msgstr "Show All"
+msgstr ""
 
 #: components/theme/Comments/Comments
 msgid "Show Replies"
-msgstr "Show Replies"
+msgstr ""
 
 #: components/manage/Widgets/ObjectListWidget
 msgid "Show item"
-msgstr "Show item"
+msgstr ""
 
 #: components/manage/Sidebar/Sidebar
 msgid "Shrink sidebar"
-msgstr "Shrink sidebar"
+msgstr ""
 
 #: components/manage/Toolbar/Toolbar
 msgid "Shrink toolbar"
-msgstr "Shrink toolbar"
+msgstr ""
 
 #: components/theme/Login/Login
 msgid "Sign in to start session"
-msgstr "Sign in to start session"
+msgstr ""
 
 #: components/theme/Logo/Logo
 msgid "Site"
-msgstr "Site"
+msgstr ""
 
 #: components/theme/NotFound/NotFound
 #: components/theme/Unauthorized/Unauthorized
 msgid "Site Administration"
-msgstr "Site Administration"
+msgstr ""
 
 #: components/theme/Footer/Footer
 msgid "Site Map"
-msgstr "Site Map"
+msgstr ""
 
 #: components/manage/Controlpanels/Controlpanels
 #: components/manage/Toolbar/PersonalTools
 msgid "Site Setup"
-msgstr "Site Setup"
+msgstr ""
 
 #: components/theme/Sitemap/Sitemap
 msgid "Sitemap"
-msgstr "Sitemap"
+msgstr ""
 
 #: components/manage/Blocks/Image/ImageSidebar
 msgid "Size"
-msgstr "Size"
+msgstr ""
 
 #: components/theme/View/ImageView
 msgid "Size: {size}"
-msgstr "Size: {size}"
+msgstr ""
 
 #: error
 msgid "Sorry, something went wrong with your request"
-msgstr "Sorry, something went wrong with your request "
+msgstr ""
 
 #: components/theme/Search/Search
 msgid "Sort By:"
-msgstr "Sort by:"
+msgstr ""
 
 #: components/manage/Widgets/QuerySortOnWidget
 #: components/manage/Widgets/QuerystringWidget
 msgid "Sort on"
-msgstr "Sort on"
+msgstr ""
 
 #: components/manage/Blocks/HTML/Edit
 msgid "Source"
-msgstr "Source"
+msgstr ""
 
 #: components/manage/Blocks/Video/Edit
 msgid "Specify a youtube video or playlist url"
-msgstr "Specify a youtube video or playlist url"
+msgstr ""
 
 #: components/manage/Diff/Diff
 msgid "Split"
-msgstr "Split"
+msgstr ""
 
 #: components/manage/Contents/Contents
 msgid "Start Date"
-msgstr "Start Date"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
 msgid "Start of the recurrence"
-msgstr "Start of the recurrence"
+msgstr ""
 
 #: components/theme/PasswordReset/RequestPasswordReset
 msgid "Start password reset"
-msgstr "Start password reset"
+msgstr ""
 
 #: components/manage/Contents/Contents
 #: components/manage/Workflow/Workflow
 #: components/theme/View/TabularView
 msgid "State"
-msgstr "State"
+msgstr ""
 
 #: components/manage/Multilingual/CompareLanguages
 msgid "Stop compare"
-msgstr "Stop compare"
+msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
 msgid "String"
-msgstr "String"
+msgstr ""
 
 #: components/manage/Blocks/Table/Edit
 msgid "Stripe alternate rows with color"
-msgstr "Alternate row background color"
+msgstr ""
 
 #: components/theme/ContactForm/ContactForm
 msgid "Subject"
-msgstr "Subject"
+msgstr ""
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
@@ -1887,132 +1887,132 @@ msgstr "Subject"
 #: components/theme/ContactForm/ContactForm
 #: helpers/MessageLabels/MessageLabels
 msgid "Success"
-msgstr "Success"
+msgstr ""
 
 #: components/theme/LanguageSelector/LanguageSelector
 msgid "Switch to"
-msgstr "Switch to"
+msgstr ""
 
 #: components/manage/Blocks/Table/Edit
 msgid "Table"
-msgstr "Table"
+msgstr ""
 
 #: components/manage/Blocks/ToC/View
 msgid "Table of Contents"
-msgstr "Table of Contents"
+msgstr ""
 
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsTagsModal
 msgid "Tags"
-msgstr "Tags"
+msgstr ""
 
 #: components/manage/Contents/ContentsTagsModal
 msgid "Tags to add"
-msgstr "Tags to add"
+msgstr ""
 
 #: components/manage/Contents/ContentsTagsModal
 msgid "Tags to remove"
-msgstr "Tags to remove"
+msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
 msgid "Target memory size per cache in bytes"
-msgstr "Target memory size per cache in bytes"
+msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
 msgid "Target number of objects in memory per cache"
-msgstr "Target number of objects in memory per cache"
+msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
 msgid "Text"
-msgstr "Text"
+msgstr ""
 
 #: components/theme/ConnectionRefused/ConnectionRefused
 #: components/theme/CorsError/CorsError
 #: components/theme/NotFound/NotFound
 #: components/theme/Unauthorized/Unauthorized
 msgid "Thank you."
-msgstr "Thank you."
+msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
 msgid "The Database Manager allow you to view database status information"
-msgstr "The Database Manager allow you to view database status information"
+msgstr ""
 
 #: components/manage/Preferences/PersonalInformation
 msgid "The URL for your external home page, if you have one."
-msgstr "The URL for your external home page, if you have one."
+msgstr ""
 
 #: components/theme/ConnectionRefused/ConnectionRefused
 msgid "The backend is not responding, please check if you have started Plone, check your project's configuration object apiPath (or if you are using the internal proxy, devProxyToApiPath) or the RAZZLE_API_PATH Volto's environment variable."
-msgstr "The backend is not responding, please check if you have started Plone, check your project's configuration object apiPath (or if you are using the internal proxy, devProxyToApiPath) or the RAZZLE_API_PATH Volto's environment variable."
+msgstr ""
 
 #: components/theme/CorsError/CorsError
 msgid "The backend is responding, but the CORS headers are not configured properly and the browser has denied the access to the backend resources."
-msgstr "The backend is responding, but the CORS headers are not configured properly and the browser has denied the access to the backend resources."
+msgstr ""
 
 #: components/theme/CorsError/CorsError
 msgid "The backend server of your website is not anwering, we apologize for the inconvenience. Please try to re-load the page and try again. If the problem persists please contact the site administrators."
-msgstr "The backend server of your website is not anwering, we apologize for the inconvenience. Please try to re-load the page and try again. If the problem persists please contact the site administrators."
+msgstr ""
 
 #: components/manage/Contents/Contents
 msgid "The item could not be deleted."
-msgstr "The item could not be deleted."
+msgstr ""
 
 #: components/theme/Register/Register
 msgid "The registration process has been successful. Please check your e-mail inbox for information on how activate your account."
-msgstr "The registration process has been successful. Please check your e-mail inbox for information on how activate your account."
+msgstr ""
 
 #: components/manage/Preferences/PersonalInformation
 msgid "The user portrait/avatar"
-msgstr "The user portrait/avatar"
+msgstr ""
 
 #: components/manage/Toolbar/More
 msgid "The working copy was discarded"
-msgstr "The working copy was discarded"
+msgstr ""
 
 #: components/theme/Footer/Footer
 msgid "The {plonecms} is {copyright} 2000-{current_year} by the {plonefoundation} and friends."
-msgstr "The {plonecms} is {copyright} 2000-{current_year} by the {plonefoundation} and friends."
+msgstr ""
 
 #: components/theme/CorsError/CorsError
 msgid "There is a configuration problem on the backend"
-msgstr "There is a configuration problem on the backend"
+msgstr ""
 
 #: components/manage/Form/InlineForm
 msgid "There were some errors"
-msgstr "There were some errors"
+msgstr ""
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
 msgid "There were some errors."
-msgstr "There were some errors."
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
 msgid "Third"
-msgstr "Third"
+msgstr ""
 
 #: components/manage/WorkingCopyToastsFactory/WorkingCopyToastsFactory
 msgid "This has an ongoing working copy in {title}"
-msgstr "This has an ongoing working copy in {title}"
+msgstr ""
 
 #: components/manage/WorkingCopyToastsFactory/WorkingCopyToastsFactory
 msgid "This is a working copy of {title}"
-msgstr "This is a working copy of {title}"
+msgstr ""
 
 #: components/manage/LockingToastsFactory/LockingToastsFactory
 msgid "This item was locked by {creator} on {date}"
-msgstr "This item was locked by {creator} on {date}"
+msgstr ""
 
 #: components/manage/Contents/ContentsRenameModal
 msgid "This name will be displayed in the URL."
-msgstr "This name will be displayed in the URL."
+msgstr ""
 
 #: components/theme/NotFound/NotFound
 msgid "This page does not seem to exist…"
-msgstr "This page does not seem to exist…"
+msgstr ""
 
 #: components/manage/Widgets/DatetimeWidget
 msgid "Time"
-msgstr "Time"
+msgstr ""
 
 #: components/manage/Blocks/HeroImageLeft/Edit
 #: components/manage/Contents/Contents
@@ -2024,78 +2024,78 @@ msgstr "Time"
 #: components/theme/View/TabularView
 #: helpers/MessageLabels/MessageLabels
 msgid "Title"
-msgstr "Title"
+msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
 msgid "Total active and non-active objects"
-msgstr "Total active and non-active objects"
+msgstr ""
 
 #: components/manage/Contents/Contents
 msgid "Total comments"
-msgstr "Total comments"
+msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
 msgid "Total number of objects in each cache"
-msgstr "Total number of objects in each cache"
+msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
 msgid "Total number of objects in memory from all caches"
-msgstr "Total number of objects in memory from all caches"
+msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
 msgid "Total number of objects in the database"
-msgstr "Total number of objects in the database"
+msgstr ""
 
 #: components/manage/Add/Add
 #: components/manage/Toolbar/Types
 msgid "Translate to {lang}"
-msgstr "Translate to {lang}"
+msgstr ""
 
 #: components/manage/Multilingual/ManageTranslations
 msgid "Translation linked"
-msgstr "Translation linked"
+msgstr ""
 
 #: components/manage/Multilingual/ManageTranslations
 msgid "Translation linking removed"
-msgstr "Translation linking removed"
+msgstr ""
 
 #: components/manage/Controlpanels/ContentTypes
 #: components/manage/Widgets/SchemaWidget
 #: components/theme/View/TabularView
 msgid "Type"
-msgstr "Type"
+msgstr ""
 
 #: components/manage/Blocks/Video/Edit
 msgid "Type a Video (YouTube, Vimeo or mp4) URL"
-msgstr "Type a Video (YouTube, Vimeo or mp4) URL"
+msgstr ""
 
 #: components/manage/Blocks/Text/Edit
 msgid "Type text…"
-msgstr "Type text…"
+msgstr ""
 
 #: components/manage/Blocks/Title/Edit
 msgid "Type the title…"
-msgstr "Type the title…"
+msgstr ""
 
 #: components/manage/Contents/Contents
 msgid "UID"
-msgstr "UID"
+msgstr ""
 
 #: components/theme/Unauthorized/Unauthorized
 msgid "Unauthorized"
-msgstr "Unauthorized"
+msgstr ""
 
 #: components/manage/BlockChooser/BlockChooser
 msgid "Unfold"
-msgstr "Unfold"
+msgstr ""
 
 #: components/manage/Diff/Diff
 msgid "Unified"
-msgstr "Unified"
+msgstr ""
 
 #: components/manage/Controlpanels/AddonsControlpanel
 msgid "Uninstall"
-msgstr "Uninstall"
+msgstr ""
 
 #: components/manage/Blocks/Block/Edit
 #: components/theme/View/DefaultView
@@ -2105,632 +2105,632 @@ msgstr "Unknown Block {block}"
 
 #: components/manage/Multilingual/ManageTranslations
 msgid "Unlink translation for"
-msgstr "Unlink translation for"
+msgstr ""
 
 #: components/manage/Toolbar/Toolbar
 msgid "Unlock"
-msgstr "Unlock"
+msgstr ""
 
 #: components/manage/Controlpanels/AddonsControlpanel
 msgid "Update"
-msgstr "Update"
+msgstr ""
 
 #: components/manage/Controlpanels/AddonsControlpanel
 msgid "Update installed addons"
-msgstr "Update installed addons"
+msgstr ""
 
 #: components/manage/Controlpanels/AddonsControlpanel
 msgid "Update installed addons:"
-msgstr "Update installed addons:"
+msgstr ""
 
 #: components/manage/Controlpanels/AddonsControlpanel
 msgid "Updates available"
-msgstr "Updates available"
+msgstr ""
 
 #: components/manage/Contents/Contents
 msgid "Upload"
-msgstr "Upload"
+msgstr ""
 
 #: components/manage/Blocks/LeadImage/Edit
 msgid "Upload a lead image in the 'Lead Image' content field."
-msgstr "Upload a lead image in the 'Lead Image' content field."
+msgstr ""
 
 #: components/manage/Blocks/HeroImageLeft/Edit
 msgid "Upload a new image"
-msgstr "Upload a new image"
+msgstr ""
 
 #: components/manage/Contents/ContentsUploadModal
 msgid "Upload files"
-msgstr "Upload files"
+msgstr ""
 
 #: components/manage/Contents/ContentsUploadModal
 msgid "Uploading files"
-msgstr "Uploading files"
+msgstr ""
 
 #: components/manage/Blocks/HeroImageLeft/Edit
 msgid "Uploading image"
-msgstr "Uploading image"
+msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/WysiwygWidget
 msgid "Used for programmatic access to the fieldset."
-msgstr "Used for programmatic access to the fieldset."
+msgstr ""
 
 #: components/manage/Sharing/Sharing
 msgid "User"
-msgstr "User"
+msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
 msgid "User created"
-msgstr "User created"
+msgstr ""
 
 #: components/manage/Controlpanels/Users/UsersControlpanel
 msgid "User name"
-msgstr "User name"
+msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
 msgid "User roles updated"
-msgstr "User roles updated"
+msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
 msgid "Username"
-msgstr "Username"
+msgstr ""
 
 #: components/manage/Controlpanels/Controlpanels
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: helpers/MessageLabels/MessageLabels
 msgid "Users"
-msgstr "Users"
+msgstr ""
 
 #: components/manage/Controlpanels/Controlpanels
 msgid "Users and Groups"
-msgstr "Users and Groups"
+msgstr ""
 
 #: helpers/Extensions/withBlockSchemaEnhancer
 msgid "Variation"
-msgstr "Variation"
+msgstr ""
 
 #: components/manage/Controlpanels/Controlpanels
 msgid "Version Overview"
-msgstr "Version Overview"
+msgstr ""
 
 #: components/manage/Blocks/Video/VideoSidebar
 msgid "Video"
-msgstr "Video"
+msgstr ""
 
 #: components/manage/Blocks/Video/VideoSidebar
 msgid "Video URL"
-msgstr "Video URL"
+msgstr ""
 
 #: components/manage/Contents/ContentsItem
 msgid "View"
-msgstr "View"
+msgstr ""
 
 #: components/manage/History/History
 msgid "View changes"
-msgstr "View changes"
+msgstr ""
 
 #: components/manage/History/History
 msgid "View this revision"
-msgstr "View this revision"
+msgstr ""
 
 #: components/manage/Toolbar/More
 msgid "View working copy"
-msgstr "View working copy"
+msgstr ""
 
 #: components/manage/Display/Display
 msgid "Viewmode"
-msgstr "View"
+msgstr ""
 
 #: components/manage/Widgets/VocabularyTermsWidget
 msgid "Vocabulary term"
-msgstr "Vocabulary term"
+msgstr ""
 
 #: components/manage/Widgets/VocabularyTermsWidget
 msgid "Vocabulary term title"
-msgstr "Title"
+msgstr ""
 
 #: components/manage/Widgets/VocabularyTermsWidget
 msgid "Vocabulary terms"
-msgstr "Vocabulary terms"
+msgstr ""
 
 #: components/manage/Controlpanels/VersionOverview
 msgid "Warning Regarding debug mode"
-msgstr "You are running in 'debug mode'. This mode is intended for sites that are under development. This allows many configuration changes to be immediately visible, but will make your site run more slowly. To turn off debug mode, stop the server, set 'debug-mode=off' in your buildout.cfg, re-run bin/buildout and then restart the server process."
+msgstr ""
 
 #: components/theme/ConnectionRefused/ConnectionRefused
 msgid "We apologize for the inconvenience, but the backend of the site you are accessing is not available right now. Please, try again later."
-msgstr "We apologize for the inconvenience, but the backend of the site you are accessing is not available right now. Please, try again later."
+msgstr ""
 
 #: components/theme/NotFound/NotFound
 msgid "We apologize for the inconvenience, but the page you were trying to access is not at this address. You can use the links below to help you find what you are looking for."
-msgstr "We apologize for the inconvenience, but the page you were trying to access is not at this address. You can use the links below to help you find what you are looking for."
+msgstr ""
 
 #: components/theme/Forbidden/Forbidden
 msgid "We apologize for the inconvenience, but you don't have permissions on this resource."
-msgstr "We apologize for the inconvenience, but you don't have permissions on this resource."
+msgstr ""
 
 #: components/manage/Preferences/PersonalInformation
 msgid "We will use this address if you need to recover your password"
-msgstr "We will use this address if you need to recover your password"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
 msgid "Weeek day of month"
-msgstr "The"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
 msgid "Weekday"
-msgstr "Weekday"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
 msgid "Weekly"
-msgstr "Weekly"
+msgstr ""
 
 #: components/manage/History/History
 msgid "What"
-msgstr "What"
+msgstr ""
 
 #: components/manage/History/History
 msgid "When"
-msgstr "When"
+msgstr ""
 
 #: components/manage/Contents/ContentsPropertiesModal
 msgid "When this date is reached, the content will nolonger be visible in listings and searches."
-msgstr "When this date is reached, the content will nolonger be visible in listings and searches."
+msgstr ""
 
 #: components/manage/History/History
 msgid "Who"
-msgstr "Who"
+msgstr ""
 
 #: components/manage/Contents/ContentsWorkflowModal
 msgid "Workflow Change Loading Message"
-msgstr "Updating workflow states..."
+msgstr ""
 
 #: components/manage/Workflow/Workflow
 msgid "Workflow updated."
-msgstr "Workflow updated."
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
 msgid "Yearly"
-msgstr "Yearly"
+msgstr ""
 
 #: components/manage/Contents/ContentsItem
 #: components/manage/Controlpanels/ContentTypes
 msgid "Yes"
-msgstr "Yes"
+msgstr ""
 
 #: components/theme/Unauthorized/Unauthorized
 msgid "You are trying to access a protected resource, please {login} first."
-msgstr "You are trying to access a protected resource, please {login} first."
+msgstr ""
 
 #: components/theme/OutdatedBrowser/OutdatedBrowser
 msgid "You are using an outdated browser"
-msgstr "You are using an outdated browser"
+msgstr ""
 
 #: components/theme/Comments/Comments
 msgid "You can add a comment by filling out the form below. Plain text formatting."
-msgstr "You can add a comment by filling out the form below. Plain text formatting."
+msgstr ""
 
 #: components/manage/Sharing/Sharing
 msgid "You can control who can view and edit your item using the list below."
-msgstr "You can control who can view and edit your item using the list below."
+msgstr ""
 
 #: components/manage/Diff/Diff
 msgid "You can view the difference of the revisions below."
-msgstr "You can view the difference of the revisions below."
+msgstr ""
 
 #: components/manage/History/History
 msgid "You can view the history of your item below."
-msgstr "You can view the history of your item below."
+msgstr ""
 
 #: components/manage/Contents/Contents
 msgid "You can't paste this content here"
-msgstr "You can't paste this content here"
+msgstr ""
 
 #: components/theme/PasswordReset/RequestPasswordReset
 msgid "Your email is required for reset your password."
-msgstr "Your email is required for reset your password."
+msgstr ""
 
 #: components/manage/Preferences/PersonalInformation
 msgid "Your location - either city and country - or in a company setting, where your office is located."
-msgstr "Your location - either city and country - or in a company setting, where your office is located."
+msgstr ""
 
 #: components/theme/PasswordReset/PasswordReset
 msgid "Your password has been set successfully. You may now {link} with your new password."
-msgstr "Your password has been set successfully. You may now {link} with your new password."
+msgstr ""
 
 #: components/manage/Preferences/PersonalPreferences
 msgid "Your preferred language"
-msgstr "Your preferred language"
+msgstr ""
 
 #: components/theme/Login/Login
 #: components/theme/PasswordReset/RequestPasswordReset
 msgid "box_forgot_password_option"
-msgstr "Forgot your password?"
+msgstr ""
 
 #: config/Blocks
 msgid "common"
-msgstr "Common"
+msgstr ""
 
 #: components/manage/Multilingual/CompareLanguages
 msgid "compare_to"
-msgstr "Compare to language"
+msgstr ""
 
 #: components/manage/Blocks/Block/EditBlockWrapper
 msgid "delete"
-msgstr "delete"
+msgstr ""
 
 #: components/theme/OutdatedBrowser/OutdatedBrowser
 msgid "deprecated_browser_notice_message"
-msgstr "You are using {browsername} {browserversion} which is deprecated by its vendor. That means that it does not get security updates and it is not ready for current modern web features, which deteriorates the user experience. Please upgrade to a modern browser."
+msgstr ""
 
 #: config/Blocks
 msgid "description"
-msgstr "Description"
+msgstr ""
 
 #: components/theme/PasswordReset/RequestPasswordReset
 msgid "description_lost_password"
-msgstr "For security reasons, we store your password encrypted, and cannot mail it to you. If you would like to reset your password, fill out the form below and we will send you an email at the address you gave when you registered to start the process of resetting your password."
+msgstr ""
 
 #: components/theme/PasswordReset/RequestPasswordReset
 msgid "description_sent_password"
-msgstr "Your password reset request has been mailed. It should arrive in your mailbox shortly. When you receive the message, visit the address it contains to reset your password."
+msgstr ""
 
 #: components/manage/Contents/ContentsItem
 msgid "draft"
-msgstr "Draft"
+msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
-msgstr "Input must be valid email (something@domain.com)"
+msgstr ""
 
 #: components/theme/View/EventView
 msgid "event_alldates"
-msgstr "All dates"
+msgstr ""
 
 #: components/theme/View/EventView
 msgid "event_attendees"
-msgstr "Attendees"
+msgstr ""
 
 #: components/theme/View/EventView
 msgid "event_contactname"
-msgstr "Contact Name"
+msgstr ""
 
 #: components/theme/View/EventView
 msgid "event_contactphone"
-msgstr "Contact Phone"
+msgstr ""
 
 #: components/theme/View/EventView
 msgid "event_website"
-msgstr "Website"
+msgstr ""
 
 #: components/theme/View/EventView
 msgid "event_what"
-msgstr "What"
+msgstr ""
 
 #: components/theme/View/EventView
 msgid "event_when"
-msgstr "When"
+msgstr ""
 
 #: components/theme/View/EventView
 msgid "event_where"
-msgstr "Where"
+msgstr ""
 
 #: components/theme/PasswordReset/RequestPasswordReset
 msgid "heading_sent_password"
-msgstr "Password reset confirmation sent"
+msgstr ""
 
 #: config/Blocks
 msgid "hero"
-msgstr "Hero"
+msgstr ""
 
 #: config/Blocks
 msgid "html"
-msgstr "HTML"
+msgstr ""
 
 #: config/Blocks
 msgid "image"
-msgstr "Image"
+msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
 msgid "integer"
-msgstr "Input must be integer"
+msgstr ""
 
 #: components/manage/Contents/ContentsItem
 msgid "intranet"
-msgstr "Intranet"
+msgstr ""
 
 #: components/theme/PasswordReset/RequestPasswordReset
 msgid "label_my_email_address_is"
-msgstr "My email address is"
+msgstr ""
 
 #: config/Blocks
 msgid "leadimage"
-msgstr "Lead Image Field"
+msgstr ""
 
 #: config/Blocks
 msgid "listing"
-msgstr "Listing"
+msgstr ""
 
 #: components/manage/Blocks/Listing/ListingBody
 #: components/manage/Contents/Contents
 msgid "loading"
-msgstr "Loading"
+msgstr ""
 
 #: components/theme/Unauthorized/Unauthorized
 msgid "log in"
-msgstr "log in"
+msgstr ""
 
 #: config/Blocks
 msgid "maps"
-msgstr "Maps"
+msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
 msgid "maxLength"
-msgstr "Maximum Length"
+msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
 msgid "maximum"
-msgstr "End of the range (including the value itself)"
+msgstr ""
 
 #: config/Blocks
 msgid "media"
-msgstr "Media"
+msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
 msgid "minLength"
-msgstr "Minimum Length"
+msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
 msgid "minimum"
-msgstr "Start of the range"
+msgstr ""
 
 #: config/Blocks
 msgid "mostUsed"
-msgstr "Most used"
+msgstr ""
 
 #: components/manage/Contents/ContentsItem
 msgid "no workflow state"
-msgstr "No workflow state"
+msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
 msgid "number"
-msgstr "Input must be number"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/ByMonthDayField
 #: components/manage/Widgets/RecurrenceWidget/ByYearField
 msgid "of the month"
-msgstr "of the month"
+msgstr ""
 
 #: error
 msgid "or try a different page."
-msgstr "or try a different page."
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
 msgid "others"
-msgstr "others"
+msgstr ""
 
 #: components/manage/Contents/ContentsItem
 msgid "private"
-msgstr "Private"
+msgstr ""
 
 #: components/manage/Contents/ContentsItem
 msgid "published"
-msgstr "Published"
+msgstr ""
 
 #: components/manage/Widgets/QueryWidget
 msgid "querystring-widget-select"
-msgstr "Select…"
+msgstr ""
 
 #: components/theme/Search/Search
 msgid "results found"
-msgstr "results"
+msgstr ""
 
 #: error
 msgid "return to the site root"
-msgstr "return to the site root"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_and"
-msgstr "and"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_approximate"
-msgstr "(~approximate)"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_at"
-msgstr "at"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_dateFormat"
-msgstr "[month] [day], [year]"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_day"
-msgstr "day"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_days"
-msgstr "days"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_every"
-msgstr "every"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_for"
-msgstr "for"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_hour"
-msgstr "hour"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_hours"
-msgstr "hours"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_in"
-msgstr "in"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_last"
-msgstr "last"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_minutes"
-msgstr "minutes"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_month"
-msgstr "month"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_months"
-msgstr "months"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_nd"
-msgstr "nd"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_on"
-msgstr "on"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_on the"
-msgstr "on the"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_or"
-msgstr "or"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_rd"
-msgstr "rd"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_st"
-msgstr "st"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_th"
-msgstr "th"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_the"
-msgstr "the"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_time"
-msgstr "time"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_times"
-msgstr "times"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_until"
-msgstr "until"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_week"
-msgstr "week"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_weekday"
-msgstr "weekday"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_weekdays"
-msgstr "weekdays"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_weeks"
-msgstr "weeks"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_year"
-msgstr "year"
+msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_years"
-msgstr "years"
+msgstr ""
 
 #: components/theme/SkipLinks/SkipLinks
 msgid "skiplink-footer"
-msgstr "Skip to footer"
+msgstr ""
 
 #: components/theme/SkipLinks/SkipLinks
 msgid "skiplink-main-content"
-msgstr "Skip to main content"
+msgstr ""
 
 #: components/theme/SkipLinks/SkipLinks
 msgid "skiplink-navigation"
-msgstr "Skip to navigation"
+msgstr ""
 
 #: components/manage/Contents/Contents
 msgid "sort"
-msgstr "sort"
+msgstr ""
 
 #: config/Blocks
 msgid "table"
-msgstr "Table"
+msgstr ""
 
 #: config/Blocks
 msgid "text"
-msgstr "Text"
+msgstr ""
 
 #: config/Blocks
 msgid "title"
-msgstr "Title"
+msgstr ""
 
 #: config/Blocks
 msgid "toc"
-msgstr "Table of Contents"
+msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
 msgid "url"
-msgstr "Input must be valid url (www.something.com or http(s)://www.something.com)"
+msgstr ""
 
 #: components/manage/Toolbar/PersonalTools
 msgid "user avatar"
-msgstr "user avatar"
+msgstr ""
 
 #: config/Blocks
 msgid "video"
-msgstr "Video"
+msgstr ""
 
 #: components/theme/View/EventView
 msgid "visit_external_website"
-msgstr "Visit external website"
+msgstr ""
 
 #: components/manage/Contents/ContentsUploadModal
 msgid "{count, plural, one {Upload {count} file} other {Upload {count} files}}"
-msgstr "{count, plural, one {Upload {count} file} other {Upload {count} files}}"
+msgstr ""
 
 #: components/manage/Contents/Contents
 msgid "{count} selected"
-msgstr "{count} selected"
+msgstr ""
 
 #: components/manage/Controlpanels/ContentType
 msgid "{id} Content Type"
-msgstr "{id} Content Type"
+msgstr ""
 
 #: components/manage/Controlpanels/ContentTypeSchema
 msgid "{id} Schema"
-msgstr "{id} Schema"
+msgstr ""
 
 #: components/manage/Actions/Actions
 msgid "{title} copied."
-msgstr "{title} copied."
+msgstr ""
 
 #: components/manage/Actions/Actions
 msgid "{title} cut."
-msgstr "{title} cut."
+msgstr ""
 
 #: components/manage/Actions/Actions
 msgid "{title} has been deleted."
-msgstr "{title} has been deleted."
+msgstr ""

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -2237,7 +2237,7 @@ msgstr "Vocabulary terms"
 
 #: components/manage/Controlpanels/VersionOverview
 msgid "Warning Regarding debug mode"
-msgstr "You are running in \"debug mode\". This mode is intended for sites that are under development. This allows many configuration changes to be immediately visible, but will make your site run more slowly. To turn off debug mode, stop the server, set \"debug-mode=off\" in your buildout.cfg, re-run bin/buildout and then restart the server process."
+msgstr "You are running in 'debug mode'. This mode is intended for sites that are under development. This allows many configuration changes to be immediately visible, but will make your site run more slowly. To turn off debug mode, stop the server, set 'debug-mode=off' in your buildout.cfg, re-run bin/buildout and then restart the server process."
 
 #: components/theme/ConnectionRefused/ConnectionRefused
 msgid "We apologize for the inconvenience, but the backend of the site you are accessing is not available right now. Please, try again later."

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -13,23 +13,23 @@ msgstr ""
 
 #: components/manage/Blocks/HTML/Edit
 msgid "<p>Add some HTML here</p>"
-msgstr ""
+msgstr "<p>Add some HTML here</p>"
 
 #: components/theme/Footer/Footer
 msgid "Accessibility"
-msgstr ""
+msgstr "Accessibility"
 
 #: components/theme/Register/Register
 msgid "Account Registration Completed"
-msgstr ""
+msgstr "Account Registration Completed"
 
 #: components/theme/PasswordReset/PasswordReset
 msgid "Account activation completed"
-msgstr ""
+msgstr "Account activation completed"
 
 #: components/manage/Controlpanels/ModerateComments
 msgid "Action"
-msgstr ""
+msgstr "Action"
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
@@ -37,138 +37,138 @@ msgstr ""
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 msgid "Actions"
-msgstr ""
+msgstr "Actions"
 
 #: components/manage/Controlpanels/AddonsControlpanel
 msgid "Activate and deactivate"
-msgstr ""
+msgstr "Activate and deactivate add-ons in the lists below."
 
 #: components/manage/Controlpanels/ContentTypes
 #: components/manage/Toolbar/Toolbar
 #: components/manage/Widgets/SchemaWidget
 #: helpers/MessageLabels/MessageLabels
 msgid "Add"
-msgstr ""
+msgstr "Add"
 
 #: components/manage/Controlpanels/AddonsControlpanel
 msgid "Add Addons"
-msgstr ""
+msgstr "To make new add-ons show up here, add them to your buildout configuration, run buildout, and restart the server process. For detailed instructions see"
 
 #: components/manage/Toolbar/Types
 msgid "Add Content"
-msgstr ""
+msgstr "Add Content…"
 
 #: components/manage/Toolbar/Types
 msgid "Add Translation…"
-msgstr ""
+msgstr "Add Translation…"
 
 #: helpers/MessageLabels/MessageLabels
 msgid "Add User"
-msgstr ""
+msgstr "Add User"
 
 #: components/manage/Blocks/Description/Edit
 msgid "Add a description…"
-msgstr ""
+msgstr "Add a description…"
 
 #: components/manage/BlockChooser/BlockChooserButton
 msgid "Add block"
-msgstr ""
+msgstr "Add block"
 
 #: helpers/MessageLabels/MessageLabels
 msgid "Add block…"
-msgstr ""
+msgstr "Add block…"
 
 #: components/manage/Widgets/QueryWidget
 msgid "Add criteria"
-msgstr ""
+msgstr "Add criteria"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
 msgid "Add date"
-msgstr ""
+msgstr "Add date"
 
 #: components/manage/Widgets/SchemaWidget
 msgid "Add field"
-msgstr ""
+msgstr "Add field"
 
 #: components/manage/Widgets/SchemaWidget
 msgid "Add fieldset"
-msgstr ""
+msgstr "Add fieldset"
 
 #: helpers/MessageLabels/MessageLabels
 msgid "Add group"
-msgstr ""
+msgstr "Add group"
 
 #: components/manage/Controlpanels/ContentTypes
 msgid "Add new content type"
-msgstr ""
+msgstr "Add new content type"
 
 #: helpers/MessageLabels/MessageLabels
 msgid "Add new group"
-msgstr ""
+msgstr "Add new group"
 
 #: helpers/MessageLabels/MessageLabels
 msgid "Add new user"
-msgstr ""
+msgstr "Add new user"
 
 #: helpers/MessageLabels/MessageLabels
 msgid "Add to Groups"
-msgstr ""
+msgstr "Add to Groups"
 
 #: components/manage/Widgets/VocabularyTermsWidget
 msgid "Add vocabulary term"
-msgstr ""
+msgstr "Add term"
 
 #: components/manage/Add/Add
 msgid "Add {type}"
-msgstr ""
+msgstr "Add {type}"
 
 #: components/manage/Controlpanels/AddonsControlpanel
 msgid "Add-ons Settings"
-msgstr ""
+msgstr "Add-ons Settings"
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
 msgid "Additional date"
-msgstr ""
+msgstr "Additional date"
 
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
 #: components/manage/Blocks/Maps/MapsSidebar
 #: components/manage/Blocks/Video/VideoSidebar
 msgid "Alignment"
-msgstr ""
+msgstr "Alignment"
 
 #: components/manage/Contents/Contents
 msgid "All"
-msgstr ""
+msgstr "All"
 
 #: components/theme/Search/Search
 msgid "Alphabetically"
-msgstr ""
+msgstr "Alphabetically"
 
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
 msgid "Alt text"
-msgstr ""
+msgstr "Alt text"
 
 #: components/manage/Toolbar/More
 msgid "Apply working copy"
-msgstr ""
+msgstr "Apply working copy"
 
 #: components/manage/Widgets/SchemaWidget
 msgid "Are you sure you want to delete this field?"
-msgstr ""
+msgstr "Are you sure you want to delete this field?"
 
 #: components/manage/Widgets/SchemaWidget
 msgid "Are you sure you want to delete this fieldset including all fields?"
-msgstr ""
+msgstr "Are you sure you want to delete this fieldset including all fields?"
 
 #: components/manage/Contents/Contents
 msgid "Ascending"
-msgstr ""
+msgstr "Ascending"
 
 #: components/manage/Controlpanels/AddonsControlpanel
 msgid "Available"
-msgstr ""
+msgstr "Available"
 
 #: components/manage/Contents/Contents
 #: components/manage/Controlpanels/AddonsControlpanel
@@ -192,49 +192,49 @@ msgstr ""
 #: components/theme/ContactForm/ContactForm
 #: helpers/MessageLabels/MessageLabels
 msgid "Back"
-msgstr ""
+msgstr "Back"
 
 #: components/manage/Diff/Diff
 msgid "Base"
-msgstr ""
+msgstr "Base"
 
 #: components/manage/Sidebar/Sidebar
 msgid "Block"
-msgstr ""
+msgstr "Block"
 
 #: components/theme/Login/Login
 msgid "Both email address and password are case sensitive, check that caps lock is not enabled."
-msgstr ""
+msgstr "Both email address and password are case sensitive, check that caps lock is not enabled."
 
 #: components/theme/Breadcrumbs/Breadcrumbs
 msgid "Breadcrumbs"
-msgstr ""
+msgstr "Breadcrumbs"
 
 #: components/manage/Blocks/HeroImageLeft/Edit
 #: components/manage/Contents/ContentsUploadModal
 #: components/manage/Sidebar/ObjectBrowserNav
 msgid "Browse"
-msgstr ""
+msgstr "Browse"
 
 #: components/manage/Blocks/Image/Edit
 msgid "Browse the site, drop an image, or type an URL"
-msgstr ""
+msgstr "Browse the site, drop an image, or type an URL"
 
 #: components/manage/Sharing/Sharing
 msgid "By default, permissions from the container of this item are inherited. If you disable this, only the explicitly defined sharing permissions will be valid. In the overview, the symbol {inherited} indicates an inherited value. Similarly, the symbol {global} indicates a global role, which is managed by the site administrator."
-msgstr ""
+msgstr "By default, permissions from the container of this item are inherited. If you disable this, only the explicitly defined sharing permissions will be valid. In the overview, the symbol {inherited} indicates an inherited value. Similarly, the symbol {global} indicates a global role, which is managed by the site administrator."
 
 #: components/manage/Controlpanels/DatabaseInformation
 msgid "Cache Name"
-msgstr ""
+msgstr "Cache Name"
 
 #: components/manage/Controlpanels/ContentTypeLayout
 msgid "Can not edit Layout for <strong>{type}</strong> content-type as it doesn't have support for <strong>Volto Blocks</strong> enabled"
-msgstr ""
+msgstr "Can not edit Layout for <strong>{type}</strong> content-type as it doesn't have support for <strong>Volto Blocks</strong> enabled"
 
 #: components/manage/Controlpanels/ContentTypeLayout
 msgid "Can not edit Layout for <strong>{type}</strong> content-type as the <strong>Blocks behavior</strong> is enabled and <strong>read-only</strong>"
-msgstr ""
+msgstr "Can not edit Layout for <strong>{type}</strong> content-type as the <strong>Blocks behavior</strong> is enabled and <strong>read-only</strong>"
 
 #: components/manage/Add/Add
 #: components/manage/Contents/ContentsUploadModal
@@ -249,236 +249,236 @@ msgstr ""
 #: components/theme/Login/Login
 #: helpers/MessageLabels/MessageLabels
 msgid "Cancel"
-msgstr ""
+msgstr "Cancel"
 
 #: components/manage/Blocks/Table/Edit
 msgid "Cell"
-msgstr ""
+msgstr "Cell"
 
 #: components/manage/Blocks/Image/ImageSizeWidget
 #: components/manage/Blocks/Maps/Edit
 #: components/manage/Sidebar/AlignBlock
 msgid "Center"
-msgstr ""
+msgstr "Center"
 
 #: components/manage/History/History
 msgid "Change Note"
-msgstr ""
+msgstr "Change Note"
 
 #: components/manage/Preferences/ChangePassword
 msgid "Change Password"
-msgstr ""
+msgstr "Change Password"
 
 #: components/manage/Contents/ContentsWorkflowModal
 msgid "Change State"
-msgstr ""
+msgstr "Change State"
 
 #: components/manage/Contents/ContentsWorkflowModal
 msgid "Change workflow state recursively"
-msgstr ""
+msgstr "Change workflow state recursively"
 
 #: components/manage/Toolbar/More
 msgid "Changes applied."
-msgstr ""
+msgstr "Changes applied"
 
 #: components/manage/Preferences/ChangePassword
 #: components/manage/Preferences/PersonalInformation
 #: components/manage/Preferences/PersonalPreferences
 msgid "Changes saved"
-msgstr ""
+msgstr "Changes saved"
 
 #: components/manage/Controlpanels/ContentType
 #: components/manage/Controlpanels/ContentTypeLayout
 #: components/manage/Controlpanels/ContentTypeSchema
 #: components/manage/Controlpanels/Controlpanel
 msgid "Changes saved."
-msgstr ""
+msgstr "Changes saved."
 
 #: components/manage/Widgets/SchemaWidget
 msgid "Checkbox"
-msgstr ""
+msgstr "Checkbox"
 
 #: components/manage/Widgets/SelectWidget
 msgid "Choices"
-msgstr ""
+msgstr "Choices"
 
 #: components/manage/Sidebar/ObjectBrowserBody
 msgid "Choose Image"
-msgstr ""
+msgstr "Choose Image"
 
 #: components/manage/Sidebar/ObjectBrowserBody
 msgid "Choose Target"
-msgstr ""
+msgstr "Choose Target"
 
 #: components/manage/Widgets/FileWidget
 msgid "Choose a file"
-msgstr ""
+msgstr "Choose a file"
 
 #: components/manage/Blocks/HTML/Edit
 msgid "Clear"
-msgstr ""
+msgstr "Clear"
 
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"
-msgstr ""
+msgstr "Click to download full sized image"
 
 #: components/manage/Widgets/SelectWidget
 msgid "Close"
-msgstr ""
+msgstr "Close"
 
 #: components/theme/Navigation/Navigation
 msgid "Close menu"
-msgstr ""
+msgstr "Close menu"
 
 #: components/manage/Blocks/HTML/Edit
 msgid "Code"
-msgstr ""
+msgstr "Code"
 
 #: components/manage/Widgets/ObjectListWidget
 msgid "Collapse item"
-msgstr ""
+msgstr "Collapse item"
 
 #: components/manage/Toolbar/Toolbar
 msgid "Collection"
-msgstr ""
+msgstr "Collection"
 
 #: components/manage/Controlpanels/ModerateComments
 #: components/theme/Comments/CommentEditModal
 #: components/theme/Comments/Comments
 msgid "Comment"
-msgstr ""
+msgstr "Comment"
 
 #: components/manage/Controlpanels/ModerateComments
 msgid "Commenter"
-msgstr ""
+msgstr "Commenter"
 
 #: components/theme/Comments/Comments
 msgid "Comments"
-msgstr ""
+msgstr "Comments"
 
 #: components/manage/Diff/Diff
 msgid "Compare"
-msgstr ""
+msgstr "Compare"
 
 #: components/manage/Preferences/ChangePassword
 #: components/theme/PasswordReset/PasswordReset
 msgid "Confirm password"
-msgstr ""
+msgstr "Confirm password"
 
 #: components/theme/ConnectionRefused/ConnectionRefused
 msgid "Connection refused"
-msgstr ""
+msgstr "Connection refused"
 
 #: components/theme/Footer/Footer
 msgid "Contact"
-msgstr ""
+msgstr "Contact"
 
 #: components/theme/ContactForm/ContactForm
 msgid "Contact form"
-msgstr ""
+msgstr "Contact form"
 
 #: components/manage/Blocks/Listing/Edit
 msgid "Contained items"
-msgstr ""
+msgstr "Contained items"
 
 #: components/manage/Controlpanels/ContentTypes
 msgid "Content type created"
-msgstr ""
+msgstr "Content type created"
 
 #: components/manage/Controlpanels/ContentTypes
 msgid "Content type deleted"
-msgstr ""
+msgstr "Content type deleted"
 
 #: components/manage/Contents/Contents
 #: components/manage/Toolbar/Toolbar
 msgid "Contents"
-msgstr ""
+msgstr "Contents"
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsItem
 msgid "Copy"
-msgstr ""
+msgstr "Copy"
 
 #: helpers/MessageLabels/MessageLabels
 msgid "Copy blocks"
-msgstr ""
+msgstr "undefined"
 
 #: components/theme/Footer/Footer
 msgid "Copyright"
-msgstr ""
+msgstr "Copyright"
 
 #: components/manage/Contents/ContentsPropertiesModal
 msgid "Copyright statement or other rights information on this item."
-msgstr ""
+msgstr "Copyright statement or other rights information on this item."
 
 #: components/manage/Toolbar/More
 msgid "Create working copy"
-msgstr ""
+msgstr "Create working copy"
 
 #: components/manage/WorkingCopyToastsFactory/WorkingCopyToastsFactory
 msgid "Created by {creator} on {date}"
-msgstr ""
+msgstr "Created by {creator} on {date}"
 
 #: components/manage/Contents/Contents
 msgid "Created on"
-msgstr ""
+msgstr "Created on"
 
 #: components/manage/Contents/Contents
 msgid "Creator"
-msgstr ""
+msgstr "Creator"
 
 #: components/manage/Contents/ContentsPropertiesModal
 msgid "Creators"
-msgstr ""
+msgstr "Creators"
 
 #: components/manage/Widgets/QuerystringWidget
 #: components/manage/Widgets/QueryWidget
 msgid "Criteria"
-msgstr ""
+msgstr "Criteria"
 
 #: components/manage/Preferences/ChangePassword
 msgid "Current password"
-msgstr ""
+msgstr "Current password"
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsItem
 msgid "Cut"
-msgstr ""
+msgstr "Cut"
 
 #: helpers/MessageLabels/MessageLabels
 msgid "Cut blocks"
-msgstr ""
+msgstr "undefined"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
 msgid "Daily"
-msgstr ""
+msgstr "Daily"
 
 #: components/manage/Controlpanels/DatabaseInformation
 msgid "Database Information"
-msgstr ""
+msgstr "Database Information"
 
 #: components/manage/Controlpanels/DatabaseInformation
 msgid "Database Location"
-msgstr ""
+msgstr "Database Location"
 
 #: components/manage/Controlpanels/DatabaseInformation
 msgid "Database Size"
-msgstr ""
+msgstr "Database Size"
 
 #: components/manage/Controlpanels/DatabaseInformation
 msgid "Database main"
-msgstr ""
+msgstr "Database main"
 
 #: components/manage/Controlpanels/ModerateComments
 #: components/manage/Widgets/DatetimeWidget
 msgid "Date"
-msgstr ""
+msgstr "Date"
 
 #: components/theme/Search/Search
 msgid "Date (newest first)"
-msgstr ""
+msgstr "Date (newest first)"
 
 #: components/manage/Contents/ContentsPropertiesModal
 #: components/manage/Contents/ContentsRenameModal
@@ -497,7 +497,7 @@ msgstr ""
 #: components/theme/PasswordReset/RequestPasswordReset
 #: components/theme/Register/Register
 msgid "Default"
-msgstr ""
+msgstr "Default"
 
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsItem
@@ -511,39 +511,39 @@ msgstr ""
 #: components/manage/Widgets/WysiwygWidget
 #: components/theme/Comments/Comments
 msgid "Delete"
-msgstr ""
+msgstr "Delete"
 
 #: helpers/MessageLabels/MessageLabels
 msgid "Delete Group"
-msgstr ""
+msgstr "Delete Group"
 
 #: components/manage/Controlpanels/ContentTypes
 msgid "Delete Type"
-msgstr ""
+msgstr "Delete Type"
 
 #: helpers/MessageLabels/MessageLabels
 msgid "Delete User"
-msgstr ""
+msgstr "Delete User"
 
 #: helpers/MessageLabels/MessageLabels
 msgid "Delete blocks"
-msgstr ""
+msgstr "undefined"
 
 #: components/manage/Blocks/Table/Edit
 msgid "Delete col"
-msgstr ""
+msgstr "Delete col"
 
 #: components/manage/Blocks/Table/Edit
 msgid "Delete row"
-msgstr ""
+msgstr "Delete row"
 
 #: components/manage/Widgets/QuerystringWidget
 msgid "Depth"
-msgstr ""
+msgstr "Depth"
 
 #: components/manage/Contents/Contents
 msgid "Descending"
-msgstr ""
+msgstr "Descending"
 
 #: components/manage/Blocks/HeroImageLeft/Edit
 #: components/manage/Controlpanels/ContentTypes
@@ -553,73 +553,73 @@ msgstr ""
 #: components/theme/View/TabularView
 #: helpers/MessageLabels/MessageLabels
 msgid "Description"
-msgstr ""
+msgstr "Description"
 
 #: components/manage/Diff/Diff
 msgid "Diff"
-msgstr ""
+msgstr "Diff"
 
 #: components/manage/Diff/Diff
 msgid "Difference between revision {one} and {two} of {title}"
-msgstr ""
+msgstr "Difference between revision {one} and {two} of {title}"
 
 #: components/theme/Footer/Footer
 msgid "Distributed under the {license}."
-msgstr ""
+msgstr "Distributed under the {license}."
 
 #: components/manage/Blocks/Table/Edit
 msgid "Divide each row into separate cells"
-msgstr ""
+msgstr "Add border to inner columns"
 
 #: components/manage/Contents/Contents
 msgid "Do you really want to delete the following items?"
-msgstr ""
+msgstr "Do you really want to delete the following items?"
 
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 msgid "Do you really want to delete the group {groupname}?"
-msgstr ""
+msgstr "Do you really want to delete the group {groupname}?"
 
 #: components/manage/Controlpanels/ContentTypes
 msgid "Do you really want to delete the type {typename}?"
-msgstr ""
+msgstr "Do you really want to delete type {typename}?"
 
 #: components/manage/Controlpanels/Users/UsersControlpanel
 msgid "Do you really want to delete the user {username}?"
-msgstr ""
+msgstr "Do you really want to delete the user {username}?"
 
 #: components/manage/Delete/Delete
 msgid "Do you really want to delete this item?"
-msgstr ""
+msgstr "Do you really want to delete this item?"
 
 #: components/manage/Multilingual/TranslationObject
 #: components/manage/Sidebar/Sidebar
 msgid "Document"
-msgstr ""
+msgstr "Document"
 
 #: components/manage/Contents/ContentsUploadModal
 msgid "Drag and drop files from your computer onto this area or click the “Browse” button."
-msgstr ""
+msgstr "Drag and drop files from your computer onto this area or click the “Browse” button."
 
 #: components/manage/Widgets/FileWidget
 msgid "Drop file here to replace the existing file"
-msgstr ""
+msgstr "Drop file here to replace the existing file"
 
 #: components/manage/Widgets/FileWidget
 msgid "Drop file here to upload a new file"
-msgstr ""
+msgstr "Drop file here to upload a new file"
 
 #: components/manage/Widgets/FileWidget
 msgid "Drop files here ..."
-msgstr ""
+msgstr "Drop files here ..."
 
 #: components/manage/Preferences/PersonalInformation
 #: components/theme/Register/Register
 msgid "E-mail"
-msgstr ""
+msgstr "E-mail"
 
 #: components/theme/PasswordReset/PasswordReset
 msgid "E-mail addresses do not match."
-msgstr ""
+msgstr "E-mail addresses do not match."
 
 #: components/manage/Contents/ContentsItem
 #: components/manage/Controlpanels/ContentTypesActions
@@ -629,94 +629,94 @@ msgstr ""
 #: components/manage/Widgets/ObjectBrowserWidget
 #: components/theme/Comments/Comments
 msgid "Edit"
-msgstr ""
+msgstr "Edit"
 
 #: components/theme/Comments/CommentEditModal
 msgid "Edit comment"
-msgstr ""
+msgstr "Edit comment"
 
 #: components/manage/Widgets/SchemaWidget
 msgid "Edit field"
-msgstr ""
+msgstr "Edit field"
 
 #: components/manage/Widgets/SchemaWidget
 msgid "Edit fieldset"
-msgstr ""
+msgstr "Edit fieldset"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
 msgid "Edit recurrence"
-msgstr ""
+msgstr "Edit recurrence"
 
 #: components/manage/Form/InlineForm
 msgid "Edit values"
-msgstr ""
+msgstr "Edit values"
 
 #: components/manage/Edit/Edit
 msgid "Edit {title}"
-msgstr ""
+msgstr "Edit {title}"
 
 #: helpers/MessageLabels/MessageLabels
 msgid "Email"
-msgstr ""
+msgstr "Email"
 
 #: components/theme/ContactForm/ContactForm
 msgid "Email sent"
-msgstr ""
+msgstr "Email sent"
 
 #: components/manage/Blocks/Maps/Edit
 msgid "Embed code error, please follow the instructions and try again."
-msgstr ""
+msgstr "Embed code error, please follow the instructions and try again."
 
 #: components/manage/Blocks/Maps/View
 msgid "Embeded Google Maps"
-msgstr ""
+msgstr "Embeded Google Maps"
 
 #: components/manage/Widgets/ObjectListWidget
 msgid "Empty object list"
-msgstr ""
+msgstr "Empty object list"
 
 #: components/manage/Controlpanels/ContentTypeLayout
 msgid "Enable editable Blocks"
-msgstr ""
+msgstr "Enable editable Blocks"
 
 #: components/manage/Contents/Contents
 msgid "End Date"
-msgstr ""
+msgstr "End Date"
 
 #: components/manage/AnchorPlugin/components/LinkButton/AddLinkForm
 msgid "Enter URL or select an item"
-msgstr ""
+msgstr "Enter URL or select an item"
 
 #: helpers/MessageLabels/MessageLabels
 msgid "Enter a username above to search or click 'Show All'"
-msgstr ""
+msgstr "Enter a username above to search or click 'Show All'"
 
 #: components/theme/Register/Register
 msgid "Enter an email address. This will be your login name. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
-msgstr ""
+msgstr "Enter an email address. This will be your login name. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 
 #: components/manage/Preferences/PersonalInformation
 #: components/theme/PasswordReset/PasswordReset
 #: components/theme/Register/Register
 msgid "Enter full name, e.g. John Smith."
-msgstr ""
+msgstr "Enter full name, e.g. John Smith."
 
 #: components/manage/Blocks/Maps/Edit
 msgid "Enter map Embed Code"
-msgstr ""
+msgstr "Enter map Embed Code"
 
 #: components/manage/Preferences/ChangePassword
 msgid "Enter your current password."
-msgstr ""
+msgstr "Enter your current password."
 
 #: components/theme/PasswordReset/PasswordReset
 msgid "Enter your email address for verification."
-msgstr ""
+msgstr "Enter your email address for verification."
 
 #: components/manage/Preferences/ChangePassword
 #: components/theme/PasswordReset/PasswordReset
 msgid "Enter your new password. Minimum 5 characters."
-msgstr ""
+msgstr "Enter your new password. Minimum 5 characters."
 
 #: components/manage/Add/Add
 #: components/manage/Controlpanels/ContentTypeSchema
@@ -727,343 +727,343 @@ msgstr ""
 #: components/theme/Login/Login
 #: helpers/MessageLabels/MessageLabels
 msgid "Error"
-msgstr ""
+msgstr "Error"
 
 #: components/manage/Contents/ContentsPropertiesModal
 msgid "Exclude from navigation"
-msgstr ""
+msgstr "Exclude from navigation"
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
 msgid "Exclude this occurence"
-msgstr ""
+msgstr "Exclude this occurence"
 
 #: components/manage/Contents/Contents
 msgid "Excluded from navigation"
-msgstr ""
+msgstr "Excluded from navigation"
 
 #: components/manage/Sidebar/Sidebar
 msgid "Expand sidebar"
-msgstr ""
+msgstr "Expand sidebar"
 
 #: components/manage/Contents/ContentsPropertiesModal
 msgid "Expiration Date"
-msgstr ""
+msgstr "Expiration Date"
 
 #: components/manage/Contents/Contents
 msgid "Expiration date"
-msgstr ""
+msgstr "Expiration date"
 
 #: components/manage/Contents/ContentsItem
 msgid "Expired"
-msgstr ""
+msgstr "Expired"
 
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
 msgid "External URL"
-msgstr ""
+msgstr "External URL"
 
 #: components/manage/Toolbar/Toolbar
 msgid "File"
-msgstr ""
+msgstr "File"
 
 #: components/manage/Contents/ContentsUploadModal
 msgid "File size"
-msgstr ""
+msgstr "File size"
 
 #: components/manage/Contents/ContentsUploadModal
 msgid "Filename"
-msgstr ""
+msgstr "Filename"
 
 #: components/manage/Contents/Contents
 msgid "Filter…"
-msgstr ""
+msgstr "Filter…"
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
 msgid "First"
-msgstr ""
+msgstr "First"
 
 #: components/manage/Blocks/Table/Edit
 msgid "Fixed width table cells"
-msgstr ""
+msgstr "Fixed width columns"
 
 #: components/manage/BlockChooser/BlockChooser
 msgid "Fold"
-msgstr ""
+msgstr "Fold"
 
 #: components/manage/Contents/Contents
 msgid "Folder"
-msgstr ""
+msgstr "Folder"
 
 #: components/theme/Forbidden/Forbidden
 msgid "Forbidden"
-msgstr ""
+msgstr "Forbidden"
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
 msgid "Fourth"
-msgstr ""
+msgstr "Fourth"
 
 #: components/theme/ContactForm/ContactForm
 msgid "From"
-msgstr ""
+msgstr "From"
 
 #: components/manage/Blocks/Maps/Edit
 #: components/manage/Sidebar/AlignBlock
 msgid "Full"
-msgstr ""
+msgstr "Full"
 
 #: components/manage/Preferences/PersonalInformation
 #: components/theme/PasswordReset/PasswordReset
 #: components/theme/Register/Register
 msgid "Full Name"
-msgstr ""
+msgstr "Full Name"
 
 #: helpers/MessageLabels/MessageLabels
 msgid "Fullname"
-msgstr ""
+msgstr "Fullname"
 
 #: components/theme/Footer/Footer
 msgid "GNU GPL license"
-msgstr ""
+msgstr "GNU GPL license"
 
 #: components/manage/Sharing/Sharing
 msgid "Global role"
-msgstr ""
+msgstr "Global role"
 
 #: components/manage/Blocks/Maps/Edit
 msgid "Google Maps Embedded Block"
-msgstr ""
+msgstr "Google Maps Embedded Block"
 
 #: components/manage/Sharing/Sharing
 msgid "Group"
-msgstr ""
+msgstr "Group"
 
 #: helpers/MessageLabels/MessageLabels
 msgid "Group created"
-msgstr ""
+msgstr "Group created"
 
 #: helpers/MessageLabels/MessageLabels
 msgid "Group roles updated"
-msgstr ""
+msgstr "Group roles updated"
 
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: helpers/MessageLabels/MessageLabels
 msgid "Groupname"
-msgstr ""
+msgstr "Groupname"
 
 #: components/manage/Controlpanels/Controlpanels
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: helpers/MessageLabels/MessageLabels
 msgid "Groups"
-msgstr ""
+msgstr "Groups"
 
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 msgid "Groups are logical collections of users, such as departments and business units. Groups are not directly related to permissions on a global level, you normally use Roles for that - and let certain Groups have a particular role. The symbol{plone_svg}indicates a role inherited from membership in another group."
-msgstr ""
+msgstr "Groups are logical collections of users, such as departments and business units. Groups are not directly related to permissions on a global level, you normally use Roles for that - and let certain Groups have a particular role. The symbol{plone_svg}indicates a role inherited from membership in another group."
 
 #: components/manage/Blocks/Table/Edit
 msgid "Header cell"
-msgstr ""
+msgstr "Header cell"
 
 #: components/theme/Comments/Comments
 msgid "Hide Replies"
-msgstr ""
+msgstr "Hide Replies"
 
 #: components/manage/History/History
 #: components/manage/Toolbar/More
 msgid "History"
-msgstr ""
+msgstr "History"
 
 #: components/manage/History/History
 msgid "History Version Number"
-msgstr ""
+msgstr "#"
 
 #: components/manage/History/History
 msgid "History of {title}"
-msgstr ""
+msgstr "History of {title}"
 
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsBreadcrumbs
 #: components/theme/Breadcrumbs/Breadcrumbs
 msgid "Home"
-msgstr ""
+msgstr "Home"
 
 #: components/manage/Preferences/PersonalInformation
 msgid "Home page"
-msgstr ""
+msgstr "Home page"
 
 #: components/manage/Contents/Contents
 msgid "ID"
-msgstr ""
+msgstr "ID"
 
 #: components/manage/Contents/ContentsPropertiesModal
 msgid "If selected, this item will not appear in the navigation tree"
-msgstr ""
+msgstr "If selected, this item will not appear in the navigation tree"
 
 #: components/manage/Contents/ContentsPropertiesModal
 msgid "If this date is in the future, the content will not show up in listings and searches until this date."
-msgstr ""
+msgstr "If this date is in the future, the content will not show up in listings and searches until this date."
 
 #: components/manage/LockingToastsFactory/LockingToastsFactory
 msgid "If you are certain this user has abandoned the object, you may unlock the object. You will then be able to edit it."
-msgstr ""
+msgstr "If you are certain this user has abandoned the object, you may unlock the object. You will then be able to edit it."
 
 #: components/theme/NotFound/NotFound
 #: components/theme/Unauthorized/Unauthorized
 msgid "If you are certain you have the correct web address but are encountering an error, please contact the {site_admin}."
-msgstr ""
+msgstr "If you are certain you have the correct web address but are encountering an error, please contact the {site_admin}."
 
 #: components/manage/Blocks/HeroImageLeft/Edit
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
 msgid "Image"
-msgstr ""
+msgstr "Image"
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
 msgid "Include this occurence"
-msgstr ""
+msgstr "Include this occurence"
 
 #: components/manage/Controlpanels/ContentType
 #: components/manage/Controlpanels/ContentTypeLayout
 #: components/manage/Controlpanels/ContentTypeSchema
 #: components/manage/Controlpanels/Controlpanel
 msgid "Info"
-msgstr ""
+msgstr "Info"
 
 #: components/manage/Sharing/Sharing
 msgid "Inherit permissions from higher levels"
-msgstr ""
+msgstr "Inherit permissions from higher levels"
 
 #: components/manage/Sharing/Sharing
 msgid "Inherited value"
-msgstr ""
+msgstr "Inherited value"
 
 #: components/manage/Blocks/Table/Edit
 msgid "Insert col after"
-msgstr ""
+msgstr "Insert col after"
 
 #: components/manage/Blocks/Table/Edit
 msgid "Insert col before"
-msgstr ""
+msgstr "Insert col before"
 
 #: components/manage/Blocks/Table/Edit
 msgid "Insert row after"
-msgstr ""
+msgstr "Insert row after"
 
 #: components/manage/Blocks/Table/Edit
 msgid "Insert row before"
-msgstr ""
+msgstr "Insert row before"
 
 #: components/manage/Controlpanels/AddonsControlpanel
 msgid "Install"
-msgstr ""
+msgstr "Install"
 
 #: components/manage/Controlpanels/AddonsControlpanel
 msgid "Installed"
-msgstr ""
+msgstr "Installed"
 
 #: components/manage/Controlpanels/AddonsControlpanel
 msgid "Installed version"
-msgstr ""
+msgstr "Installed version"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
 msgid "Interval Daily"
-msgstr ""
+msgstr "days"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
 msgid "Interval Monthly"
-msgstr ""
+msgstr "Month(s)"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
 msgid "Interval Weekly"
-msgstr ""
+msgstr "week(s)"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
 msgid "Interval Yearly"
-msgstr ""
+msgstr "year(s)"
 
 #: components/manage/Widgets/QuerystringWidget
 msgid "Item batch size"
-msgstr ""
+msgstr "Item batch size"
 
 #: components/manage/Contents/Contents
 msgid "Item succesfully moved."
-msgstr ""
+msgstr "Item succesfully moved."
 
 #: components/manage/Contents/Contents
 msgid "Item(s) copied."
-msgstr ""
+msgstr "Item(s) copied."
 
 #: components/manage/Contents/Contents
 msgid "Item(s) cut."
-msgstr ""
+msgstr "Item(s) cut."
 
 #: components/manage/Contents/Contents
 msgid "Item(s) has been updated."
-msgstr ""
+msgstr "Item(s) has been updated."
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
 msgid "Item(s) pasted."
-msgstr ""
+msgstr "Item(s) pasted."
 
 #: components/manage/Contents/Contents
 msgid "Item(s) state has been updated."
-msgstr ""
+msgstr "Item(s) state has been updated."
 
 #: components/manage/Controlpanels/ContentTypes
 msgid "Items"
-msgstr ""
+msgstr "Items"
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
 msgid "Items must be unique."
-msgstr ""
+msgstr "Items must be unique."
 
 #: components/manage/Preferences/PersonalPreferences
 msgid "Language"
-msgstr ""
+msgstr "Language"
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
 msgid "Last"
-msgstr ""
+msgstr "Last"
 
 #: components/manage/Contents/Contents
 msgid "Last comment date"
-msgstr ""
+msgstr "Last comment date"
 
 #: components/manage/Contents/ContentsUploadModal
 msgid "Last modified"
-msgstr ""
+msgstr "Last modified"
 
 #: components/manage/Controlpanels/AddonsControlpanel
 msgid "Latest version"
-msgstr ""
+msgstr "Latest version"
 
 #: components/manage/Controlpanels/ContentTypesActions
 msgid "Layout"
-msgstr ""
+msgstr "Layout"
 
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
 msgid "Lead Image"
-msgstr ""
+msgstr "Lead Image"
 
 #: components/manage/Blocks/Image/ImageSizeWidget
 #: components/manage/Blocks/Maps/Edit
 #: components/manage/Sidebar/AlignBlock
 msgid "Left"
-msgstr ""
+msgstr "Left"
 
 #: components/manage/Toolbar/Toolbar
 msgid "Link"
-msgstr ""
+msgstr "Link"
 
 #: components/manage/Blocks/Listing/schema
 msgid "Link more"
-msgstr ""
+msgstr "Link more"
 
 #: components/manage/Blocks/Listing/schema
 msgid "Link title"
-msgstr ""
+msgstr "Link Title"
 
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
@@ -1071,555 +1071,555 @@ msgstr ""
 #: components/manage/Blocks/Maps/MapsSidebar
 #: components/manage/Blocks/Video/VideoSidebar
 msgid "Link to"
-msgstr ""
+msgstr "Link to"
 
 #: components/manage/Multilingual/ManageTranslations
 msgid "Link translation for"
-msgstr ""
+msgstr "Link translation for"
 
 #: components/manage/Blocks/Listing/schema
 msgid "Listing"
-msgstr ""
+msgstr "Listing"
 
 #: components/theme/Comments/Comments
 msgid "Load more"
-msgstr ""
+msgstr "Load more..."
 
 #: components/manage/Form/ModalForm
 msgid "Loading"
-msgstr ""
+msgstr "Loading."
 
 #: components/manage/Preferences/PersonalInformation
 msgid "Location"
-msgstr ""
+msgstr "Location"
 
 #: components/theme/Login/Login
 msgid "Log In"
-msgstr ""
+msgstr "Login"
 
 #: components/theme/Anontools/Anontools
 #: components/theme/Login/Login
 msgid "Log in"
-msgstr ""
+msgstr "Log in"
 
 #: components/theme/Login/Login
 msgid "Login"
-msgstr ""
+msgstr "Login"
 
 #: components/theme/Login/Login
 msgid "Login Failed"
-msgstr ""
+msgstr "Login Failed"
 
 #: components/theme/Login/Login
 msgid "Login Name"
-msgstr ""
+msgstr "Login Name"
 
 #: components/manage/Toolbar/PersonalTools
 msgid "Logout"
-msgstr ""
+msgstr "Logout"
 
 #: components/manage/Toolbar/More
 msgid "Made by {creator} on {date}. This is not a working copy anymore, but the main content."
-msgstr ""
+msgstr "Made by {creator} on {date}. This is not a working copy anymore, but the main content."
 
 #: components/manage/Blocks/Table/Edit
 msgid "Make the table compact"
-msgstr ""
+msgstr "Reduce cell padding"
 
 #: components/manage/Multilingual/ManageTranslations
 #: components/manage/Toolbar/More
 msgid "Manage Translations"
-msgstr ""
+msgstr "Manage Translations"
 
 #: components/manage/Multilingual/ManageTranslations
 msgid "Manage translations for {title}"
-msgstr ""
+msgstr "Manage translations for {title}"
 
 #: components/manage/Blocks/Maps/MapsSidebar
 msgid "Map"
-msgstr ""
+msgstr "Map"
 
 #: components/manage/Blocks/Maps/MapsSidebar
 msgid "Maps URL"
-msgstr ""
+msgstr "Maps URL"
 
 #: helpers/MessageLabels/MessageLabels
 msgid "Maximum length is {len}."
-msgstr ""
+msgstr "Maximum length is {len}."
 
 #: helpers/MessageLabels/MessageLabels
 msgid "Maximum value is {len}."
-msgstr ""
+msgstr "Maximum value is {len}."
 
 #: components/theme/ContactForm/ContactForm
 msgid "Message"
-msgstr ""
+msgstr "Message"
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
 msgid "Minimum length is {len}."
-msgstr ""
+msgstr "Minimum length is {len}."
 
 #: helpers/MessageLabels/MessageLabels
 msgid "Minimum value is {len}."
-msgstr ""
+msgstr "Minimum value is {len}."
 
 #: components/manage/Controlpanels/Controlpanels
 msgid "Moderate Comments"
-msgstr ""
+msgstr "Moderate Comments"
 
 #: components/manage/Controlpanels/ModerateComments
 msgid "Moderate comments"
-msgstr ""
+msgstr "Moderate comments"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
 msgid "Monday and Friday"
-msgstr ""
+msgstr "Monday and Friday"
 
 #: components/manage/Widgets/RecurrenceWidget/ByMonthDayField
 msgid "Month day"
-msgstr ""
+msgstr "Day"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
 msgid "Monthly"
-msgstr ""
+msgstr "Monthly"
 
 #: components/manage/Toolbar/Toolbar
 msgid "More"
-msgstr ""
+msgstr "More"
 
 #: components/manage/Contents/ContentsItem
 msgid "Move to bottom of folder"
-msgstr ""
+msgstr "Move to bottom of folder"
 
 #: components/manage/Contents/ContentsItem
 msgid "Move to top of folder"
-msgstr ""
+msgstr "Move to top of folder"
 
 #: components/theme/PasswordReset/PasswordReset
 msgid "My email address is"
-msgstr ""
+msgstr "My email address is"
 
 #: components/manage/Sharing/Sharing
 #: components/theme/ContactForm/ContactForm
 msgid "Name"
-msgstr ""
+msgstr "Name"
 
 #: error
 msgid "Navigate back"
-msgstr ""
+msgstr "Navigate back"
 
 #: components/theme/Navigation/ContextNavigation
 msgid "Navigation"
-msgstr ""
+msgstr "Navigation"
 
 #: components/manage/Preferences/ChangePassword
 #: components/theme/PasswordReset/PasswordReset
 msgid "New password"
-msgstr ""
+msgstr "New password"
 
 #: components/manage/Toolbar/Toolbar
 msgid "News Item"
-msgstr ""
+msgstr "News Item"
 
 #: components/manage/Contents/ContentsItem
 #: components/manage/Controlpanels/ContentTypes
 msgid "No"
-msgstr ""
+msgstr "No"
 
 #: components/manage/Blocks/Image/ImageSidebar
 msgid "No image selected"
-msgstr ""
+msgstr "No image selected"
 
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
 msgid "No image set in Lead Image content field"
-msgstr ""
+msgstr "No image set in Lead Image content field"
 
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
 msgid "No image set in image content field"
-msgstr ""
+msgstr "No image set in image content field"
 
 #: components/manage/Blocks/Listing/ListingBody
 msgid "No items found in this container."
-msgstr ""
+msgstr "No items found in this container."
 
 #: components/manage/Widgets/ObjectBrowserWidget
 msgid "No items selected"
-msgstr ""
+msgstr "No items selected"
 
 #: components/manage/Blocks/Maps/MapsSidebar
 msgid "No map selected"
-msgstr ""
+msgstr "No map selected"
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
 msgid "No occurences set"
-msgstr ""
+msgstr "No occurences set"
 
 #: components/manage/Widgets/ArrayWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/TokenWidget
 msgid "No options"
-msgstr ""
+msgstr "No options"
 
 #: components/theme/Search/Search
 msgid "No results found"
-msgstr ""
+msgstr "No results found"
 
 #: components/manage/Blocks/Listing/ListingBody
 #: components/manage/Widgets/ReferenceWidget
 msgid "No results found."
-msgstr ""
+msgstr "No results found."
 
 #: components/manage/Widgets/QuerySortOnWidget
 #: components/manage/Widgets/QuerystringWidget
 msgid "No selection"
-msgstr ""
+msgstr "No selection"
 
 #: components/manage/Controlpanels/AddonsControlpanel
 msgid "No uninstall profile"
-msgstr ""
+msgstr "This addon does not provide an uninstall profile."
 
 #: components/manage/Widgets/ArrayWidget
 #: components/manage/Widgets/ReferenceWidget
 #: components/manage/Widgets/SelectUtils
 #: components/manage/Widgets/SelectWidget
 msgid "No value"
-msgstr ""
+msgstr "No value"
 
 #: components/manage/Blocks/Video/VideoSidebar
 msgid "No video selected"
-msgstr ""
+msgstr "No video selected"
 
 #: components/manage/Workflow/Workflow
 msgid "No workflow"
-msgstr ""
+msgstr "No workflow"
 
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsItem
 msgid "None"
-msgstr ""
+msgstr "None"
 
 #: components/manage/Controlpanels/Users/UsersControlpanel
 msgid "Note that roles set here apply directly to a user. The symbol{plone_svg}indicates a role inherited from membership in a group."
-msgstr ""
+msgstr "Note that roles set here apply directly to a user. The symbol{plone_svg}indicates a role inherited from membership in a group."
 
 #: components/manage/Controlpanels/DatabaseInformation
 msgid "Number of active objects"
-msgstr ""
+msgstr "Number of active objects"
 
 #: components/manage/Contents/Contents
 msgid "Object Size"
-msgstr ""
+msgstr "Object Size"
 
 #: components/manage/Widgets/RecurrenceWidget/EndField
 msgid "Occurences"
-msgstr ""
+msgstr "occurrence(s)"
 
 #: components/manage/Delete/Delete
 msgid "Ok"
-msgstr ""
+msgstr "Ok"
 
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
 #: components/manage/Blocks/Maps/MapsSidebar
 #: components/manage/Blocks/Video/VideoSidebar
 msgid "Open in a new tab"
-msgstr ""
+msgstr "Open in a new tab"
 
 #: components/theme/Navigation/Navigation
 msgid "Open menu"
-msgstr ""
+msgstr "Open menu"
 
 #: components/manage/Widgets/ObjectBrowserWidget
 msgid "Open object browser"
-msgstr ""
+msgstr "Open object browser"
 
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
 msgid "Origin"
-msgstr ""
+msgstr "Origin"
 
 #: components/manage/Toolbar/Toolbar
 msgid "Page"
-msgstr ""
+msgstr "Page"
 
 #: components/manage/Widgets/SchemaWidget
 msgid "Parent fieldset"
-msgstr ""
+msgstr "Parent fieldset"
 
 #: components/theme/Login/Login
 #: helpers/MessageLabels/MessageLabels
 msgid "Password"
-msgstr ""
+msgstr "Password"
 
 #: components/theme/PasswordReset/PasswordReset
 #: components/theme/PasswordReset/RequestPasswordReset
 msgid "Password reset"
-msgstr ""
+msgstr "Password reset"
 
 #: components/theme/PasswordReset/PasswordReset
 msgid "Passwords do not match."
-msgstr ""
+msgstr "Passwords do not match."
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
 msgid "Paste"
-msgstr ""
+msgstr "Paste"
 
 #: helpers/MessageLabels/MessageLabels
 msgid "Paste blocks"
-msgstr ""
+msgstr "undefined"
 
 #: components/manage/Sharing/Sharing
 msgid "Permissions have been updated successfully"
-msgstr ""
+msgstr "Permissions have been updated successfully"
 
 #: components/manage/Sharing/Sharing
 msgid "Permissions updated"
-msgstr ""
+msgstr "Permissions updated"
 
 #: components/manage/Preferences/PersonalInformation
 #: components/manage/Toolbar/Toolbar
 msgid "Personal Information"
-msgstr ""
+msgstr "Personal Information"
 
 #: components/manage/Preferences/PersonalPreferences
 #: components/manage/Toolbar/Toolbar
 msgid "Personal Preferences"
-msgstr ""
+msgstr "Personal Preferences"
 
 #: components/manage/Toolbar/More
 #: components/manage/Toolbar/Toolbar
 msgid "Personal tools"
-msgstr ""
+msgstr "Personal tools"
 
 #: components/manage/Contents/ContentsPropertiesModal
 msgid "Persons responsible for creating the content of this item. Please enter a list of user names, one per line. The principal creator should come first."
-msgstr ""
+msgstr "Persons responsible for creating the content of this item. Please enter a list of user names, one per line. The principal creator should come first."
 
 #: components/manage/Blocks/Video/Edit
 msgid "Please enter a valid URL by deleting the block and adding a new video block."
-msgstr ""
+msgstr "Please enter a valid URL by deleting the block and adding a new video block."
 
 #: components/manage/Blocks/Maps/Edit
 msgid "Please enter the Embed Code provided by Google Maps -> Share -> Embed map. It should contain the <iframe> code on it."
-msgstr ""
+msgstr "Please enter the Embed Code provided by Google Maps -> Share -> Embed map. It should contain the <iframe> code on it."
 
 #: components/theme/PasswordReset/PasswordReset
 msgid "Please fill out the form below to set your password."
-msgstr ""
+msgstr "Please fill out the form below to set your password."
 
 #: components/theme/Footer/Footer
 msgid "Plone Foundation"
-msgstr ""
+msgstr "Plone Foundation"
 
 #: components/theme/Logo/Logo
 msgid "Plone Site"
-msgstr ""
+msgstr "Plone Site"
 
 #: components/theme/Footer/Footer
 msgid "Plone{reg} Open Source CMS/WCM"
-msgstr ""
+msgstr "Plone{reg} Open Source CMS/WCM"
 
 #: components/manage/Preferences/PersonalInformation
 msgid "Portrait"
-msgstr ""
+msgstr "Portrait"
 
 #: components/manage/Widgets/SchemaWidget
 msgid "Possible values"
-msgstr ""
+msgstr "Possible values (Enter allowed choices one per line)."
 
 #: components/theme/Footer/Footer
 msgid "Powered by Plone & Python"
-msgstr ""
+msgstr "Powered by Plone & Python"
 
 #: components/manage/Toolbar/PersonalTools
 msgid "Preferences"
-msgstr ""
+msgstr "Preferences"
 
 #: components/manage/Blocks/HTML/Edit
 msgid "Prettify your code"
-msgstr ""
+msgstr "Prettify your code"
 
 #: components/manage/Blocks/HTML/Edit
 #: components/manage/Contents/ContentsUploadModal
 msgid "Preview"
-msgstr ""
+msgstr "Preview"
 
 #: components/manage/Blocks/Video/VideoSidebar
 msgid "Preview Image URL"
-msgstr ""
+msgstr "Preview Image URL"
 
 #: components/manage/Toolbar/PersonalTools
 msgid "Profile"
-msgstr ""
+msgstr "Profile"
 
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsPropertiesModal
 msgid "Properties"
-msgstr ""
+msgstr "Properties"
 
 #: components/manage/Contents/Contents
 msgid "Publication date"
-msgstr ""
+msgstr "Publication date"
 
 #: components/manage/Contents/ContentsPropertiesModal
 msgid "Publishing Date"
-msgstr ""
+msgstr "Publishing Date"
 
 #: components/manage/Blocks/Listing/schema
 msgid "Query"
-msgstr ""
+msgstr "Query"
 
 #: components/manage/Preferences/ChangePassword
 #: components/theme/PasswordReset/PasswordReset
 msgid "Re-enter the password. Make sure the passwords are identical."
-msgstr ""
+msgstr "Re-enter the password. Make sure the passwords are identical."
 
 #: components/theme/Search/Search
 #: components/theme/View/SummaryView
 msgid "Read More…"
-msgstr ""
+msgstr "Read More…"
 
 #: components/manage/Contents/Contents
 msgid "Rearrange items by…"
-msgstr ""
+msgstr "Rearrange items by…"
 
 #: components/manage/Widgets/RecurrenceWidget/EndField
 msgid "Recurrence ends"
-msgstr ""
+msgstr "Ends"
 
 #: components/manage/Widgets/RecurrenceWidget/EndField
 msgid "Recurrence ends after"
-msgstr ""
+msgstr "after"
 
 #: components/manage/Widgets/RecurrenceWidget/EndField
 msgid "Recurrence ends on"
-msgstr ""
+msgstr "on"
 
 #: components/manage/Blocks/Table/Edit
 msgid "Reduce complexity"
-msgstr ""
+msgstr "Minimalistic table design"
 
 #: components/theme/Anontools/Anontools
 #: components/theme/Login/Login
 #: components/theme/Register/Register
 msgid "Register"
-msgstr ""
+msgstr "Register"
 
 #: components/theme/Register/Register
 msgid "Registration form"
-msgstr ""
+msgstr "Registration form"
 
 #: components/theme/Search/Search
 msgid "Relevance"
-msgstr ""
+msgstr "Relevance"
 
 #: components/manage/Widgets/ObjectListWidget
 msgid "Remove item"
-msgstr ""
+msgstr "Remove item"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
 msgid "Remove recurrence"
-msgstr ""
+msgstr "Remove"
 
 #: components/manage/Widgets/VocabularyTermsWidget
 msgid "Remove term"
-msgstr ""
+msgstr "Remove term"
 
 #: components/manage/Toolbar/More
 msgid "Remove working copy"
-msgstr ""
+msgstr "Remove working copy"
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
 msgid "Rename"
-msgstr ""
+msgstr "Rename"
 
 #: components/manage/Contents/ContentsRenameModal
 msgid "Rename Items Loading Message"
-msgstr ""
+msgstr "Renaming items..."
 
 #: components/manage/Contents/ContentsRenameModal
 msgid "Rename items"
-msgstr ""
+msgstr "Rename items"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
 msgid "Repeat"
-msgstr ""
+msgstr "Repeat"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
 msgid "Repeat every"
-msgstr ""
+msgstr "Repeat every"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
 msgid "Repeat on"
-msgstr ""
+msgstr "Repeat on"
 
 #: components/manage/Widgets/FileWidget
 msgid "Replace existing file"
-msgstr ""
+msgstr "Replace existing file"
 
 #: components/theme/Comments/Comments
 msgid "Reply"
-msgstr ""
+msgstr "Reply"
 
 #: components/manage/Widgets/SchemaWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/WysiwygWidget
 msgid "Required"
-msgstr ""
+msgstr "Required"
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
 msgid "Required input is missing."
-msgstr ""
+msgstr "Required input is missing."
 
 #: components/manage/Widgets/VocabularyTermsWidget
 msgid "Reset term title"
-msgstr ""
+msgstr "Reset title"
 
 #: components/manage/Widgets/QuerystringWidget
 msgid "Results limit"
-msgstr ""
+msgstr "Results limit"
 
 #: components/manage/Blocks/Listing/Edit
 msgid "Results preview"
-msgstr ""
+msgstr "Results preview"
 
 #: components/manage/Widgets/QuerystringWidget
 msgid "Reversed order"
-msgstr ""
+msgstr "Reversed order"
 
 #: components/manage/History/History
 msgid "Revert to this revision"
-msgstr ""
+msgstr "Revert to this revision"
 
 #: components/manage/Contents/Contents
 msgid "Review state"
-msgstr ""
+msgstr "Review state"
 
 #: components/manage/Widgets/SchemaWidget
 msgid "Richtext"
-msgstr ""
+msgstr "Richtext"
 
 #: components/manage/Blocks/Image/ImageSizeWidget
 #: components/manage/Blocks/Maps/Edit
 #: components/manage/Sidebar/AlignBlock
 msgid "Right"
-msgstr ""
+msgstr "Right"
 
 #: components/manage/Contents/ContentsPropertiesModal
 msgid "Rights"
-msgstr ""
+msgstr "Rights"
 
 #: helpers/MessageLabels/MessageLabels
 msgid "Roles"
-msgstr ""
+msgstr "Roles"
 
 #: components/manage/Contents/ContentsBreadcrumbs
 msgid "Root"
-msgstr ""
+msgstr "Root"
 
 #: components/manage/Add/Add
 #: components/manage/Controlpanels/ContentType
@@ -1631,250 +1631,250 @@ msgstr ""
 #: components/manage/Sharing/Sharing
 #: helpers/MessageLabels/MessageLabels
 msgid "Save"
-msgstr ""
+msgstr "Save"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
 msgid "Save recurrence"
-msgstr ""
+msgstr "Save"
 
 #: components/manage/Controlpanels/ContentTypesActions
 msgid "Schema"
-msgstr ""
+msgstr "Schema"
 
 #: components/manage/Controlpanels/ContentTypeSchema
 msgid "Schema updates"
-msgstr ""
+msgstr "Schema updates"
 
 #: components/theme/SearchWidget/SearchWidget
 msgid "Search"
-msgstr ""
+msgstr "Search"
 
 #: components/manage/Sidebar/ObjectBrowserBody
 msgid "Search SVG"
-msgstr ""
+msgstr "Search SVG"
 
 #: components/theme/SearchWidget/SearchWidget
 msgid "Search Site"
-msgstr ""
+msgstr "Search Site"
 
 #: components/manage/Sidebar/ObjectBrowserBody
 msgid "Search content"
-msgstr ""
+msgstr "Search content"
 
 #: components/manage/Sharing/Sharing
 msgid "Search for user or group"
-msgstr ""
+msgstr "Search for user or group"
 
 #: helpers/MessageLabels/MessageLabels
 msgid "Search group…"
-msgstr ""
+msgstr "Search group…"
 
 #: components/theme/Search/Search
 msgid "Search results"
-msgstr ""
+msgstr "Search results"
 
 #: components/theme/Search/Search
 msgid "Search results for {term}"
-msgstr ""
+msgstr "Search results for {term}"
 
 #: helpers/MessageLabels/MessageLabels
 msgid "Search users…"
-msgstr ""
+msgstr "Search users…"
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
 msgid "Second"
-msgstr ""
+msgstr "Second"
 
 #: components/manage/Sidebar/ObjectBrowserNav
 msgid "Select"
-msgstr ""
+msgstr "Select"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
 msgid "Select a date to add to recurrence"
-msgstr ""
+msgstr "Select a date to add to recurrence"
 
 #: components/manage/Contents/Contents
 msgid "Select columns to show"
-msgstr ""
+msgstr "Select columns to show"
 
 #: components/manage/Contents/ContentsWorkflowModal
 msgid "Select the transition to be used for modifying the items state."
-msgstr ""
+msgstr "Select the transition to be used for modifying the items state."
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
 msgid "Selected dates"
-msgstr ""
+msgstr "Selected dates"
 
 #: components/manage/Sidebar/ObjectBrowserBody
 msgid "Selected items"
-msgstr ""
+msgstr "Selected items"
 
 #: components/manage/Sidebar/ObjectBrowserBody
 msgid "Selected items - x of y"
-msgstr ""
+msgstr "of"
 
 #: components/manage/Widgets/SchemaWidget
 msgid "Selection"
-msgstr ""
+msgstr "Selection"
 
 #: components/manage/Contents/Contents
 #: components/manage/Widgets/ArrayWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/TokenWidget
 msgid "Select…"
-msgstr ""
+msgstr "Select…"
 
 #: components/theme/ContactForm/ContactForm
 msgid "Send"
-msgstr ""
+msgstr "Send"
 
 #: components/theme/PasswordReset/PasswordReset
 msgid "Set my password"
-msgstr ""
+msgstr "Set my password"
 
 #: components/theme/PasswordReset/PasswordReset
 msgid "Set your password"
-msgstr ""
+msgstr "Set your password"
 
 #: components/manage/Sidebar/Sidebar
 msgid "Settings"
-msgstr ""
+msgstr "Settings"
 
 #: components/manage/Sharing/Sharing
 #: components/manage/Toolbar/More
 msgid "Sharing"
-msgstr ""
+msgstr "Sharing"
 
 #: components/manage/Sharing/Sharing
 msgid "Sharing for {title}"
-msgstr ""
+msgstr "Sharing for {title}"
 
 #: components/manage/Widgets/SchemaWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/WysiwygWidget
 msgid "Short Name"
-msgstr ""
+msgstr "Short Name"
 
 #: components/manage/Contents/ContentsRenameModal
 msgid "Short name"
-msgstr ""
+msgstr "Short name"
 
 #: components/theme/Pagination/Pagination
 msgid "Show"
-msgstr ""
+msgstr "Show"
 
 #: helpers/MessageLabels/MessageLabels
 msgid "Show All"
-msgstr ""
+msgstr "Show All"
 
 #: components/theme/Comments/Comments
 msgid "Show Replies"
-msgstr ""
+msgstr "Show Replies"
 
 #: components/manage/Widgets/ObjectListWidget
 msgid "Show item"
-msgstr ""
+msgstr "Show item"
 
 #: components/manage/Sidebar/Sidebar
 msgid "Shrink sidebar"
-msgstr ""
+msgstr "Shrink sidebar"
 
 #: components/manage/Toolbar/Toolbar
 msgid "Shrink toolbar"
-msgstr ""
+msgstr "Shrink toolbar"
 
 #: components/theme/Login/Login
 msgid "Sign in to start session"
-msgstr ""
+msgstr "Sign in to start session"
 
 #: components/theme/Logo/Logo
 msgid "Site"
-msgstr ""
+msgstr "Site"
 
 #: components/theme/NotFound/NotFound
 #: components/theme/Unauthorized/Unauthorized
 msgid "Site Administration"
-msgstr ""
+msgstr "Site Administration"
 
 #: components/theme/Footer/Footer
 msgid "Site Map"
-msgstr ""
+msgstr "Site Map"
 
 #: components/manage/Controlpanels/Controlpanels
 #: components/manage/Toolbar/PersonalTools
 msgid "Site Setup"
-msgstr ""
+msgstr "Site Setup"
 
 #: components/theme/Sitemap/Sitemap
 msgid "Sitemap"
-msgstr ""
+msgstr "Sitemap"
 
 #: components/manage/Blocks/Image/ImageSidebar
 msgid "Size"
-msgstr ""
+msgstr "Size"
 
 #: components/theme/View/ImageView
 msgid "Size: {size}"
-msgstr ""
+msgstr "Size: {size}"
 
 #: error
 msgid "Sorry, something went wrong with your request"
-msgstr ""
+msgstr "Sorry, something went wrong with your request "
 
 #: components/theme/Search/Search
 msgid "Sort By:"
-msgstr ""
+msgstr "Sort by:"
 
 #: components/manage/Widgets/QuerySortOnWidget
 #: components/manage/Widgets/QuerystringWidget
 msgid "Sort on"
-msgstr ""
+msgstr "Sort on"
 
 #: components/manage/Blocks/HTML/Edit
 msgid "Source"
-msgstr ""
+msgstr "Source"
 
 #: components/manage/Blocks/Video/Edit
 msgid "Specify a youtube video or playlist url"
-msgstr ""
+msgstr "Specify a youtube video or playlist url"
 
 #: components/manage/Diff/Diff
 msgid "Split"
-msgstr ""
+msgstr "Split"
 
 #: components/manage/Contents/Contents
 msgid "Start Date"
-msgstr ""
+msgstr "Start Date"
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
 msgid "Start of the recurrence"
-msgstr ""
+msgstr "Start of the recurrence"
 
 #: components/theme/PasswordReset/RequestPasswordReset
 msgid "Start password reset"
-msgstr ""
+msgstr "Start password reset"
 
 #: components/manage/Contents/Contents
 #: components/manage/Workflow/Workflow
 #: components/theme/View/TabularView
 msgid "State"
-msgstr ""
+msgstr "State"
 
 #: components/manage/Multilingual/CompareLanguages
 msgid "Stop compare"
-msgstr ""
+msgstr "Stop compare"
 
 #: components/manage/Widgets/SchemaWidget
 msgid "String"
-msgstr ""
+msgstr "String"
 
 #: components/manage/Blocks/Table/Edit
 msgid "Stripe alternate rows with color"
-msgstr ""
+msgstr "Alternate row background color"
 
 #: components/theme/ContactForm/ContactForm
 msgid "Subject"
-msgstr ""
+msgstr "Subject"
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
@@ -1887,132 +1887,132 @@ msgstr ""
 #: components/theme/ContactForm/ContactForm
 #: helpers/MessageLabels/MessageLabels
 msgid "Success"
-msgstr ""
+msgstr "Success"
 
 #: components/theme/LanguageSelector/LanguageSelector
 msgid "Switch to"
-msgstr ""
+msgstr "Switch to"
 
 #: components/manage/Blocks/Table/Edit
 msgid "Table"
-msgstr ""
+msgstr "Table"
 
 #: components/manage/Blocks/ToC/View
 msgid "Table of Contents"
-msgstr ""
+msgstr "Table of Contents"
 
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsTagsModal
 msgid "Tags"
-msgstr ""
+msgstr "Tags"
 
 #: components/manage/Contents/ContentsTagsModal
 msgid "Tags to add"
-msgstr ""
+msgstr "Tags to add"
 
 #: components/manage/Contents/ContentsTagsModal
 msgid "Tags to remove"
-msgstr ""
+msgstr "Tags to remove"
 
 #: components/manage/Controlpanels/DatabaseInformation
 msgid "Target memory size per cache in bytes"
-msgstr ""
+msgstr "Target memory size per cache in bytes"
 
 #: components/manage/Controlpanels/DatabaseInformation
 msgid "Target number of objects in memory per cache"
-msgstr ""
+msgstr "Target number of objects in memory per cache"
 
 #: components/manage/Widgets/SchemaWidget
 msgid "Text"
-msgstr ""
+msgstr "Text"
 
 #: components/theme/ConnectionRefused/ConnectionRefused
 #: components/theme/CorsError/CorsError
 #: components/theme/NotFound/NotFound
 #: components/theme/Unauthorized/Unauthorized
 msgid "Thank you."
-msgstr ""
+msgstr "Thank you."
 
 #: components/manage/Controlpanels/DatabaseInformation
 msgid "The Database Manager allow you to view database status information"
-msgstr ""
+msgstr "The Database Manager allow you to view database status information"
 
 #: components/manage/Preferences/PersonalInformation
 msgid "The URL for your external home page, if you have one."
-msgstr ""
+msgstr "The URL for your external home page, if you have one."
 
 #: components/theme/ConnectionRefused/ConnectionRefused
 msgid "The backend is not responding, please check if you have started Plone, check your project's configuration object apiPath (or if you are using the internal proxy, devProxyToApiPath) or the RAZZLE_API_PATH Volto's environment variable."
-msgstr ""
+msgstr "The backend is not responding, please check if you have started Plone, check your project's configuration object apiPath (or if you are using the internal proxy, devProxyToApiPath) or the RAZZLE_API_PATH Volto's environment variable."
 
 #: components/theme/CorsError/CorsError
 msgid "The backend is responding, but the CORS headers are not configured properly and the browser has denied the access to the backend resources."
-msgstr ""
+msgstr "The backend is responding, but the CORS headers are not configured properly and the browser has denied the access to the backend resources."
 
 #: components/theme/CorsError/CorsError
 msgid "The backend server of your website is not anwering, we apologize for the inconvenience. Please try to re-load the page and try again. If the problem persists please contact the site administrators."
-msgstr ""
+msgstr "The backend server of your website is not anwering, we apologize for the inconvenience. Please try to re-load the page and try again. If the problem persists please contact the site administrators."
 
 #: components/manage/Contents/Contents
 msgid "The item could not be deleted."
-msgstr ""
+msgstr "The item could not be deleted."
 
 #: components/theme/Register/Register
 msgid "The registration process has been successful. Please check your e-mail inbox for information on how activate your account."
-msgstr ""
+msgstr "The registration process has been successful. Please check your e-mail inbox for information on how activate your account."
 
 #: components/manage/Preferences/PersonalInformation
 msgid "The user portrait/avatar"
-msgstr ""
+msgstr "The user portrait/avatar"
 
 #: components/manage/Toolbar/More
 msgid "The working copy was discarded"
-msgstr ""
+msgstr "The working copy was discarded"
 
 #: components/theme/Footer/Footer
 msgid "The {plonecms} is {copyright} 2000-{current_year} by the {plonefoundation} and friends."
-msgstr ""
+msgstr "The {plonecms} is {copyright} 2000-{current_year} by the {plonefoundation} and friends."
 
 #: components/theme/CorsError/CorsError
 msgid "There is a configuration problem on the backend"
-msgstr ""
+msgstr "There is a configuration problem on the backend"
 
 #: components/manage/Form/InlineForm
 msgid "There were some errors"
-msgstr ""
+msgstr "There were some errors"
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
 msgid "There were some errors."
-msgstr ""
+msgstr "There were some errors."
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
 msgid "Third"
-msgstr ""
+msgstr "Third"
 
 #: components/manage/WorkingCopyToastsFactory/WorkingCopyToastsFactory
 msgid "This has an ongoing working copy in {title}"
-msgstr ""
+msgstr "This has an ongoing working copy in {title}"
 
 #: components/manage/WorkingCopyToastsFactory/WorkingCopyToastsFactory
 msgid "This is a working copy of {title}"
-msgstr ""
+msgstr "This is a working copy of {title}"
 
 #: components/manage/LockingToastsFactory/LockingToastsFactory
 msgid "This item was locked by {creator} on {date}"
-msgstr ""
+msgstr "This item was locked by {creator} on {date}"
 
 #: components/manage/Contents/ContentsRenameModal
 msgid "This name will be displayed in the URL."
-msgstr ""
+msgstr "This name will be displayed in the URL."
 
 #: components/theme/NotFound/NotFound
 msgid "This page does not seem to exist…"
-msgstr ""
+msgstr "This page does not seem to exist…"
 
 #: components/manage/Widgets/DatetimeWidget
 msgid "Time"
-msgstr ""
+msgstr "Time"
 
 #: components/manage/Blocks/HeroImageLeft/Edit
 #: components/manage/Contents/Contents
@@ -2024,78 +2024,78 @@ msgstr ""
 #: components/theme/View/TabularView
 #: helpers/MessageLabels/MessageLabels
 msgid "Title"
-msgstr ""
+msgstr "Title"
 
 #: components/manage/Controlpanels/DatabaseInformation
 msgid "Total active and non-active objects"
-msgstr ""
+msgstr "Total active and non-active objects"
 
 #: components/manage/Contents/Contents
 msgid "Total comments"
-msgstr ""
+msgstr "Total comments"
 
 #: components/manage/Controlpanels/DatabaseInformation
 msgid "Total number of objects in each cache"
-msgstr ""
+msgstr "Total number of objects in each cache"
 
 #: components/manage/Controlpanels/DatabaseInformation
 msgid "Total number of objects in memory from all caches"
-msgstr ""
+msgstr "Total number of objects in memory from all caches"
 
 #: components/manage/Controlpanels/DatabaseInformation
 msgid "Total number of objects in the database"
-msgstr ""
+msgstr "Total number of objects in the database"
 
 #: components/manage/Add/Add
 #: components/manage/Toolbar/Types
 msgid "Translate to {lang}"
-msgstr ""
+msgstr "Translate to {lang}"
 
 #: components/manage/Multilingual/ManageTranslations
 msgid "Translation linked"
-msgstr ""
+msgstr "Translation linked"
 
 #: components/manage/Multilingual/ManageTranslations
 msgid "Translation linking removed"
-msgstr ""
+msgstr "Translation linking removed"
 
 #: components/manage/Controlpanels/ContentTypes
 #: components/manage/Widgets/SchemaWidget
 #: components/theme/View/TabularView
 msgid "Type"
-msgstr ""
+msgstr "Type"
 
 #: components/manage/Blocks/Video/Edit
 msgid "Type a Video (YouTube, Vimeo or mp4) URL"
-msgstr ""
+msgstr "Type a Video (YouTube, Vimeo or mp4) URL"
 
 #: components/manage/Blocks/Text/Edit
 msgid "Type text…"
-msgstr ""
+msgstr "Type text…"
 
 #: components/manage/Blocks/Title/Edit
 msgid "Type the title…"
-msgstr ""
+msgstr "Type the title…"
 
 #: components/manage/Contents/Contents
 msgid "UID"
-msgstr ""
+msgstr "UID"
 
 #: components/theme/Unauthorized/Unauthorized
 msgid "Unauthorized"
-msgstr ""
+msgstr "Unauthorized"
 
 #: components/manage/BlockChooser/BlockChooser
 msgid "Unfold"
-msgstr ""
+msgstr "Unfold"
 
 #: components/manage/Diff/Diff
 msgid "Unified"
-msgstr ""
+msgstr "Unified"
 
 #: components/manage/Controlpanels/AddonsControlpanel
 msgid "Uninstall"
-msgstr ""
+msgstr "Uninstall"
 
 #: components/manage/Blocks/Block/Edit
 #: components/theme/View/DefaultView
@@ -2105,632 +2105,636 @@ msgstr "Unknown Block {block}"
 
 #: components/manage/Multilingual/ManageTranslations
 msgid "Unlink translation for"
-msgstr ""
+msgstr "Unlink translation for"
 
 #: components/manage/Toolbar/Toolbar
 msgid "Unlock"
-msgstr ""
+msgstr "Unlock"
 
 #: components/manage/Controlpanels/AddonsControlpanel
 msgid "Update"
-msgstr ""
+msgstr "Update"
 
 #: components/manage/Controlpanels/AddonsControlpanel
 msgid "Update installed addons"
-msgstr ""
+msgstr "Update installed addons"
 
 #: components/manage/Controlpanels/AddonsControlpanel
 msgid "Update installed addons:"
-msgstr ""
+msgstr "Update installed addons:"
 
 #: components/manage/Controlpanels/AddonsControlpanel
 msgid "Updates available"
-msgstr ""
+msgstr "Updates available"
 
 #: components/manage/Contents/Contents
 msgid "Upload"
-msgstr ""
+msgstr "Upload"
 
 #: components/manage/Blocks/LeadImage/Edit
 msgid "Upload a lead image in the 'Lead Image' content field."
-msgstr ""
+msgstr "Upload a lead image in the 'Lead Image' content field."
 
 #: components/manage/Blocks/HeroImageLeft/Edit
 msgid "Upload a new image"
-msgstr ""
+msgstr "Upload a new image"
 
 #: components/manage/Contents/ContentsUploadModal
 msgid "Upload files"
-msgstr ""
+msgstr "Upload files"
 
 #: components/manage/Contents/ContentsUploadModal
 msgid "Uploading files"
-msgstr ""
+msgstr "Uploading files"
 
 #: components/manage/Blocks/HeroImageLeft/Edit
 msgid "Uploading image"
-msgstr ""
+msgstr "Uploading image"
 
 #: components/manage/Widgets/SchemaWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/WysiwygWidget
 msgid "Used for programmatic access to the fieldset."
-msgstr ""
+msgstr "Used for programmatic access to the fieldset."
 
 #: components/manage/Sharing/Sharing
 msgid "User"
-msgstr ""
+msgstr "User"
 
 #: helpers/MessageLabels/MessageLabels
 msgid "User created"
-msgstr ""
+msgstr "User created"
 
 #: components/manage/Controlpanels/Users/UsersControlpanel
 msgid "User name"
-msgstr ""
+msgstr "User name"
 
 #: helpers/MessageLabels/MessageLabels
 msgid "User roles updated"
-msgstr ""
+msgstr "User roles updated"
 
 #: helpers/MessageLabels/MessageLabels
 msgid "Username"
-msgstr ""
+msgstr "Username"
 
 #: components/manage/Controlpanels/Controlpanels
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: helpers/MessageLabels/MessageLabels
 msgid "Users"
-msgstr ""
+msgstr "Users"
 
 #: components/manage/Controlpanels/Controlpanels
 msgid "Users and Groups"
-msgstr ""
+msgstr "Users and Groups"
 
 #: helpers/Extensions/withBlockSchemaEnhancer
 msgid "Variation"
-msgstr ""
+msgstr "Variation"
 
 #: components/manage/Controlpanels/Controlpanels
 msgid "Version Overview"
-msgstr ""
+msgstr "Version Overview"
 
 #: components/manage/Blocks/Video/VideoSidebar
 msgid "Video"
-msgstr ""
+msgstr "Video"
 
 #: components/manage/Blocks/Video/VideoSidebar
 msgid "Video URL"
-msgstr ""
+msgstr "Video URL"
 
 #: components/manage/Contents/ContentsItem
 msgid "View"
-msgstr ""
+msgstr "View"
 
 #: components/manage/History/History
 msgid "View changes"
-msgstr ""
+msgstr "View changes"
 
 #: components/manage/History/History
 msgid "View this revision"
-msgstr ""
+msgstr "View this revision"
 
 #: components/manage/Toolbar/More
 msgid "View working copy"
-msgstr ""
+msgstr "View working copy"
 
 #: components/manage/Display/Display
 msgid "Viewmode"
-msgstr ""
+msgstr "View"
 
 #: components/manage/Widgets/VocabularyTermsWidget
 msgid "Vocabulary term"
-msgstr ""
+msgstr "Vocabulary term"
 
 #: components/manage/Widgets/VocabularyTermsWidget
 msgid "Vocabulary term title"
-msgstr ""
+msgstr "Title"
 
 #: components/manage/Widgets/VocabularyTermsWidget
 msgid "Vocabulary terms"
-msgstr ""
+msgstr "Vocabulary terms"
 
 #: components/manage/Controlpanels/VersionOverview
 msgid "Warning Regarding debug mode"
-msgstr ""
+msgstr "You are running in "debug mode". This mode is intended for sites that
+        are under development. This allows many configuration changes to be
+        immediately visible, but will make your site run more slowly. To turn
+        off debug mode, stop the server, set "debug-mode=off" in your
+        buildout.cfg, re-run bin/buildout and then restart the server process."
 
 #: components/theme/ConnectionRefused/ConnectionRefused
 msgid "We apologize for the inconvenience, but the backend of the site you are accessing is not available right now. Please, try again later."
-msgstr ""
+msgstr "We apologize for the inconvenience, but the backend of the site you are accessing is not available right now. Please, try again later."
 
 #: components/theme/NotFound/NotFound
 msgid "We apologize for the inconvenience, but the page you were trying to access is not at this address. You can use the links below to help you find what you are looking for."
-msgstr ""
+msgstr "We apologize for the inconvenience, but the page you were trying to access is not at this address. You can use the links below to help you find what you are looking for."
 
 #: components/theme/Forbidden/Forbidden
 msgid "We apologize for the inconvenience, but you don't have permissions on this resource."
-msgstr ""
+msgstr "We apologize for the inconvenience, but you don't have permissions on this resource."
 
 #: components/manage/Preferences/PersonalInformation
 msgid "We will use this address if you need to recover your password"
-msgstr ""
+msgstr "We will use this address if you need to recover your password"
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
 msgid "Weeek day of month"
-msgstr ""
+msgstr "The"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
 msgid "Weekday"
-msgstr ""
+msgstr "Weekday"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
 msgid "Weekly"
-msgstr ""
+msgstr "Weekly"
 
 #: components/manage/History/History
 msgid "What"
-msgstr ""
+msgstr "What"
 
 #: components/manage/History/History
 msgid "When"
-msgstr ""
+msgstr "When"
 
 #: components/manage/Contents/ContentsPropertiesModal
 msgid "When this date is reached, the content will nolonger be visible in listings and searches."
-msgstr ""
+msgstr "When this date is reached, the content will nolonger be visible in listings and searches."
 
 #: components/manage/History/History
 msgid "Who"
-msgstr ""
+msgstr "Who"
 
 #: components/manage/Contents/ContentsWorkflowModal
 msgid "Workflow Change Loading Message"
-msgstr ""
+msgstr "Updating workflow states..."
 
 #: components/manage/Workflow/Workflow
 msgid "Workflow updated."
-msgstr ""
+msgstr "Workflow updated."
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
 msgid "Yearly"
-msgstr ""
+msgstr "Yearly"
 
 #: components/manage/Contents/ContentsItem
 #: components/manage/Controlpanels/ContentTypes
 msgid "Yes"
-msgstr ""
+msgstr "Yes"
 
 #: components/theme/Unauthorized/Unauthorized
 msgid "You are trying to access a protected resource, please {login} first."
-msgstr ""
+msgstr "You are trying to access a protected resource, please {login} first."
 
 #: components/theme/OutdatedBrowser/OutdatedBrowser
 msgid "You are using an outdated browser"
-msgstr ""
+msgstr "You are using an outdated browser"
 
 #: components/theme/Comments/Comments
 msgid "You can add a comment by filling out the form below. Plain text formatting."
-msgstr ""
+msgstr "You can add a comment by filling out the form below. Plain text formatting."
 
 #: components/manage/Sharing/Sharing
 msgid "You can control who can view and edit your item using the list below."
-msgstr ""
+msgstr "You can control who can view and edit your item using the list below."
 
 #: components/manage/Diff/Diff
 msgid "You can view the difference of the revisions below."
-msgstr ""
+msgstr "You can view the difference of the revisions below."
 
 #: components/manage/History/History
 msgid "You can view the history of your item below."
-msgstr ""
+msgstr "You can view the history of your item below."
 
 #: components/manage/Contents/Contents
 msgid "You can't paste this content here"
-msgstr ""
+msgstr "You can't paste this content here"
 
 #: components/theme/PasswordReset/RequestPasswordReset
 msgid "Your email is required for reset your password."
-msgstr ""
+msgstr "Your email is required for reset your password."
 
 #: components/manage/Preferences/PersonalInformation
 msgid "Your location - either city and country - or in a company setting, where your office is located."
-msgstr ""
+msgstr "Your location - either city and country - or in a company setting, where your office is located."
 
 #: components/theme/PasswordReset/PasswordReset
 msgid "Your password has been set successfully. You may now {link} with your new password."
-msgstr ""
+msgstr "Your password has been set successfully. You may now {link} with your new password."
 
 #: components/manage/Preferences/PersonalPreferences
 msgid "Your preferred language"
-msgstr ""
+msgstr "Your preferred language"
 
 #: components/theme/Login/Login
 #: components/theme/PasswordReset/RequestPasswordReset
 msgid "box_forgot_password_option"
-msgstr ""
+msgstr "Forgot your password?"
 
 #: config/Blocks
 msgid "common"
-msgstr ""
+msgstr "Common"
 
 #: components/manage/Multilingual/CompareLanguages
 msgid "compare_to"
-msgstr ""
+msgstr "Compare to language"
 
 #: components/manage/Blocks/Block/EditBlockWrapper
 msgid "delete"
-msgstr ""
+msgstr "delete"
 
 #: components/theme/OutdatedBrowser/OutdatedBrowser
 msgid "deprecated_browser_notice_message"
-msgstr ""
+msgstr "You are using {browsername} {browserversion} which is deprecated by its vendor. That means that it does not get security updates and it is not ready for current modern web features, which deteriorates the user experience. Please upgrade to a modern browser."
 
 #: config/Blocks
 msgid "description"
-msgstr ""
+msgstr "Description"
 
 #: components/theme/PasswordReset/RequestPasswordReset
 msgid "description_lost_password"
-msgstr ""
+msgstr "For security reasons, we store your password encrypted, and cannot mail it to you. If you would like to reset your password, fill out the form below and we will send you an email at the address you gave when you registered to start the process of resetting your password."
 
 #: components/theme/PasswordReset/RequestPasswordReset
 msgid "description_sent_password"
-msgstr ""
+msgstr "Your password reset request has been mailed. It should arrive in your mailbox shortly. When you receive the message, visit the address it contains to reset your password."
 
 #: components/manage/Contents/ContentsItem
 msgid "draft"
-msgstr ""
+msgstr "Draft"
 
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
-msgstr ""
+msgstr "Input must be valid email (something@domain.com)"
 
 #: components/theme/View/EventView
 msgid "event_alldates"
-msgstr ""
+msgstr "All dates"
 
 #: components/theme/View/EventView
 msgid "event_attendees"
-msgstr ""
+msgstr "Attendees"
 
 #: components/theme/View/EventView
 msgid "event_contactname"
-msgstr ""
+msgstr "Contact Name"
 
 #: components/theme/View/EventView
 msgid "event_contactphone"
-msgstr ""
+msgstr "Contact Phone"
 
 #: components/theme/View/EventView
 msgid "event_website"
-msgstr ""
+msgstr "Website"
 
 #: components/theme/View/EventView
 msgid "event_what"
-msgstr ""
+msgstr "What"
 
 #: components/theme/View/EventView
 msgid "event_when"
-msgstr ""
+msgstr "When"
 
 #: components/theme/View/EventView
 msgid "event_where"
-msgstr ""
+msgstr "Where"
 
 #: components/theme/PasswordReset/RequestPasswordReset
 msgid "heading_sent_password"
-msgstr ""
+msgstr "Password reset confirmation sent"
 
 #: config/Blocks
 msgid "hero"
-msgstr ""
+msgstr "Hero"
 
 #: config/Blocks
 msgid "html"
-msgstr ""
+msgstr "HTML"
 
 #: config/Blocks
 msgid "image"
-msgstr ""
+msgstr "Image"
 
 #: helpers/MessageLabels/MessageLabels
 msgid "integer"
-msgstr ""
+msgstr "Input must be integer"
 
 #: components/manage/Contents/ContentsItem
 msgid "intranet"
-msgstr ""
+msgstr "Intranet"
 
 #: components/theme/PasswordReset/RequestPasswordReset
 msgid "label_my_email_address_is"
-msgstr ""
+msgstr "My email address is"
 
 #: config/Blocks
 msgid "leadimage"
-msgstr ""
+msgstr "Lead Image Field"
 
 #: config/Blocks
 msgid "listing"
-msgstr ""
+msgstr "Listing"
 
 #: components/manage/Blocks/Listing/ListingBody
 #: components/manage/Contents/Contents
 msgid "loading"
-msgstr ""
+msgstr "Loading"
 
 #: components/theme/Unauthorized/Unauthorized
 msgid "log in"
-msgstr ""
+msgstr "log in"
 
 #: config/Blocks
 msgid "maps"
-msgstr ""
+msgstr "Maps"
 
 #: components/manage/Widgets/SchemaWidget
 msgid "maxLength"
-msgstr ""
+msgstr "Maximum Length"
 
 #: components/manage/Widgets/SchemaWidget
 msgid "maximum"
-msgstr ""
+msgstr "End of the range (including the value itself)"
 
 #: config/Blocks
 msgid "media"
-msgstr ""
+msgstr "Media"
 
 #: components/manage/Widgets/SchemaWidget
 msgid "minLength"
-msgstr ""
+msgstr "Minimum Length"
 
 #: components/manage/Widgets/SchemaWidget
 msgid "minimum"
-msgstr ""
+msgstr "Start of the range"
 
 #: config/Blocks
 msgid "mostUsed"
-msgstr ""
+msgstr "Most used"
 
 #: components/manage/Contents/ContentsItem
 msgid "no workflow state"
-msgstr ""
+msgstr "No workflow state"
 
 #: helpers/MessageLabels/MessageLabels
 msgid "number"
-msgstr ""
+msgstr "Input must be number"
 
 #: components/manage/Widgets/RecurrenceWidget/ByMonthDayField
 #: components/manage/Widgets/RecurrenceWidget/ByYearField
 msgid "of the month"
-msgstr ""
+msgstr "of the month"
 
 #: error
 msgid "or try a different page."
-msgstr ""
+msgstr "or try a different page."
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
 msgid "others"
-msgstr ""
+msgstr "others"
 
 #: components/manage/Contents/ContentsItem
 msgid "private"
-msgstr ""
+msgstr "Private"
 
 #: components/manage/Contents/ContentsItem
 msgid "published"
-msgstr ""
+msgstr "Published"
 
 #: components/manage/Widgets/QueryWidget
 msgid "querystring-widget-select"
-msgstr ""
+msgstr "Select…"
 
 #: components/theme/Search/Search
 msgid "results found"
-msgstr ""
+msgstr "results"
 
 #: error
 msgid "return to the site root"
-msgstr ""
+msgstr "return to the site root"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_and"
-msgstr ""
+msgstr "and"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_approximate"
-msgstr ""
+msgstr "(~approximate)"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_at"
-msgstr ""
+msgstr "at"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_dateFormat"
-msgstr ""
+msgstr "[month] [day], [year]"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_day"
-msgstr ""
+msgstr "day"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_days"
-msgstr ""
+msgstr "days"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_every"
-msgstr ""
+msgstr "every"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_for"
-msgstr ""
+msgstr "for"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_hour"
-msgstr ""
+msgstr "hour"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_hours"
-msgstr ""
+msgstr "hours"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_in"
-msgstr ""
+msgstr "in"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_last"
-msgstr ""
+msgstr "last"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_minutes"
-msgstr ""
+msgstr "minutes"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_month"
-msgstr ""
+msgstr "month"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_months"
-msgstr ""
+msgstr "months"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_nd"
-msgstr ""
+msgstr "nd"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_on"
-msgstr ""
+msgstr "on"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_on the"
-msgstr ""
+msgstr "on the"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_or"
-msgstr ""
+msgstr "or"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_rd"
-msgstr ""
+msgstr "rd"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_st"
-msgstr ""
+msgstr "st"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_th"
-msgstr ""
+msgstr "th"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_the"
-msgstr ""
+msgstr "the"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_time"
-msgstr ""
+msgstr "time"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_times"
-msgstr ""
+msgstr "times"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_until"
-msgstr ""
+msgstr "until"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_week"
-msgstr ""
+msgstr "week"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_weekday"
-msgstr ""
+msgstr "weekday"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_weekdays"
-msgstr ""
+msgstr "weekdays"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_weeks"
-msgstr ""
+msgstr "weeks"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_year"
-msgstr ""
+msgstr "year"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
 msgid "rrule_years"
-msgstr ""
+msgstr "years"
 
 #: components/theme/SkipLinks/SkipLinks
 msgid "skiplink-footer"
-msgstr ""
+msgstr "Skip to footer"
 
 #: components/theme/SkipLinks/SkipLinks
 msgid "skiplink-main-content"
-msgstr ""
+msgstr "Skip to main content"
 
 #: components/theme/SkipLinks/SkipLinks
 msgid "skiplink-navigation"
-msgstr ""
+msgstr "Skip to navigation"
 
 #: components/manage/Contents/Contents
 msgid "sort"
-msgstr ""
+msgstr "sort"
 
 #: config/Blocks
 msgid "table"
-msgstr ""
+msgstr "Table"
 
 #: config/Blocks
 msgid "text"
-msgstr ""
+msgstr "Text"
 
 #: config/Blocks
 msgid "title"
-msgstr ""
+msgstr "Title"
 
 #: config/Blocks
 msgid "toc"
-msgstr ""
+msgstr "Table of Contents"
 
 #: helpers/MessageLabels/MessageLabels
 msgid "url"
-msgstr ""
+msgstr "Input must be valid url (www.something.com or http(s)://www.something.com)"
 
 #: components/manage/Toolbar/PersonalTools
 msgid "user avatar"
-msgstr ""
+msgstr "user avatar"
 
 #: config/Blocks
 msgid "video"
-msgstr ""
+msgstr "Video"
 
 #: components/theme/View/EventView
 msgid "visit_external_website"
-msgstr ""
+msgstr "Visit external website"
 
 #: components/manage/Contents/ContentsUploadModal
 msgid "{count, plural, one {Upload {count} file} other {Upload {count} files}}"
-msgstr ""
+msgstr "{count, plural, one {Upload {count} file} other {Upload {count} files}}"
 
 #: components/manage/Contents/Contents
 msgid "{count} selected"
-msgstr ""
+msgstr "{count} selected"
 
 #: components/manage/Controlpanels/ContentType
 msgid "{id} Content Type"
-msgstr ""
+msgstr "{id} Content Type"
 
 #: components/manage/Controlpanels/ContentTypeSchema
 msgid "{id} Schema"
-msgstr ""
+msgstr "{id} Schema"
 
 #: components/manage/Actions/Actions
 msgid "{title} copied."
-msgstr ""
+msgstr "{title} copied."
 
 #: components/manage/Actions/Actions
 msgid "{title} cut."
-msgstr ""
+msgstr "{title} cut."
 
 #: components/manage/Actions/Actions
 msgid "{title} has been deleted."
-msgstr ""
+msgstr "{title} has been deleted."

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -12,22 +12,27 @@ msgstr ""
 "Plural-Forms: \n"
 
 #: components/manage/Blocks/HTML/Edit
+# defaultMessage: <p>Add some HTML here</p>
 msgid "<p>Add some HTML here</p>"
 msgstr ""
 
 #: components/theme/Footer/Footer
+# defaultMessage: Accessibility
 msgid "Accessibility"
 msgstr ""
 
 #: components/theme/Register/Register
+# defaultMessage: Account Registration Completed
 msgid "Account Registration Completed"
 msgstr ""
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Account activation completed
 msgid "Account activation completed"
 msgstr ""
 
 #: components/manage/Controlpanels/ModerateComments
+# defaultMessage: Action
 msgid "Action"
 msgstr ""
 
@@ -36,10 +41,12 @@ msgstr ""
 #: components/manage/Controlpanels/ContentTypes
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
+# defaultMessage: Actions
 msgid "Actions"
 msgstr ""
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Activate and deactivate add-ons in the lists below.
 msgid "Activate and deactivate"
 msgstr ""
 
@@ -47,86 +54,107 @@ msgstr ""
 #: components/manage/Toolbar/Toolbar
 #: components/manage/Widgets/SchemaWidget
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add
 msgid "Add"
 msgstr ""
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: To make new add-ons show up here, add them to your buildout configuration, run buildout, and restart the server process. For detailed instructions see
 msgid "Add Addons"
 msgstr ""
 
 #: components/manage/Toolbar/Types
+# defaultMessage: Add Content…
 msgid "Add Content"
 msgstr ""
 
 #: components/manage/Toolbar/Types
+# defaultMessage: Add Translation…
 msgid "Add Translation…"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add User
 msgid "Add User"
 msgstr ""
 
 #: components/manage/Blocks/Description/Edit
+# defaultMessage: Add a description…
 msgid "Add a description…"
 msgstr ""
 
 #: components/manage/BlockChooser/BlockChooserButton
+# defaultMessage: Add block
 msgid "Add block"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add block…
 msgid "Add block…"
 msgstr ""
 
 #: components/manage/Widgets/QueryWidget
+# defaultMessage: Add criteria
 msgid "Add criteria"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Add date
 msgid "Add date"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Add field
 msgid "Add field"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Add fieldset
 msgid "Add fieldset"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add group
 msgid "Add group"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Add new content type
 msgid "Add new content type"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add new group
 msgid "Add new group"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add new user
 msgid "Add new user"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add to Groups
 msgid "Add to Groups"
 msgstr ""
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Add term
 msgid "Add vocabulary term"
 msgstr ""
 
 #: components/manage/Add/Add
+# defaultMessage: Add {type}
 msgid "Add {type}"
 msgstr ""
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Add-ons Settings
 msgid "Add-ons Settings"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: Additional date
 msgid "Additional date"
 msgstr ""
 
@@ -134,39 +162,48 @@ msgstr ""
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
 #: components/manage/Blocks/Maps/MapsSidebar
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Alignment
 msgid "Alignment"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: All
 msgid "All"
 msgstr ""
 
 #: components/theme/Search/Search
+# defaultMessage: Alphabetically
 msgid "Alphabetically"
 msgstr ""
 
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: Alt text
 msgid "Alt text"
 msgstr ""
 
 #: components/manage/Toolbar/More
+# defaultMessage: Apply working copy
 msgid "Apply working copy"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Are you sure you want to delete this field?
 msgid "Are you sure you want to delete this field?"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Are you sure you want to delete this fieldset including all fields?
 msgid "Are you sure you want to delete this fieldset including all fields?"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Ascending
 msgid "Ascending"
 msgstr ""
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Available
 msgid "Available"
 msgstr ""
 
@@ -191,48 +228,59 @@ msgstr ""
 #: components/manage/Toolbar/Toolbar
 #: components/theme/ContactForm/ContactForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Back
 msgid "Back"
 msgstr ""
 
 #: components/manage/Diff/Diff
+# defaultMessage: Base
 msgid "Base"
 msgstr ""
 
 #: components/manage/Sidebar/Sidebar
+# defaultMessage: Block
 msgid "Block"
 msgstr ""
 
 #: components/theme/Login/Login
+# defaultMessage: Both email address and password are case sensitive, check that caps lock is not enabled.
 msgid "Both email address and password are case sensitive, check that caps lock is not enabled."
 msgstr ""
 
 #: components/theme/Breadcrumbs/Breadcrumbs
+# defaultMessage: Breadcrumbs
 msgid "Breadcrumbs"
 msgstr ""
 
 #: components/manage/Blocks/HeroImageLeft/Edit
 #: components/manage/Contents/ContentsUploadModal
 #: components/manage/Sidebar/ObjectBrowserNav
+# defaultMessage: Browse
 msgid "Browse"
 msgstr ""
 
 #: components/manage/Blocks/Image/Edit
+# defaultMessage: Browse the site, drop an image, or type an URL
 msgid "Browse the site, drop an image, or type an URL"
 msgstr ""
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: By default, permissions from the container of this item are inherited. If you disable this, only the explicitly defined sharing permissions will be valid. In the overview, the symbol {inherited} indicates an inherited value. Similarly, the symbol {global} indicates a global role, which is managed by the site administrator.
 msgid "By default, permissions from the container of this item are inherited. If you disable this, only the explicitly defined sharing permissions will be valid. In the overview, the symbol {inherited} indicates an inherited value. Similarly, the symbol {global} indicates a global role, which is managed by the site administrator."
 msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Cache Name
 msgid "Cache Name"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypeLayout
+# defaultMessage: Can not edit Layout for <strong>{type}</strong> content-type as it doesn't have support for <strong>Volto Blocks</strong> enabled
 msgid "Can not edit Layout for <strong>{type}</strong> content-type as it doesn't have support for <strong>Volto Blocks</strong> enabled"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypeLayout
+# defaultMessage: Can not edit Layout for <strong>{type}</strong> content-type as the <strong>Blocks behavior</strong> is enabled and <strong>read-only</strong>
 msgid "Can not edit Layout for <strong>{type}</strong> content-type as the <strong>Blocks behavior</strong> is enabled and <strong>read-only</strong>"
 msgstr ""
 
@@ -248,42 +296,51 @@ msgstr ""
 #: components/manage/Sharing/Sharing
 #: components/theme/Login/Login
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Cancel
 msgid "Cancel"
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Cell
 msgid "Cell"
 msgstr ""
 
 #: components/manage/Blocks/Image/ImageSizeWidget
 #: components/manage/Blocks/Maps/Edit
 #: components/manage/Sidebar/AlignBlock
+# defaultMessage: Center
 msgid "Center"
 msgstr ""
 
 #: components/manage/History/History
+# defaultMessage: Change Note
 msgid "Change Note"
 msgstr ""
 
 #: components/manage/Preferences/ChangePassword
+# defaultMessage: Change Password
 msgid "Change Password"
 msgstr ""
 
 #: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Change State
 msgid "Change State"
 msgstr ""
 
 #: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Change workflow state recursively
 msgid "Change workflow state recursively"
 msgstr ""
 
 #: components/manage/Toolbar/More
+# defaultMessage: Changes applied
 msgid "Changes applied."
 msgstr ""
 
 #: components/manage/Preferences/ChangePassword
 #: components/manage/Preferences/PersonalInformation
 #: components/manage/Preferences/PersonalPreferences
+# defaultMessage: Changes saved
 msgid "Changes saved"
 msgstr ""
 
@@ -291,192 +348,237 @@ msgstr ""
 #: components/manage/Controlpanels/ContentTypeLayout
 #: components/manage/Controlpanels/ContentTypeSchema
 #: components/manage/Controlpanels/Controlpanel
+# defaultMessage: Changes saved.
 msgid "Changes saved."
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Checkbox
 msgid "Checkbox"
 msgstr ""
 
 #: components/manage/Widgets/SelectWidget
+# defaultMessage: Choices
 msgid "Choices"
 msgstr ""
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: Choose Image
 msgid "Choose Image"
 msgstr ""
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: Choose Target
 msgid "Choose Target"
 msgstr ""
 
 #: components/manage/Widgets/FileWidget
+# defaultMessage: Choose a file
 msgid "Choose a file"
 msgstr ""
 
 #: components/manage/Blocks/HTML/Edit
+# defaultMessage: Clear
 msgid "Clear"
 msgstr ""
 
 #: components/theme/View/ImageView
+# defaultMessage: Click to download full sized image
 msgid "Click to download full sized image"
 msgstr ""
 
 #: components/manage/Widgets/SelectWidget
+# defaultMessage: Close
 msgid "Close"
 msgstr ""
 
 #: components/theme/Navigation/Navigation
+# defaultMessage: Close menu
 msgid "Close menu"
 msgstr ""
 
 #: components/manage/Blocks/HTML/Edit
+# defaultMessage: Code
 msgid "Code"
 msgstr ""
 
 #: components/manage/Widgets/ObjectListWidget
+# defaultMessage: Collapse item
 msgid "Collapse item"
 msgstr ""
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Collection
 msgid "Collection"
 msgstr ""
 
 #: components/manage/Controlpanels/ModerateComments
 #: components/theme/Comments/CommentEditModal
 #: components/theme/Comments/Comments
+# defaultMessage: Comment
 msgid "Comment"
 msgstr ""
 
 #: components/manage/Controlpanels/ModerateComments
+# defaultMessage: Commenter
 msgid "Commenter"
 msgstr ""
 
 #: components/theme/Comments/Comments
+# defaultMessage: Comments
 msgid "Comments"
 msgstr ""
 
 #: components/manage/Diff/Diff
+# defaultMessage: Compare
 msgid "Compare"
 msgstr ""
 
 #: components/manage/Preferences/ChangePassword
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Confirm password
 msgid "Confirm password"
 msgstr ""
 
 #: components/theme/ConnectionRefused/ConnectionRefused
+# defaultMessage: Connection refused
 msgid "Connection refused"
 msgstr ""
 
 #: components/theme/Footer/Footer
+# defaultMessage: Contact
 msgid "Contact"
 msgstr ""
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Contact form
 msgid "Contact form"
 msgstr ""
 
 #: components/manage/Blocks/Listing/Edit
+# defaultMessage: Contained items
 msgid "Contained items"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Content type created
 msgid "Content type created"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Content type deleted
 msgid "Content type deleted"
 msgstr ""
 
 #: components/manage/Contents/Contents
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Contents
 msgid "Contents"
 msgstr ""
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Copy
 msgid "Copy"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: undefined
 msgid "Copy blocks"
 msgstr ""
 
 #: components/theme/Footer/Footer
+# defaultMessage: Copyright
 msgid "Copyright"
 msgstr ""
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Copyright statement or other rights information on this item.
 msgid "Copyright statement or other rights information on this item."
 msgstr ""
 
 #: components/manage/Toolbar/More
+# defaultMessage: Create working copy
 msgid "Create working copy"
 msgstr ""
 
 #: components/manage/WorkingCopyToastsFactory/WorkingCopyToastsFactory
+# defaultMessage: Created by {creator} on {date}
 msgid "Created by {creator} on {date}"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Created on
 msgid "Created on"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Creator
 msgid "Creator"
 msgstr ""
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Creators
 msgid "Creators"
 msgstr ""
 
 #: components/manage/Widgets/QuerystringWidget
 #: components/manage/Widgets/QueryWidget
+# defaultMessage: Criteria
 msgid "Criteria"
 msgstr ""
 
 #: components/manage/Preferences/ChangePassword
+# defaultMessage: Current password
 msgid "Current password"
 msgstr ""
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Cut
 msgid "Cut"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: undefined
 msgid "Cut blocks"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Daily
 msgid "Daily"
 msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Database Information
 msgid "Database Information"
 msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Database Location
 msgid "Database Location"
 msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Database Size
 msgid "Database Size"
 msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Database main
 msgid "Database main"
 msgstr ""
 
 #: components/manage/Controlpanels/ModerateComments
 #: components/manage/Widgets/DatetimeWidget
+# defaultMessage: Date
 msgid "Date"
 msgstr ""
 
 #: components/theme/Search/Search
+# defaultMessage: Date (newest first)
 msgid "Date (newest first)"
 msgstr ""
 
@@ -496,6 +598,7 @@ msgstr ""
 #: components/theme/PasswordReset/PasswordReset
 #: components/theme/PasswordReset/RequestPasswordReset
 #: components/theme/Register/Register
+# defaultMessage: Default
 msgid "Default"
 msgstr ""
 
@@ -510,38 +613,47 @@ msgstr ""
 #: components/manage/Widgets/ObjectBrowserWidget
 #: components/manage/Widgets/WysiwygWidget
 #: components/theme/Comments/Comments
+# defaultMessage: Delete
 msgid "Delete"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Delete Group
 msgid "Delete Group"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Delete Type
 msgid "Delete Type"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Delete User
 msgid "Delete User"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: undefined
 msgid "Delete blocks"
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Delete col
 msgid "Delete col"
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Delete row
 msgid "Delete row"
 msgstr ""
 
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: Depth
 msgid "Depth"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Descending
 msgid "Descending"
 msgstr ""
 
@@ -552,72 +664,89 @@ msgstr ""
 #: components/manage/Widgets/WysiwygWidget
 #: components/theme/View/TabularView
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Description
 msgid "Description"
 msgstr ""
 
 #: components/manage/Diff/Diff
+# defaultMessage: Diff
 msgid "Diff"
 msgstr ""
 
 #: components/manage/Diff/Diff
+# defaultMessage: Difference between revision {one} and {two} of {title}
 msgid "Difference between revision {one} and {two} of {title}"
 msgstr ""
 
 #: components/theme/Footer/Footer
+# defaultMessage: Distributed under the {license}.
 msgid "Distributed under the {license}."
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Add border to inner columns
 msgid "Divide each row into separate cells"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Do you really want to delete the following items?
 msgid "Do you really want to delete the following items?"
 msgstr ""
 
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
+# defaultMessage: Do you really want to delete the group {groupname}?
 msgid "Do you really want to delete the group {groupname}?"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Do you really want to delete type {typename}?
 msgid "Do you really want to delete the type {typename}?"
 msgstr ""
 
 #: components/manage/Controlpanels/Users/UsersControlpanel
+# defaultMessage: Do you really want to delete the user {username}?
 msgid "Do you really want to delete the user {username}?"
 msgstr ""
 
 #: components/manage/Delete/Delete
+# defaultMessage: Do you really want to delete this item?
 msgid "Do you really want to delete this item?"
 msgstr ""
 
 #: components/manage/Multilingual/TranslationObject
 #: components/manage/Sidebar/Sidebar
+# defaultMessage: Document
 msgid "Document"
 msgstr ""
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Drag and drop files from your computer onto this area or click the “Browse” button.
 msgid "Drag and drop files from your computer onto this area or click the “Browse” button."
 msgstr ""
 
 #: components/manage/Widgets/FileWidget
+# defaultMessage: Drop file here to replace the existing file
 msgid "Drop file here to replace the existing file"
 msgstr ""
 
 #: components/manage/Widgets/FileWidget
+# defaultMessage: Drop file here to upload a new file
 msgid "Drop file here to upload a new file"
 msgstr ""
 
 #: components/manage/Widgets/FileWidget
+# defaultMessage: Drop files here ...
 msgid "Drop files here ..."
 msgstr ""
 
 #: components/manage/Preferences/PersonalInformation
 #: components/theme/Register/Register
+# defaultMessage: E-mail
 msgid "E-mail"
 msgstr ""
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: E-mail addresses do not match.
 msgid "E-mail addresses do not match."
 msgstr ""
 
@@ -628,93 +757,115 @@ msgstr ""
 #: components/manage/Widgets/FormFieldWrapper
 #: components/manage/Widgets/ObjectBrowserWidget
 #: components/theme/Comments/Comments
+# defaultMessage: Edit
 msgid "Edit"
 msgstr ""
 
 #: components/theme/Comments/CommentEditModal
+# defaultMessage: Edit comment
 msgid "Edit comment"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Edit field
 msgid "Edit field"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Edit fieldset
 msgid "Edit fieldset"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Edit recurrence
 msgid "Edit recurrence"
 msgstr ""
 
 #: components/manage/Form/InlineForm
+# defaultMessage: Edit values
 msgid "Edit values"
 msgstr ""
 
 #: components/manage/Edit/Edit
+# defaultMessage: Edit {title}
 msgid "Edit {title}"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Email
 msgid "Email"
 msgstr ""
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Email sent
 msgid "Email sent"
 msgstr ""
 
 #: components/manage/Blocks/Maps/Edit
+# defaultMessage: Embed code error, please follow the instructions and try again.
 msgid "Embed code error, please follow the instructions and try again."
 msgstr ""
 
 #: components/manage/Blocks/Maps/View
+# defaultMessage: Embeded Google Maps
 msgid "Embeded Google Maps"
 msgstr ""
 
 #: components/manage/Widgets/ObjectListWidget
+# defaultMessage: Empty object list
 msgid "Empty object list"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypeLayout
+# defaultMessage: Enable editable Blocks
 msgid "Enable editable Blocks"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: End Date
 msgid "End Date"
 msgstr ""
 
 #: components/manage/AnchorPlugin/components/LinkButton/AddLinkForm
+# defaultMessage: Enter URL or select an item
 msgid "Enter URL or select an item"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Enter a username above to search or click 'Show All'
 msgid "Enter a username above to search or click 'Show All'"
 msgstr ""
 
 #: components/theme/Register/Register
+# defaultMessage: Enter an email address. This will be your login name. We respect your privacy, and will not give the address away to any third parties or expose it anywhere.
 msgid "Enter an email address. This will be your login name. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr ""
 
 #: components/manage/Preferences/PersonalInformation
 #: components/theme/PasswordReset/PasswordReset
 #: components/theme/Register/Register
+# defaultMessage: Enter full name, e.g. John Smith.
 msgid "Enter full name, e.g. John Smith."
 msgstr ""
 
 #: components/manage/Blocks/Maps/Edit
+# defaultMessage: Enter map Embed Code
 msgid "Enter map Embed Code"
 msgstr ""
 
 #: components/manage/Preferences/ChangePassword
+# defaultMessage: Enter your current password.
 msgid "Enter your current password."
 msgstr ""
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Enter your email address for verification.
 msgid "Enter your email address for verification."
 msgstr ""
 
 #: components/manage/Preferences/ChangePassword
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Enter your new password. Minimum 5 characters.
 msgid "Enter your new password. Minimum 5 characters."
 msgstr ""
 
@@ -726,199 +877,245 @@ msgstr ""
 #: components/theme/ContactForm/ContactForm
 #: components/theme/Login/Login
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Error
 msgid "Error"
 msgstr ""
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Exclude from navigation
 msgid "Exclude from navigation"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: Exclude this occurence
 msgid "Exclude this occurence"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Excluded from navigation
 msgid "Excluded from navigation"
 msgstr ""
 
 #: components/manage/Sidebar/Sidebar
+# defaultMessage: Expand sidebar
 msgid "Expand sidebar"
 msgstr ""
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Expiration Date
 msgid "Expiration Date"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Expiration date
 msgid "Expiration date"
 msgstr ""
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Expired
 msgid "Expired"
 msgstr ""
 
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: External URL
 msgid "External URL"
 msgstr ""
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: File
 msgid "File"
 msgstr ""
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: File size
 msgid "File size"
 msgstr ""
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Filename
 msgid "Filename"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Filter…
 msgid "Filter…"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: First
 msgid "First"
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Fixed width columns
 msgid "Fixed width table cells"
 msgstr ""
 
 #: components/manage/BlockChooser/BlockChooser
+# defaultMessage: Fold
 msgid "Fold"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Folder
 msgid "Folder"
 msgstr ""
 
 #: components/theme/Forbidden/Forbidden
+# defaultMessage: Forbidden
 msgid "Forbidden"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: Fourth
 msgid "Fourth"
 msgstr ""
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: From
 msgid "From"
 msgstr ""
 
 #: components/manage/Blocks/Maps/Edit
 #: components/manage/Sidebar/AlignBlock
+# defaultMessage: Full
 msgid "Full"
 msgstr ""
 
 #: components/manage/Preferences/PersonalInformation
 #: components/theme/PasswordReset/PasswordReset
 #: components/theme/Register/Register
+# defaultMessage: Full Name
 msgid "Full Name"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Fullname
 msgid "Fullname"
 msgstr ""
 
 #: components/theme/Footer/Footer
+# defaultMessage: GNU GPL license
 msgid "GNU GPL license"
 msgstr ""
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Global role
 msgid "Global role"
 msgstr ""
 
 #: components/manage/Blocks/Maps/Edit
+# defaultMessage: Google Maps Embedded Block
 msgid "Google Maps Embedded Block"
 msgstr ""
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Group
 msgid "Group"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Group created
 msgid "Group created"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Group roles updated
 msgid "Group roles updated"
 msgstr ""
 
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Groupname
 msgid "Groupname"
 msgstr ""
 
 #: components/manage/Controlpanels/Controlpanels
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Groups
 msgid "Groups"
 msgstr ""
 
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
+# defaultMessage: Groups are logical collections of users, such as departments and business units. Groups are not directly related to permissions on a global level, you normally use Roles for that - and let certain Groups have a particular role. The symbol{plone_svg}indicates a role inherited from membership in another group.
 msgid "Groups are logical collections of users, such as departments and business units. Groups are not directly related to permissions on a global level, you normally use Roles for that - and let certain Groups have a particular role. The symbol{plone_svg}indicates a role inherited from membership in another group."
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Header cell
 msgid "Header cell"
 msgstr ""
 
 #: components/theme/Comments/Comments
+# defaultMessage: Hide Replies
 msgid "Hide Replies"
 msgstr ""
 
 #: components/manage/History/History
 #: components/manage/Toolbar/More
+# defaultMessage: History
 msgid "History"
 msgstr ""
 
 #: components/manage/History/History
+# defaultMessage: #
 msgid "History Version Number"
 msgstr ""
 
 #: components/manage/History/History
+# defaultMessage: History of {title}
 msgid "History of {title}"
 msgstr ""
 
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsBreadcrumbs
 #: components/theme/Breadcrumbs/Breadcrumbs
+# defaultMessage: Home
 msgid "Home"
 msgstr ""
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: Home page
 msgid "Home page"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: ID
 msgid "ID"
 msgstr ""
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: If selected, this item will not appear in the navigation tree
 msgid "If selected, this item will not appear in the navigation tree"
 msgstr ""
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: If this date is in the future, the content will not show up in listings and searches until this date.
 msgid "If this date is in the future, the content will not show up in listings and searches until this date."
 msgstr ""
 
 #: components/manage/LockingToastsFactory/LockingToastsFactory
+# defaultMessage: If you are certain this user has abandoned the object, you may unlock the object. You will then be able to edit it.
 msgid "If you are certain this user has abandoned the object, you may unlock the object. You will then be able to edit it."
 msgstr ""
 
 #: components/theme/NotFound/NotFound
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: If you are certain you have the correct web address but are encountering an error, please contact the {site_admin}.
 msgid "If you are certain you have the correct web address but are encountering an error, please contact the {site_admin}."
 msgstr ""
 
 #: components/manage/Blocks/HeroImageLeft/Edit
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: Image
 msgid "Image"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: Include this occurence
 msgid "Include this occurence"
 msgstr ""
 
@@ -926,142 +1123,176 @@ msgstr ""
 #: components/manage/Controlpanels/ContentTypeLayout
 #: components/manage/Controlpanels/ContentTypeSchema
 #: components/manage/Controlpanels/Controlpanel
+# defaultMessage: Info
 msgid "Info"
 msgstr ""
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Inherit permissions from higher levels
 msgid "Inherit permissions from higher levels"
 msgstr ""
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Inherited value
 msgid "Inherited value"
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Insert col after
 msgid "Insert col after"
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Insert col before
 msgid "Insert col before"
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Insert row after
 msgid "Insert row after"
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Insert row before
 msgid "Insert row before"
 msgstr ""
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Install
 msgid "Install"
 msgstr ""
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Installed
 msgid "Installed"
 msgstr ""
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Installed version
 msgid "Installed version"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: days
 msgid "Interval Daily"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Month(s)
 msgid "Interval Monthly"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: week(s)
 msgid "Interval Weekly"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: year(s)
 msgid "Interval Yearly"
 msgstr ""
 
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: Item batch size
 msgid "Item batch size"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Item succesfully moved.
 msgid "Item succesfully moved."
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Item(s) copied.
 msgid "Item(s) copied."
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Item(s) cut.
 msgid "Item(s) cut."
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Item(s) has been updated.
 msgid "Item(s) has been updated."
 msgstr ""
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
+# defaultMessage: Item(s) pasted.
 msgid "Item(s) pasted."
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Item(s) state has been updated.
 msgid "Item(s) state has been updated."
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Items
 msgid "Items"
 msgstr ""
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Items must be unique.
 msgid "Items must be unique."
 msgstr ""
 
 #: components/manage/Preferences/PersonalPreferences
+# defaultMessage: Language
 msgid "Language"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: Last
 msgid "Last"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Last comment date
 msgid "Last comment date"
 msgstr ""
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Last modified
 msgid "Last modified"
 msgstr ""
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Latest version
 msgid "Latest version"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypesActions
+# defaultMessage: Layout
 msgid "Layout"
 msgstr ""
 
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: Lead Image
 msgid "Lead Image"
 msgstr ""
 
 #: components/manage/Blocks/Image/ImageSizeWidget
 #: components/manage/Blocks/Maps/Edit
 #: components/manage/Sidebar/AlignBlock
+# defaultMessage: Left
 msgid "Left"
 msgstr ""
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Link
 msgid "Link"
 msgstr ""
 
 #: components/manage/Blocks/Listing/schema
+# defaultMessage: Link more
 msgid "Link more"
 msgstr ""
 
 #: components/manage/Blocks/Listing/schema
+# defaultMessage: Link Title
 msgid "Link title"
 msgstr ""
 
@@ -1070,212 +1301,262 @@ msgstr ""
 #: components/manage/Blocks/Listing/schema
 #: components/manage/Blocks/Maps/MapsSidebar
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Link to
 msgid "Link to"
 msgstr ""
 
 #: components/manage/Multilingual/ManageTranslations
+# defaultMessage: Link translation for
 msgid "Link translation for"
 msgstr ""
 
 #: components/manage/Blocks/Listing/schema
+# defaultMessage: Listing
 msgid "Listing"
 msgstr ""
 
 #: components/theme/Comments/Comments
+# defaultMessage: Load more...
 msgid "Load more"
 msgstr ""
 
 #: components/manage/Form/ModalForm
+# defaultMessage: Loading.
 msgid "Loading"
 msgstr ""
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: Location
 msgid "Location"
 msgstr ""
 
 #: components/theme/Login/Login
+# defaultMessage: Login
 msgid "Log In"
 msgstr ""
 
 #: components/theme/Anontools/Anontools
 #: components/theme/Login/Login
+# defaultMessage: Log in
 msgid "Log in"
 msgstr ""
 
 #: components/theme/Login/Login
+# defaultMessage: Login
 msgid "Login"
 msgstr ""
 
 #: components/theme/Login/Login
+# defaultMessage: Login Failed
 msgid "Login Failed"
 msgstr ""
 
 #: components/theme/Login/Login
+# defaultMessage: Login Name
 msgid "Login Name"
 msgstr ""
 
 #: components/manage/Toolbar/PersonalTools
+# defaultMessage: Logout
 msgid "Logout"
 msgstr ""
 
 #: components/manage/Toolbar/More
+# defaultMessage: Made by {creator} on {date}. This is not a working copy anymore, but the main content.
 msgid "Made by {creator} on {date}. This is not a working copy anymore, but the main content."
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Reduce cell padding
 msgid "Make the table compact"
 msgstr ""
 
 #: components/manage/Multilingual/ManageTranslations
 #: components/manage/Toolbar/More
+# defaultMessage: Manage Translations
 msgid "Manage Translations"
 msgstr ""
 
 #: components/manage/Multilingual/ManageTranslations
+# defaultMessage: Manage translations for {title}
 msgid "Manage translations for {title}"
 msgstr ""
 
 #: components/manage/Blocks/Maps/MapsSidebar
+# defaultMessage: Map
 msgid "Map"
 msgstr ""
 
 #: components/manage/Blocks/Maps/MapsSidebar
+# defaultMessage: Maps URL
 msgid "Maps URL"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Maximum length is {len}.
 msgid "Maximum length is {len}."
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Maximum value is {len}.
 msgid "Maximum value is {len}."
 msgstr ""
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Message
 msgid "Message"
 msgstr ""
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Minimum length is {len}.
 msgid "Minimum length is {len}."
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Minimum value is {len}.
 msgid "Minimum value is {len}."
 msgstr ""
 
 #: components/manage/Controlpanels/Controlpanels
+# defaultMessage: Moderate Comments
 msgid "Moderate Comments"
 msgstr ""
 
 #: components/manage/Controlpanels/ModerateComments
+# defaultMessage: Moderate comments
 msgid "Moderate comments"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Monday and Friday
 msgid "Monday and Friday"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/ByMonthDayField
+# defaultMessage: Day
 msgid "Month day"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Monthly
 msgid "Monthly"
 msgstr ""
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: More
 msgid "More"
 msgstr ""
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Move to bottom of folder
 msgid "Move to bottom of folder"
 msgstr ""
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Move to top of folder
 msgid "Move to top of folder"
 msgstr ""
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: My email address is
 msgid "My email address is"
 msgstr ""
 
 #: components/manage/Sharing/Sharing
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Name
 msgid "Name"
 msgstr ""
 
 #: error
+# defaultMessage: Navigate back
 msgid "Navigate back"
 msgstr ""
 
 #: components/theme/Navigation/ContextNavigation
+# defaultMessage: Navigation
 msgid "Navigation"
 msgstr ""
 
 #: components/manage/Preferences/ChangePassword
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: New password
 msgid "New password"
 msgstr ""
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: News Item
 msgid "News Item"
 msgstr ""
 
 #: components/manage/Contents/ContentsItem
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: No
 msgid "No"
 msgstr ""
 
 #: components/manage/Blocks/Image/ImageSidebar
+# defaultMessage: No image selected
 msgid "No image selected"
 msgstr ""
 
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: No image set in Lead Image content field
 msgid "No image set in Lead Image content field"
 msgstr ""
 
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: No image set in image content field
 msgid "No image set in image content field"
 msgstr ""
 
 #: components/manage/Blocks/Listing/ListingBody
+# defaultMessage: No items found in this container.
 msgid "No items found in this container."
 msgstr ""
 
 #: components/manage/Widgets/ObjectBrowserWidget
+# defaultMessage: No items selected
 msgid "No items selected"
 msgstr ""
 
 #: components/manage/Blocks/Maps/MapsSidebar
+# defaultMessage: No map selected
 msgid "No map selected"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: No occurences set
 msgid "No occurences set"
 msgstr ""
 
 #: components/manage/Widgets/ArrayWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/TokenWidget
+# defaultMessage: No options
 msgid "No options"
 msgstr ""
 
 #: components/theme/Search/Search
+# defaultMessage: No results found
 msgid "No results found"
 msgstr ""
 
 #: components/manage/Blocks/Listing/ListingBody
 #: components/manage/Widgets/ReferenceWidget
+# defaultMessage: No results found.
 msgid "No results found."
 msgstr ""
 
 #: components/manage/Widgets/QuerySortOnWidget
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: No selection
 msgid "No selection"
 msgstr ""
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: This addon does not provide an uninstall profile.
 msgid "No uninstall profile"
 msgstr ""
 
@@ -1283,39 +1564,48 @@ msgstr ""
 #: components/manage/Widgets/ReferenceWidget
 #: components/manage/Widgets/SelectUtils
 #: components/manage/Widgets/SelectWidget
+# defaultMessage: No value
 msgid "No value"
 msgstr ""
 
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: No video selected
 msgid "No video selected"
 msgstr ""
 
 #: components/manage/Workflow/Workflow
+# defaultMessage: No workflow
 msgid "No workflow"
 msgstr ""
 
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsItem
+# defaultMessage: None
 msgid "None"
 msgstr ""
 
 #: components/manage/Controlpanels/Users/UsersControlpanel
+# defaultMessage: Note that roles set here apply directly to a user. The symbol{plone_svg}indicates a role inherited from membership in a group.
 msgid "Note that roles set here apply directly to a user. The symbol{plone_svg}indicates a role inherited from membership in a group."
 msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Number of active objects
 msgid "Number of active objects"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Object Size
 msgid "Object Size"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/EndField
+# defaultMessage: occurrence(s)
 msgid "Occurences"
 msgstr ""
 
 #: components/manage/Delete/Delete
+# defaultMessage: Ok
 msgid "Ok"
 msgstr ""
 
@@ -1323,301 +1613,371 @@ msgstr ""
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
 #: components/manage/Blocks/Maps/MapsSidebar
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Open in a new tab
 msgid "Open in a new tab"
 msgstr ""
 
 #: components/theme/Navigation/Navigation
+# defaultMessage: Open menu
 msgid "Open menu"
 msgstr ""
 
 #: components/manage/Widgets/ObjectBrowserWidget
+# defaultMessage: Open object browser
 msgid "Open object browser"
 msgstr ""
 
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: Origin
 msgid "Origin"
 msgstr ""
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Page
 msgid "Page"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Parent fieldset
 msgid "Parent fieldset"
 msgstr ""
 
 #: components/theme/Login/Login
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Password
 msgid "Password"
 msgstr ""
 
 #: components/theme/PasswordReset/PasswordReset
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Password reset
 msgid "Password reset"
 msgstr ""
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Passwords do not match.
 msgid "Passwords do not match."
 msgstr ""
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
+# defaultMessage: Paste
 msgid "Paste"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: undefined
 msgid "Paste blocks"
 msgstr ""
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Permissions have been updated successfully
 msgid "Permissions have been updated successfully"
 msgstr ""
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Permissions updated
 msgid "Permissions updated"
 msgstr ""
 
 #: components/manage/Preferences/PersonalInformation
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Personal Information
 msgid "Personal Information"
 msgstr ""
 
 #: components/manage/Preferences/PersonalPreferences
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Personal Preferences
 msgid "Personal Preferences"
 msgstr ""
 
 #: components/manage/Toolbar/More
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Personal tools
 msgid "Personal tools"
 msgstr ""
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Persons responsible for creating the content of this item. Please enter a list of user names, one per line. The principal creator should come first.
 msgid "Persons responsible for creating the content of this item. Please enter a list of user names, one per line. The principal creator should come first."
 msgstr ""
 
 #: components/manage/Blocks/Video/Edit
+# defaultMessage: Please enter a valid URL by deleting the block and adding a new video block.
 msgid "Please enter a valid URL by deleting the block and adding a new video block."
 msgstr ""
 
 #: components/manage/Blocks/Maps/Edit
+# defaultMessage: Please enter the Embed Code provided by Google Maps -> Share -> Embed map. It should contain the <iframe> code on it.
 msgid "Please enter the Embed Code provided by Google Maps -> Share -> Embed map. It should contain the <iframe> code on it."
 msgstr ""
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Please fill out the form below to set your password.
 msgid "Please fill out the form below to set your password."
 msgstr ""
 
 #: components/theme/Footer/Footer
+# defaultMessage: Plone Foundation
 msgid "Plone Foundation"
 msgstr ""
 
 #: components/theme/Logo/Logo
+# defaultMessage: Plone Site
 msgid "Plone Site"
 msgstr ""
 
 #: components/theme/Footer/Footer
+# defaultMessage: Plone{reg} Open Source CMS/WCM
 msgid "Plone{reg} Open Source CMS/WCM"
 msgstr ""
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: Portrait
 msgid "Portrait"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Possible values (Enter allowed choices one per line).
 msgid "Possible values"
 msgstr ""
 
 #: components/theme/Footer/Footer
+# defaultMessage: Powered by Plone & Python
 msgid "Powered by Plone & Python"
 msgstr ""
 
 #: components/manage/Toolbar/PersonalTools
+# defaultMessage: Preferences
 msgid "Preferences"
 msgstr ""
 
 #: components/manage/Blocks/HTML/Edit
+# defaultMessage: Prettify your code
 msgid "Prettify your code"
 msgstr ""
 
 #: components/manage/Blocks/HTML/Edit
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Preview
 msgid "Preview"
 msgstr ""
 
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Preview Image URL
 msgid "Preview Image URL"
 msgstr ""
 
 #: components/manage/Toolbar/PersonalTools
+# defaultMessage: Profile
 msgid "Profile"
 msgstr ""
 
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Properties
 msgid "Properties"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Publication date
 msgid "Publication date"
 msgstr ""
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Publishing Date
 msgid "Publishing Date"
 msgstr ""
 
 #: components/manage/Blocks/Listing/schema
+# defaultMessage: Query
 msgid "Query"
 msgstr ""
 
 #: components/manage/Preferences/ChangePassword
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Re-enter the password. Make sure the passwords are identical.
 msgid "Re-enter the password. Make sure the passwords are identical."
 msgstr ""
 
 #: components/theme/Search/Search
 #: components/theme/View/SummaryView
+# defaultMessage: Read More…
 msgid "Read More…"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Rearrange items by…
 msgid "Rearrange items by…"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/EndField
+# defaultMessage: Ends
 msgid "Recurrence ends"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/EndField
+# defaultMessage: after
 msgid "Recurrence ends after"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/EndField
+# defaultMessage: on
 msgid "Recurrence ends on"
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Minimalistic table design
 msgid "Reduce complexity"
 msgstr ""
 
 #: components/theme/Anontools/Anontools
 #: components/theme/Login/Login
 #: components/theme/Register/Register
+# defaultMessage: Register
 msgid "Register"
 msgstr ""
 
 #: components/theme/Register/Register
+# defaultMessage: Registration form
 msgid "Registration form"
 msgstr ""
 
 #: components/theme/Search/Search
+# defaultMessage: Relevance
 msgid "Relevance"
 msgstr ""
 
 #: components/manage/Widgets/ObjectListWidget
+# defaultMessage: Remove item
 msgid "Remove item"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Remove
 msgid "Remove recurrence"
 msgstr ""
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Remove term
 msgid "Remove term"
 msgstr ""
 
 #: components/manage/Toolbar/More
+# defaultMessage: Remove working copy
 msgid "Remove working copy"
 msgstr ""
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
+# defaultMessage: Rename
 msgid "Rename"
 msgstr ""
 
 #: components/manage/Contents/ContentsRenameModal
+# defaultMessage: Renaming items...
 msgid "Rename Items Loading Message"
 msgstr ""
 
 #: components/manage/Contents/ContentsRenameModal
+# defaultMessage: Rename items
 msgid "Rename items"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Repeat
 msgid "Repeat"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Repeat every
 msgid "Repeat every"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Repeat on
 msgid "Repeat on"
 msgstr ""
 
 #: components/manage/Widgets/FileWidget
+# defaultMessage: Replace existing file
 msgid "Replace existing file"
 msgstr ""
 
 #: components/theme/Comments/Comments
+# defaultMessage: Reply
 msgid "Reply"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/WysiwygWidget
+# defaultMessage: Required
 msgid "Required"
 msgstr ""
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Required input is missing.
 msgid "Required input is missing."
 msgstr ""
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Reset title
 msgid "Reset term title"
 msgstr ""
 
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: Results limit
 msgid "Results limit"
 msgstr ""
 
 #: components/manage/Blocks/Listing/Edit
+# defaultMessage: Results preview
 msgid "Results preview"
 msgstr ""
 
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: Reversed order
 msgid "Reversed order"
 msgstr ""
 
 #: components/manage/History/History
+# defaultMessage: Revert to this revision
 msgid "Revert to this revision"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Review state
 msgid "Review state"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Richtext
 msgid "Richtext"
 msgstr ""
 
 #: components/manage/Blocks/Image/ImageSizeWidget
 #: components/manage/Blocks/Maps/Edit
 #: components/manage/Sidebar/AlignBlock
+# defaultMessage: Right
 msgid "Right"
 msgstr ""
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Rights
 msgid "Rights"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Roles
 msgid "Roles"
 msgstr ""
 
 #: components/manage/Contents/ContentsBreadcrumbs
+# defaultMessage: Root
 msgid "Root"
 msgstr ""
 
@@ -1630,90 +1990,112 @@ msgstr ""
 #: components/manage/Form/ModalForm
 #: components/manage/Sharing/Sharing
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Save
 msgid "Save"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Save
 msgid "Save recurrence"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypesActions
+# defaultMessage: Schema
 msgid "Schema"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypeSchema
+# defaultMessage: Schema updates
 msgid "Schema updates"
 msgstr ""
 
 #: components/theme/SearchWidget/SearchWidget
+# defaultMessage: Search
 msgid "Search"
 msgstr ""
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: Search SVG
 msgid "Search SVG"
 msgstr ""
 
 #: components/theme/SearchWidget/SearchWidget
+# defaultMessage: Search Site
 msgid "Search Site"
 msgstr ""
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: Search content
 msgid "Search content"
 msgstr ""
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Search for user or group
 msgid "Search for user or group"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Search group…
 msgid "Search group…"
 msgstr ""
 
 #: components/theme/Search/Search
+# defaultMessage: Search results
 msgid "Search results"
 msgstr ""
 
 #: components/theme/Search/Search
+# defaultMessage: Search results for {term}
 msgid "Search results for {term}"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Search users…
 msgid "Search users…"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: Second
 msgid "Second"
 msgstr ""
 
 #: components/manage/Sidebar/ObjectBrowserNav
+# defaultMessage: Select
 msgid "Select"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Select a date to add to recurrence
 msgid "Select a date to add to recurrence"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Select columns to show
 msgid "Select columns to show"
 msgstr ""
 
 #: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Select the transition to be used for modifying the items state.
 msgid "Select the transition to be used for modifying the items state."
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: Selected dates
 msgid "Selected dates"
 msgstr ""
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: Selected items
 msgid "Selected items"
 msgstr ""
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: of
 msgid "Selected items - x of y"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Selection
 msgid "Selection"
 msgstr ""
 
@@ -1721,158 +2103,195 @@ msgstr ""
 #: components/manage/Widgets/ArrayWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/TokenWidget
+# defaultMessage: Select…
 msgid "Select…"
 msgstr ""
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Send
 msgid "Send"
 msgstr ""
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Set my password
 msgid "Set my password"
 msgstr ""
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Set your password
 msgid "Set your password"
 msgstr ""
 
 #: components/manage/Sidebar/Sidebar
+# defaultMessage: Settings
 msgid "Settings"
 msgstr ""
 
 #: components/manage/Sharing/Sharing
 #: components/manage/Toolbar/More
+# defaultMessage: Sharing
 msgid "Sharing"
 msgstr ""
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Sharing for {title}
 msgid "Sharing for {title}"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/WysiwygWidget
+# defaultMessage: Short Name
 msgid "Short Name"
 msgstr ""
 
 #: components/manage/Contents/ContentsRenameModal
+# defaultMessage: Short name
 msgid "Short name"
 msgstr ""
 
 #: components/theme/Pagination/Pagination
+# defaultMessage: Show
 msgid "Show"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Show All
 msgid "Show All"
 msgstr ""
 
 #: components/theme/Comments/Comments
+# defaultMessage: Show Replies
 msgid "Show Replies"
 msgstr ""
 
 #: components/manage/Widgets/ObjectListWidget
+# defaultMessage: Show item
 msgid "Show item"
 msgstr ""
 
 #: components/manage/Sidebar/Sidebar
+# defaultMessage: Shrink sidebar
 msgid "Shrink sidebar"
 msgstr ""
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Shrink toolbar
 msgid "Shrink toolbar"
 msgstr ""
 
 #: components/theme/Login/Login
+# defaultMessage: Sign in to start session
 msgid "Sign in to start session"
 msgstr ""
 
 #: components/theme/Logo/Logo
+# defaultMessage: Site
 msgid "Site"
 msgstr ""
 
 #: components/theme/NotFound/NotFound
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: Site Administration
 msgid "Site Administration"
 msgstr ""
 
 #: components/theme/Footer/Footer
+# defaultMessage: Site Map
 msgid "Site Map"
 msgstr ""
 
 #: components/manage/Controlpanels/Controlpanels
 #: components/manage/Toolbar/PersonalTools
+# defaultMessage: Site Setup
 msgid "Site Setup"
 msgstr ""
 
 #: components/theme/Sitemap/Sitemap
+# defaultMessage: Sitemap
 msgid "Sitemap"
 msgstr ""
 
 #: components/manage/Blocks/Image/ImageSidebar
+# defaultMessage: Size
 msgid "Size"
 msgstr ""
 
 #: components/theme/View/ImageView
+# defaultMessage: Size: {size}
 msgid "Size: {size}"
 msgstr ""
 
 #: error
+# defaultMessage: Sorry, something went wrong with your request
 msgid "Sorry, something went wrong with your request"
 msgstr ""
 
 #: components/theme/Search/Search
+# defaultMessage: Sort by:
 msgid "Sort By:"
 msgstr ""
 
 #: components/manage/Widgets/QuerySortOnWidget
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: Sort on
 msgid "Sort on"
 msgstr ""
 
 #: components/manage/Blocks/HTML/Edit
+# defaultMessage: Source
 msgid "Source"
 msgstr ""
 
 #: components/manage/Blocks/Video/Edit
+# defaultMessage: Specify a youtube video or playlist url
 msgid "Specify a youtube video or playlist url"
 msgstr ""
 
 #: components/manage/Diff/Diff
+# defaultMessage: Split
 msgid "Split"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Start Date
 msgid "Start Date"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: Start of the recurrence
 msgid "Start of the recurrence"
 msgstr ""
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Start password reset
 msgid "Start password reset"
 msgstr ""
 
 #: components/manage/Contents/Contents
 #: components/manage/Workflow/Workflow
 #: components/theme/View/TabularView
+# defaultMessage: State
 msgid "State"
 msgstr ""
 
 #: components/manage/Multilingual/CompareLanguages
+# defaultMessage: Stop compare
 msgid "Stop compare"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: String
 msgid "String"
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Alternate row background color
 msgid "Stripe alternate rows with color"
 msgstr ""
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Subject
 msgid "Subject"
 msgstr ""
 
@@ -1886,43 +2305,53 @@ msgstr ""
 #: components/manage/Preferences/PersonalPreferences
 #: components/theme/ContactForm/ContactForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Success
 msgid "Success"
 msgstr ""
 
 #: components/theme/LanguageSelector/LanguageSelector
+# defaultMessage: Switch to
 msgid "Switch to"
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Table
 msgid "Table"
 msgstr ""
 
 #: components/manage/Blocks/ToC/View
+# defaultMessage: Table of Contents
 msgid "Table of Contents"
 msgstr ""
 
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsTagsModal
+# defaultMessage: Tags
 msgid "Tags"
 msgstr ""
 
 #: components/manage/Contents/ContentsTagsModal
+# defaultMessage: Tags to add
 msgid "Tags to add"
 msgstr ""
 
 #: components/manage/Contents/ContentsTagsModal
+# defaultMessage: Tags to remove
 msgid "Tags to remove"
 msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Target memory size per cache in bytes
 msgid "Target memory size per cache in bytes"
 msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Target number of objects in memory per cache
 msgid "Target number of objects in memory per cache"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Text
 msgid "Text"
 msgstr ""
 
@@ -1930,87 +2359,108 @@ msgstr ""
 #: components/theme/CorsError/CorsError
 #: components/theme/NotFound/NotFound
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: Thank you.
 msgid "Thank you."
 msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: The Database Manager allow you to view database status information
 msgid "The Database Manager allow you to view database status information"
 msgstr ""
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: The URL for your external home page, if you have one.
 msgid "The URL for your external home page, if you have one."
 msgstr ""
 
 #: components/theme/ConnectionRefused/ConnectionRefused
+# defaultMessage: The backend is not responding, please check if you have started Plone, check your project's configuration object apiPath (or if you are using the internal proxy, devProxyToApiPath) or the RAZZLE_API_PATH Volto's environment variable.
 msgid "The backend is not responding, please check if you have started Plone, check your project's configuration object apiPath (or if you are using the internal proxy, devProxyToApiPath) or the RAZZLE_API_PATH Volto's environment variable."
 msgstr ""
 
 #: components/theme/CorsError/CorsError
+# defaultMessage: The backend is responding, but the CORS headers are not configured properly and the browser has denied the access to the backend resources.
 msgid "The backend is responding, but the CORS headers are not configured properly and the browser has denied the access to the backend resources."
 msgstr ""
 
 #: components/theme/CorsError/CorsError
+# defaultMessage: The backend server of your website is not anwering, we apologize for the inconvenience. Please try to re-load the page and try again. If the problem persists please contact the site administrators.
 msgid "The backend server of your website is not anwering, we apologize for the inconvenience. Please try to re-load the page and try again. If the problem persists please contact the site administrators."
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: The item could not be deleted.
 msgid "The item could not be deleted."
 msgstr ""
 
 #: components/theme/Register/Register
+# defaultMessage: The registration process has been successful. Please check your e-mail inbox for information on how activate your account.
 msgid "The registration process has been successful. Please check your e-mail inbox for information on how activate your account."
 msgstr ""
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: The user portrait/avatar
 msgid "The user portrait/avatar"
 msgstr ""
 
 #: components/manage/Toolbar/More
+# defaultMessage: The working copy was discarded
 msgid "The working copy was discarded"
 msgstr ""
 
 #: components/theme/Footer/Footer
+# defaultMessage: The {plonecms} is {copyright} 2000-{current_year} by the {plonefoundation} and friends.
 msgid "The {plonecms} is {copyright} 2000-{current_year} by the {plonefoundation} and friends."
 msgstr ""
 
 #: components/theme/CorsError/CorsError
+# defaultMessage: There is a configuration problem on the backend
 msgid "There is a configuration problem on the backend"
 msgstr ""
 
 #: components/manage/Form/InlineForm
+# defaultMessage: There were some errors
 msgid "There were some errors"
 msgstr ""
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: There were some errors.
 msgid "There were some errors."
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: Third
 msgid "Third"
 msgstr ""
 
 #: components/manage/WorkingCopyToastsFactory/WorkingCopyToastsFactory
+# defaultMessage: This has an ongoing working copy in {title}
 msgid "This has an ongoing working copy in {title}"
 msgstr ""
 
 #: components/manage/WorkingCopyToastsFactory/WorkingCopyToastsFactory
+# defaultMessage: This is a working copy of {title}
 msgid "This is a working copy of {title}"
 msgstr ""
 
 #: components/manage/LockingToastsFactory/LockingToastsFactory
+# defaultMessage: This item was locked by {creator} on {date}
 msgid "This item was locked by {creator} on {date}"
 msgstr ""
 
 #: components/manage/Contents/ContentsRenameModal
+# defaultMessage: This name will be displayed in the URL.
 msgid "This name will be displayed in the URL."
 msgstr ""
 
 #: components/theme/NotFound/NotFound
+# defaultMessage: This page does not seem to exist…
 msgid "This page does not seem to exist…"
 msgstr ""
 
 #: components/manage/Widgets/DatetimeWidget
+# defaultMessage: Time
 msgid "Time"
 msgstr ""
 
@@ -2023,714 +2473,889 @@ msgstr ""
 #: components/manage/Widgets/WysiwygWidget
 #: components/theme/View/TabularView
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Title
 msgid "Title"
 msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Total active and non-active objects
 msgid "Total active and non-active objects"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Total comments
 msgid "Total comments"
 msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Total number of objects in each cache
 msgid "Total number of objects in each cache"
 msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Total number of objects in memory from all caches
 msgid "Total number of objects in memory from all caches"
 msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Total number of objects in the database
 msgid "Total number of objects in the database"
 msgstr ""
 
 #: components/manage/Add/Add
 #: components/manage/Toolbar/Types
+# defaultMessage: Translate to {lang}
 msgid "Translate to {lang}"
 msgstr ""
 
 #: components/manage/Multilingual/ManageTranslations
+# defaultMessage: Translation linked
 msgid "Translation linked"
 msgstr ""
 
 #: components/manage/Multilingual/ManageTranslations
+# defaultMessage: Translation linking removed
 msgid "Translation linking removed"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypes
 #: components/manage/Widgets/SchemaWidget
 #: components/theme/View/TabularView
+# defaultMessage: Type
 msgid "Type"
 msgstr ""
 
 #: components/manage/Blocks/Video/Edit
+# defaultMessage: Type a Video (YouTube, Vimeo or mp4) URL
 msgid "Type a Video (YouTube, Vimeo or mp4) URL"
 msgstr ""
 
 #: components/manage/Blocks/Text/Edit
+# defaultMessage: Type text…
 msgid "Type text…"
 msgstr ""
 
 #: components/manage/Blocks/Title/Edit
+# defaultMessage: Type the title…
 msgid "Type the title…"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: UID
 msgid "UID"
 msgstr ""
 
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: Unauthorized
 msgid "Unauthorized"
 msgstr ""
 
 #: components/manage/BlockChooser/BlockChooser
+# defaultMessage: Unfold
 msgid "Unfold"
 msgstr ""
 
 #: components/manage/Diff/Diff
+# defaultMessage: Unified
 msgid "Unified"
 msgstr ""
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Uninstall
 msgid "Uninstall"
 msgstr ""
 
 #: components/manage/Blocks/Block/Edit
 #: components/theme/View/DefaultView
 #: components/theme/View/RenderBlocks
+# defaultMessage: Unknown Block {block}
 msgid "Unknown Block"
 msgstr "Unknown Block {block}"
 
 #: components/manage/Multilingual/ManageTranslations
+# defaultMessage: Unlink translation for
 msgid "Unlink translation for"
 msgstr ""
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Unlock
 msgid "Unlock"
 msgstr ""
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Update
 msgid "Update"
 msgstr ""
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Update installed addons
 msgid "Update installed addons"
 msgstr ""
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Update installed addons:
 msgid "Update installed addons:"
 msgstr ""
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Updates available
 msgid "Updates available"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Upload
 msgid "Upload"
 msgstr ""
 
 #: components/manage/Blocks/LeadImage/Edit
+# defaultMessage: Upload a lead image in the 'Lead Image' content field.
 msgid "Upload a lead image in the 'Lead Image' content field."
 msgstr ""
 
 #: components/manage/Blocks/HeroImageLeft/Edit
+# defaultMessage: Upload a new image
 msgid "Upload a new image"
 msgstr ""
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Upload files
 msgid "Upload files"
 msgstr ""
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Uploading files
 msgid "Uploading files"
 msgstr ""
 
 #: components/manage/Blocks/HeroImageLeft/Edit
+# defaultMessage: Uploading image
 msgid "Uploading image"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/WysiwygWidget
+# defaultMessage: Used for programmatic access to the fieldset.
 msgid "Used for programmatic access to the fieldset."
 msgstr ""
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: User
 msgid "User"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: User created
 msgid "User created"
 msgstr ""
 
 #: components/manage/Controlpanels/Users/UsersControlpanel
+# defaultMessage: User name
 msgid "User name"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: User roles updated
 msgid "User roles updated"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Username
 msgid "Username"
 msgstr ""
 
 #: components/manage/Controlpanels/Controlpanels
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Users
 msgid "Users"
 msgstr ""
 
 #: components/manage/Controlpanels/Controlpanels
+# defaultMessage: Users and Groups
 msgid "Users and Groups"
 msgstr ""
 
 #: helpers/Extensions/withBlockSchemaEnhancer
+# defaultMessage: Variation
 msgid "Variation"
 msgstr ""
 
 #: components/manage/Controlpanels/Controlpanels
+# defaultMessage: Version Overview
 msgid "Version Overview"
 msgstr ""
 
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Video
 msgid "Video"
 msgstr ""
 
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Video URL
 msgid "Video URL"
 msgstr ""
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: View
 msgid "View"
 msgstr ""
 
 #: components/manage/History/History
+# defaultMessage: View changes
 msgid "View changes"
 msgstr ""
 
 #: components/manage/History/History
+# defaultMessage: View this revision
 msgid "View this revision"
 msgstr ""
 
 #: components/manage/Toolbar/More
+# defaultMessage: View working copy
 msgid "View working copy"
 msgstr ""
 
 #: components/manage/Display/Display
+# defaultMessage: View
 msgid "Viewmode"
 msgstr ""
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Vocabulary term
 msgid "Vocabulary term"
 msgstr ""
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Title
 msgid "Vocabulary term title"
 msgstr ""
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Vocabulary terms
 msgid "Vocabulary terms"
 msgstr ""
 
 #: components/manage/Controlpanels/VersionOverview
+# defaultMessage: You are running in 'debug mode'. This mode is intended for sites that are under development. This allows many configuration changes to be immediately visible, but will make your site run more slowly. To turn off debug mode, stop the server, set 'debug-mode=off' in your buildout.cfg, re-run bin/buildout and then restart the server process.
 msgid "Warning Regarding debug mode"
 msgstr ""
 
 #: components/theme/ConnectionRefused/ConnectionRefused
+# defaultMessage: We apologize for the inconvenience, but the backend of the site you are accessing is not available right now. Please, try again later.
 msgid "We apologize for the inconvenience, but the backend of the site you are accessing is not available right now. Please, try again later."
 msgstr ""
 
 #: components/theme/NotFound/NotFound
+# defaultMessage: We apologize for the inconvenience, but the page you were trying to access is not at this address. You can use the links below to help you find what you are looking for.
 msgid "We apologize for the inconvenience, but the page you were trying to access is not at this address. You can use the links below to help you find what you are looking for."
 msgstr ""
 
 #: components/theme/Forbidden/Forbidden
+# defaultMessage: We apologize for the inconvenience, but you don't have permissions on this resource.
 msgid "We apologize for the inconvenience, but you don't have permissions on this resource."
 msgstr ""
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: We will use this address if you need to recover your password
 msgid "We will use this address if you need to recover your password"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: The
 msgid "Weeek day of month"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Weekday
 msgid "Weekday"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Weekly
 msgid "Weekly"
 msgstr ""
 
 #: components/manage/History/History
+# defaultMessage: What
 msgid "What"
 msgstr ""
 
 #: components/manage/History/History
+# defaultMessage: When
 msgid "When"
 msgstr ""
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: When this date is reached, the content will nolonger be visible in listings and searches.
 msgid "When this date is reached, the content will nolonger be visible in listings and searches."
 msgstr ""
 
 #: components/manage/History/History
+# defaultMessage: Who
 msgid "Who"
 msgstr ""
 
 #: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Updating workflow states...
 msgid "Workflow Change Loading Message"
 msgstr ""
 
 #: components/manage/Workflow/Workflow
+# defaultMessage: Workflow updated.
 msgid "Workflow updated."
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Yearly
 msgid "Yearly"
 msgstr ""
 
 #: components/manage/Contents/ContentsItem
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Yes
 msgid "Yes"
 msgstr ""
 
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: You are trying to access a protected resource, please {login} first.
 msgid "You are trying to access a protected resource, please {login} first."
 msgstr ""
 
 #: components/theme/OutdatedBrowser/OutdatedBrowser
+# defaultMessage: You are using an outdated browser
 msgid "You are using an outdated browser"
 msgstr ""
 
 #: components/theme/Comments/Comments
+# defaultMessage: You can add a comment by filling out the form below. Plain text formatting.
 msgid "You can add a comment by filling out the form below. Plain text formatting."
 msgstr ""
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: You can control who can view and edit your item using the list below.
 msgid "You can control who can view and edit your item using the list below."
 msgstr ""
 
 #: components/manage/Diff/Diff
+# defaultMessage: You can view the difference of the revisions below.
 msgid "You can view the difference of the revisions below."
 msgstr ""
 
 #: components/manage/History/History
+# defaultMessage: You can view the history of your item below.
 msgid "You can view the history of your item below."
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: You can't paste this content here
 msgid "You can't paste this content here"
 msgstr ""
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Your email is required for reset your password.
 msgid "Your email is required for reset your password."
 msgstr ""
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: Your location - either city and country - or in a company setting, where your office is located.
 msgid "Your location - either city and country - or in a company setting, where your office is located."
 msgstr ""
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Your password has been set successfully. You may now {link} with your new password.
 msgid "Your password has been set successfully. You may now {link} with your new password."
 msgstr ""
 
 #: components/manage/Preferences/PersonalPreferences
+# defaultMessage: Your preferred language
 msgid "Your preferred language"
 msgstr ""
 
 #: components/theme/Login/Login
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Forgot your password?
 msgid "box_forgot_password_option"
 msgstr ""
 
 #: config/Blocks
+# defaultMessage: Common
 msgid "common"
 msgstr ""
 
 #: components/manage/Multilingual/CompareLanguages
+# defaultMessage: Compare to language
 msgid "compare_to"
 msgstr ""
 
 #: components/manage/Blocks/Block/EditBlockWrapper
+# defaultMessage: delete
 msgid "delete"
 msgstr ""
 
 #: components/theme/OutdatedBrowser/OutdatedBrowser
+# defaultMessage: You are using {browsername} {browserversion} which is deprecated by its vendor. That means that it does not get security updates and it is not ready for current modern web features, which deteriorates the user experience. Please upgrade to a modern browser.
 msgid "deprecated_browser_notice_message"
 msgstr ""
 
 #: config/Blocks
+# defaultMessage: Description
 msgid "description"
 msgstr ""
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: For security reasons, we store your password encrypted, and cannot mail it to you. If you would like to reset your password, fill out the form below and we will send you an email at the address you gave when you registered to start the process of resetting your password.
 msgid "description_lost_password"
 msgstr ""
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Your password reset request has been mailed. It should arrive in your mailbox shortly. When you receive the message, visit the address it contains to reset your password.
 msgid "description_sent_password"
 msgstr ""
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Draft
 msgid "draft"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Input must be valid email (something@domain.com)
 msgid "email"
 msgstr ""
 
 #: components/theme/View/EventView
+# defaultMessage: All dates
 msgid "event_alldates"
 msgstr ""
 
 #: components/theme/View/EventView
+# defaultMessage: Attendees
 msgid "event_attendees"
 msgstr ""
 
 #: components/theme/View/EventView
+# defaultMessage: Contact Name
 msgid "event_contactname"
 msgstr ""
 
 #: components/theme/View/EventView
+# defaultMessage: Contact Phone
 msgid "event_contactphone"
 msgstr ""
 
 #: components/theme/View/EventView
+# defaultMessage: Website
 msgid "event_website"
 msgstr ""
 
 #: components/theme/View/EventView
+# defaultMessage: What
 msgid "event_what"
 msgstr ""
 
 #: components/theme/View/EventView
+# defaultMessage: When
 msgid "event_when"
 msgstr ""
 
 #: components/theme/View/EventView
+# defaultMessage: Where
 msgid "event_where"
 msgstr ""
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Password reset confirmation sent
 msgid "heading_sent_password"
 msgstr ""
 
 #: config/Blocks
+# defaultMessage: Hero
 msgid "hero"
 msgstr ""
 
 #: config/Blocks
+# defaultMessage: HTML
 msgid "html"
 msgstr ""
 
 #: config/Blocks
+# defaultMessage: Image
 msgid "image"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Input must be integer
 msgid "integer"
 msgstr ""
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Intranet
 msgid "intranet"
 msgstr ""
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: My email address is
 msgid "label_my_email_address_is"
 msgstr ""
 
 #: config/Blocks
+# defaultMessage: Lead Image Field
 msgid "leadimage"
 msgstr ""
 
 #: config/Blocks
+# defaultMessage: Listing
 msgid "listing"
 msgstr ""
 
 #: components/manage/Blocks/Listing/ListingBody
 #: components/manage/Contents/Contents
+# defaultMessage: Loading
 msgid "loading"
 msgstr ""
 
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: log in
 msgid "log in"
 msgstr ""
 
 #: config/Blocks
+# defaultMessage: Maps
 msgid "maps"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Maximum Length
 msgid "maxLength"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: End of the range (including the value itself)
 msgid "maximum"
 msgstr ""
 
 #: config/Blocks
+# defaultMessage: Media
 msgid "media"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Minimum Length
 msgid "minLength"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Start of the range
 msgid "minimum"
 msgstr ""
 
 #: config/Blocks
+# defaultMessage: Most used
 msgid "mostUsed"
 msgstr ""
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: No workflow state
 msgid "no workflow state"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Input must be number
 msgid "number"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/ByMonthDayField
 #: components/manage/Widgets/RecurrenceWidget/ByYearField
+# defaultMessage: of the month
 msgid "of the month"
 msgstr ""
 
 #: error
+# defaultMessage: or try a different page.
 msgid "or try a different page."
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: others
 msgid "others"
 msgstr ""
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Private
 msgid "private"
 msgstr ""
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Published
 msgid "published"
 msgstr ""
 
 #: components/manage/Widgets/QueryWidget
+# defaultMessage: Select…
 msgid "querystring-widget-select"
 msgstr ""
 
 #: components/theme/Search/Search
+# defaultMessage: results
 msgid "results found"
 msgstr ""
 
 #: error
+# defaultMessage: return to the site root
 msgid "return to the site root"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: and
 msgid "rrule_and"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: (~approximate)
 msgid "rrule_approximate"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: at
 msgid "rrule_at"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: [month] [day], [year]
 msgid "rrule_dateFormat"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: day
 msgid "rrule_day"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: days
 msgid "rrule_days"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: every
 msgid "rrule_every"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: for
 msgid "rrule_for"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: hour
 msgid "rrule_hour"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: hours
 msgid "rrule_hours"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: in
 msgid "rrule_in"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: last
 msgid "rrule_last"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: minutes
 msgid "rrule_minutes"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: month
 msgid "rrule_month"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: months
 msgid "rrule_months"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: nd
 msgid "rrule_nd"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: on
 msgid "rrule_on"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: on the
 msgid "rrule_on the"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: or
 msgid "rrule_or"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: rd
 msgid "rrule_rd"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: st
 msgid "rrule_st"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: th
 msgid "rrule_th"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: the
 msgid "rrule_the"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: time
 msgid "rrule_time"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: times
 msgid "rrule_times"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: until
 msgid "rrule_until"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: week
 msgid "rrule_week"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: weekday
 msgid "rrule_weekday"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: weekdays
 msgid "rrule_weekdays"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: weeks
 msgid "rrule_weeks"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: year
 msgid "rrule_year"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: years
 msgid "rrule_years"
 msgstr ""
 
 #: components/theme/SkipLinks/SkipLinks
+# defaultMessage: Skip to footer
 msgid "skiplink-footer"
 msgstr ""
 
 #: components/theme/SkipLinks/SkipLinks
+# defaultMessage: Skip to main content
 msgid "skiplink-main-content"
 msgstr ""
 
 #: components/theme/SkipLinks/SkipLinks
+# defaultMessage: Skip to navigation
 msgid "skiplink-navigation"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: sort
 msgid "sort"
 msgstr ""
 
 #: config/Blocks
+# defaultMessage: Table
 msgid "table"
 msgstr ""
 
 #: config/Blocks
+# defaultMessage: Text
 msgid "text"
 msgstr ""
 
 #: config/Blocks
+# defaultMessage: Title
 msgid "title"
 msgstr ""
 
 #: config/Blocks
+# defaultMessage: Table of Contents
 msgid "toc"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Input must be valid url (www.something.com or http(s)://www.something.com)
 msgid "url"
 msgstr ""
 
 #: components/manage/Toolbar/PersonalTools
+# defaultMessage: user avatar
 msgid "user avatar"
 msgstr ""
 
 #: config/Blocks
+# defaultMessage: Video
 msgid "video"
 msgstr ""
 
 #: components/theme/View/EventView
+# defaultMessage: Visit external website
 msgid "visit_external_website"
 msgstr ""
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: {count, plural, one {Upload {count} file} other {Upload {count} files}}
 msgid "{count, plural, one {Upload {count} file} other {Upload {count} files}}"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: {count} selected
 msgid "{count} selected"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentType
+# defaultMessage: {id} Content Type
 msgid "{id} Content Type"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypeSchema
+# defaultMessage: {id} Schema
 msgid "{id} Schema"
 msgstr ""
 
 #: components/manage/Actions/Actions
+# defaultMessage: {title} copied.
 msgid "{title} copied."
 msgstr ""
 
 #: components/manage/Actions/Actions
+# defaultMessage: {title} cut.
 msgid "{title} cut."
 msgstr ""
 
 #: components/manage/Actions/Actions
+# defaultMessage: {title} has been deleted.
 msgid "{title} has been deleted."
 msgstr ""

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -2237,11 +2237,7 @@ msgstr "Vocabulary terms"
 
 #: components/manage/Controlpanels/VersionOverview
 msgid "Warning Regarding debug mode"
-msgstr "You are running in "debug mode". This mode is intended for sites that
-        are under development. This allows many configuration changes to be
-        immediately visible, but will make your site run more slowly. To turn
-        off debug mode, stop the server, set "debug-mode=off" in your
-        buildout.cfg, re-run bin/buildout and then restart the server process."
+msgstr "You are running in \"debug mode\". This mode is intended for sites that are under development. This allows many configuration changes to be immediately visible, but will make your site run more slowly. To turn off debug mode, stop the server, set \"debug-mode=off\" in your buildout.cfg, re-run bin/buildout and then restart the server process."
 
 #: components/theme/ConnectionRefused/ConnectionRefused
 msgid "We apologize for the inconvenience, but the backend of the site you are accessing is not available right now. Please, try again later."

--- a/locales/es/LC_MESSAGES/volto.po
+++ b/locales/es/LC_MESSAGES/volto.po
@@ -22,22 +22,27 @@ msgstr ""
 "X-Is-Fallback-For: es-ar es-bo es-cl es-co es-cr es-do es-ec es-es es-sv es-gt es-hn es-mx es-ni es-pa es-py es-pe es-pr es-us es-uy es-ve\n"
 
 #: components/manage/Blocks/HTML/Edit
+# defaultMessage: <p>Add some HTML here</p>
 msgid "<p>Add some HTML here</p>"
 msgstr "<p>Escriba HTML aquí</p>"
 
 #: components/theme/Footer/Footer
+# defaultMessage: Accessibility
 msgid "Accessibility"
 msgstr "Accesibilidad"
 
 #: components/theme/Register/Register
+# defaultMessage: Account Registration Completed
 msgid "Account Registration Completed"
 msgstr "Registro de cuenta completada"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Account activation completed
 msgid "Account activation completed"
 msgstr "Activación de cuenta completada"
 
 #: components/manage/Controlpanels/ModerateComments
+# defaultMessage: Action
 msgid "Action"
 msgstr "Acción"
 
@@ -46,10 +51,12 @@ msgstr "Acción"
 #: components/manage/Controlpanels/ContentTypes
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
+# defaultMessage: Actions
 msgid "Actions"
 msgstr "Acciones"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Activate and deactivate add-ons in the lists below.
 msgid "Activate and deactivate"
 msgstr "Activar y desactivar"
 
@@ -57,86 +64,107 @@ msgstr "Activar y desactivar"
 #: components/manage/Toolbar/Toolbar
 #: components/manage/Widgets/SchemaWidget
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add
 msgid "Add"
 msgstr "Agregar"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: To make new add-ons show up here, add them to your buildout configuration, run buildout, and restart the server process. For detailed instructions see
 msgid "Add Addons"
 msgstr "Añadir complementos"
 
 #: components/manage/Toolbar/Types
+# defaultMessage: Add Content…
 msgid "Add Content"
 msgstr "Agregar contenido"
 
 #: components/manage/Toolbar/Types
+# defaultMessage: Add Translation…
 msgid "Add Translation…"
 msgstr "Añadir traducción..."
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add User
 msgid "Add User"
 msgstr "Agregar Usuario"
 
 #: components/manage/Blocks/Description/Edit
+# defaultMessage: Add a description…
 msgid "Add a description…"
 msgstr "Agregar una descripción…"
 
 #: components/manage/BlockChooser/BlockChooserButton
+# defaultMessage: Add block
 msgid "Add block"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add block…
 msgid "Add block…"
 msgstr "Agregar bloque…"
 
 #: components/manage/Widgets/QueryWidget
+# defaultMessage: Add criteria
 msgid "Add criteria"
 msgstr "Añadir criterio"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Add date
 msgid "Add date"
 msgstr "Añadir fecha"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Add field
 msgid "Add field"
 msgstr "Agregar campo"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Add fieldset
 msgid "Add fieldset"
 msgstr "Agregar un nuevo conjunto de campos"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add group
 msgid "Add group"
 msgstr "Agregar grupo"
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Add new content type
 msgid "Add new content type"
 msgstr "Añadir un nuevo tipo de contenido"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add new group
 msgid "Add new group"
 msgstr "Agregar nuevo grupo"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add new user
 msgid "Add new user"
 msgstr "Agregar nuevo usuario"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add to Groups
 msgid "Add to Groups"
 msgstr "Agregar a Grupos"
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Add term
 msgid "Add vocabulary term"
 msgstr ""
 
 #: components/manage/Add/Add
+# defaultMessage: Add {type}
 msgid "Add {type}"
 msgstr "Agregar {type}"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Add-ons Settings
 msgid "Add-ons Settings"
 msgstr "Configuración de complementos"
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: Additional date
 msgid "Additional date"
 msgstr "Fecha adicional"
 
@@ -144,39 +172,48 @@ msgstr "Fecha adicional"
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
 #: components/manage/Blocks/Maps/MapsSidebar
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Alignment
 msgid "Alignment"
 msgstr "Alineamiento"
 
 #: components/manage/Contents/Contents
+# defaultMessage: All
 msgid "All"
 msgstr "Todo"
 
 #: components/theme/Search/Search
+# defaultMessage: Alphabetically
 msgid "Alphabetically"
 msgstr "Alfabéticamente"
 
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: Alt text
 msgid "Alt text"
 msgstr "Texto alternativo"
 
 #: components/manage/Toolbar/More
+# defaultMessage: Apply working copy
 msgid "Apply working copy"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Are you sure you want to delete this field?
 msgid "Are you sure you want to delete this field?"
 msgstr "¿Esta seguro de querer eliminar este campo?"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Are you sure you want to delete this fieldset including all fields?
 msgid "Are you sure you want to delete this fieldset including all fields?"
 msgstr "¿Esta seguro de querer eliminar este conjunto de campo incluyendo todos los campos contenidos?"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Ascending
 msgid "Ascending"
 msgstr "Ascendente"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Available
 msgid "Available"
 msgstr "Disponible"
 
@@ -201,48 +238,59 @@ msgstr "Disponible"
 #: components/manage/Toolbar/Toolbar
 #: components/theme/ContactForm/ContactForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Back
 msgid "Back"
 msgstr "Volver"
 
 #: components/manage/Diff/Diff
+# defaultMessage: Base
 msgid "Base"
 msgstr "Base"
 
 #: components/manage/Sidebar/Sidebar
+# defaultMessage: Block
 msgid "Block"
 msgstr "Bloque"
 
 #: components/theme/Login/Login
+# defaultMessage: Both email address and password are case sensitive, check that caps lock is not enabled.
 msgid "Both email address and password are case sensitive, check that caps lock is not enabled."
 msgstr "Tanto la dirección de correo electrónico y la contraseña son sensible a mayúsculas, verifique que la tecla Caps Lock no este habilitada."
 
 #: components/theme/Breadcrumbs/Breadcrumbs
+# defaultMessage: Breadcrumbs
 msgid "Breadcrumbs"
 msgstr "Barra de ruta"
 
 #: components/manage/Blocks/HeroImageLeft/Edit
 #: components/manage/Contents/ContentsUploadModal
 #: components/manage/Sidebar/ObjectBrowserNav
+# defaultMessage: Browse
 msgid "Browse"
 msgstr "Navegue"
 
 #: components/manage/Blocks/Image/Edit
+# defaultMessage: Browse the site, drop an image, or type an URL
 msgid "Browse the site, drop an image, or type an URL"
 msgstr "Navegue el contenido, arrastre un imagen o ingrese una dirección URL"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: By default, permissions from the container of this item are inherited. If you disable this, only the explicitly defined sharing permissions will be valid. In the overview, the symbol {inherited} indicates an inherited value. Similarly, the symbol {global} indicates a global role, which is managed by the site administrator.
 msgid "By default, permissions from the container of this item are inherited. If you disable this, only the explicitly defined sharing permissions will be valid. In the overview, the symbol {inherited} indicates an inherited value. Similarly, the symbol {global} indicates a global role, which is managed by the site administrator."
 msgstr "Por defecto, los permisos desde el contenedor de este elemento son heredados. Si usted deshabilita esta opción, solamente los permisos compartidos definidos explícitamente serán validos. En la vista general, el símbolo {inherited} indica un valor heredado. Similarmente, el símbolo {global} indica un rol global, el cual es administrado por el administrador del sitio."
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Cache Name
 msgid "Cache Name"
 msgstr "Nombre de la caché"
 
 #: components/manage/Controlpanels/ContentTypeLayout
+# defaultMessage: Can not edit Layout for <strong>{type}</strong> content-type as it doesn't have support for <strong>Volto Blocks</strong> enabled
 msgid "Can not edit Layout for <strong>{type}</strong> content-type as it doesn't have support for <strong>Volto Blocks</strong> enabled"
 msgstr "No se puede editar la plantilla de <strong>{type}</strong> porque no tiene activado el soporte de <strong>Bloques Volto</strong>"
 
 #: components/manage/Controlpanels/ContentTypeLayout
+# defaultMessage: Can not edit Layout for <strong>{type}</strong> content-type as the <strong>Blocks behavior</strong> is enabled and <strong>read-only</strong>
 msgid "Can not edit Layout for <strong>{type}</strong> content-type as the <strong>Blocks behavior</strong> is enabled and <strong>read-only</strong>"
 msgstr "No se puede editar la plantilla de <strong>{type}</strong> porque el soporte de <strong>Bloques Volto</strong> está activado y es de <strong>solo lectura</strong>"
 
@@ -258,42 +306,51 @@ msgstr "No se puede editar la plantilla de <strong>{type}</strong> porque el sop
 #: components/manage/Sharing/Sharing
 #: components/theme/Login/Login
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Cancel
 msgid "Cancel"
 msgstr "Cancelar"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Cell
 msgid "Cell"
 msgstr "Celda"
 
 #: components/manage/Blocks/Image/ImageSizeWidget
 #: components/manage/Blocks/Maps/Edit
 #: components/manage/Sidebar/AlignBlock
+# defaultMessage: Center
 msgid "Center"
 msgstr "Centro"
 
 #: components/manage/History/History
+# defaultMessage: Change Note
 msgid "Change Note"
 msgstr "Cambiar Nota"
 
 #: components/manage/Preferences/ChangePassword
+# defaultMessage: Change Password
 msgid "Change Password"
 msgstr "Cambiar Contraseña"
 
 #: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Change State
 msgid "Change State"
 msgstr "Cambiar Estado"
 
 #: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Change workflow state recursively
 msgid "Change workflow state recursively"
 msgstr "Cambiar el estado del flujo de trabajo recursivamente"
 
 #: components/manage/Toolbar/More
+# defaultMessage: Changes applied
 msgid "Changes applied."
 msgstr ""
 
 #: components/manage/Preferences/ChangePassword
 #: components/manage/Preferences/PersonalInformation
 #: components/manage/Preferences/PersonalPreferences
+# defaultMessage: Changes saved
 msgid "Changes saved"
 msgstr "Cambios guardados"
 
@@ -301,192 +358,237 @@ msgstr "Cambios guardados"
 #: components/manage/Controlpanels/ContentTypeLayout
 #: components/manage/Controlpanels/ContentTypeSchema
 #: components/manage/Controlpanels/Controlpanel
+# defaultMessage: Changes saved.
 msgid "Changes saved."
 msgstr "Cambios guardados."
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Checkbox
 msgid "Checkbox"
 msgstr "Casilla de comprobación"
 
 #: components/manage/Widgets/SelectWidget
+# defaultMessage: Choices
 msgid "Choices"
 msgstr "Selección múltiple"
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: Choose Image
 msgid "Choose Image"
 msgstr "Seleccione imagen"
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: Choose Target
 msgid "Choose Target"
 msgstr "Seleccione destino"
 
 #: components/manage/Widgets/FileWidget
+# defaultMessage: Choose a file
 msgid "Choose a file"
 msgstr "Seleccionar Archivo"
 
 #: components/manage/Blocks/HTML/Edit
+# defaultMessage: Clear
 msgid "Clear"
 msgstr "Limpiar"
 
 #: components/theme/View/ImageView
+# defaultMessage: Click to download full sized image
 msgid "Click to download full sized image"
 msgstr "Haga clic aquí para descargar la imagen a tamaño completo"
 
 #: components/manage/Widgets/SelectWidget
+# defaultMessage: Close
 msgid "Close"
 msgstr "Cerrar"
 
 #: components/theme/Navigation/Navigation
+# defaultMessage: Close menu
 msgid "Close menu"
 msgstr "Cerrar menú"
 
 #: components/manage/Blocks/HTML/Edit
+# defaultMessage: Code
 msgid "Code"
 msgstr "Código"
 
 #: components/manage/Widgets/ObjectListWidget
+# defaultMessage: Collapse item
 msgid "Collapse item"
 msgstr "Plegar elemento"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Collection
 msgid "Collection"
 msgstr "Colección"
 
 #: components/manage/Controlpanels/ModerateComments
 #: components/theme/Comments/CommentEditModal
 #: components/theme/Comments/Comments
+# defaultMessage: Comment
 msgid "Comment"
 msgstr "Comentario"
 
 #: components/manage/Controlpanels/ModerateComments
+# defaultMessage: Commenter
 msgid "Commenter"
 msgstr "Autor de comentario"
 
 #: components/theme/Comments/Comments
+# defaultMessage: Comments
 msgid "Comments"
 msgstr "Comentarios"
 
 #: components/manage/Diff/Diff
+# defaultMessage: Compare
 msgid "Compare"
 msgstr "Comparar"
 
 #: components/manage/Preferences/ChangePassword
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Confirm password
 msgid "Confirm password"
 msgstr "Confirme contraseña"
 
 #: components/theme/ConnectionRefused/ConnectionRefused
+# defaultMessage: Connection refused
 msgid "Connection refused"
 msgstr "Conexión rechazada"
 
 #: components/theme/Footer/Footer
+# defaultMessage: Contact
 msgid "Contact"
 msgstr "Contactos"
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Contact form
 msgid "Contact form"
 msgstr "Formulario de contacto"
 
 #: components/manage/Blocks/Listing/Edit
+# defaultMessage: Contained items
 msgid "Contained items"
 msgstr "Elementos contenidos"
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Content type created
 msgid "Content type created"
 msgstr "Tipo de contenido creado correctamente"
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Content type deleted
 msgid "Content type deleted"
 msgstr "Tipo de contenido eliminado correctamente"
 
 #: components/manage/Contents/Contents
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Contents
 msgid "Contents"
 msgstr "Contenidos"
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Copy
 msgid "Copy"
 msgstr "Copia"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: undefined
 msgid "Copy blocks"
 msgstr "Copiar bloques"
 
 #: components/theme/Footer/Footer
+# defaultMessage: Copyright
 msgid "Copyright"
 msgstr "Copyright"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Copyright statement or other rights information on this item.
 msgid "Copyright statement or other rights information on this item."
 msgstr "Información del copyright o otros derechos en este elemento."
 
 #: components/manage/Toolbar/More
+# defaultMessage: Create working copy
 msgid "Create working copy"
 msgstr ""
 
 #: components/manage/WorkingCopyToastsFactory/WorkingCopyToastsFactory
+# defaultMessage: Created by {creator} on {date}
 msgid "Created by {creator} on {date}"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Created on
 msgid "Created on"
 msgstr "Creado el"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Creator
 msgid "Creator"
 msgstr "Creador"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Creators
 msgid "Creators"
 msgstr "Autores"
 
 #: components/manage/Widgets/QuerystringWidget
 #: components/manage/Widgets/QueryWidget
+# defaultMessage: Criteria
 msgid "Criteria"
 msgstr "Criterios"
 
 #: components/manage/Preferences/ChangePassword
+# defaultMessage: Current password
 msgid "Current password"
 msgstr "Actual contraseña"
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Cut
 msgid "Cut"
 msgstr "Cortar"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: undefined
 msgid "Cut blocks"
 msgstr "Cortar bloques"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Daily
 msgid "Daily"
 msgstr "Diario"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Database Information
 msgid "Database Information"
 msgstr "Información de la base de datos"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Database Location
 msgid "Database Location"
 msgstr "Ubicación de la base de datos"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Database Size
 msgid "Database Size"
 msgstr "Tamaño de la base de datos"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Database main
 msgid "Database main"
 msgstr "Base de datos principal"
 
 #: components/manage/Controlpanels/ModerateComments
 #: components/manage/Widgets/DatetimeWidget
+# defaultMessage: Date
 msgid "Date"
 msgstr "Fecha"
 
 #: components/theme/Search/Search
+# defaultMessage: Date (newest first)
 msgid "Date (newest first)"
 msgstr "Fecha (primero los más recientes)"
 
@@ -506,6 +608,7 @@ msgstr "Fecha (primero los más recientes)"
 #: components/theme/PasswordReset/PasswordReset
 #: components/theme/PasswordReset/RequestPasswordReset
 #: components/theme/Register/Register
+# defaultMessage: Default
 msgid "Default"
 msgstr "Por defecto"
 
@@ -520,38 +623,47 @@ msgstr "Por defecto"
 #: components/manage/Widgets/ObjectBrowserWidget
 #: components/manage/Widgets/WysiwygWidget
 #: components/theme/Comments/Comments
+# defaultMessage: Delete
 msgid "Delete"
 msgstr "Eliminar"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Delete Group
 msgid "Delete Group"
 msgstr "Eliminar Grupo"
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Delete Type
 msgid "Delete Type"
 msgstr "Eliminar tipo"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Delete User
 msgid "Delete User"
 msgstr "Eliminar Usuario"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: undefined
 msgid "Delete blocks"
 msgstr "Eliminar bloques"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Delete col
 msgid "Delete col"
 msgstr "Eliminar columna"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Delete row
 msgid "Delete row"
 msgstr "Eliminar fila"
 
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: Depth
 msgid "Depth"
 msgstr "Profundidad"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Descending
 msgid "Descending"
 msgstr "Descendente"
 
@@ -562,72 +674,89 @@ msgstr "Descendente"
 #: components/manage/Widgets/WysiwygWidget
 #: components/theme/View/TabularView
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Description
 msgid "Description"
 msgstr "Descripción"
 
 #: components/manage/Diff/Diff
+# defaultMessage: Diff
 msgid "Diff"
 msgstr "Diferencias"
 
 #: components/manage/Diff/Diff
+# defaultMessage: Difference between revision {one} and {two} of {title}
 msgid "Difference between revision {one} and {two} of {title}"
 msgstr "Diferencias entre la revisión {one} y {two} del {title}"
 
 #: components/theme/Footer/Footer
+# defaultMessage: Distributed under the {license}.
 msgid "Distributed under the {license}."
 msgstr "Distribuido bajo la {license}."
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Add border to inner columns
 msgid "Divide each row into separate cells"
 msgstr "Divide cada fila en celdas separadas"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Do you really want to delete the following items?
 msgid "Do you really want to delete the following items?"
 msgstr "¿Usted realmente quiere eliminar los siguientes elementos?"
 
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
+# defaultMessage: Do you really want to delete the group {groupname}?
 msgid "Do you really want to delete the group {groupname}?"
 msgstr "¿Esta seguro que quiere eliminar el grupo {groupname}?"
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Do you really want to delete type {typename}?
 msgid "Do you really want to delete the type {typename}?"
 msgstr "¿Realmente quiere eliminar el tipo {typename}?"
 
 #: components/manage/Controlpanels/Users/UsersControlpanel
+# defaultMessage: Do you really want to delete the user {username}?
 msgid "Do you really want to delete the user {username}?"
 msgstr "¿Esta seguro que quiere eliminar el usuario {username}?"
 
 #: components/manage/Delete/Delete
+# defaultMessage: Do you really want to delete this item?
 msgid "Do you really want to delete this item?"
 msgstr "¿Usted realmente quiere eliminar este elemento?"
 
 #: components/manage/Multilingual/TranslationObject
 #: components/manage/Sidebar/Sidebar
+# defaultMessage: Document
 msgid "Document"
 msgstr "Documento"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Drag and drop files from your computer onto this area or click the “Browse” button.
 msgid "Drag and drop files from your computer onto this area or click the “Browse” button."
 msgstr "Arrastre y suelte los archivos desde su computador en esta área o haga clic al botón “Seleccionar”."
 
 #: components/manage/Widgets/FileWidget
+# defaultMessage: Drop file here to replace the existing file
 msgid "Drop file here to replace the existing file"
 msgstr "Arrastre aquí el archivo para reemplazar el actual"
 
 #: components/manage/Widgets/FileWidget
+# defaultMessage: Drop file here to upload a new file
 msgid "Drop file here to upload a new file"
 msgstr "Arrastre aquí el archivo para añadir un nuevo"
 
 #: components/manage/Widgets/FileWidget
+# defaultMessage: Drop files here ...
 msgid "Drop files here ..."
 msgstr "Arrastrar archivos aquí..."
 
 #: components/manage/Preferences/PersonalInformation
 #: components/theme/Register/Register
+# defaultMessage: E-mail
 msgid "E-mail"
 msgstr "Correo electrónico"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: E-mail addresses do not match.
 msgid "E-mail addresses do not match."
 msgstr "La dirección de correo electrónico no coincide."
 
@@ -638,93 +767,115 @@ msgstr "La dirección de correo electrónico no coincide."
 #: components/manage/Widgets/FormFieldWrapper
 #: components/manage/Widgets/ObjectBrowserWidget
 #: components/theme/Comments/Comments
+# defaultMessage: Edit
 msgid "Edit"
 msgstr "Editar"
 
 #: components/theme/Comments/CommentEditModal
+# defaultMessage: Edit comment
 msgid "Edit comment"
 msgstr "Editar comentario"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Edit field
 msgid "Edit field"
 msgstr "Editar campo"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Edit fieldset
 msgid "Edit fieldset"
 msgstr "Editar conjunto de campo"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Edit recurrence
 msgid "Edit recurrence"
 msgstr "Editar repetición"
 
 #: components/manage/Form/InlineForm
+# defaultMessage: Edit values
 msgid "Edit values"
 msgstr "Editar valores"
 
 #: components/manage/Edit/Edit
+# defaultMessage: Edit {title}
 msgid "Edit {title}"
 msgstr "Editar {title}"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Email
 msgid "Email"
 msgstr "Correo electrónico"
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Email sent
 msgid "Email sent"
 msgstr "Correo electrónico enviado"
 
 #: components/manage/Blocks/Maps/Edit
+# defaultMessage: Embed code error, please follow the instructions and try again.
 msgid "Embed code error, please follow the instructions and try again."
 msgstr "Ha habido un error el código de encapsulación, siga las instrucciones e inténtelo de nuevo."
 
 #: components/manage/Blocks/Maps/View
+# defaultMessage: Embeded Google Maps
 msgid "Embeded Google Maps"
 msgstr "Insertar Google Maps"
 
 #: components/manage/Widgets/ObjectListWidget
+# defaultMessage: Empty object list
 msgid "Empty object list"
 msgstr "Lista de objetos vacía"
 
 #: components/manage/Controlpanels/ContentTypeLayout
+# defaultMessage: Enable editable Blocks
 msgid "Enable editable Blocks"
 msgstr "Activar bloques editables"
 
 #: components/manage/Contents/Contents
+# defaultMessage: End Date
 msgid "End Date"
 msgstr "Fecha final"
 
 #: components/manage/AnchorPlugin/components/LinkButton/AddLinkForm
+# defaultMessage: Enter URL or select an item
 msgid "Enter URL or select an item"
 msgstr "Introduzca una URL o seleccione un elemento"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Enter a username above to search or click 'Show All'
 msgid "Enter a username above to search or click 'Show All'"
 msgstr "Introduzca un nombre de usuario o haga clic en "Mostrar todos""
 
 #: components/theme/Register/Register
+# defaultMessage: Enter an email address. This will be your login name. We respect your privacy, and will not give the address away to any third parties or expose it anywhere.
 msgid "Enter an email address. This will be your login name. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr "Ingrese una dirección de correo electrónico. Este será el nombre de usuario. Nosotros respetamos su privacidad: y no daremos la dirección de correo electrónico a terceros, o la expondremos de alguna forma en el portal."
 
 #: components/manage/Preferences/PersonalInformation
 #: components/theme/PasswordReset/PasswordReset
 #: components/theme/Register/Register
+# defaultMessage: Enter full name, e.g. John Smith.
 msgid "Enter full name, e.g. John Smith."
 msgstr "Ingrese el nombre completo, por ejemplo Leonardo Caballero."
 
 #: components/manage/Blocks/Maps/Edit
+# defaultMessage: Enter map Embed Code
 msgid "Enter map Embed Code"
 msgstr "Introduzca el código de un mapa"
 
 #: components/manage/Preferences/ChangePassword
+# defaultMessage: Enter your current password.
 msgid "Enter your current password."
 msgstr "Ingrese su contraseña actual."
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Enter your email address for verification.
 msgid "Enter your email address for verification."
 msgstr "Ingrese su dirección de correo electrónico para verificar."
 
 #: components/manage/Preferences/ChangePassword
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Enter your new password. Minimum 5 characters.
 msgid "Enter your new password. Minimum 5 characters."
 msgstr "Ingrese su nueva contraseña. Mínimo 5 caracteres."
 
@@ -736,199 +887,245 @@ msgstr "Ingrese su nueva contraseña. Mínimo 5 caracteres."
 #: components/theme/ContactForm/ContactForm
 #: components/theme/Login/Login
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Error
 msgid "Error"
 msgstr "Error"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Exclude from navigation
 msgid "Exclude from navigation"
 msgstr "Excluir de la navegación"
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: Exclude this occurence
 msgid "Exclude this occurence"
 msgstr "Excluir esta repetición"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Excluded from navigation
 msgid "Excluded from navigation"
 msgstr "Exluido de la navegación"
 
 #: components/manage/Sidebar/Sidebar
+# defaultMessage: Expand sidebar
 msgid "Expand sidebar"
 msgstr "Expandir barra lateral"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Expiration Date
 msgid "Expiration Date"
 msgstr "Fecha de expiración"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Expiration date
 msgid "Expiration date"
 msgstr "Fecha de caducidad"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Expired
 msgid "Expired"
 msgstr "Caducado"
 
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: External URL
 msgid "External URL"
 msgstr "Dirección URL externa"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: File
 msgid "File"
 msgstr "Archivo"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: File size
 msgid "File size"
 msgstr "Tamaño del archivo"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Filename
 msgid "Filename"
 msgstr "Nombre del archivo"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Filter…
 msgid "Filter…"
 msgstr "Filtrar…"
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: First
 msgid "First"
 msgstr "Primero"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Fixed width columns
 msgid "Fixed width table cells"
 msgstr "Celdas de tabla de ancho fijo"
 
 #: components/manage/BlockChooser/BlockChooser
+# defaultMessage: Fold
 msgid "Fold"
 msgstr "Plegar"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Folder
 msgid "Folder"
 msgstr "Carpeta"
 
 #: components/theme/Forbidden/Forbidden
+# defaultMessage: Forbidden
 msgid "Forbidden"
 msgstr "Prohibido"
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: Fourth
 msgid "Fourth"
 msgstr "Cuarto"
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: From
 msgid "From"
 msgstr "De"
 
 #: components/manage/Blocks/Maps/Edit
 #: components/manage/Sidebar/AlignBlock
+# defaultMessage: Full
 msgid "Full"
 msgstr "Completo"
 
 #: components/manage/Preferences/PersonalInformation
 #: components/theme/PasswordReset/PasswordReset
 #: components/theme/Register/Register
+# defaultMessage: Full Name
 msgid "Full Name"
 msgstr "Nombre completo"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Fullname
 msgid "Fullname"
 msgstr "Nombre completo"
 
 #: components/theme/Footer/Footer
+# defaultMessage: GNU GPL license
 msgid "GNU GPL license"
 msgstr "licencia GNU GPL"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Global role
 msgid "Global role"
 msgstr "Rol global"
 
 #: components/manage/Blocks/Maps/Edit
+# defaultMessage: Google Maps Embedded Block
 msgid "Google Maps Embedded Block"
 msgstr "Bloque incrustado de Google Maps"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Group
 msgid "Group"
 msgstr "Grupo"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Group created
 msgid "Group created"
 msgstr "Grupo creado"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Group roles updated
 msgid "Group roles updated"
 msgstr ""
 
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Groupname
 msgid "Groupname"
 msgstr "Nombre de grupo"
 
 #: components/manage/Controlpanels/Controlpanels
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Groups
 msgid "Groups"
 msgstr "Grupos"
 
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
+# defaultMessage: Groups are logical collections of users, such as departments and business units. Groups are not directly related to permissions on a global level, you normally use Roles for that - and let certain Groups have a particular role. The symbol{plone_svg}indicates a role inherited from membership in another group.
 msgid "Groups are logical collections of users, such as departments and business units. Groups are not directly related to permissions on a global level, you normally use Roles for that - and let certain Groups have a particular role. The symbol{plone_svg}indicates a role inherited from membership in another group."
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Header cell
 msgid "Header cell"
 msgstr "Celda de cabecera"
 
 #: components/theme/Comments/Comments
+# defaultMessage: Hide Replies
 msgid "Hide Replies"
 msgstr "Ocultar respuestas"
 
 #: components/manage/History/History
 #: components/manage/Toolbar/More
+# defaultMessage: History
 msgid "History"
 msgstr "Historial"
 
 #: components/manage/History/History
+# defaultMessage: #
 msgid "History Version Number"
 msgstr ""
 
 #: components/manage/History/History
+# defaultMessage: History of {title}
 msgid "History of {title}"
 msgstr "Historial de {title}"
 
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsBreadcrumbs
 #: components/theme/Breadcrumbs/Breadcrumbs
+# defaultMessage: Home
 msgid "Home"
 msgstr "Inicio"
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: Home page
 msgid "Home page"
 msgstr "Página personal"
 
 #: components/manage/Contents/Contents
+# defaultMessage: ID
 msgid "ID"
 msgstr "ID"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: If selected, this item will not appear in the navigation tree
 msgid "If selected, this item will not appear in the navigation tree"
 msgstr "Si es seleccionado, este elemento no aparecerá en el árbol de navegación del sitio"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: If this date is in the future, the content will not show up in listings and searches until this date.
 msgid "If this date is in the future, the content will not show up in listings and searches until this date."
 msgstr "Si esta fecha es en el futuro, el contenido no se mostrará en los listado y búsquedas hasta que sea la fecha."
 
 #: components/manage/LockingToastsFactory/LockingToastsFactory
+# defaultMessage: If you are certain this user has abandoned the object, you may unlock the object. You will then be able to edit it.
 msgid "If you are certain this user has abandoned the object, you may unlock the object. You will then be able to edit it."
 msgstr ""
 
 #: components/theme/NotFound/NotFound
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: If you are certain you have the correct web address but are encountering an error, please contact the {site_admin}.
 msgid "If you are certain you have the correct web address but are encountering an error, please contact the {site_admin}."
 msgstr "Si usted esta seguro de haber ingresado la dirección web correcta pero mas obtiene un, por favor, contante al {site_admin}."
 
 #: components/manage/Blocks/HeroImageLeft/Edit
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: Image
 msgid "Image"
 msgstr "Imagen"
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: Include this occurence
 msgid "Include this occurence"
 msgstr "Incluir esta repetición"
 
@@ -936,142 +1133,176 @@ msgstr "Incluir esta repetición"
 #: components/manage/Controlpanels/ContentTypeLayout
 #: components/manage/Controlpanels/ContentTypeSchema
 #: components/manage/Controlpanels/Controlpanel
+# defaultMessage: Info
 msgid "Info"
 msgstr "Información"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Inherit permissions from higher levels
 msgid "Inherit permissions from higher levels"
 msgstr "Hereda los permisos de niveles superiores"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Inherited value
 msgid "Inherited value"
 msgstr "Valor heredado"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Insert col after
 msgid "Insert col after"
 msgstr "Insertar columna después"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Insert col before
 msgid "Insert col before"
 msgstr "Insertar columna antes"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Insert row after
 msgid "Insert row after"
 msgstr "Insertar fila después"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Insert row before
 msgid "Insert row before"
 msgstr "Insertar fila antes"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Install
 msgid "Install"
 msgstr "Instalar"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Installed
 msgid "Installed"
 msgstr "Instalado"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Installed version
 msgid "Installed version"
 msgstr "Versión instalada"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: days
 msgid "Interval Daily"
 msgstr "Intervalo diario"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Month(s)
 msgid "Interval Monthly"
 msgstr "Intervalo mensual"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: week(s)
 msgid "Interval Weekly"
 msgstr "Intervalo semanal"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: year(s)
 msgid "Interval Yearly"
 msgstr "Intervalo anual"
 
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: Item batch size
 msgid "Item batch size"
 msgstr "Número de elementos"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Item succesfully moved.
 msgid "Item succesfully moved."
 msgstr "Elemento movido correctamente."
 
 #: components/manage/Contents/Contents
+# defaultMessage: Item(s) copied.
 msgid "Item(s) copied."
 msgstr "Elemento(s) copiado(s)."
 
 #: components/manage/Contents/Contents
+# defaultMessage: Item(s) cut.
 msgid "Item(s) cut."
 msgstr "Elemento(s) cortado(s)."
 
 #: components/manage/Contents/Contents
+# defaultMessage: Item(s) has been updated.
 msgid "Item(s) has been updated."
 msgstr "Los elementos se han actualizado correctamente."
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
+# defaultMessage: Item(s) pasted.
 msgid "Item(s) pasted."
 msgstr "Elemento(s) pegado(s)."
 
 #: components/manage/Contents/Contents
+# defaultMessage: Item(s) state has been updated.
 msgid "Item(s) state has been updated."
 msgstr "El estado de los elementos se ha actualizado correctamente."
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Items
 msgid "Items"
 msgstr "Elementos"
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Items must be unique.
 msgid "Items must be unique."
 msgstr "Los elementos deben ser únicos."
 
 #: components/manage/Preferences/PersonalPreferences
+# defaultMessage: Language
 msgid "Language"
 msgstr "Idioma"
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: Last
 msgid "Last"
 msgstr "Último"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Last comment date
 msgid "Last comment date"
 msgstr "Fecha de último comentario"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Last modified
 msgid "Last modified"
 msgstr "Última modificación"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Latest version
 msgid "Latest version"
 msgstr "Última versión"
 
 #: components/manage/Controlpanels/ContentTypesActions
+# defaultMessage: Layout
 msgid "Layout"
 msgstr "Plantilla"
 
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: Lead Image
 msgid "Lead Image"
 msgstr "Imagen principal"
 
 #: components/manage/Blocks/Image/ImageSizeWidget
 #: components/manage/Blocks/Maps/Edit
 #: components/manage/Sidebar/AlignBlock
+# defaultMessage: Left
 msgid "Left"
 msgstr "Izquierda"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Link
 msgid "Link"
 msgstr "Enlace"
 
 #: components/manage/Blocks/Listing/schema
+# defaultMessage: Link more
 msgid "Link more"
 msgstr "Enlazar "más""
 
 #: components/manage/Blocks/Listing/schema
+# defaultMessage: Link Title
 msgid "Link title"
 msgstr "Enlazar título"
 
@@ -1080,212 +1311,262 @@ msgstr "Enlazar título"
 #: components/manage/Blocks/Listing/schema
 #: components/manage/Blocks/Maps/MapsSidebar
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Link to
 msgid "Link to"
 msgstr "Enlazar a"
 
 #: components/manage/Multilingual/ManageTranslations
+# defaultMessage: Link translation for
 msgid "Link translation for"
 msgstr "Enlazar traducción de"
 
 #: components/manage/Blocks/Listing/schema
+# defaultMessage: Listing
 msgid "Listing"
 msgstr "Listado"
 
 #: components/theme/Comments/Comments
+# defaultMessage: Load more...
 msgid "Load more"
 msgstr "Cargar más"
 
 #: components/manage/Form/ModalForm
+# defaultMessage: Loading.
 msgid "Loading"
 msgstr "Cargando"
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: Location
 msgid "Location"
 msgstr "Ubicación"
 
 #: components/theme/Login/Login
+# defaultMessage: Login
 msgid "Log In"
 msgstr "Inicio de Sesión"
 
 #: components/theme/Anontools/Anontools
 #: components/theme/Login/Login
+# defaultMessage: Log in
 msgid "Log in"
 msgstr "Inicio de sesión"
 
 #: components/theme/Login/Login
+# defaultMessage: Login
 msgid "Login"
 msgstr "Inicio de sesión"
 
 #: components/theme/Login/Login
+# defaultMessage: Login Failed
 msgid "Login Failed"
 msgstr "Inicio de Sesión fallo"
 
 #: components/theme/Login/Login
+# defaultMessage: Login Name
 msgid "Login Name"
 msgstr "Nombre de usuario"
 
 #: components/manage/Toolbar/PersonalTools
+# defaultMessage: Logout
 msgid "Logout"
 msgstr ""
 
 #: components/manage/Toolbar/More
+# defaultMessage: Made by {creator} on {date}. This is not a working copy anymore, but the main content.
 msgid "Made by {creator} on {date}. This is not a working copy anymore, but the main content."
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Reduce cell padding
 msgid "Make the table compact"
 msgstr "Hacer la tabla compacta"
 
 #: components/manage/Multilingual/ManageTranslations
 #: components/manage/Toolbar/More
+# defaultMessage: Manage Translations
 msgid "Manage Translations"
 msgstr "Administrar traducciones"
 
 #: components/manage/Multilingual/ManageTranslations
+# defaultMessage: Manage translations for {title}
 msgid "Manage translations for {title}"
 msgstr "Administrar traducciones de {title}"
 
 #: components/manage/Blocks/Maps/MapsSidebar
+# defaultMessage: Map
 msgid "Map"
 msgstr "Mapa"
 
 #: components/manage/Blocks/Maps/MapsSidebar
+# defaultMessage: Maps URL
 msgid "Maps URL"
 msgstr "URL del mapa"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Maximum length is {len}.
 msgid "Maximum length is {len}."
 msgstr "La longitud máxima es {len}"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Maximum value is {len}.
 msgid "Maximum value is {len}."
 msgstr "El valor máximo es {len}."
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Message
 msgid "Message"
 msgstr "Mensaje"
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Minimum length is {len}.
 msgid "Minimum length is {len}."
 msgstr "El tamaño mínimo es {len}."
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Minimum value is {len}.
 msgid "Minimum value is {len}."
 msgstr "El valor mínimo es {len}."
 
 #: components/manage/Controlpanels/Controlpanels
+# defaultMessage: Moderate Comments
 msgid "Moderate Comments"
 msgstr "Moderar Comentarios"
 
 #: components/manage/Controlpanels/ModerateComments
+# defaultMessage: Moderate comments
 msgid "Moderate comments"
 msgstr "Moderar comentarios"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Monday and Friday
 msgid "Monday and Friday"
 msgstr "Lunes y viernes"
 
 #: components/manage/Widgets/RecurrenceWidget/ByMonthDayField
+# defaultMessage: Day
 msgid "Month day"
 msgstr "Día del mes"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Monthly
 msgid "Monthly"
 msgstr "Mensualmente"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: More
 msgid "More"
 msgstr "Más"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Move to bottom of folder
 msgid "Move to bottom of folder"
 msgstr "Mover al fondo de la carpeta"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Move to top of folder
 msgid "Move to top of folder"
 msgstr "Mover encima de la carpeta"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: My email address is
 msgid "My email address is"
 msgstr "Mi dirección de correo electrónico es"
 
 #: components/manage/Sharing/Sharing
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Name
 msgid "Name"
 msgstr "Nombre"
 
 #: error
+# defaultMessage: Navigate back
 msgid "Navigate back"
 msgstr "Navegar hacia atrás"
 
 #: components/theme/Navigation/ContextNavigation
+# defaultMessage: Navigation
 msgid "Navigation"
 msgstr "Navegación"
 
 #: components/manage/Preferences/ChangePassword
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: New password
 msgid "New password"
 msgstr "Nueva contraseña"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: News Item
 msgid "News Item"
 msgstr "Noticia"
 
 #: components/manage/Contents/ContentsItem
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: No
 msgid "No"
 msgstr "No"
 
 #: components/manage/Blocks/Image/ImageSidebar
+# defaultMessage: No image selected
 msgid "No image selected"
 msgstr "Ninguna imagen seleccionada"
 
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: No image set in Lead Image content field
 msgid "No image set in Lead Image content field"
 msgstr "No hay imagen en el campo de imagen principal"
 
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: No image set in image content field
 msgid "No image set in image content field"
 msgstr "No hay imagen en el campo de imagen"
 
 #: components/manage/Blocks/Listing/ListingBody
+# defaultMessage: No items found in this container.
 msgid "No items found in this container."
 msgstr "No hay elementos en esta carpeta"
 
 #: components/manage/Widgets/ObjectBrowserWidget
+# defaultMessage: No items selected
 msgid "No items selected"
 msgstr "No se han seleccionado elementos"
 
 #: components/manage/Blocks/Maps/MapsSidebar
+# defaultMessage: No map selected
 msgid "No map selected"
 msgstr "No se ha seleccionado el mapa"
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: No occurences set
 msgid "No occurences set"
 msgstr "No hay repeticiones"
 
 #: components/manage/Widgets/ArrayWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/TokenWidget
+# defaultMessage: No options
 msgid "No options"
 msgstr "No hay opciones"
 
 #: components/theme/Search/Search
+# defaultMessage: No results found
 msgid "No results found"
 msgstr "No hay resultados"
 
 #: components/manage/Blocks/Listing/ListingBody
 #: components/manage/Widgets/ReferenceWidget
+# defaultMessage: No results found.
 msgid "No results found."
 msgstr "La búsqueda no produjo resultados."
 
 #: components/manage/Widgets/QuerySortOnWidget
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: No selection
 msgid "No selection"
 msgstr "No hay selección"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: This addon does not provide an uninstall profile.
 msgid "No uninstall profile"
 msgstr "No hay perfil para desinstalar"
 
@@ -1293,39 +1574,48 @@ msgstr "No hay perfil para desinstalar"
 #: components/manage/Widgets/ReferenceWidget
 #: components/manage/Widgets/SelectUtils
 #: components/manage/Widgets/SelectWidget
+# defaultMessage: No value
 msgid "No value"
 msgstr "Sin valor"
 
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: No video selected
 msgid "No video selected"
 msgstr "No se ha seleccionado el vídeo"
 
 #: components/manage/Workflow/Workflow
+# defaultMessage: No workflow
 msgid "No workflow"
 msgstr "Sin flujo de trabajo"
 
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsItem
+# defaultMessage: None
 msgid "None"
 msgstr "Ninguno"
 
 #: components/manage/Controlpanels/Users/UsersControlpanel
+# defaultMessage: Note that roles set here apply directly to a user. The symbol{plone_svg}indicates a role inherited from membership in a group.
 msgid "Note that roles set here apply directly to a user. The symbol{plone_svg}indicates a role inherited from membership in a group."
 msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Number of active objects
 msgid "Number of active objects"
 msgstr "Número de objetos activos"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Object Size
 msgid "Object Size"
 msgstr "Tamaño del objeto"
 
 #: components/manage/Widgets/RecurrenceWidget/EndField
+# defaultMessage: occurrence(s)
 msgid "Occurences"
 msgstr "Apariciones"
 
 #: components/manage/Delete/Delete
+# defaultMessage: Ok
 msgid "Ok"
 msgstr "Ok"
 
@@ -1333,301 +1623,371 @@ msgstr "Ok"
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
 #: components/manage/Blocks/Maps/MapsSidebar
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Open in a new tab
 msgid "Open in a new tab"
 msgstr "Abrir en un nueva pestaña"
 
 #: components/theme/Navigation/Navigation
+# defaultMessage: Open menu
 msgid "Open menu"
 msgstr "Abrir menú"
 
 #: components/manage/Widgets/ObjectBrowserWidget
+# defaultMessage: Open object browser
 msgid "Open object browser"
 msgstr "Abrir buscador de objetos"
 
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: Origin
 msgid "Origin"
 msgstr "Origen"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Page
 msgid "Page"
 msgstr "Página"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Parent fieldset
 msgid "Parent fieldset"
 msgstr "Grupo de campos padre"
 
 #: components/theme/Login/Login
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Password
 msgid "Password"
 msgstr "Contraseña"
 
 #: components/theme/PasswordReset/PasswordReset
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Password reset
 msgid "Password reset"
 msgstr "Restablecer contraseña"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Passwords do not match.
 msgid "Passwords do not match."
 msgstr "La contraseña no coincide."
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
+# defaultMessage: Paste
 msgid "Paste"
 msgstr "Pegar"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: undefined
 msgid "Paste blocks"
 msgstr "Pegar bloques"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Permissions have been updated successfully
 msgid "Permissions have been updated successfully"
 msgstr "Los permisos se han actualizado correctamente"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Permissions updated
 msgid "Permissions updated"
 msgstr "Permisos actualizados"
 
 #: components/manage/Preferences/PersonalInformation
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Personal Information
 msgid "Personal Information"
 msgstr "Información Personal"
 
 #: components/manage/Preferences/PersonalPreferences
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Personal Preferences
 msgid "Personal Preferences"
 msgstr "Preferencias Personales"
 
 #: components/manage/Toolbar/More
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Personal tools
 msgid "Personal tools"
 msgstr "Herramientas personales"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Persons responsible for creating the content of this item. Please enter a list of user names, one per line. The principal creator should come first.
 msgid "Persons responsible for creating the content of this item. Please enter a list of user names, one per line. The principal creator should come first."
 msgstr "Las personas responsables de la creación del contenido de este elemento. Por favor, ingrese una lista de nombres de usuarios, uno por linea. El principal autor debe aparecer de primer lugar."
 
 #: components/manage/Blocks/Video/Edit
+# defaultMessage: Please enter a valid URL by deleting the block and adding a new video block.
 msgid "Please enter a valid URL by deleting the block and adding a new video block."
 msgstr "Por favor, ingrese una URL válida eliminando el bloque y agregando un nuevo bloque de vídeo."
 
 #: components/manage/Blocks/Maps/Edit
+# defaultMessage: Please enter the Embed Code provided by Google Maps -> Share -> Embed map. It should contain the <iframe> code on it.
 msgid "Please enter the Embed Code provided by Google Maps -> Share -> Embed map. It should contain the <iframe> code on it."
 msgstr "Por favor introduzca el código de encapsulamiento de Google Maps que se obtiene en Google Maps -> Compartir -> Compartir mapa. Tiene que contener una etiqueta <iframe>"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Please fill out the form below to set your password.
 msgid "Please fill out the form below to set your password."
 msgstr "Por favor, complete el siguiente formulario para establecer su contraseña."
 
 #: components/theme/Footer/Footer
+# defaultMessage: Plone Foundation
 msgid "Plone Foundation"
 msgstr "Fundación Plone"
 
 #: components/theme/Logo/Logo
+# defaultMessage: Plone Site
 msgid "Plone Site"
 msgstr "Sitio Plone"
 
 #: components/theme/Footer/Footer
+# defaultMessage: Plone{reg} Open Source CMS/WCM
 msgid "Plone{reg} Open Source CMS/WCM"
 msgstr "Plone{reg} CMS/WCM de Fuentes Abiertos"
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: Portrait
 msgid "Portrait"
 msgstr "Retrato"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Possible values (Enter allowed choices one per line).
 msgid "Possible values"
 msgstr "Valores posibles"
 
 #: components/theme/Footer/Footer
+# defaultMessage: Powered by Plone & Python
 msgid "Powered by Plone & Python"
 msgstr "Hecho con Plone & Python"
 
 #: components/manage/Toolbar/PersonalTools
+# defaultMessage: Preferences
 msgid "Preferences"
 msgstr "Preferencias"
 
 #: components/manage/Blocks/HTML/Edit
+# defaultMessage: Prettify your code
 msgid "Prettify your code"
 msgstr "Embellezca su código"
 
 #: components/manage/Blocks/HTML/Edit
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Preview
 msgid "Preview"
 msgstr "Vista previa"
 
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Preview Image URL
 msgid "Preview Image URL"
 msgstr "URL de la vista preliminar de la imagen"
 
 #: components/manage/Toolbar/PersonalTools
+# defaultMessage: Profile
 msgid "Profile"
 msgstr "Perfil"
 
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Properties
 msgid "Properties"
 msgstr "Propiedades"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Publication date
 msgid "Publication date"
 msgstr "Fecha de publicación"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Publishing Date
 msgid "Publishing Date"
 msgstr "Fecha de publicación"
 
 #: components/manage/Blocks/Listing/schema
+# defaultMessage: Query
 msgid "Query"
 msgstr "Consulta"
 
 #: components/manage/Preferences/ChangePassword
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Re-enter the password. Make sure the passwords are identical.
 msgid "Re-enter the password. Make sure the passwords are identical."
 msgstr "Ingrese de nuevo su contraseña. Debe asegurarse que las contraseñas sean idénticas."
 
 #: components/theme/Search/Search
 #: components/theme/View/SummaryView
+# defaultMessage: Read More…
 msgid "Read More…"
 msgstr "Leer Más…"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Rearrange items by…
 msgid "Rearrange items by…"
 msgstr "Reordenar elementos por…"
 
 #: components/manage/Widgets/RecurrenceWidget/EndField
+# defaultMessage: Ends
 msgid "Recurrence ends"
 msgstr "Fin de la repetición"
 
 #: components/manage/Widgets/RecurrenceWidget/EndField
+# defaultMessage: after
 msgid "Recurrence ends after"
 msgstr "La repetición finaliza después de"
 
 #: components/manage/Widgets/RecurrenceWidget/EndField
+# defaultMessage: on
 msgid "Recurrence ends on"
 msgstr "La repetición finaliza el"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Minimalistic table design
 msgid "Reduce complexity"
 msgstr "Reducir complejidad"
 
 #: components/theme/Anontools/Anontools
 #: components/theme/Login/Login
 #: components/theme/Register/Register
+# defaultMessage: Register
 msgid "Register"
 msgstr "Registro"
 
 #: components/theme/Register/Register
+# defaultMessage: Registration form
 msgid "Registration form"
 msgstr "Formulario de registro"
 
 #: components/theme/Search/Search
+# defaultMessage: Relevance
 msgid "Relevance"
 msgstr "Relevancia"
 
 #: components/manage/Widgets/ObjectListWidget
+# defaultMessage: Remove item
 msgid "Remove item"
 msgstr "Eliminar elemento"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Remove
 msgid "Remove recurrence"
 msgstr "Eliminar repetición"
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Remove term
 msgid "Remove term"
 msgstr ""
 
 #: components/manage/Toolbar/More
+# defaultMessage: Remove working copy
 msgid "Remove working copy"
 msgstr ""
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
+# defaultMessage: Rename
 msgid "Rename"
 msgstr "Renombrar"
 
 #: components/manage/Contents/ContentsRenameModal
+# defaultMessage: Renaming items...
 msgid "Rename Items Loading Message"
 msgstr "Renombrar el mensaje "elementos cargando""
 
 #: components/manage/Contents/ContentsRenameModal
+# defaultMessage: Rename items
 msgid "Rename items"
 msgstr "Renombrar elementos"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Repeat
 msgid "Repeat"
 msgstr "Repetir"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Repeat every
 msgid "Repeat every"
 msgstr "Repetir todos"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Repeat on
 msgid "Repeat on"
 msgstr "Repetir el"
 
 #: components/manage/Widgets/FileWidget
+# defaultMessage: Replace existing file
 msgid "Replace existing file"
 msgstr "Sustituir el archivo actual"
 
 #: components/theme/Comments/Comments
+# defaultMessage: Reply
 msgid "Reply"
 msgstr "Responder"
 
 #: components/manage/Widgets/SchemaWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/WysiwygWidget
+# defaultMessage: Required
 msgid "Required"
 msgstr "Obligatorio"
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Required input is missing.
 msgid "Required input is missing."
 msgstr "Un campo requerido esta sin tomar en cuenta."
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Reset title
 msgid "Reset term title"
 msgstr ""
 
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: Results limit
 msgid "Results limit"
 msgstr "Limitar resultados de búsqueda"
 
 #: components/manage/Blocks/Listing/Edit
+# defaultMessage: Results preview
 msgid "Results preview"
 msgstr "Vista previa de resultados"
 
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: Reversed order
 msgid "Reversed order"
 msgstr "Orden inverso"
 
 #: components/manage/History/History
+# defaultMessage: Revert to this revision
 msgid "Revert to this revision"
 msgstr "Revertir a esta revisión"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Review state
 msgid "Review state"
 msgstr "Estado"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Richtext
 msgid "Richtext"
 msgstr "Texto formateado"
 
 #: components/manage/Blocks/Image/ImageSizeWidget
 #: components/manage/Blocks/Maps/Edit
 #: components/manage/Sidebar/AlignBlock
+# defaultMessage: Right
 msgid "Right"
 msgstr "Derecha"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Rights
 msgid "Rights"
 msgstr "Derechos"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Roles
 msgid "Roles"
 msgstr "Roles"
 
 #: components/manage/Contents/ContentsBreadcrumbs
+# defaultMessage: Root
 msgid "Root"
 msgstr "Raíz"
 
@@ -1640,90 +2000,112 @@ msgstr "Raíz"
 #: components/manage/Form/ModalForm
 #: components/manage/Sharing/Sharing
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Save
 msgid "Save"
 msgstr "Guardar"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Save
 msgid "Save recurrence"
 msgstr "Guardar repetición"
 
 #: components/manage/Controlpanels/ContentTypesActions
+# defaultMessage: Schema
 msgid "Schema"
 msgstr "Esquema"
 
 #: components/manage/Controlpanels/ContentTypeSchema
+# defaultMessage: Schema updates
 msgid "Schema updates"
 msgstr "Actualización de esquema"
 
 #: components/theme/SearchWidget/SearchWidget
+# defaultMessage: Search
 msgid "Search"
 msgstr "Búsqueda"
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: Search SVG
 msgid "Search SVG"
 msgstr ""
 
 #: components/theme/SearchWidget/SearchWidget
+# defaultMessage: Search Site
 msgid "Search Site"
 msgstr "Buscar en el sitio"
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: Search content
 msgid "Search content"
 msgstr "Buscar contenido"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Search for user or group
 msgid "Search for user or group"
 msgstr "Buscar por nombre de usuario o grupo"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Search group…
 msgid "Search group…"
 msgstr "Buscar grupo..."
 
 #: components/theme/Search/Search
+# defaultMessage: Search results
 msgid "Search results"
 msgstr "Resultado de la búsqueda"
 
 #: components/theme/Search/Search
+# defaultMessage: Search results for {term}
 msgid "Search results for {term}"
 msgstr "Resultados de búsqueda para {term}"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Search users…
 msgid "Search users…"
 msgstr "Buscar usuarios..."
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: Second
 msgid "Second"
 msgstr "Segundo"
 
 #: components/manage/Sidebar/ObjectBrowserNav
+# defaultMessage: Select
 msgid "Select"
 msgstr "Seleccionar"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Select a date to add to recurrence
 msgid "Select a date to add to recurrence"
 msgstr "Seleccione una fecha para añadirla a la repetición"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Select columns to show
 msgid "Select columns to show"
 msgstr "Selecciona la columna a mostrar"
 
 #: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Select the transition to be used for modifying the items state.
 msgid "Select the transition to be used for modifying the items state."
 msgstr "Seleccione la transición a ser efectuada al cambiar el estado del contenido."
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: Selected dates
 msgid "Selected dates"
 msgstr "Seleccionar fechas"
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: Selected items
 msgid "Selected items"
 msgstr "Seleccionar elementos"
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: of
 msgid "Selected items - x of y"
 msgstr "Elementos seleccionados - x de y"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Selection
 msgid "Selection"
 msgstr "Selección"
 
@@ -1731,158 +2113,195 @@ msgstr "Selección"
 #: components/manage/Widgets/ArrayWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/TokenWidget
+# defaultMessage: Select…
 msgid "Select…"
 msgstr "Selecciona…"
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Send
 msgid "Send"
 msgstr "Enviar"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Set my password
 msgid "Set my password"
 msgstr "Defina la contraseña"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Set your password
 msgid "Set your password"
 msgstr "Defina su contraseña"
 
 #: components/manage/Sidebar/Sidebar
+# defaultMessage: Settings
 msgid "Settings"
 msgstr "Configuración"
 
 #: components/manage/Sharing/Sharing
 #: components/manage/Toolbar/More
+# defaultMessage: Sharing
 msgid "Sharing"
 msgstr "Compartir"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Sharing for {title}
 msgid "Sharing for {title}"
 msgstr "Compartir para {title}"
 
 #: components/manage/Widgets/SchemaWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/WysiwygWidget
+# defaultMessage: Short Name
 msgid "Short Name"
 msgstr "Nombre Corto"
 
 #: components/manage/Contents/ContentsRenameModal
+# defaultMessage: Short name
 msgid "Short name"
 msgstr "Nombre corto"
 
 #: components/theme/Pagination/Pagination
+# defaultMessage: Show
 msgid "Show"
 msgstr "Mostrar"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Show All
 msgid "Show All"
 msgstr "Mostrar todos"
 
 #: components/theme/Comments/Comments
+# defaultMessage: Show Replies
 msgid "Show Replies"
 msgstr "Mostrar respuestas"
 
 #: components/manage/Widgets/ObjectListWidget
+# defaultMessage: Show item
 msgid "Show item"
 msgstr "Mostrar elemento"
 
 #: components/manage/Sidebar/Sidebar
+# defaultMessage: Shrink sidebar
 msgid "Shrink sidebar"
 msgstr "Contraer barra lateral"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Shrink toolbar
 msgid "Shrink toolbar"
 msgstr "Contraer barra de herramientas"
 
 #: components/theme/Login/Login
+# defaultMessage: Sign in to start session
 msgid "Sign in to start session"
 msgstr "Acceda para iniciar sesión"
 
 #: components/theme/Logo/Logo
+# defaultMessage: Site
 msgid "Site"
 msgstr "Sitio"
 
 #: components/theme/NotFound/NotFound
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: Site Administration
 msgid "Site Administration"
 msgstr "Administrador del sitio"
 
 #: components/theme/Footer/Footer
+# defaultMessage: Site Map
 msgid "Site Map"
 msgstr "Mapa del sitio"
 
 #: components/manage/Controlpanels/Controlpanels
 #: components/manage/Toolbar/PersonalTools
+# defaultMessage: Site Setup
 msgid "Site Setup"
 msgstr "Configuración del sitio"
 
 #: components/theme/Sitemap/Sitemap
+# defaultMessage: Sitemap
 msgid "Sitemap"
 msgstr "Mapa del sitio"
 
 #: components/manage/Blocks/Image/ImageSidebar
+# defaultMessage: Size
 msgid "Size"
 msgstr "Tamaño"
 
 #: components/theme/View/ImageView
+# defaultMessage: Size: {size}
 msgid "Size: {size}"
 msgstr "Tamaño: {size}"
 
 #: error
+# defaultMessage: Sorry, something went wrong with your request
 msgid "Sorry, something went wrong with your request"
 msgstr "Lo siento, algo estuvo mal con su solicitud "
 
 #: components/theme/Search/Search
+# defaultMessage: Sort by:
 msgid "Sort By:"
 msgstr "Ordenar por:"
 
 #: components/manage/Widgets/QuerySortOnWidget
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: Sort on
 msgid "Sort on"
 msgstr "Ordenar por"
 
 #: components/manage/Blocks/HTML/Edit
+# defaultMessage: Source
 msgid "Source"
 msgstr "Fuente"
 
 #: components/manage/Blocks/Video/Edit
+# defaultMessage: Specify a youtube video or playlist url
 msgid "Specify a youtube video or playlist url"
 msgstr "Especifica la dirección URL de un vídeo o una lista de reproducción de youtube"
 
 #: components/manage/Diff/Diff
+# defaultMessage: Split
 msgid "Split"
 msgstr "División"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Start Date
 msgid "Start Date"
 msgstr "Fecha de inicio"
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: Start of the recurrence
 msgid "Start of the recurrence"
 msgstr "Inicio de la repetición"
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Start password reset
 msgid "Start password reset"
 msgstr "Renueve la contraseña"
 
 #: components/manage/Contents/Contents
 #: components/manage/Workflow/Workflow
 #: components/theme/View/TabularView
+# defaultMessage: State
 msgid "State"
 msgstr "Estado"
 
 #: components/manage/Multilingual/CompareLanguages
+# defaultMessage: Stop compare
 msgid "Stop compare"
 msgstr "Para la comparación"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: String
 msgid "String"
 msgstr "Cadena de texto"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Alternate row background color
 msgid "Stripe alternate rows with color"
 msgstr "Raya las filas alternas con color"
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Subject
 msgid "Subject"
 msgstr "Asunto"
 
@@ -1896,43 +2315,53 @@ msgstr "Asunto"
 #: components/manage/Preferences/PersonalPreferences
 #: components/theme/ContactForm/ContactForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Success
 msgid "Success"
 msgstr "Éxito"
 
 #: components/theme/LanguageSelector/LanguageSelector
+# defaultMessage: Switch to
 msgid "Switch to"
 msgstr "Cambiar a"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Table
 msgid "Table"
 msgstr "Tabla"
 
 #: components/manage/Blocks/ToC/View
+# defaultMessage: Table of Contents
 msgid "Table of Contents"
 msgstr "Tabla de contenidos"
 
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsTagsModal
+# defaultMessage: Tags
 msgid "Tags"
 msgstr "Categoría"
 
 #: components/manage/Contents/ContentsTagsModal
+# defaultMessage: Tags to add
 msgid "Tags to add"
 msgstr "Categoría a agregar"
 
 #: components/manage/Contents/ContentsTagsModal
+# defaultMessage: Tags to remove
 msgid "Tags to remove"
 msgstr "Categoría a remover"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Target memory size per cache in bytes
 msgid "Target memory size per cache in bytes"
 msgstr "Número objetivo del tamaño de la memoria por caché en bytes"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Target number of objects in memory per cache
 msgid "Target number of objects in memory per cache"
 msgstr "Número objetivo de elementos en la memoria por caché"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Text
 msgid "Text"
 msgstr "Texto"
 
@@ -1940,87 +2369,108 @@ msgstr "Texto"
 #: components/theme/CorsError/CorsError
 #: components/theme/NotFound/NotFound
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: Thank you.
 msgid "Thank you."
 msgstr "Gracias."
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: The Database Manager allow you to view database status information
 msgid "The Database Manager allow you to view database status information"
 msgstr "El Bestor de la Base de Datos permite ver la infromación del estado de la base de datos"
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: The URL for your external home page, if you have one.
 msgid "The URL for your external home page, if you have one."
 msgstr "La dirección URL de su página personal externa, si tiene una."
 
 #: components/theme/ConnectionRefused/ConnectionRefused
+# defaultMessage: The backend is not responding, please check if you have started Plone, check your project's configuration object apiPath (or if you are using the internal proxy, devProxyToApiPath) or the RAZZLE_API_PATH Volto's environment variable.
 msgid "The backend is not responding, please check if you have started Plone, check your project's configuration object apiPath (or if you are using the internal proxy, devProxyToApiPath) or the RAZZLE_API_PATH Volto's environment variable."
 msgstr "La base de datos no responde, verifique si Plone está en marcha, revise la configuración de su proyecto y el apiPath (o si está utilizando el proxy intero, devProxyToApiPath) o la varialbe RAZZLE_API_PATH de Volto."
 
 #: components/theme/CorsError/CorsError
+# defaultMessage: The backend is responding, but the CORS headers are not configured properly and the browser has denied the access to the backend resources.
 msgid "The backend is responding, but the CORS headers are not configured properly and the browser has denied the access to the backend resources."
 msgstr "La base de datos responde pero las cabeceras CORS no están configuradas correctamente y el navegador no puede acceder a los datos."
 
 #: components/theme/CorsError/CorsError
+# defaultMessage: The backend server of your website is not anwering, we apologize for the inconvenience. Please try to re-load the page and try again. If the problem persists please contact the site administrators.
 msgid "The backend server of your website is not anwering, we apologize for the inconvenience. Please try to re-load the page and try again. If the problem persists please contact the site administrators."
 msgstr "La base de datos no responde, disculpe las molestias. Intente cargar la página otra vez. Si el problema continúa póngase en contacto con el administrador del sitio."
 
 #: components/manage/Contents/Contents
+# defaultMessage: The item could not be deleted.
 msgid "The item could not be deleted."
 msgstr ""
 
 #: components/theme/Register/Register
+# defaultMessage: The registration process has been successful. Please check your e-mail inbox for information on how activate your account.
 msgid "The registration process has been successful. Please check your e-mail inbox for information on how activate your account."
 msgstr "El registro fue exitoso. Verifique su bandeja de entrada para obtener información sobre cómo activar su cuenta."
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: The user portrait/avatar
 msgid "The user portrait/avatar"
 msgstr "El retrato/avatar del usuario"
 
 #: components/manage/Toolbar/More
+# defaultMessage: The working copy was discarded
 msgid "The working copy was discarded"
 msgstr ""
 
 #: components/theme/Footer/Footer
+# defaultMessage: The {plonecms} is {copyright} 2000-{current_year} by the {plonefoundation} and friends.
 msgid "The {plonecms} is {copyright} 2000-{current_year} by the {plonefoundation} and friends."
 msgstr "El {plonecms} es {copyright} 2000-{current_year} por la {plonefoundation} y amigos."
 
 #: components/theme/CorsError/CorsError
+# defaultMessage: There is a configuration problem on the backend
 msgid "There is a configuration problem on the backend"
 msgstr "Hay un error de configuración en el servidor."
 
 #: components/manage/Form/InlineForm
+# defaultMessage: There were some errors
 msgid "There were some errors"
 msgstr "Ha habido algunos errores"
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: There were some errors.
 msgid "There were some errors."
 msgstr "Hay algunos errores."
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: Third
 msgid "Third"
 msgstr "Tercero"
 
 #: components/manage/WorkingCopyToastsFactory/WorkingCopyToastsFactory
+# defaultMessage: This has an ongoing working copy in {title}
 msgid "This has an ongoing working copy in {title}"
 msgstr ""
 
 #: components/manage/WorkingCopyToastsFactory/WorkingCopyToastsFactory
+# defaultMessage: This is a working copy of {title}
 msgid "This is a working copy of {title}"
 msgstr ""
 
 #: components/manage/LockingToastsFactory/LockingToastsFactory
+# defaultMessage: This item was locked by {creator} on {date}
 msgid "This item was locked by {creator} on {date}"
 msgstr ""
 
 #: components/manage/Contents/ContentsRenameModal
+# defaultMessage: This name will be displayed in the URL.
 msgid "This name will be displayed in the URL."
 msgstr "Este nombre se mostrará en la URL."
 
 #: components/theme/NotFound/NotFound
+# defaultMessage: This page does not seem to exist…
 msgid "This page does not seem to exist…"
 msgstr "Esta página no existe…"
 
 #: components/manage/Widgets/DatetimeWidget
+# defaultMessage: Time
 msgid "Time"
 msgstr "Hora"
 
@@ -2033,714 +2483,889 @@ msgstr "Hora"
 #: components/manage/Widgets/WysiwygWidget
 #: components/theme/View/TabularView
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Title
 msgid "Title"
 msgstr "Título"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Total active and non-active objects
 msgid "Total active and non-active objects"
 msgstr "Número de objetos activos y no activos"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Total comments
 msgid "Total comments"
 msgstr "Comentarios totales"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Total number of objects in each cache
 msgid "Total number of objects in each cache"
 msgstr "Número total de objetos en cada caché"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Total number of objects in memory from all caches
 msgid "Total number of objects in memory from all caches"
 msgstr "Número total de objetos en todas las cachés"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Total number of objects in the database
 msgid "Total number of objects in the database"
 msgstr "Número total de objetos en la base de datos"
 
 #: components/manage/Add/Add
 #: components/manage/Toolbar/Types
+# defaultMessage: Translate to {lang}
 msgid "Translate to {lang}"
 msgstr "Traducir a {lang}"
 
 #: components/manage/Multilingual/ManageTranslations
+# defaultMessage: Translation linked
 msgid "Translation linked"
 msgstr "Traducción enlazada"
 
 #: components/manage/Multilingual/ManageTranslations
+# defaultMessage: Translation linking removed
 msgid "Translation linking removed"
 msgstr "Enlace a la traducción eliminado"
 
 #: components/manage/Controlpanels/ContentTypes
 #: components/manage/Widgets/SchemaWidget
 #: components/theme/View/TabularView
+# defaultMessage: Type
 msgid "Type"
 msgstr "Tipo"
 
 #: components/manage/Blocks/Video/Edit
+# defaultMessage: Type a Video (YouTube, Vimeo or mp4) URL
 msgid "Type a Video (YouTube, Vimeo or mp4) URL"
 msgstr "Escriba la URL de un vídeo (YouTube, Vimeo o mp4)"
 
 #: components/manage/Blocks/Text/Edit
+# defaultMessage: Type text…
 msgid "Type text…"
 msgstr "Ingrese texto…"
 
 #: components/manage/Blocks/Title/Edit
+# defaultMessage: Type the title…
 msgid "Type the title…"
 msgstr "Ingrese el título…"
 
 #: components/manage/Contents/Contents
+# defaultMessage: UID
 msgid "UID"
 msgstr "UID"
 
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: Unauthorized
 msgid "Unauthorized"
 msgstr "No autorizado"
 
 #: components/manage/BlockChooser/BlockChooser
+# defaultMessage: Unfold
 msgid "Unfold"
 msgstr "Desplegar"
 
 #: components/manage/Diff/Diff
+# defaultMessage: Unified
 msgid "Unified"
 msgstr "Unificado"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Uninstall
 msgid "Uninstall"
 msgstr "Desinstalar"
 
 #: components/manage/Blocks/Block/Edit
 #: components/theme/View/DefaultView
 #: components/theme/View/RenderBlocks
+# defaultMessage: Unknown Block {block}
 msgid "Unknown Block"
 msgstr "Bloque desconocido"
 
 #: components/manage/Multilingual/ManageTranslations
+# defaultMessage: Unlink translation for
 msgid "Unlink translation for"
 msgstr "Eliminar enlace de traducción de"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Unlock
 msgid "Unlock"
 msgstr ""
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Update
 msgid "Update"
 msgstr "Actualizar"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Update installed addons
 msgid "Update installed addons"
 msgstr "Actualizar complementos instalados"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Update installed addons:
 msgid "Update installed addons:"
 msgstr "Actualizar complementos instalados:"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Updates available
 msgid "Updates available"
 msgstr "Actualizaciones disponibles"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Upload
 msgid "Upload"
 msgstr "Cargar"
 
 #: components/manage/Blocks/LeadImage/Edit
+# defaultMessage: Upload a lead image in the 'Lead Image' content field.
 msgid "Upload a lead image in the 'Lead Image' content field."
 msgstr "Cargar una imagen principal en el campo 'Imagen Principal'"
 
 #: components/manage/Blocks/HeroImageLeft/Edit
+# defaultMessage: Upload a new image
 msgid "Upload a new image"
 msgstr "Cargar nueva imagen"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Upload files
 msgid "Upload files"
 msgstr "Cargar archivos"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Uploading files
 msgid "Uploading files"
 msgstr "Cargando archivos"
 
 #: components/manage/Blocks/HeroImageLeft/Edit
+# defaultMessage: Uploading image
 msgid "Uploading image"
 msgstr "Cargando imagen"
 
 #: components/manage/Widgets/SchemaWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/WysiwygWidget
+# defaultMessage: Used for programmatic access to the fieldset.
 msgid "Used for programmatic access to the fieldset."
 msgstr "Usado para acceso programático al conjunto de campos."
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: User
 msgid "User"
 msgstr "Usuario"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: User created
 msgid "User created"
 msgstr "Usuario creado"
 
 #: components/manage/Controlpanels/Users/UsersControlpanel
+# defaultMessage: User name
 msgid "User name"
 msgstr "Nombre de usuario"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: User roles updated
 msgid "User roles updated"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Username
 msgid "Username"
 msgstr "Nombre de usuario"
 
 #: components/manage/Controlpanels/Controlpanels
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Users
 msgid "Users"
 msgstr "Usuarios"
 
 #: components/manage/Controlpanels/Controlpanels
+# defaultMessage: Users and Groups
 msgid "Users and Groups"
 msgstr "Usuarios y Grupos"
 
 #: helpers/Extensions/withBlockSchemaEnhancer
+# defaultMessage: Variation
 msgid "Variation"
 msgstr "Variación"
 
 #: components/manage/Controlpanels/Controlpanels
+# defaultMessage: Version Overview
 msgid "Version Overview"
 msgstr "Visión Global de Versiones"
 
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Video
 msgid "Video"
 msgstr "Vídeo"
 
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Video URL
 msgid "Video URL"
 msgstr "URL del vídeo"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: View
 msgid "View"
 msgstr "Ver"
 
 #: components/manage/History/History
+# defaultMessage: View changes
 msgid "View changes"
 msgstr "Mostrar los cambios"
 
 #: components/manage/History/History
+# defaultMessage: View this revision
 msgid "View this revision"
 msgstr "Mostrar esta revisión"
 
 #: components/manage/Toolbar/More
+# defaultMessage: View working copy
 msgid "View working copy"
 msgstr ""
 
 #: components/manage/Display/Display
+# defaultMessage: View
 msgid "Viewmode"
 msgstr "Modo Ver"
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Vocabulary term
 msgid "Vocabulary term"
 msgstr ""
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Title
 msgid "Vocabulary term title"
 msgstr ""
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Vocabulary terms
 msgid "Vocabulary terms"
 msgstr ""
 
 #: components/manage/Controlpanels/VersionOverview
+# defaultMessage: You are running in 'debug mode'. This mode is intended for sites that are under development. This allows many configuration changes to be immediately visible, but will make your site run more slowly. To turn off debug mode, stop the server, set 'debug-mode=off' in your buildout.cfg, re-run bin/buildout and then restart the server process.
 msgid "Warning Regarding debug mode"
 msgstr "Aviso del modo desarrollo"
 
 #: components/theme/ConnectionRefused/ConnectionRefused
+# defaultMessage: We apologize for the inconvenience, but the backend of the site you are accessing is not available right now. Please, try again later.
 msgid "We apologize for the inconvenience, but the backend of the site you are accessing is not available right now. Please, try again later."
 msgstr "Disculpe las molestias, pero la base de datos no está disponible en este momento. Inténtelo más tarde."
 
 #: components/theme/NotFound/NotFound
+# defaultMessage: We apologize for the inconvenience, but the page you were trying to access is not at this address. You can use the links below to help you find what you are looking for.
 msgid "We apologize for the inconvenience, but the page you were trying to access is not at this address. You can use the links below to help you find what you are looking for."
 msgstr "Disculpe las molestias, la página a la que está intentando acceder no existe en esta dirección. Puede usar el siguiente enlace para encontrar lo que estaba buscando."
 
 #: components/theme/Forbidden/Forbidden
+# defaultMessage: We apologize for the inconvenience, but you don't have permissions on this resource.
 msgid "We apologize for the inconvenience, but you don't have permissions on this resource."
 msgstr "Disculpe las molestias pero no tiene permisos en este elemento."
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: We will use this address if you need to recover your password
 msgid "We will use this address if you need to recover your password"
 msgstr "Usaremos esta dirección de correo electrónico, en el caso si usted necesita recuperar su contraseña"
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: The
 msgid "Weeek day of month"
 msgstr "Día de la semana del mes"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Weekday
 msgid "Weekday"
 msgstr "Día de la semana"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Weekly
 msgid "Weekly"
 msgstr "Semanalmente"
 
 #: components/manage/History/History
+# defaultMessage: What
 msgid "What"
 msgstr "Que"
 
 #: components/manage/History/History
+# defaultMessage: When
 msgid "When"
 msgstr "Cuando"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: When this date is reached, the content will nolonger be visible in listings and searches.
 msgid "When this date is reached, the content will nolonger be visible in listings and searches."
 msgstr "Cuando se alcanza esta fecha, el contenido ya no será visible en listas y búsquedas."
 
 #: components/manage/History/History
+# defaultMessage: Who
 msgid "Who"
 msgstr "Quien"
 
 #: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Updating workflow states...
 msgid "Workflow Change Loading Message"
 msgstr "Mensaje de cargar un cambio del flujo de trabajo"
 
 #: components/manage/Workflow/Workflow
+# defaultMessage: Workflow updated.
 msgid "Workflow updated."
 msgstr "Flujo de trabajo actualizado."
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Yearly
 msgid "Yearly"
 msgstr "Anualmente"
 
 #: components/manage/Contents/ContentsItem
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Yes
 msgid "Yes"
 msgstr "Sí"
 
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: You are trying to access a protected resource, please {login} first.
 msgid "You are trying to access a protected resource, please {login} first."
 msgstr "Está intentando acceder a un elemento protegido, haga {login} primero"
 
 #: components/theme/OutdatedBrowser/OutdatedBrowser
+# defaultMessage: You are using an outdated browser
 msgid "You are using an outdated browser"
 msgstr "Está utilizando un navegador anticuado"
 
 #: components/theme/Comments/Comments
+# defaultMessage: You can add a comment by filling out the form below. Plain text formatting.
 msgid "You can add a comment by filling out the form below. Plain text formatting."
 msgstr "Usted puede agregar un comentario completando el formulario a continuación. Utilice formato de texto sin formato."
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: You can control who can view and edit your item using the list below.
 msgid "You can control who can view and edit your item using the list below."
 msgstr "Usted puede controlar quien puede ver y editar su elemento usando la lista a continuación."
 
 #: components/manage/Diff/Diff
+# defaultMessage: You can view the difference of the revisions below.
 msgid "You can view the difference of the revisions below."
 msgstr "Usted puede ver las diferencias de las revisiones a continuación."
 
 #: components/manage/History/History
+# defaultMessage: You can view the history of your item below.
 msgid "You can view the history of your item below."
 msgstr "Usted puede ver el historial de su elemento a continuación."
 
 #: components/manage/Contents/Contents
+# defaultMessage: You can't paste this content here
 msgid "You can't paste this content here"
 msgstr "No puede pegar el contenido aquí"
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Your email is required for reset your password.
 msgid "Your email is required for reset your password."
 msgstr "La dirección de correo electrónico es necesaria para restablecer su contraseña."
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: Your location - either city and country - or in a company setting, where your office is located.
 msgid "Your location - either city and country - or in a company setting, where your office is located."
 msgstr "Su ubicación, ya sea ciudad y país, o en un entorno de empresa, donde se encuentra su oficina."
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Your password has been set successfully. You may now {link} with your new password.
 msgid "Your password has been set successfully. You may now {link} with your new password."
 msgstr "Su contraseña ha sido restablecida exitosamente. Usted puede {link} usando la nueva contraseña."
 
 #: components/manage/Preferences/PersonalPreferences
+# defaultMessage: Your preferred language
 msgid "Your preferred language"
 msgstr "Su idioma preferido"
 
 #: components/theme/Login/Login
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Forgot your password?
 msgid "box_forgot_password_option"
 msgstr "¿Olvidaste tu contraseña?"
 
 #: config/Blocks
+# defaultMessage: Common
 msgid "common"
 msgstr "Común"
 
 #: components/manage/Multilingual/CompareLanguages
+# defaultMessage: Compare to language
 msgid "compare_to"
 msgstr "Comparar"
 
 #: components/manage/Blocks/Block/EditBlockWrapper
+# defaultMessage: delete
 msgid "delete"
 msgstr "eliminar"
 
 #: components/theme/OutdatedBrowser/OutdatedBrowser
+# defaultMessage: You are using {browsername} {browserversion} which is deprecated by its vendor. That means that it does not get security updates and it is not ready for current modern web features, which deteriorates the user experience. Please upgrade to a modern browser.
 msgid "deprecated_browser_notice_message"
 msgstr "Aviso de navegador anticuado"
 
 #: config/Blocks
+# defaultMessage: Description
 msgid "description"
 msgstr "Descripción"
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: For security reasons, we store your password encrypted, and cannot mail it to you. If you would like to reset your password, fill out the form below and we will send you an email at the address you gave when you registered to start the process of resetting your password.
 msgid "description_lost_password"
 msgstr "Por razones de seguridad, las contraseñas se almacenan en forma cifrada y, por lo tanto, no se le pueden enviar. Si desea restablecer su contraseña, complete el siguiente formulario: se enviarán más instrucciones para completar el proceso a la dirección de correo electrónico que especificó al registrarse."
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Your password reset request has been mailed. It should arrive in your mailbox shortly. When you receive the message, visit the address it contains to reset your password.
 msgid "description_sent_password"
 msgstr "Se han enviado las instrucciones para restablecer su contraseña. Deben llegar a su bandeja de entrada pronto. Una vez que reciba el mensaje, visite la dirección indicada para restablecer la contraseña."
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Draft
 msgid "draft"
 msgstr "Borrador"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Input must be valid email (something@domain.com)
 msgid "email"
 msgstr "Correo electrónico"
 
 #: components/theme/View/EventView
+# defaultMessage: All dates
 msgid "event_alldates"
 msgstr "Todas las fechas"
 
 #: components/theme/View/EventView
+# defaultMessage: Attendees
 msgid "event_attendees"
 msgstr "Asistentes"
 
 #: components/theme/View/EventView
+# defaultMessage: Contact Name
 msgid "event_contactname"
 msgstr "Nombre del contacto"
 
 #: components/theme/View/EventView
+# defaultMessage: Contact Phone
 msgid "event_contactphone"
 msgstr "Teléfono del contacto"
 
 #: components/theme/View/EventView
+# defaultMessage: Website
 msgid "event_website"
 msgstr "Web"
 
 #: components/theme/View/EventView
+# defaultMessage: What
 msgid "event_what"
 msgstr "Qué"
 
 #: components/theme/View/EventView
+# defaultMessage: When
 msgid "event_when"
 msgstr "Cuándo"
 
 #: components/theme/View/EventView
+# defaultMessage: Where
 msgid "event_where"
 msgstr "Dónde"
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Password reset confirmation sent
 msgid "heading_sent_password"
 msgstr "Solicitud de confirmación de restablecimiento de contraseña enviada"
 
 #: config/Blocks
+# defaultMessage: Hero
 msgid "hero"
 msgstr "Hero"
 
 #: config/Blocks
+# defaultMessage: HTML
 msgid "html"
 msgstr "HTML"
 
 #: config/Blocks
+# defaultMessage: Image
 msgid "image"
 msgstr "Imagen"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Input must be integer
 msgid "integer"
 msgstr "Número entero"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Intranet
 msgid "intranet"
 msgstr "Intranet"
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: My email address is
 msgid "label_my_email_address_is"
 msgstr "Mi dirección de correo electrónico es"
 
 #: config/Blocks
+# defaultMessage: Lead Image Field
 msgid "leadimage"
 msgstr "Imagen Principal"
 
 #: config/Blocks
+# defaultMessage: Listing
 msgid "listing"
 msgstr "Listado"
 
 #: components/manage/Blocks/Listing/ListingBody
 #: components/manage/Contents/Contents
+# defaultMessage: Loading
 msgid "loading"
 msgstr "Cargando"
 
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: log in
 msgid "log in"
 msgstr "entrar"
 
 #: config/Blocks
+# defaultMessage: Maps
 msgid "maps"
 msgstr "Mapas"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Maximum Length
 msgid "maxLength"
 msgstr "Tamaño máximo"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: End of the range (including the value itself)
 msgid "maximum"
 msgstr "Máximo"
 
 #: config/Blocks
+# defaultMessage: Media
 msgid "media"
 msgstr "Multimedia"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Minimum Length
 msgid "minLength"
 msgstr "Tamaño mínimo"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Start of the range
 msgid "minimum"
 msgstr "Mínimo"
 
 #: config/Blocks
+# defaultMessage: Most used
 msgid "mostUsed"
 msgstr "Más usado"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: No workflow state
 msgid "no workflow state"
 msgstr "No hay estado del flujo de trabajo"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Input must be number
 msgid "number"
 msgstr "Número"
 
 #: components/manage/Widgets/RecurrenceWidget/ByMonthDayField
 #: components/manage/Widgets/RecurrenceWidget/ByYearField
+# defaultMessage: of the month
 msgid "of the month"
 msgstr "del mes"
 
 #: error
+# defaultMessage: or try a different page.
 msgid "or try a different page."
 msgstr "o intente con una página diferente."
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: others
 msgid "others"
 msgstr "Otros"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Private
 msgid "private"
 msgstr "Privado"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Published
 msgid "published"
 msgstr "Publicado"
 
 #: components/manage/Widgets/QueryWidget
+# defaultMessage: Select…
 msgid "querystring-widget-select"
 msgstr "Seleccionar la consulta"
 
 #: components/theme/Search/Search
+# defaultMessage: results
 msgid "results found"
 msgstr "Se han encontrado resultados"
 
 #: error
+# defaultMessage: return to the site root
 msgid "return to the site root"
 msgstr "regrese al directorio raíz del sitio"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: and
 msgid "rrule_and"
 msgstr "Y"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: (~approximate)
 msgid "rrule_approximate"
 msgstr "Aproximadamente"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: at
 msgid "rrule_at"
 msgstr "a las"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: [month] [day], [year]
 msgid "rrule_dateFormat"
 msgstr "formato de fecha"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: day
 msgid "rrule_day"
 msgstr "día"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: days
 msgid "rrule_days"
 msgstr "días"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: every
 msgid "rrule_every"
 msgstr "todos los"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: for
 msgid "rrule_for"
 msgstr "para"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: hour
 msgid "rrule_hour"
 msgstr "hora"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: hours
 msgid "rrule_hours"
 msgstr "horas"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: in
 msgid "rrule_in"
 msgstr "en"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: last
 msgid "rrule_last"
 msgstr "último"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: minutes
 msgid "rrule_minutes"
 msgstr "minutos"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: month
 msgid "rrule_month"
 msgstr "mes"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: months
 msgid "rrule_months"
 msgstr "meses"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: nd
 msgid "rrule_nd"
 msgstr " "
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: on
 msgid "rrule_on"
 msgstr "el"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: on the
 msgid "rrule_on the"
 msgstr "el "
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: or
 msgid "rrule_or"
 msgstr "o"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: rd
 msgid "rrule_rd"
 msgstr " "
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: st
 msgid "rrule_st"
 msgstr " "
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: th
 msgid "rrule_th"
 msgstr " "
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: the
 msgid "rrule_the"
 msgstr "el"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: time
 msgid "rrule_time"
 msgstr "vez"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: times
 msgid "rrule_times"
 msgstr "veces"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: until
 msgid "rrule_until"
 msgstr "hasta el"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: week
 msgid "rrule_week"
 msgstr "semana"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: weekday
 msgid "rrule_weekday"
 msgstr "día de la semana"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: weekdays
 msgid "rrule_weekdays"
 msgstr "días de la semana"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: weeks
 msgid "rrule_weeks"
 msgstr "semanas"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: year
 msgid "rrule_year"
 msgstr "año"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: years
 msgid "rrule_years"
 msgstr "años"
 
 #: components/theme/SkipLinks/SkipLinks
+# defaultMessage: Skip to footer
 msgid "skiplink-footer"
 msgstr "Saltar al pie de página"
 
 #: components/theme/SkipLinks/SkipLinks
+# defaultMessage: Skip to main content
 msgid "skiplink-main-content"
 msgstr "Saltar a contenido"
 
 #: components/theme/SkipLinks/SkipLinks
+# defaultMessage: Skip to navigation
 msgid "skiplink-navigation"
 msgstr "Saltar a navegación"
 
 #: components/manage/Contents/Contents
+# defaultMessage: sort
 msgid "sort"
 msgstr "Ordenar"
 
 #: config/Blocks
+# defaultMessage: Table
 msgid "table"
 msgstr "Tabla"
 
 #: config/Blocks
+# defaultMessage: Text
 msgid "text"
 msgstr "Texto"
 
 #: config/Blocks
+# defaultMessage: Title
 msgid "title"
 msgstr "Título"
 
 #: config/Blocks
+# defaultMessage: Table of Contents
 msgid "toc"
 msgstr "Tabla de contenidos"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Input must be valid url (www.something.com or http(s)://www.something.com)
 msgid "url"
 msgstr "URL"
 
 #: components/manage/Toolbar/PersonalTools
+# defaultMessage: user avatar
 msgid "user avatar"
 msgstr "avatar de usuario"
 
 #: config/Blocks
+# defaultMessage: Video
 msgid "video"
 msgstr "Vídeo"
 
 #: components/theme/View/EventView
+# defaultMessage: Visit external website
 msgid "visit_external_website"
 msgstr "Visitar web externa"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: {count, plural, one {Upload {count} file} other {Upload {count} files}}
 msgid "{count, plural, one {Upload {count} file} other {Upload {count} files}}"
 msgstr "{count, plural, one {Cargar {count} archivo} other {Cargar {count} archivos}}"
 
 #: components/manage/Contents/Contents
+# defaultMessage: {count} selected
 msgid "{count} selected"
 msgstr "{count} seleccionado"
 
 #: components/manage/Controlpanels/ContentType
+# defaultMessage: {id} Content Type
 msgid "{id} Content Type"
 msgstr "{id} Tipo de Contenido"
 
 #: components/manage/Controlpanels/ContentTypeSchema
+# defaultMessage: {id} Schema
 msgid "{id} Schema"
 msgstr "{id} Esquema"
 
 #: components/manage/Actions/Actions
+# defaultMessage: {title} copied.
 msgid "{title} copied."
 msgstr "{title} copiado."
 
 #: components/manage/Actions/Actions
+# defaultMessage: {title} cut.
 msgid "{title} cut."
 msgstr "{title} cortado."
 
 #: components/manage/Actions/Actions
+# defaultMessage: {title} has been deleted.
 msgid "{title} has been deleted."
 msgstr "{title} ha sido eliminado."

--- a/locales/eu/LC_MESSAGES/volto.po
+++ b/locales/eu/LC_MESSAGES/volto.po
@@ -19,22 +19,27 @@ msgstr ""
 "X-Poedit-Bookmarks: -1,38,-1,-1,-1,-1,-1,-1,-1,-1\n"
 
 #: components/manage/Blocks/HTML/Edit
+# defaultMessage: <p>Add some HTML here</p>
 msgid "<p>Add some HTML here</p>"
 msgstr "<p>HTMLa idatzi hemen</p>"
 
 #: components/theme/Footer/Footer
+# defaultMessage: Accessibility
 msgid "Accessibility"
 msgstr "Irisgarritasuna"
 
 #: components/theme/Register/Register
+# defaultMessage: Account Registration Completed
 msgid "Account Registration Completed"
 msgstr "Izen-ematea ondo egin da"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Account activation completed
 msgid "Account activation completed"
 msgstr "Erabiltzaile kontua ondo sortu da"
 
 #: components/manage/Controlpanels/ModerateComments
+# defaultMessage: Action
 msgid "Action"
 msgstr "Ekintza"
 
@@ -43,10 +48,12 @@ msgstr "Ekintza"
 #: components/manage/Controlpanels/ContentTypes
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
+# defaultMessage: Actions
 msgid "Actions"
 msgstr "Ekintzak"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Activate and deactivate add-ons in the lists below.
 msgid "Activate and deactivate"
 msgstr "Aktibatu eta desaktibatu"
 
@@ -54,86 +61,107 @@ msgstr "Aktibatu eta desaktibatu"
 #: components/manage/Toolbar/Toolbar
 #: components/manage/Widgets/SchemaWidget
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add
 msgid "Add"
 msgstr "Gehitu"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: To make new add-ons show up here, add them to your buildout configuration, run buildout, and restart the server process. For detailed instructions see
 msgid "Add Addons"
 msgstr "Gehitu gehigarriak"
 
 #: components/manage/Toolbar/Types
+# defaultMessage: Add Content…
 msgid "Add Content"
 msgstr "Gehitu edukia"
 
 #: components/manage/Toolbar/Types
+# defaultMessage: Add Translation…
 msgid "Add Translation…"
 msgstr "Gehitu itzulpena..."
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add User
 msgid "Add User"
 msgstr "Gehitu erabiltzailea"
 
 #: components/manage/Blocks/Description/Edit
+# defaultMessage: Add a description…
 msgid "Add a description…"
 msgstr "Gehitu deskribapena..."
 
 #: components/manage/BlockChooser/BlockChooserButton
+# defaultMessage: Add block
 msgid "Add block"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add block…
 msgid "Add block…"
 msgstr "Gehitu blokea..."
 
 #: components/manage/Widgets/QueryWidget
+# defaultMessage: Add criteria
 msgid "Add criteria"
 msgstr "Gehitu irizpidea"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Add date
 msgid "Add date"
 msgstr "Gehitu data"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Add field
 msgid "Add field"
 msgstr "Gehitu eremua"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Add fieldset
 msgid "Add fieldset"
 msgstr "Gehitu eremu-multzoa"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add group
 msgid "Add group"
 msgstr "Gehitu taldea"
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Add new content type
 msgid "Add new content type"
 msgstr "Gehitu elementu-mota berria"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add new group
 msgid "Add new group"
 msgstr "Gehitu talde berria"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add new user
 msgid "Add new user"
 msgstr "Gehitu erabiltzaile berria"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add to Groups
 msgid "Add to Groups"
 msgstr "Gehitu taldeetara"
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Add term
 msgid "Add vocabulary term"
 msgstr ""
 
 #: components/manage/Add/Add
+# defaultMessage: Add {type}
 msgid "Add {type}"
 msgstr "Gehitu {type}"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Add-ons Settings
 msgid "Add-ons Settings"
 msgstr "Gehigarrien ezarpenak"
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: Additional date
 msgid "Additional date"
 msgstr "Data gehigarria"
 
@@ -141,39 +169,48 @@ msgstr "Data gehigarria"
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
 #: components/manage/Blocks/Maps/MapsSidebar
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Alignment
 msgid "Alignment"
 msgstr "Alineazio-estiloak"
 
 #: components/manage/Contents/Contents
+# defaultMessage: All
 msgid "All"
 msgstr "Guztiak"
 
 #: components/theme/Search/Search
+# defaultMessage: Alphabetically
 msgid "Alphabetically"
 msgstr "Alfabetikoki"
 
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: Alt text
 msgid "Alt text"
 msgstr "Ordezko testua (alt)"
 
 #: components/manage/Toolbar/More
+# defaultMessage: Apply working copy
 msgid "Apply working copy"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Are you sure you want to delete this field?
 msgid "Are you sure you want to delete this field?"
 msgstr "Eremu hau ezabatu egin nahi duzu?"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Are you sure you want to delete this fieldset including all fields?
 msgid "Are you sure you want to delete this fieldset including all fields?"
 msgstr "Eremu-multzo hau eta bere eremu guztiak ezabatu nahi dituzu?"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Ascending
 msgid "Ascending"
 msgstr "Goraka"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Available
 msgid "Available"
 msgstr "Aukerak"
 
@@ -198,48 +235,59 @@ msgstr "Aukerak"
 #: components/manage/Toolbar/Toolbar
 #: components/theme/ContactForm/ContactForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Back
 msgid "Back"
 msgstr "Atzera"
 
 #: components/manage/Diff/Diff
+# defaultMessage: Base
 msgid "Base"
 msgstr "Oinarria"
 
 #: components/manage/Sidebar/Sidebar
+# defaultMessage: Block
 msgid "Block"
 msgstr "Blokea"
 
 #: components/theme/Login/Login
+# defaultMessage: Both email address and password are case sensitive, check that caps lock is not enabled.
 msgid "Both email address and password are case sensitive, check that caps lock is not enabled."
 msgstr "Bai e-posta helbideak eta bai pasahitzak maiuskula eta minuskulak bereizten dituzte, egiaztatu maiuskulak blokeatzeko tekla ez dagoela aktibatuta."
 
 #: components/theme/Breadcrumbs/Breadcrumbs
+# defaultMessage: Breadcrumbs
 msgid "Breadcrumbs"
 msgstr "Nabigazio arrastoa"
 
 #: components/manage/Blocks/HeroImageLeft/Edit
 #: components/manage/Contents/ContentsUploadModal
 #: components/manage/Sidebar/ObjectBrowserNav
+# defaultMessage: Browse
 msgid "Browse"
 msgstr "Arakatu"
 
 #: components/manage/Blocks/Image/Edit
+# defaultMessage: Browse the site, drop an image, or type an URL
 msgid "Browse the site, drop an image, or type an URL"
 msgstr "Atarian bilatu, irudi bat hona arrastatu edo URL bat idatzi"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: By default, permissions from the container of this item are inherited. If you disable this, only the explicitly defined sharing permissions will be valid. In the overview, the symbol {inherited} indicates an inherited value. Similarly, the symbol {global} indicates a global role, which is managed by the site administrator.
 msgid "By default, permissions from the container of this item are inherited. If you disable this, only the explicitly defined sharing permissions will be valid. In the overview, the symbol {inherited} indicates an inherited value. Similarly, the symbol {global} indicates a global role, which is managed by the site administrator."
 msgstr "Defektuz, elementu hau barnean duen karpetaren baimenak heredatu egiten dira. Hau desaktibatzen baduzu, hemen zehaztutako baimenak bakarrik aplikatuko dira. {inherited} ikurrak heredatutako balioa adierazten du. Era berean, {global} ikurrak rol globala adierazten du, atariaren kudeatzaileak kudeatzen duen rola."
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Cache Name
 msgid "Cache Name"
 msgstr "Katxearen izena"
 
 #: components/manage/Controlpanels/ContentTypeLayout
+# defaultMessage: Can not edit Layout for <strong>{type}</strong> content-type as it doesn't have support for <strong>Volto Blocks</strong> enabled
 msgid "Can not edit Layout for <strong>{type}</strong> content-type as it doesn't have support for <strong>Volto Blocks</strong> enabled"
 msgstr "Ezin da <strong>{type}</strong> elementu-motaren itxura aldatu, ez baitu <strong>Volto Blocks</strong> portaera aktibatuta"
 
 #: components/manage/Controlpanels/ContentTypeLayout
+# defaultMessage: Can not edit Layout for <strong>{type}</strong> content-type as the <strong>Blocks behavior</strong> is enabled and <strong>read-only</strong>
 msgid "Can not edit Layout for <strong>{type}</strong> content-type as the <strong>Blocks behavior</strong> is enabled and <strong>read-only</strong>"
 msgstr "Ezin da <strong>{type}</strong> elementu-motaren itxura aldatu, <strong>Volto Blocks</strong> portaera aktibatuta izan arren <strong>irakurtzeko-moduan bakarrik</strong> baitago"
 
@@ -255,42 +303,51 @@ msgstr "Ezin da <strong>{type}</strong> elementu-motaren itxura aldatu, <strong>
 #: components/manage/Sharing/Sharing
 #: components/theme/Login/Login
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Cancel
 msgid "Cancel"
 msgstr "Utzi"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Cell
 msgid "Cell"
 msgstr "Zelda"
 
 #: components/manage/Blocks/Image/ImageSizeWidget
 #: components/manage/Blocks/Maps/Edit
 #: components/manage/Sidebar/AlignBlock
+# defaultMessage: Center
 msgid "Center"
 msgstr "Erdiratu"
 
 #: components/manage/History/History
+# defaultMessage: Change Note
 msgid "Change Note"
 msgstr "Aldaketaren inguruko oharra"
 
 #: components/manage/Preferences/ChangePassword
+# defaultMessage: Change Password
 msgid "Change Password"
 msgstr "Pasahitza aldatu"
 
 #: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Change State
 msgid "Change State"
 msgstr "Egoera aldatu"
 
 #: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Change workflow state recursively
 msgid "Change workflow state recursively"
 msgstr "Lan-fluxuaren egoera errekurtsiboki aldatu"
 
 #: components/manage/Toolbar/More
+# defaultMessage: Changes applied
 msgid "Changes applied."
 msgstr ""
 
 #: components/manage/Preferences/ChangePassword
 #: components/manage/Preferences/PersonalInformation
 #: components/manage/Preferences/PersonalPreferences
+# defaultMessage: Changes saved
 msgid "Changes saved"
 msgstr "Aldaketak ondo gorde dira"
 
@@ -298,192 +355,237 @@ msgstr "Aldaketak ondo gorde dira"
 #: components/manage/Controlpanels/ContentTypeLayout
 #: components/manage/Controlpanels/ContentTypeSchema
 #: components/manage/Controlpanels/Controlpanel
+# defaultMessage: Changes saved.
 msgid "Changes saved."
 msgstr "Aldaketak ondo gorde dira."
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Checkbox
 msgid "Checkbox"
 msgstr "Aukeraketa-kutxa"
 
 #: components/manage/Widgets/SelectWidget
+# defaultMessage: Choices
 msgid "Choices"
 msgstr "Aukerak"
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: Choose Image
 msgid "Choose Image"
 msgstr "Aukeratu irudia"
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: Choose Target
 msgid "Choose Target"
 msgstr "Aukeratu helburua"
 
 #: components/manage/Widgets/FileWidget
+# defaultMessage: Choose a file
 msgid "Choose a file"
 msgstr ""
 
 #: components/manage/Blocks/HTML/Edit
+# defaultMessage: Clear
 msgid "Clear"
 msgstr ""
 
 #: components/theme/View/ImageView
+# defaultMessage: Click to download full sized image
 msgid "Click to download full sized image"
 msgstr "Egin klik tamaina osoko irudia deskargatzeko..."
 
 #: components/manage/Widgets/SelectWidget
+# defaultMessage: Close
 msgid "Close"
 msgstr "Itxi"
 
 #: components/theme/Navigation/Navigation
+# defaultMessage: Close menu
 msgid "Close menu"
 msgstr "Itxi menua"
 
 #: components/manage/Blocks/HTML/Edit
+# defaultMessage: Code
 msgid "Code"
 msgstr ""
 
 #: components/manage/Widgets/ObjectListWidget
+# defaultMessage: Collapse item
 msgid "Collapse item"
 msgstr ""
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Collection
 msgid "Collection"
 msgstr "Bilduma"
 
 #: components/manage/Controlpanels/ModerateComments
 #: components/theme/Comments/CommentEditModal
 #: components/theme/Comments/Comments
+# defaultMessage: Comment
 msgid "Comment"
 msgstr "Iruzkina"
 
 #: components/manage/Controlpanels/ModerateComments
+# defaultMessage: Commenter
 msgid "Commenter"
 msgstr "Erantzuna eman duena"
 
 #: components/theme/Comments/Comments
+# defaultMessage: Comments
 msgid "Comments"
 msgstr ""
 
 #: components/manage/Diff/Diff
+# defaultMessage: Compare
 msgid "Compare"
 msgstr "Alderatu"
 
 #: components/manage/Preferences/ChangePassword
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Confirm password
 msgid "Confirm password"
 msgstr "Pasahitza berretsi"
 
 #: components/theme/ConnectionRefused/ConnectionRefused
+# defaultMessage: Connection refused
 msgid "Connection refused"
 msgstr "Konexioak huts egin du"
 
 #: components/theme/Footer/Footer
+# defaultMessage: Contact
 msgid "Contact"
 msgstr "Kontaktua"
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Contact form
 msgid "Contact form"
 msgstr "Kontaktu-formularioa"
 
 #: components/manage/Blocks/Listing/Edit
+# defaultMessage: Contained items
 msgid "Contained items"
 msgstr "Barneko elementuak"
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Content type created
 msgid "Content type created"
 msgstr "Elementu-mota gehitu da"
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Content type deleted
 msgid "Content type deleted"
 msgstr "Elementu-mota ezabatu da"
 
 #: components/manage/Contents/Contents
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Contents
 msgid "Contents"
 msgstr "Edukiak"
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Copy
 msgid "Copy"
 msgstr "Kopiatu"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: undefined
 msgid "Copy blocks"
 msgstr ""
 
 #: components/theme/Footer/Footer
+# defaultMessage: Copyright
 msgid "Copyright"
 msgstr "Copyright"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Copyright statement or other rights information on this item.
 msgid "Copyright statement or other rights information on this item."
 msgstr "Elementu honen Copyright adierazpena"
 
 #: components/manage/Toolbar/More
+# defaultMessage: Create working copy
 msgid "Create working copy"
 msgstr ""
 
 #: components/manage/WorkingCopyToastsFactory/WorkingCopyToastsFactory
+# defaultMessage: Created by {creator} on {date}
 msgid "Created by {creator} on {date}"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Created on
 msgid "Created on"
 msgstr "Sorrera data"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Creator
 msgid "Creator"
 msgstr "Sortzailea"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Creators
 msgid "Creators"
 msgstr "Sortzaileak"
 
 #: components/manage/Widgets/QuerystringWidget
 #: components/manage/Widgets/QueryWidget
+# defaultMessage: Criteria
 msgid "Criteria"
 msgstr "Irizpidea"
 
 #: components/manage/Preferences/ChangePassword
+# defaultMessage: Current password
 msgid "Current password"
 msgstr "Oraingo pasahitza"
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Cut
 msgid "Cut"
 msgstr "Ebaki"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: undefined
 msgid "Cut blocks"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Daily
 msgid "Daily"
 msgstr "Egunero"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Database Information
 msgid "Database Information"
 msgstr "Datu-basearen informazioa"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Database Location
 msgid "Database Location"
 msgstr "Datu-basearen kokalekua"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Database Size
 msgid "Database Size"
 msgstr "Datu-basearen tamaina"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Database main
 msgid "Database main"
 msgstr "Datu-base nagusia"
 
 #: components/manage/Controlpanels/ModerateComments
 #: components/manage/Widgets/DatetimeWidget
+# defaultMessage: Date
 msgid "Date"
 msgstr "Data"
 
 #: components/theme/Search/Search
+# defaultMessage: Date (newest first)
 msgid "Date (newest first)"
 msgstr "Data (berriena lehenengo)"
 
@@ -503,6 +605,7 @@ msgstr "Data (berriena lehenengo)"
 #: components/theme/PasswordReset/PasswordReset
 #: components/theme/PasswordReset/RequestPasswordReset
 #: components/theme/Register/Register
+# defaultMessage: Default
 msgid "Default"
 msgstr "Defektuzkoa"
 
@@ -517,38 +620,47 @@ msgstr "Defektuzkoa"
 #: components/manage/Widgets/ObjectBrowserWidget
 #: components/manage/Widgets/WysiwygWidget
 #: components/theme/Comments/Comments
+# defaultMessage: Delete
 msgid "Delete"
 msgstr "Ezabatu"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Delete Group
 msgid "Delete Group"
 msgstr "Ezabatu taldea"
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Delete Type
 msgid "Delete Type"
 msgstr "Ezabatu elementu-mota"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Delete User
 msgid "Delete User"
 msgstr "Ezabatu erabiltzailea"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: undefined
 msgid "Delete blocks"
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Delete col
 msgid "Delete col"
 msgstr "Ezabatu zutabea"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Delete row
 msgid "Delete row"
 msgstr "Ezabatu errenkada"
 
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: Depth
 msgid "Depth"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Descending
 msgid "Descending"
 msgstr "Beheraka"
 
@@ -559,72 +671,89 @@ msgstr "Beheraka"
 #: components/manage/Widgets/WysiwygWidget
 #: components/theme/View/TabularView
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Description
 msgid "Description"
 msgstr "Deskribapena"
 
 #: components/manage/Diff/Diff
+# defaultMessage: Diff
 msgid "Diff"
 msgstr "Desberdintasunak"
 
 #: components/manage/Diff/Diff
+# defaultMessage: Difference between revision {one} and {two} of {title}
 msgid "Difference between revision {one} and {two} of {title}"
 msgstr "{title} elementuaren {one} eta {two} errebisioen arteko desberdintasunak"
 
 #: components/theme/Footer/Footer
+# defaultMessage: Distributed under the {license}.
 msgid "Distributed under the {license}."
 msgstr "{license} lizentziapean banatuta."
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Add border to inner columns
 msgid "Divide each row into separate cells"
 msgstr "Errenkada bakoitza zeldatan banatu"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Do you really want to delete the following items?
 msgid "Do you really want to delete the following items?"
 msgstr "Elementu hauek ezabatu egin nahi dituzu?"
 
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
+# defaultMessage: Do you really want to delete the group {groupname}?
 msgid "Do you really want to delete the group {groupname}?"
 msgstr "{groupname} taldea ezabatu egin nahi duzu?"
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Do you really want to delete type {typename}?
 msgid "Do you really want to delete the type {typename}?"
 msgstr "{typename} elementu-mota ezabatu egin nahi duzu?"
 
 #: components/manage/Controlpanels/Users/UsersControlpanel
+# defaultMessage: Do you really want to delete the user {username}?
 msgid "Do you really want to delete the user {username}?"
 msgstr "{username} erabiltzailea ezabatu egin nahi duzu?"
 
 #: components/manage/Delete/Delete
+# defaultMessage: Do you really want to delete this item?
 msgid "Do you really want to delete this item?"
 msgstr "Elementu hau ezabatu egin nahi duzu?"
 
 #: components/manage/Multilingual/TranslationObject
 #: components/manage/Sidebar/Sidebar
+# defaultMessage: Document
 msgid "Document"
 msgstr "Dokumentua"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Drag and drop files from your computer onto this area or click the “Browse” button.
 msgid "Drag and drop files from your computer onto this area or click the “Browse” button."
 msgstr "Arrastatu fitxategiak hona edo erabili Arakatu botoia."
 
 #: components/manage/Widgets/FileWidget
+# defaultMessage: Drop file here to replace the existing file
 msgid "Drop file here to replace the existing file"
 msgstr ""
 
 #: components/manage/Widgets/FileWidget
+# defaultMessage: Drop file here to upload a new file
 msgid "Drop file here to upload a new file"
 msgstr ""
 
 #: components/manage/Widgets/FileWidget
+# defaultMessage: Drop files here ...
 msgid "Drop files here ..."
 msgstr ""
 
 #: components/manage/Preferences/PersonalInformation
 #: components/theme/Register/Register
+# defaultMessage: E-mail
 msgid "E-mail"
 msgstr "Eposta"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: E-mail addresses do not match.
 msgid "E-mail addresses do not match."
 msgstr "Eposta helbideak ez datoz bat"
 
@@ -635,93 +764,115 @@ msgstr "Eposta helbideak ez datoz bat"
 #: components/manage/Widgets/FormFieldWrapper
 #: components/manage/Widgets/ObjectBrowserWidget
 #: components/theme/Comments/Comments
+# defaultMessage: Edit
 msgid "Edit"
 msgstr "Editatu"
 
 #: components/theme/Comments/CommentEditModal
+# defaultMessage: Edit comment
 msgid "Edit comment"
 msgstr "Editatu erantzuna"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Edit field
 msgid "Edit field"
 msgstr "Editatu eramua"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Edit fieldset
 msgid "Edit fieldset"
 msgstr "Editatu eremu-multzoa"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Edit recurrence
 msgid "Edit recurrence"
 msgstr "Editatu errepikapena"
 
 #: components/manage/Form/InlineForm
+# defaultMessage: Edit values
 msgid "Edit values"
 msgstr "Editatu balioak"
 
 #: components/manage/Edit/Edit
+# defaultMessage: Edit {title}
 msgid "Edit {title}"
 msgstr "Editatu {title}"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Email
 msgid "Email"
 msgstr "Eposta"
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Email sent
 msgid "Email sent"
 msgstr "Eposta ondo bidali da"
 
 #: components/manage/Blocks/Maps/Edit
+# defaultMessage: Embed code error, please follow the instructions and try again.
 msgid "Embed code error, please follow the instructions and try again."
 msgstr "Itsatsitako kodearen errorea, jarraitu argibideak eta saiatu berriz."
 
 #: components/manage/Blocks/Maps/View
+# defaultMessage: Embeded Google Maps
 msgid "Embeded Google Maps"
 msgstr "Itsatsitako Google Maps"
 
 #: components/manage/Widgets/ObjectListWidget
+# defaultMessage: Empty object list
 msgid "Empty object list"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypeLayout
+# defaultMessage: Enable editable Blocks
 msgid "Enable editable Blocks"
 msgstr "Aktibatu editatu daitezkeen blokeak"
 
 #: components/manage/Contents/Contents
+# defaultMessage: End Date
 msgid "End Date"
 msgstr "Bukaera data"
 
 #: components/manage/AnchorPlugin/components/LinkButton/AddLinkForm
+# defaultMessage: Enter URL or select an item
 msgid "Enter URL or select an item"
 msgstr "Sartu URL bat edo aukeratu elementu bat"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Enter a username above to search or click 'Show All'
 msgid "Enter a username above to search or click 'Show All'"
 msgstr ""
 
 #: components/theme/Register/Register
+# defaultMessage: Enter an email address. This will be your login name. We respect your privacy, and will not give the address away to any third parties or expose it anywhere.
 msgid "Enter an email address. This will be your login name. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr "Idatzi eposta helbidea. Hau zure erabiltzaile-izena izango da. Zure pribatutasuna errespetatzen dugu eta ez dugu helbidea argitaratu edo inori emango."
 
 #: components/manage/Preferences/PersonalInformation
 #: components/theme/PasswordReset/PasswordReset
 #: components/theme/Register/Register
+# defaultMessage: Enter full name, e.g. John Smith.
 msgid "Enter full name, e.g. John Smith."
 msgstr "Idatzi izen osoa, adb. Jon Garmendia."
 
 #: components/manage/Blocks/Maps/Edit
+# defaultMessage: Enter map Embed Code
 msgid "Enter map Embed Code"
 msgstr "Sartu itsasteko kodea"
 
 #: components/manage/Preferences/ChangePassword
+# defaultMessage: Enter your current password.
 msgid "Enter your current password."
 msgstr "Idatzi zure pasahitza."
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Enter your email address for verification.
 msgid "Enter your email address for verification."
 msgstr "Idatzi zure eposta helbidea egiaztatu dezagun."
 
 #: components/manage/Preferences/ChangePassword
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Enter your new password. Minimum 5 characters.
 msgid "Enter your new password. Minimum 5 characters."
 msgstr "Idatzi zure pasahitz berria. Gutxienez 5 karaktere."
 
@@ -733,199 +884,245 @@ msgstr "Idatzi zure pasahitz berria. Gutxienez 5 karaktere."
 #: components/theme/ContactForm/ContactForm
 #: components/theme/Login/Login
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Error
 msgid "Error"
 msgstr "Erroea"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Exclude from navigation
 msgid "Exclude from navigation"
 msgstr "Nabigaziotik baztertu"
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: Exclude this occurence
 msgid "Exclude this occurence"
 msgstr "Kendu agerpen hau"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Excluded from navigation
 msgid "Excluded from navigation"
 msgstr "Nabigaziotik baztertuta"
 
 #: components/manage/Sidebar/Sidebar
+# defaultMessage: Expand sidebar
 msgid "Expand sidebar"
 msgstr "Alboko barra zabaldu"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Expiration Date
 msgid "Expiration Date"
 msgstr "Iraungitze-data"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Expiration date
 msgid "Expiration date"
 msgstr "Iraungitze-data"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Expired
 msgid "Expired"
 msgstr "Iraungita"
 
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: External URL
 msgid "External URL"
 msgstr "Kanpoko URLa"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: File
 msgid "File"
 msgstr "Fitxategia"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: File size
 msgid "File size"
 msgstr "Fitxategiaren tamaina"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Filename
 msgid "Filename"
 msgstr "Fitxategi izena"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Filter…
 msgid "Filter…"
 msgstr "Filtratu..."
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: First
 msgid "First"
 msgstr "Lehenengo"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Fixed width columns
 msgid "Fixed width table cells"
 msgstr "Tamaina finkoko taularen zeldak"
 
 #: components/manage/BlockChooser/BlockChooser
+# defaultMessage: Fold
 msgid "Fold"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Folder
 msgid "Folder"
 msgstr "Karpeta"
 
 #: components/theme/Forbidden/Forbidden
+# defaultMessage: Forbidden
 msgid "Forbidden"
 msgstr "Debekatuta"
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: Fourth
 msgid "Fourth"
 msgstr "Laugarren"
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: From
 msgid "From"
 msgstr "Nok"
 
 #: components/manage/Blocks/Maps/Edit
 #: components/manage/Sidebar/AlignBlock
+# defaultMessage: Full
 msgid "Full"
 msgstr "Osoa"
 
 #: components/manage/Preferences/PersonalInformation
 #: components/theme/PasswordReset/PasswordReset
 #: components/theme/Register/Register
+# defaultMessage: Full Name
 msgid "Full Name"
 msgstr "Izen-abizenak"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Fullname
 msgid "Fullname"
 msgstr "Izen-abizenak"
 
 #: components/theme/Footer/Footer
+# defaultMessage: GNU GPL license
 msgid "GNU GPL license"
 msgstr "GNU GPL"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Global role
 msgid "Global role"
 msgstr "Rol globala"
 
 #: components/manage/Blocks/Maps/Edit
+# defaultMessage: Google Maps Embedded Block
 msgid "Google Maps Embedded Block"
 msgstr "Google Maps itsasteko blokea"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Group
 msgid "Group"
 msgstr "Taldea"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Group created
 msgid "Group created"
 msgstr "Taldea ondo sortu da"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Group roles updated
 msgid "Group roles updated"
 msgstr ""
 
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Groupname
 msgid "Groupname"
 msgstr "Taldearen izena"
 
 #: components/manage/Controlpanels/Controlpanels
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Groups
 msgid "Groups"
 msgstr "Taldeak"
 
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
+# defaultMessage: Groups are logical collections of users, such as departments and business units. Groups are not directly related to permissions on a global level, you normally use Roles for that - and let certain Groups have a particular role. The symbol{plone_svg}indicates a role inherited from membership in another group.
 msgid "Groups are logical collections of users, such as departments and business units. Groups are not directly related to permissions on a global level, you normally use Roles for that - and let certain Groups have a particular role. The symbol{plone_svg}indicates a role inherited from membership in another group."
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Header cell
 msgid "Header cell"
 msgstr ""
 
 #: components/theme/Comments/Comments
+# defaultMessage: Hide Replies
 msgid "Hide Replies"
 msgstr ""
 
 #: components/manage/History/History
 #: components/manage/Toolbar/More
+# defaultMessage: History
 msgid "History"
 msgstr "Historia"
 
 #: components/manage/History/History
+# defaultMessage: #
 msgid "History Version Number"
 msgstr ""
 
 #: components/manage/History/History
+# defaultMessage: History of {title}
 msgid "History of {title}"
 msgstr "{title} elementuaren historia"
 
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsBreadcrumbs
 #: components/theme/Breadcrumbs/Breadcrumbs
+# defaultMessage: Home
 msgid "Home"
 msgstr "Hasiera"
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: Home page
 msgid "Home page"
 msgstr "Hasiera orrialdea"
 
 #: components/manage/Contents/Contents
+# defaultMessage: ID
 msgid "ID"
 msgstr "ID"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: If selected, this item will not appear in the navigation tree
 msgid "If selected, this item will not appear in the navigation tree"
 msgstr "Aukeratuta badago, elementu hau ez da nabigazio zuhaitzean agertuko"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: If this date is in the future, the content will not show up in listings and searches until this date.
 msgid "If this date is in the future, the content will not show up in listings and searches until this date."
 msgstr "Data hau etorkizunekoa bada, edukia ez da agertuko data hori iritsi arte"
 
 #: components/manage/LockingToastsFactory/LockingToastsFactory
+# defaultMessage: If you are certain this user has abandoned the object, you may unlock the object. You will then be able to edit it.
 msgid "If you are certain this user has abandoned the object, you may unlock the object. You will then be able to edit it."
 msgstr ""
 
 #: components/theme/NotFound/NotFound
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: If you are certain you have the correct web address but are encountering an error, please contact the {site_admin}.
 msgid "If you are certain you have the correct web address but are encountering an error, please contact the {site_admin}."
 msgstr "Ziurtatu helbide zuzenean zaudena, hala ere errorea baduzu jarri kontaktuan {site_admin}."
 
 #: components/manage/Blocks/HeroImageLeft/Edit
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: Image
 msgid "Image"
 msgstr "Irudia"
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: Include this occurence
 msgid "Include this occurence"
 msgstr "Sartu agerpen hau"
 
@@ -933,142 +1130,176 @@ msgstr "Sartu agerpen hau"
 #: components/manage/Controlpanels/ContentTypeLayout
 #: components/manage/Controlpanels/ContentTypeSchema
 #: components/manage/Controlpanels/Controlpanel
+# defaultMessage: Info
 msgid "Info"
 msgstr "informazioa"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Inherit permissions from higher levels
 msgid "Inherit permissions from higher levels"
 msgstr "Baimenak goragoko mailetatik heredatu"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Inherited value
 msgid "Inherited value"
 msgstr "Heredatutako balioa"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Insert col after
 msgid "Insert col after"
 msgstr "Sartu zutabea ondoren"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Insert col before
 msgid "Insert col before"
 msgstr "Sartu zutabea aurretik"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Insert row after
 msgid "Insert row after"
 msgstr "Sartu errenkada ondoren"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Insert row before
 msgid "Insert row before"
 msgstr "Sartu errendaka aurretik"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Install
 msgid "Install"
 msgstr "Instalatu"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Installed
 msgid "Installed"
 msgstr "Instalatuta"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Installed version
 msgid "Installed version"
 msgstr "Instalatutako bertsioa"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: days
 msgid "Interval Daily"
 msgstr "egunean behin"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Month(s)
 msgid "Interval Monthly"
 msgstr "hilean behin"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: week(s)
 msgid "Interval Weekly"
 msgstr "astean behin"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: year(s)
 msgid "Interval Yearly"
 msgstr "urtean behin"
 
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: Item batch size
 msgid "Item batch size"
 msgstr "Elementu-multzoaren tamaina"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Item succesfully moved.
 msgid "Item succesfully moved."
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Item(s) copied.
 msgid "Item(s) copied."
 msgstr "Elementuak ondo kopiatu dira."
 
 #: components/manage/Contents/Contents
+# defaultMessage: Item(s) cut.
 msgid "Item(s) cut."
 msgstr "Elementuak ondo ebaki dira."
 
 #: components/manage/Contents/Contents
+# defaultMessage: Item(s) has been updated.
 msgid "Item(s) has been updated."
 msgstr ""
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
+# defaultMessage: Item(s) pasted.
 msgid "Item(s) pasted."
 msgstr "Elementuak ondo itsatsi dira."
 
 #: components/manage/Contents/Contents
+# defaultMessage: Item(s) state has been updated.
 msgid "Item(s) state has been updated."
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Items
 msgid "Items"
 msgstr "Elementuak"
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Items must be unique.
 msgid "Items must be unique."
 msgstr "Elementuak bakarrak izan behar dira."
 
 #: components/manage/Preferences/PersonalPreferences
+# defaultMessage: Language
 msgid "Language"
 msgstr "Hizkuntza"
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: Last
 msgid "Last"
 msgstr "Azkena"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Last comment date
 msgid "Last comment date"
 msgstr "Azken komentarioaren data"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Last modified
 msgid "Last modified"
 msgstr "Azken aldaketa"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Latest version
 msgid "Latest version"
 msgstr "Azken bertsioa"
 
 #: components/manage/Controlpanels/ContentTypesActions
+# defaultMessage: Layout
 msgid "Layout"
 msgstr "Itxura"
 
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: Lead Image
 msgid "Lead Image"
 msgstr "Irudia"
 
 #: components/manage/Blocks/Image/ImageSizeWidget
 #: components/manage/Blocks/Maps/Edit
 #: components/manage/Sidebar/AlignBlock
+# defaultMessage: Left
 msgid "Left"
 msgstr "Ezkerrean"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Link
 msgid "Link"
 msgstr "Esteka"
 
 #: components/manage/Blocks/Listing/schema
+# defaultMessage: Link more
 msgid "Link more"
 msgstr ""Gehiago" estekatu"
 
 #: components/manage/Blocks/Listing/schema
+# defaultMessage: Link Title
 msgid "Link title"
 msgstr "Izenburua estekatu"
 
@@ -1077,212 +1308,262 @@ msgstr "Izenburua estekatu"
 #: components/manage/Blocks/Listing/schema
 #: components/manage/Blocks/Maps/MapsSidebar
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Link to
 msgid "Link to"
 msgstr "Esteka"
 
 #: components/manage/Multilingual/ManageTranslations
+# defaultMessage: Link translation for
 msgid "Link translation for"
 msgstr ""
 
 #: components/manage/Blocks/Listing/schema
+# defaultMessage: Listing
 msgid "Listing"
 msgstr "Zerrenda"
 
 #: components/theme/Comments/Comments
+# defaultMessage: Load more...
 msgid "Load more"
 msgstr ""
 
 #: components/manage/Form/ModalForm
+# defaultMessage: Loading.
 msgid "Loading"
 msgstr ""
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: Location
 msgid "Location"
 msgstr "Kokalekua"
 
 #: components/theme/Login/Login
+# defaultMessage: Login
 msgid "Log In"
 msgstr "Sartu"
 
 #: components/theme/Anontools/Anontools
 #: components/theme/Login/Login
+# defaultMessage: Log in
 msgid "Log in"
 msgstr "Sartu"
 
 #: components/theme/Login/Login
+# defaultMessage: Login
 msgid "Login"
 msgstr "Sartu"
 
 #: components/theme/Login/Login
+# defaultMessage: Login Failed
 msgid "Login Failed"
 msgstr "Sartzeak huts egin du"
 
 #: components/theme/Login/Login
+# defaultMessage: Login Name
 msgid "Login Name"
 msgstr "Erabiltzaile-izena"
 
 #: components/manage/Toolbar/PersonalTools
+# defaultMessage: Logout
 msgid "Logout"
 msgstr ""
 
 #: components/manage/Toolbar/More
+# defaultMessage: Made by {creator} on {date}. This is not a working copy anymore, but the main content.
 msgid "Made by {creator} on {date}. This is not a working copy anymore, but the main content."
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Reduce cell padding
 msgid "Make the table compact"
 msgstr "Taula trinkotu"
 
 #: components/manage/Multilingual/ManageTranslations
 #: components/manage/Toolbar/More
+# defaultMessage: Manage Translations
 msgid "Manage Translations"
 msgstr ""
 
 #: components/manage/Multilingual/ManageTranslations
+# defaultMessage: Manage translations for {title}
 msgid "Manage translations for {title}"
 msgstr ""
 
 #: components/manage/Blocks/Maps/MapsSidebar
+# defaultMessage: Map
 msgid "Map"
 msgstr "Mapa"
 
 #: components/manage/Blocks/Maps/MapsSidebar
+# defaultMessage: Maps URL
 msgid "Maps URL"
 msgstr "Maparen URLa"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Maximum length is {len}.
 msgid "Maximum length is {len}."
 msgstr "Gehienezko luzera {len} da."
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Maximum value is {len}.
 msgid "Maximum value is {len}."
 msgstr "Balio handiena {len} da."
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Message
 msgid "Message"
 msgstr "Mezua"
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Minimum length is {len}.
 msgid "Minimum length is {len}."
 msgstr "Gutxienezko luzera {len} da."
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Minimum value is {len}.
 msgid "Minimum value is {len}."
 msgstr "Balio txikiena {len} da."
 
 #: components/manage/Controlpanels/Controlpanels
+# defaultMessage: Moderate Comments
 msgid "Moderate Comments"
 msgstr "Erantzunak moderatu"
 
 #: components/manage/Controlpanels/ModerateComments
+# defaultMessage: Moderate comments
 msgid "Moderate comments"
 msgstr "Erantzunak moderatu"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Monday and Friday
 msgid "Monday and Friday"
 msgstr "Astelehen eta ostiraletan"
 
 #: components/manage/Widgets/RecurrenceWidget/ByMonthDayField
+# defaultMessage: Day
 msgid "Month day"
 msgstr "Hilabeteko"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Monthly
 msgid "Monthly"
 msgstr "Hilero"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: More
 msgid "More"
 msgstr "Gehiago"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Move to bottom of folder
 msgid "Move to bottom of folder"
 msgstr "Karpetaren barrenera mugitu"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Move to top of folder
 msgid "Move to top of folder"
 msgstr "Karpetaren gorengo tokira mugitu"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: My email address is
 msgid "My email address is"
 msgstr "Nire helbidea hauxe da: "
 
 #: components/manage/Sharing/Sharing
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Name
 msgid "Name"
 msgstr "Izena"
 
 #: error
+# defaultMessage: Navigate back
 msgid "Navigate back"
 msgstr "Atzera joan"
 
 #: components/theme/Navigation/ContextNavigation
+# defaultMessage: Navigation
 msgid "Navigation"
 msgstr ""
 
 #: components/manage/Preferences/ChangePassword
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: New password
 msgid "New password"
 msgstr "Pasahitz berria"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: News Item
 msgid "News Item"
 msgstr "Albistea ikusi"
 
 #: components/manage/Contents/ContentsItem
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: No
 msgid "No"
 msgstr "Ez"
 
 #: components/manage/Blocks/Image/ImageSidebar
+# defaultMessage: No image selected
 msgid "No image selected"
 msgstr "Ez da irudirik aukeratu"
 
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: No image set in Lead Image content field
 msgid "No image set in Lead Image content field"
 msgstr "Ez dago irudirik dagokion eremuan"
 
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: No image set in image content field
 msgid "No image set in image content field"
 msgstr "Ez dago irudirik dagokion eremuan"
 
 #: components/manage/Blocks/Listing/ListingBody
+# defaultMessage: No items found in this container.
 msgid "No items found in this container."
 msgstr "Karpeta honetan ez dago elementurik"
 
 #: components/manage/Widgets/ObjectBrowserWidget
+# defaultMessage: No items selected
 msgid "No items selected"
 msgstr "Ez da elementurik aukeratu"
 
 #: components/manage/Blocks/Maps/MapsSidebar
+# defaultMessage: No map selected
 msgid "No map selected"
 msgstr "Ez da maparik auekratu"
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: No occurences set
 msgid "No occurences set"
 msgstr "Ez da agerpenik ezarri"
 
 #: components/manage/Widgets/ArrayWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/TokenWidget
+# defaultMessage: No options
 msgid "No options"
 msgstr "Ez du aukerarik"
 
 #: components/theme/Search/Search
+# defaultMessage: No results found
 msgid "No results found"
 msgstr "Ez da emaitzarik aurkitu."
 
 #: components/manage/Blocks/Listing/ListingBody
 #: components/manage/Widgets/ReferenceWidget
+# defaultMessage: No results found.
 msgid "No results found."
 msgstr "Ez da emaitzarik aurkitu."
 
 #: components/manage/Widgets/QuerySortOnWidget
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: No selection
 msgid "No selection"
 msgstr "Ez da ezer aukeratu"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: This addon does not provide an uninstall profile.
 msgid "No uninstall profile"
 msgstr "Ez du desinstalatzeko profilik"
 
@@ -1290,39 +1571,48 @@ msgstr "Ez du desinstalatzeko profilik"
 #: components/manage/Widgets/ReferenceWidget
 #: components/manage/Widgets/SelectUtils
 #: components/manage/Widgets/SelectWidget
+# defaultMessage: No value
 msgid "No value"
 msgstr "Ez du baliorik"
 
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: No video selected
 msgid "No video selected"
 msgstr "Ez da bideorik aukeratu"
 
 #: components/manage/Workflow/Workflow
+# defaultMessage: No workflow
 msgid "No workflow"
 msgstr "Ez du workflowrik"
 
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsItem
+# defaultMessage: None
 msgid "None"
 msgstr "Bat ere ez"
 
 #: components/manage/Controlpanels/Users/UsersControlpanel
+# defaultMessage: Note that roles set here apply directly to a user. The symbol{plone_svg}indicates a role inherited from membership in a group.
 msgid "Note that roles set here apply directly to a user. The symbol{plone_svg}indicates a role inherited from membership in a group."
 msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Number of active objects
 msgid "Number of active objects"
 msgstr "Aktibo dagoen objektu kopurua"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Object Size
 msgid "Object Size"
 msgstr "Objektuaren tamaina"
 
 #: components/manage/Widgets/RecurrenceWidget/EndField
+# defaultMessage: occurrence(s)
 msgid "Occurences"
 msgstr "agerpenen ondoren"
 
 #: components/manage/Delete/Delete
+# defaultMessage: Ok
 msgid "Ok"
 msgstr "Ados"
 
@@ -1330,301 +1620,371 @@ msgstr "Ados"
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
 #: components/manage/Blocks/Maps/MapsSidebar
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Open in a new tab
 msgid "Open in a new tab"
 msgstr "Fitxa berrian ireki"
 
 #: components/theme/Navigation/Navigation
+# defaultMessage: Open menu
 msgid "Open menu"
 msgstr "Menua ireki"
 
 #: components/manage/Widgets/ObjectBrowserWidget
+# defaultMessage: Open object browser
 msgid "Open object browser"
 msgstr ""
 
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: Origin
 msgid "Origin"
 msgstr "Jatorria"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Page
 msgid "Page"
 msgstr "Orria"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Parent fieldset
 msgid "Parent fieldset"
 msgstr "Guraso den eremu-multzoa"
 
 #: components/theme/Login/Login
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Password
 msgid "Password"
 msgstr "Pasahitza"
 
 #: components/theme/PasswordReset/PasswordReset
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Password reset
 msgid "Password reset"
 msgstr "Pasahitza berrezarri"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Passwords do not match.
 msgid "Passwords do not match."
 msgstr "Pasahitzak ez datoz bat."
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
+# defaultMessage: Paste
 msgid "Paste"
 msgstr "Itsatsi"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: undefined
 msgid "Paste blocks"
 msgstr ""
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Permissions have been updated successfully
 msgid "Permissions have been updated successfully"
 msgstr ""
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Permissions updated
 msgid "Permissions updated"
 msgstr ""
 
 #: components/manage/Preferences/PersonalInformation
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Personal Information
 msgid "Personal Information"
 msgstr "Informazio pertsonala"
 
 #: components/manage/Preferences/PersonalPreferences
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Personal Preferences
 msgid "Personal Preferences"
 msgstr "Hobespen Pertsonalak"
 
 #: components/manage/Toolbar/More
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Personal tools
 msgid "Personal tools"
 msgstr "Tresna pertsonalak"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Persons responsible for creating the content of this item. Please enter a list of user names, one per line. The principal creator should come first.
 msgid "Persons responsible for creating the content of this item. Please enter a list of user names, one per line. The principal creator should come first."
 msgstr "Elementu honen edukia sortzearen arduradunak. Idatzi erabiltzaile-izen bat lerro bakoitzean. Egile nagusia lehenengoa izan beharko litzateke."
 
 #: components/manage/Blocks/Video/Edit
+# defaultMessage: Please enter a valid URL by deleting the block and adding a new video block.
 msgid "Please enter a valid URL by deleting the block and adding a new video block."
 msgstr "Txertatu URL zuzen bat blokea ezabatu eta bideo bloke berri bat gehituz."
 
 #: components/manage/Blocks/Maps/Edit
+# defaultMessage: Please enter the Embed Code provided by Google Maps -> Share -> Embed map. It should contain the <iframe> code on it.
 msgid "Please enter the Embed Code provided by Google Maps -> Share -> Embed map. It should contain the <iframe> code on it."
 msgstr "Txertatu Google Mapsek ematen duen txertatzeko kodea. <iframe> etiketa bat izan behar du."
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Please fill out the form below to set your password.
 msgid "Please fill out the form below to set your password."
 msgstr "Bete formulario hau zure pasahitza ezartzeko."
 
 #: components/theme/Footer/Footer
+# defaultMessage: Plone Foundation
 msgid "Plone Foundation"
 msgstr "Plone Fundazioa"
 
 #: components/theme/Logo/Logo
+# defaultMessage: Plone Site
 msgid "Plone Site"
 msgstr "Plone Ataria"
 
 #: components/theme/Footer/Footer
+# defaultMessage: Plone{reg} Open Source CMS/WCM
 msgid "Plone{reg} Open Source CMS/WCM"
 msgstr "Plone{reg} Open Source CMS/WCM"
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: Portrait
 msgid "Portrait"
 msgstr "Argazkia"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Possible values (Enter allowed choices one per line).
 msgid "Possible values"
 msgstr "Balio posibleak"
 
 #: components/theme/Footer/Footer
+# defaultMessage: Powered by Plone & Python
 msgid "Powered by Plone & Python"
 msgstr "Plone eta Pythonekin eginda"
 
 #: components/manage/Toolbar/PersonalTools
+# defaultMessage: Preferences
 msgid "Preferences"
 msgstr "Hobespenak"
 
 #: components/manage/Blocks/HTML/Edit
+# defaultMessage: Prettify your code
 msgid "Prettify your code"
 msgstr ""
 
 #: components/manage/Blocks/HTML/Edit
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Preview
 msgid "Preview"
 msgstr "Aurreikusi"
 
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Preview Image URL
 msgid "Preview Image URL"
 msgstr ""
 
 #: components/manage/Toolbar/PersonalTools
+# defaultMessage: Profile
 msgid "Profile"
 msgstr "Profila"
 
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Properties
 msgid "Properties"
 msgstr "Propietateak"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Publication date
 msgid "Publication date"
 msgstr "Argitaratze-data"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Publishing Date
 msgid "Publishing Date"
 msgstr "Argitaratze-data"
 
 #: components/manage/Blocks/Listing/schema
+# defaultMessage: Query
 msgid "Query"
 msgstr ""
 
 #: components/manage/Preferences/ChangePassword
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Re-enter the password. Make sure the passwords are identical.
 msgid "Re-enter the password. Make sure the passwords are identical."
 msgstr "Idatzi pasahitza berriro eta ziurtatu idatzitako biak berdinak direla."
 
 #: components/theme/Search/Search
 #: components/theme/View/SummaryView
+# defaultMessage: Read More…
 msgid "Read More…"
 msgstr "Gehiago irakurri"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Rearrange items by…
 msgid "Rearrange items by…"
 msgstr "Elementuak honen arabera berrantolatu..."
 
 #: components/manage/Widgets/RecurrenceWidget/EndField
+# defaultMessage: Ends
 msgid "Recurrence ends"
 msgstr "Errepikapenaren amaiera"
 
 #: components/manage/Widgets/RecurrenceWidget/EndField
+# defaultMessage: after
 msgid "Recurrence ends after"
 msgstr "Amaitu"
 
 #: components/manage/Widgets/RecurrenceWidget/EndField
+# defaultMessage: on
 msgid "Recurrence ends on"
 msgstr "Egun honetan amaitu"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Minimalistic table design
 msgid "Reduce complexity"
 msgstr "Konplexutasuna gutxitu"
 
 #: components/theme/Anontools/Anontools
 #: components/theme/Login/Login
 #: components/theme/Register/Register
+# defaultMessage: Register
 msgid "Register"
 msgstr "Izena eman"
 
 #: components/theme/Register/Register
+# defaultMessage: Registration form
 msgid "Registration form"
 msgstr "Erregistro formularioa"
 
 #: components/theme/Search/Search
+# defaultMessage: Relevance
 msgid "Relevance"
 msgstr "Errelebantzia"
 
 #: components/manage/Widgets/ObjectListWidget
+# defaultMessage: Remove item
 msgid "Remove item"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Remove
 msgid "Remove recurrence"
 msgstr "Errepikapena ezabatu"
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Remove term
 msgid "Remove term"
 msgstr ""
 
 #: components/manage/Toolbar/More
+# defaultMessage: Remove working copy
 msgid "Remove working copy"
 msgstr ""
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
+# defaultMessage: Rename
 msgid "Rename"
 msgstr "Berrizendatu"
 
 #: components/manage/Contents/ContentsRenameModal
+# defaultMessage: Renaming items...
 msgid "Rename Items Loading Message"
 msgstr ""
 
 #: components/manage/Contents/ContentsRenameModal
+# defaultMessage: Rename items
 msgid "Rename items"
 msgstr "Elementuak berrizendatu"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Repeat
 msgid "Repeat"
 msgstr "Errepikatu"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Repeat every
 msgid "Repeat every"
 msgstr "Errepikatu"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Repeat on
 msgid "Repeat on"
 msgstr "Egun honetan errepikatu"
 
 #: components/manage/Widgets/FileWidget
+# defaultMessage: Replace existing file
 msgid "Replace existing file"
 msgstr ""
 
 #: components/theme/Comments/Comments
+# defaultMessage: Reply
 msgid "Reply"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/WysiwygWidget
+# defaultMessage: Required
 msgid "Required"
 msgstr "Beharrezkoa"
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Required input is missing.
 msgid "Required input is missing."
 msgstr "Beharrezko balioak falta dira"
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Reset title
 msgid "Reset term title"
 msgstr ""
 
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: Results limit
 msgid "Results limit"
 msgstr "Emaitzen muga"
 
 #: components/manage/Blocks/Listing/Edit
+# defaultMessage: Results preview
 msgid "Results preview"
 msgstr "Emaitzen aurreikuspena"
 
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: Reversed order
 msgid "Reversed order"
 msgstr "Alderantzizko ordena"
 
 #: components/manage/History/History
+# defaultMessage: Revert to this revision
 msgid "Revert to this revision"
 msgstr "Bertsio honetara itzuli"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Review state
 msgid "Review state"
 msgstr "Egoera"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Richtext
 msgid "Richtext"
 msgstr "Testu aberatsa"
 
 #: components/manage/Blocks/Image/ImageSizeWidget
 #: components/manage/Blocks/Maps/Edit
 #: components/manage/Sidebar/AlignBlock
+# defaultMessage: Right
 msgid "Right"
 msgstr "Eskuman"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Rights
 msgid "Rights"
 msgstr "Eskubideak"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Roles
 msgid "Roles"
 msgstr "Rolak"
 
 #: components/manage/Contents/ContentsBreadcrumbs
+# defaultMessage: Root
 msgid "Root"
 msgstr ""
 
@@ -1637,90 +1997,112 @@ msgstr ""
 #: components/manage/Form/ModalForm
 #: components/manage/Sharing/Sharing
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Save
 msgid "Save"
 msgstr "Gorde"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Save
 msgid "Save recurrence"
 msgstr "Gorde errepikapena"
 
 #: components/manage/Controlpanels/ContentTypesActions
+# defaultMessage: Schema
 msgid "Schema"
 msgstr "Eskema"
 
 #: components/manage/Controlpanels/ContentTypeSchema
+# defaultMessage: Schema updates
 msgid "Schema updates"
 msgstr "Eskemaren eguneraketak"
 
 #: components/theme/SearchWidget/SearchWidget
+# defaultMessage: Search
 msgid "Search"
 msgstr "Bilatu"
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: Search SVG
 msgid "Search SVG"
 msgstr ""
 
 #: components/theme/SearchWidget/SearchWidget
+# defaultMessage: Search Site
 msgid "Search Site"
 msgstr "Atarian bilatu"
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: Search content
 msgid "Search content"
 msgstr "Bilatu edukia"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Search for user or group
 msgid "Search for user or group"
 msgstr "Bilatu erabiltzailea edo taldea"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Search group…
 msgid "Search group…"
 msgstr "Bilatu taldea..."
 
 #: components/theme/Search/Search
+# defaultMessage: Search results
 msgid "Search results"
 msgstr "Bilaketaren emaitzak"
 
 #: components/theme/Search/Search
+# defaultMessage: Search results for {term}
 msgid "Search results for {term}"
 msgstr "${term} bilatuz aurkitu dena"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Search users…
 msgid "Search users…"
 msgstr "Bilatu erabiltzaileak..."
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: Second
 msgid "Second"
 msgstr "Bigarren"
 
 #: components/manage/Sidebar/ObjectBrowserNav
+# defaultMessage: Select
 msgid "Select"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Select a date to add to recurrence
 msgid "Select a date to add to recurrence"
 msgstr "Aukeratu data eta gehitu errepikapenera"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Select columns to show
 msgid "Select columns to show"
 msgstr "Aukeratu erakutsiko diren zutabeak"
 
 #: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Select the transition to be used for modifying the items state.
 msgid "Select the transition to be used for modifying the items state."
 msgstr "Aukeratu elementuaren egoera aldatzeko trantsizioa."
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: Selected dates
 msgid "Selected dates"
 msgstr "Aukeratutako datak"
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: Selected items
 msgid "Selected items"
 msgstr "Aukeratutako elementuak"
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: of
 msgid "Selected items - x of y"
 msgstr "Aukeratutako elementuak x/y"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Selection
 msgid "Selection"
 msgstr "Aukeraketa"
 
@@ -1728,158 +2110,195 @@ msgstr "Aukeraketa"
 #: components/manage/Widgets/ArrayWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/TokenWidget
+# defaultMessage: Select…
 msgid "Select…"
 msgstr "Aukeratu..."
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Send
 msgid "Send"
 msgstr "Bidali"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Set my password
 msgid "Set my password"
 msgstr "Ezarri nire pasahitza"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Set your password
 msgid "Set your password"
 msgstr "Ezarri zure pasahitza"
 
 #: components/manage/Sidebar/Sidebar
+# defaultMessage: Settings
 msgid "Settings"
 msgstr "Ezarpenak"
 
 #: components/manage/Sharing/Sharing
 #: components/manage/Toolbar/More
+# defaultMessage: Sharing
 msgid "Sharing"
 msgstr "Partekatzea"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Sharing for {title}
 msgid "Sharing for {title}"
 msgstr "{title} elementuaren partekatze-aukerak"
 
 #: components/manage/Widgets/SchemaWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/WysiwygWidget
+# defaultMessage: Short Name
 msgid "Short Name"
 msgstr "Izen-laburra"
 
 #: components/manage/Contents/ContentsRenameModal
+# defaultMessage: Short name
 msgid "Short name"
 msgstr "Izen-laburra"
 
 #: components/theme/Pagination/Pagination
+# defaultMessage: Show
 msgid "Show"
 msgstr "Erakutsi"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Show All
 msgid "Show All"
 msgstr ""
 
 #: components/theme/Comments/Comments
+# defaultMessage: Show Replies
 msgid "Show Replies"
 msgstr ""
 
 #: components/manage/Widgets/ObjectListWidget
+# defaultMessage: Show item
 msgid "Show item"
 msgstr ""
 
 #: components/manage/Sidebar/Sidebar
+# defaultMessage: Shrink sidebar
 msgid "Shrink sidebar"
 msgstr "Txikitu alboko barra"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Shrink toolbar
 msgid "Shrink toolbar"
 msgstr "Txikitu tresna-barra"
 
 #: components/theme/Login/Login
+# defaultMessage: Sign in to start session
 msgid "Sign in to start session"
 msgstr "Sartu saioa hasteko"
 
 #: components/theme/Logo/Logo
+# defaultMessage: Site
 msgid "Site"
 msgstr "Ataria"
 
 #: components/theme/NotFound/NotFound
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: Site Administration
 msgid "Site Administration"
 msgstr "Atariaren kudeaketa"
 
 #: components/theme/Footer/Footer
+# defaultMessage: Site Map
 msgid "Site Map"
 msgstr "Web mapa"
 
 #: components/manage/Controlpanels/Controlpanels
 #: components/manage/Toolbar/PersonalTools
+# defaultMessage: Site Setup
 msgid "Site Setup"
 msgstr "Atariaren konfigurazioa"
 
 #: components/theme/Sitemap/Sitemap
+# defaultMessage: Sitemap
 msgid "Sitemap"
 msgstr "Web mapa"
 
 #: components/manage/Blocks/Image/ImageSidebar
+# defaultMessage: Size
 msgid "Size"
 msgstr "Tamaina"
 
 #: components/theme/View/ImageView
+# defaultMessage: Size: {size}
 msgid "Size: {size}"
 msgstr "Tamaina: {size}"
 
 #: error
+# defaultMessage: Sorry, something went wrong with your request
 msgid "Sorry, something went wrong with your request"
 msgstr "Barkatu, zerbait ez da ondo irten zure eskaeran"
 
 #: components/theme/Search/Search
+# defaultMessage: Sort by:
 msgid "Sort By:"
 msgstr "Ordenazioa:"
 
 #: components/manage/Widgets/QuerySortOnWidget
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: Sort on
 msgid "Sort on"
 msgstr "Ordenazioa"
 
 #: components/manage/Blocks/HTML/Edit
+# defaultMessage: Source
 msgid "Source"
 msgstr "Iturburua"
 
 #: components/manage/Blocks/Video/Edit
+# defaultMessage: Specify a youtube video or playlist url
 msgid "Specify a youtube video or playlist url"
 msgstr "YouTubeko bideo edo erreprodukzio-zerrenda baten URLa adierazi"
 
 #: components/manage/Diff/Diff
+# defaultMessage: Split
 msgid "Split"
 msgstr "Banatu"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Start Date
 msgid "Start Date"
 msgstr "Hasiera-data"
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: Start of the recurrence
 msgid "Start of the recurrence"
 msgstr "Errepikapenaren hasiera"
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Start password reset
 msgid "Start password reset"
 msgstr "Pasahitza berrezartzea abiatu"
 
 #: components/manage/Contents/Contents
 #: components/manage/Workflow/Workflow
 #: components/theme/View/TabularView
+# defaultMessage: State
 msgid "State"
 msgstr "Egoera"
 
 #: components/manage/Multilingual/CompareLanguages
+# defaultMessage: Stop compare
 msgid "Stop compare"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: String
 msgid "String"
 msgstr "Karaktere-katea"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Alternate row background color
 msgid "Stripe alternate rows with color"
 msgstr "Errenkaden koloreak aldatzen joan"
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Subject
 msgid "Subject"
 msgstr "Gaia"
 
@@ -1893,43 +2312,53 @@ msgstr "Gaia"
 #: components/manage/Preferences/PersonalPreferences
 #: components/theme/ContactForm/ContactForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Success
 msgid "Success"
 msgstr "Arrakasta"
 
 #: components/theme/LanguageSelector/LanguageSelector
+# defaultMessage: Switch to
 msgid "Switch to"
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Table
 msgid "Table"
 msgstr "Taula"
 
 #: components/manage/Blocks/ToC/View
+# defaultMessage: Table of Contents
 msgid "Table of Contents"
 msgstr "Edukien taula"
 
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsTagsModal
+# defaultMessage: Tags
 msgid "Tags"
 msgstr "Etiketak"
 
 #: components/manage/Contents/ContentsTagsModal
+# defaultMessage: Tags to add
 msgid "Tags to add"
 msgstr "Gehitu beharreko etiketak"
 
 #: components/manage/Contents/ContentsTagsModal
+# defaultMessage: Tags to remove
 msgid "Tags to remove"
 msgstr "Kendu beharreko etiketak"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Target memory size per cache in bytes
 msgid "Target memory size per cache in bytes"
 msgstr "Katxe bakoitzaren tamaina "
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Target number of objects in memory per cache
 msgid "Target number of objects in memory per cache"
 msgstr "Katxe bakoitzaren elementu-kopurua"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Text
 msgid "Text"
 msgstr "Testua"
 
@@ -1937,87 +2366,108 @@ msgstr "Testua"
 #: components/theme/CorsError/CorsError
 #: components/theme/NotFound/NotFound
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: Thank you.
 msgid "Thank you."
 msgstr "Eskerrik asko."
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: The Database Manager allow you to view database status information
 msgid "The Database Manager allow you to view database status information"
 msgstr "Datu-basearen kudeatzaileak datu-basearen egoera erakusten ditu"
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: The URL for your external home page, if you have one.
 msgid "The URL for your external home page, if you have one."
 msgstr "Idatzi zure webgunearen helbidea, bat baldin baduzu."
 
 #: components/theme/ConnectionRefused/ConnectionRefused
+# defaultMessage: The backend is not responding, please check if you have started Plone, check your project's configuration object apiPath (or if you are using the internal proxy, devProxyToApiPath) or the RAZZLE_API_PATH Volto's environment variable.
 msgid "The backend is not responding, please check if you have started Plone, check your project's configuration object apiPath (or if you are using the internal proxy, devProxyToApiPath) or the RAZZLE_API_PATH Volto's environment variable."
 msgstr "Zerbitzaria ez dago ondo, egiaztatu Plone martxan dagoela, egiaztatu zure proiektuaren konfigurazio-objektuaren apiPath ezarpena (edo barne-proxya badarabilzu, devProxyToApiPath) edo RAZZLE_API_PATH ingurune-aldagaia."
 
 #: components/theme/CorsError/CorsError
+# defaultMessage: The backend is responding, but the CORS headers are not configured properly and the browser has denied the access to the backend resources.
 msgid "The backend is responding, but the CORS headers are not configured properly and the browser has denied the access to the backend resources."
 msgstr "Zerbitzaria ondo dago baina CORS goiburukoak ez dira zuzenak."
 
 #: components/theme/CorsError/CorsError
+# defaultMessage: The backend server of your website is not anwering, we apologize for the inconvenience. Please try to re-load the page and try again. If the problem persists please contact the site administrators.
 msgid "The backend server of your website is not anwering, we apologize for the inconvenience. Please try to re-load the page and try again. If the problem persists please contact the site administrators."
 msgstr "Zerbitzaria ez dago ondo, barkatu eragozpenak. Saiatu orrialdea freskatzen. Arazoak jarraitzen badu jarri kontaktuan atariaren kudeatzailearekin."
 
 #: components/manage/Contents/Contents
+# defaultMessage: The item could not be deleted.
 msgid "The item could not be deleted."
 msgstr ""
 
 #: components/theme/Register/Register
+# defaultMessage: The registration process has been successful. Please check your e-mail inbox for information on how activate your account.
 msgid "The registration process has been successful. Please check your e-mail inbox for information on how activate your account."
 msgstr "Izen-emate prozesua ondo egin duzu. Begiratu zure eposta, kontua aktibatzeko informazioa bertara bidali dizugu-eta."
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: The user portrait/avatar
 msgid "The user portrait/avatar"
 msgstr "Erabiltzailearen argazkia"
 
 #: components/manage/Toolbar/More
+# defaultMessage: The working copy was discarded
 msgid "The working copy was discarded"
 msgstr ""
 
 #: components/theme/Footer/Footer
+# defaultMessage: The {plonecms} is {copyright} 2000-{current_year} by the {plonefoundation} and friends.
 msgid "The {plonecms} is {copyright} 2000-{current_year} by the {plonefoundation} and friends."
 msgstr "{plonecms} {copyright} 2000-{current_year} - {plonefoundation} eta lagunak."
 
 #: components/theme/CorsError/CorsError
+# defaultMessage: There is a configuration problem on the backend
 msgid "There is a configuration problem on the backend"
 msgstr "Zerbitzariak konfigurazio arazo bat du"
 
 #: components/manage/Form/InlineForm
+# defaultMessage: There were some errors
 msgid "There were some errors"
 msgstr "Errorea gertatu da"
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: There were some errors.
 msgid "There were some errors."
 msgstr "Errorea gertatu da"
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: Third
 msgid "Third"
 msgstr "Hirugarren"
 
 #: components/manage/WorkingCopyToastsFactory/WorkingCopyToastsFactory
+# defaultMessage: This has an ongoing working copy in {title}
 msgid "This has an ongoing working copy in {title}"
 msgstr ""
 
 #: components/manage/WorkingCopyToastsFactory/WorkingCopyToastsFactory
+# defaultMessage: This is a working copy of {title}
 msgid "This is a working copy of {title}"
 msgstr ""
 
 #: components/manage/LockingToastsFactory/LockingToastsFactory
+# defaultMessage: This item was locked by {creator} on {date}
 msgid "This item was locked by {creator} on {date}"
 msgstr ""
 
 #: components/manage/Contents/ContentsRenameModal
+# defaultMessage: This name will be displayed in the URL.
 msgid "This name will be displayed in the URL."
 msgstr "Izen hau URLan agertuko da"
 
 #: components/theme/NotFound/NotFound
+# defaultMessage: This page does not seem to exist…
 msgid "This page does not seem to exist…"
 msgstr "Orrialde hau ez da existitzen..."
 
 #: components/manage/Widgets/DatetimeWidget
+# defaultMessage: Time
 msgid "Time"
 msgstr "Ordua"
 
@@ -2030,714 +2480,889 @@ msgstr "Ordua"
 #: components/manage/Widgets/WysiwygWidget
 #: components/theme/View/TabularView
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Title
 msgid "Title"
 msgstr "Izenburua"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Total active and non-active objects
 msgid "Total active and non-active objects"
 msgstr "Objektu aktibo eta ez-aktiboak"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Total comments
 msgid "Total comments"
 msgstr "Erantzun kopurua"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Total number of objects in each cache
 msgid "Total number of objects in each cache"
 msgstr "Katxe bakoitzeko objektu kopurua"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Total number of objects in memory from all caches
 msgid "Total number of objects in memory from all caches"
 msgstr "Katxe guztietan dagoen elementu kopurua"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Total number of objects in the database
 msgid "Total number of objects in the database"
 msgstr "Datu-basean dagoen elementu kopurua"
 
 #: components/manage/Add/Add
 #: components/manage/Toolbar/Types
+# defaultMessage: Translate to {lang}
 msgid "Translate to {lang}"
 msgstr "{lang} hizkuntzara itzuli"
 
 #: components/manage/Multilingual/ManageTranslations
+# defaultMessage: Translation linked
 msgid "Translation linked"
 msgstr ""
 
 #: components/manage/Multilingual/ManageTranslations
+# defaultMessage: Translation linking removed
 msgid "Translation linking removed"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypes
 #: components/manage/Widgets/SchemaWidget
 #: components/theme/View/TabularView
+# defaultMessage: Type
 msgid "Type"
 msgstr "Elementu mota"
 
 #: components/manage/Blocks/Video/Edit
+# defaultMessage: Type a Video (YouTube, Vimeo or mp4) URL
 msgid "Type a Video (YouTube, Vimeo or mp4) URL"
 msgstr "Idatzi bideo baten URLa (YouTube, Vimeo edo mp4)"
 
 #: components/manage/Blocks/Text/Edit
+# defaultMessage: Type text…
 msgid "Type text…"
 msgstr "Idatzi testua..."
 
 #: components/manage/Blocks/Title/Edit
+# defaultMessage: Type the title…
 msgid "Type the title…"
 msgstr "Idatzi izenburua..."
 
 #: components/manage/Contents/Contents
+# defaultMessage: UID
 msgid "UID"
 msgstr "UID"
 
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: Unauthorized
 msgid "Unauthorized"
 msgstr "Ez duzu baimenik"
 
 #: components/manage/BlockChooser/BlockChooser
+# defaultMessage: Unfold
 msgid "Unfold"
 msgstr ""
 
 #: components/manage/Diff/Diff
+# defaultMessage: Unified
 msgid "Unified"
 msgstr "Elkartuta"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Uninstall
 msgid "Uninstall"
 msgstr "Desinstalatu"
 
 #: components/manage/Blocks/Block/Edit
 #: components/theme/View/DefaultView
 #: components/theme/View/RenderBlocks
+# defaultMessage: Unknown Block {block}
 msgid "Unknown Block"
 msgstr "Bloke ezezaguna"
 
 #: components/manage/Multilingual/ManageTranslations
+# defaultMessage: Unlink translation for
 msgid "Unlink translation for"
 msgstr ""
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Unlock
 msgid "Unlock"
 msgstr ""
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Update
 msgid "Update"
 msgstr "Eguneratu"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Update installed addons
 msgid "Update installed addons"
 msgstr "Eguneratu instalatutako gehigarriak"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Update installed addons:
 msgid "Update installed addons:"
 msgstr "Eguneratu instalatutako gehigarriak"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Updates available
 msgid "Updates available"
 msgstr "Instalatu daitezkeen eguneraketak"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Upload
 msgid "Upload"
 msgstr "Kargatu"
 
 #: components/manage/Blocks/LeadImage/Edit
+# defaultMessage: Upload a lead image in the 'Lead Image' content field.
 msgid "Upload a lead image in the 'Lead Image' content field."
 msgstr "Kargatu irudia"
 
 #: components/manage/Blocks/HeroImageLeft/Edit
+# defaultMessage: Upload a new image
 msgid "Upload a new image"
 msgstr "Kargatu irudi berria"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Upload files
 msgid "Upload files"
 msgstr "Kargatu fitxategiak"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Uploading files
 msgid "Uploading files"
 msgstr "Fitxategiak kargatzen"
 
 #: components/manage/Blocks/HeroImageLeft/Edit
+# defaultMessage: Uploading image
 msgid "Uploading image"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/WysiwygWidget
+# defaultMessage: Used for programmatic access to the fieldset.
 msgid "Used for programmatic access to the fieldset."
 msgstr "Eremu-multzoa programaziotik atzitzeko izena"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: User
 msgid "User"
 msgstr "Erabiltzailea"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: User created
 msgid "User created"
 msgstr "Erabiltzailea ondo sortu da"
 
 #: components/manage/Controlpanels/Users/UsersControlpanel
+# defaultMessage: User name
 msgid "User name"
 msgstr "Erabiltzaile Izena"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: User roles updated
 msgid "User roles updated"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Username
 msgid "Username"
 msgstr "Erabiltzaile izena"
 
 #: components/manage/Controlpanels/Controlpanels
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Users
 msgid "Users"
 msgstr "Erabiltzaileak"
 
 #: components/manage/Controlpanels/Controlpanels
+# defaultMessage: Users and Groups
 msgid "Users and Groups"
 msgstr "Erabiltzaile eta taldeak"
 
 #: helpers/Extensions/withBlockSchemaEnhancer
+# defaultMessage: Variation
 msgid "Variation"
 msgstr ""
 
 #: components/manage/Controlpanels/Controlpanels
+# defaultMessage: Version Overview
 msgid "Version Overview"
 msgstr "Bertsioen informazioa"
 
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Video
 msgid "Video"
 msgstr "Bideoa"
 
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Video URL
 msgid "Video URL"
 msgstr "Bideoaren URLa"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: View
 msgid "View"
 msgstr "Ikusi"
 
 #: components/manage/History/History
+# defaultMessage: View changes
 msgid "View changes"
 msgstr "Aldaketak ikusi"
 
 #: components/manage/History/History
+# defaultMessage: View this revision
 msgid "View this revision"
 msgstr "Bertsio hau ikusi"
 
 #: components/manage/Toolbar/More
+# defaultMessage: View working copy
 msgid "View working copy"
 msgstr ""
 
 #: components/manage/Display/Display
+# defaultMessage: View
 msgid "Viewmode"
 msgstr "Bistaratze modua"
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Vocabulary term
 msgid "Vocabulary term"
 msgstr ""
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Title
 msgid "Vocabulary term title"
 msgstr ""
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Vocabulary terms
 msgid "Vocabulary terms"
 msgstr ""
 
 #: components/manage/Controlpanels/VersionOverview
+# defaultMessage: You are running in 'debug mode'. This mode is intended for sites that are under development. This allows many configuration changes to be immediately visible, but will make your site run more slowly. To turn off debug mode, stop the server, set 'debug-mode=off' in your buildout.cfg, re-run bin/buildout and then restart the server process.
 msgid "Warning Regarding debug mode"
 msgstr ""Debug moduan" diharduzu. Modu hau garapenean dauden atarientzako da"
 
 #: components/theme/ConnectionRefused/ConnectionRefused
+# defaultMessage: We apologize for the inconvenience, but the backend of the site you are accessing is not available right now. Please, try again later.
 msgid "We apologize for the inconvenience, but the backend of the site you are accessing is not available right now. Please, try again later."
 msgstr "Barkatu eragozpenak baina zerbitzaria ez dago konektatuta. Saiatu beranduago mesedez."
 
 #: components/theme/NotFound/NotFound
+# defaultMessage: We apologize for the inconvenience, but the page you were trying to access is not at this address. You can use the links below to help you find what you are looking for.
 msgid "We apologize for the inconvenience, but the page you were trying to access is not at this address. You can use the links below to help you find what you are looking for."
 msgstr "Barkatu eragozpenak baina orrialde horren helbidea ez da zuzena. erabili beheko loturak bilatu nahi duzuna aurkitzeko."
 
 #: components/theme/Forbidden/Forbidden
+# defaultMessage: We apologize for the inconvenience, but you don't have permissions on this resource.
 msgid "We apologize for the inconvenience, but you don't have permissions on this resource."
 msgstr "Barkatu eragozpenak baina ez duzu orrialde hau ikusteko baimenik."
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: We will use this address if you need to recover your password
 msgid "We will use this address if you need to recover your password"
 msgstr "Helbide hau erabiliko dugu pasahitza berreskuratu behar baduzu"
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: The
 msgid "Weeek day of month"
 msgstr "Hilabeteko"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Weekday
 msgid "Weekday"
 msgstr "Astegunetan"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Weekly
 msgid "Weekly"
 msgstr "Astero"
 
 #: components/manage/History/History
+# defaultMessage: What
 msgid "What"
 msgstr "Zer"
 
 #: components/manage/History/History
+# defaultMessage: When
 msgid "When"
 msgstr "Noiz"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: When this date is reached, the content will nolonger be visible in listings and searches.
 msgid "When this date is reached, the content will nolonger be visible in listings and searches."
 msgstr "Data hau iristean, elementua ez da erakutsiko bilaketa eta zerrendetan"
 
 #: components/manage/History/History
+# defaultMessage: Who
 msgid "Who"
 msgstr "Nor"
 
 #: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Updating workflow states...
 msgid "Workflow Change Loading Message"
 msgstr ""
 
 #: components/manage/Workflow/Workflow
+# defaultMessage: Workflow updated.
 msgid "Workflow updated."
 msgstr "Workflowa eguneratu egin da"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Yearly
 msgid "Yearly"
 msgstr "Urtero"
 
 #: components/manage/Contents/ContentsItem
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Yes
 msgid "Yes"
 msgstr "Bai"
 
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: You are trying to access a protected resource, please {login} first.
 msgid "You are trying to access a protected resource, please {login} first."
 msgstr "Babestutako orrialde batera sartu nahian zabiltza, {login} lehenengo."
 
 #: components/theme/OutdatedBrowser/OutdatedBrowser
+# defaultMessage: You are using an outdated browser
 msgid "You are using an outdated browser"
 msgstr "Zure nabigatzailea zaharra da."
 
 #: components/theme/Comments/Comments
+# defaultMessage: You can add a comment by filling out the form below. Plain text formatting.
 msgid "You can add a comment by filling out the form below. Plain text formatting."
 msgstr "Erantzun bat utzi dezakezu. Testu hutsez idatzi."
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: You can control who can view and edit your item using the list below.
 msgid "You can control who can view and edit your item using the list below."
 msgstr "Zure elementua nork ikusi eta aldatu dezakeen kontrolatu dezakezu."
 
 #: components/manage/Diff/Diff
+# defaultMessage: You can view the difference of the revisions below.
 msgid "You can view the difference of the revisions below."
 msgstr "Bertsioen arteko aldeak ikusi ditzakezu"
 
 #: components/manage/History/History
+# defaultMessage: You can view the history of your item below.
 msgid "You can view the history of your item below."
 msgstr "Zure elementuaren historia ikusi dezakezu."
 
 #: components/manage/Contents/Contents
+# defaultMessage: You can't paste this content here
 msgid "You can't paste this content here"
 msgstr ""
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Your email is required for reset your password.
 msgid "Your email is required for reset your password."
 msgstr "Eposta derrigorrezkoa da zure pasahitza berrezartzeko."
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: Your location - either city and country - or in a company setting, where your office is located.
 msgid "Your location - either city and country - or in a company setting, where your office is located."
 msgstr "Zure kokalekua."
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Your password has been set successfully. You may now {link} with your new password.
 msgid "Your password has been set successfully. You may now {link} with your new password."
 msgstr "Zure pasahitza ondo berrezarri da. Orain zure pasahitz berriarekin {link}"
 
 #: components/manage/Preferences/PersonalPreferences
+# defaultMessage: Your preferred language
 msgid "Your preferred language"
 msgstr "Zure hizkuntza"
 
 #: components/theme/Login/Login
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Forgot your password?
 msgid "box_forgot_password_option"
 msgstr "Pasahitza ahaztuta?"
 
 #: config/Blocks
+# defaultMessage: Common
 msgid "common"
 msgstr "Ohikoa"
 
 #: components/manage/Multilingual/CompareLanguages
+# defaultMessage: Compare to language
 msgid "compare_to"
 msgstr ""
 
 #: components/manage/Blocks/Block/EditBlockWrapper
+# defaultMessage: delete
 msgid "delete"
 msgstr "Ezabatu"
 
 #: components/theme/OutdatedBrowser/OutdatedBrowser
+# defaultMessage: You are using {browsername} {browserversion} which is deprecated by its vendor. That means that it does not get security updates and it is not ready for current modern web features, which deteriorates the user experience. Please upgrade to a modern browser.
 msgid "deprecated_browser_notice_message"
 msgstr "{browsername} {browserversion} erabilzen ari zara eta hori zaharkituta gelditu da. Ez duzu segurtasun-eguneraketarik jasoko eta ez dago prest egungo webguneetarako. Eguneratu zure nabigatzailea"
 
 #: config/Blocks
+# defaultMessage: Description
 msgid "description"
 msgstr "Deskribapena"
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: For security reasons, we store your password encrypted, and cannot mail it to you. If you would like to reset your password, fill out the form below and we will send you an email at the address you gave when you registered to start the process of resetting your password.
 msgid "description_lost_password"
 msgstr "Segurtasun arazoak ekiditeko, zure pasahitza zifratuta gordetzen da gure sisteman eta ezin dizugu e-postaz bidali. Zure pasahitza berrezarri bahi baduzu, bete beheko formularioa eta erregistratu zinenean eman zenuen epostara bidaliko dizugu pasahitza berrezartzeko egin beharrekoaren berri."
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Your password reset request has been mailed. It should arrive in your mailbox shortly. When you receive the message, visit the address it contains to reset your password.
 msgid "description_sent_password"
 msgstr "Pasahitza berrezartzeko eskaera e-postaz bidali dizugu. Momentu batetik bestera jasoko duzu zure eposta kontuan. Mezua jasotzen duzunean, egin klik hango loturan zure pasahitza berrezartzeko."
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Draft
 msgid "draft"
 msgstr "Zirriborroa"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Input must be valid email (something@domain.com)
 msgid "email"
 msgstr "Eposta zuzen bat idatzi behar duzu (izena@domeinua.eus)"
 
 #: components/theme/View/EventView
+# defaultMessage: All dates
 msgid "event_alldates"
 msgstr "Data guztiak"
 
 #: components/theme/View/EventView
+# defaultMessage: Attendees
 msgid "event_attendees"
 msgstr "Bertaratutakoak"
 
 #: components/theme/View/EventView
+# defaultMessage: Contact Name
 msgid "event_contactname"
 msgstr "Kontaktuaren izena"
 
 #: components/theme/View/EventView
+# defaultMessage: Contact Phone
 msgid "event_contactphone"
 msgstr "Kontaktuaren telefonoa"
 
 #: components/theme/View/EventView
+# defaultMessage: Website
 msgid "event_website"
 msgstr "Hitzorduaren webgunea"
 
 #: components/theme/View/EventView
+# defaultMessage: What
 msgid "event_what"
 msgstr "Zer"
 
 #: components/theme/View/EventView
+# defaultMessage: When
 msgid "event_when"
 msgstr "Noiz"
 
 #: components/theme/View/EventView
+# defaultMessage: Where
 msgid "event_where"
 msgstr "Non"
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Password reset confirmation sent
 msgid "heading_sent_password"
 msgstr "Pasahitza aldatzeko eskaera bidalia"
 
 #: config/Blocks
+# defaultMessage: Hero
 msgid "hero"
 msgstr "Hero"
 
 #: config/Blocks
+# defaultMessage: HTML
 msgid "html"
 msgstr "HTML"
 
 #: config/Blocks
+# defaultMessage: Image
 msgid "image"
 msgstr "Irudia"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Input must be integer
 msgid "integer"
 msgstr "Zenbaki osoa izan behar da"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Intranet
 msgid "intranet"
 msgstr "Intraneta"
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: My email address is
 msgid "label_my_email_address_is"
 msgstr "Nire helbidea hauxe da: "
 
 #: config/Blocks
+# defaultMessage: Lead Image Field
 msgid "leadimage"
 msgstr "Irudi nagusiaren eremua"
 
 #: config/Blocks
+# defaultMessage: Listing
 msgid "listing"
 msgstr "Zerrenda"
 
 #: components/manage/Blocks/Listing/ListingBody
 #: components/manage/Contents/Contents
+# defaultMessage: Loading
 msgid "loading"
 msgstr ""
 
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: log in
 msgid "log in"
 msgstr "Sartu"
 
 #: config/Blocks
+# defaultMessage: Maps
 msgid "maps"
 msgstr "Mapak"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Maximum Length
 msgid "maxLength"
 msgstr "Luzera maximoa"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: End of the range (including the value itself)
 msgid "maximum"
 msgstr "Balio maximoa"
 
 #: config/Blocks
+# defaultMessage: Media
 msgid "media"
 msgstr "Media"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Minimum Length
 msgid "minLength"
 msgstr "Luzera minimoa"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Start of the range
 msgid "minimum"
 msgstr "Balio minimoa"
 
 #: config/Blocks
+# defaultMessage: Most used
 msgid "mostUsed"
 msgstr "Gehien erabilia"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: No workflow state
 msgid "no workflow state"
 msgstr "Ez du workflowrik"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Input must be number
 msgid "number"
 msgstr "Zenbakia idatzi behar duzu"
 
 #: components/manage/Widgets/RecurrenceWidget/ByMonthDayField
 #: components/manage/Widgets/RecurrenceWidget/ByYearField
+# defaultMessage: of the month
 msgid "of the month"
 msgstr ". egunean"
 
 #: error
+# defaultMessage: or try a different page.
 msgid "or try a different page."
 msgstr "edo beste orrialde bat probatu."
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: others
 msgid "others"
 msgstr "besteak"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Private
 msgid "private"
 msgstr "Pribatua"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Published
 msgid "published"
 msgstr "Argitaratuta"
 
 #: components/manage/Widgets/QueryWidget
+# defaultMessage: Select…
 msgid "querystring-widget-select"
 msgstr "Aukeratu..."
 
 #: components/theme/Search/Search
+# defaultMessage: results
 msgid "results found"
 msgstr "Emaitzak"
 
 #: error
+# defaultMessage: return to the site root
 msgid "return to the site root"
 msgstr "Atariaren errora itzuli"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: and
 msgid "rrule_and"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: (~approximate)
 msgid "rrule_approximate"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: at
 msgid "rrule_at"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: [month] [day], [year]
 msgid "rrule_dateFormat"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: day
 msgid "rrule_day"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: days
 msgid "rrule_days"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: every
 msgid "rrule_every"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: for
 msgid "rrule_for"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: hour
 msgid "rrule_hour"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: hours
 msgid "rrule_hours"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: in
 msgid "rrule_in"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: last
 msgid "rrule_last"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: minutes
 msgid "rrule_minutes"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: month
 msgid "rrule_month"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: months
 msgid "rrule_months"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: nd
 msgid "rrule_nd"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: on
 msgid "rrule_on"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: on the
 msgid "rrule_on the"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: or
 msgid "rrule_or"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: rd
 msgid "rrule_rd"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: st
 msgid "rrule_st"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: th
 msgid "rrule_th"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: the
 msgid "rrule_the"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: time
 msgid "rrule_time"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: times
 msgid "rrule_times"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: until
 msgid "rrule_until"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: week
 msgid "rrule_week"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: weekday
 msgid "rrule_weekday"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: weekdays
 msgid "rrule_weekdays"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: weeks
 msgid "rrule_weeks"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: year
 msgid "rrule_year"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: years
 msgid "rrule_years"
 msgstr ""
 
 #: components/theme/SkipLinks/SkipLinks
+# defaultMessage: Skip to footer
 msgid "skiplink-footer"
 msgstr ""
 
 #: components/theme/SkipLinks/SkipLinks
+# defaultMessage: Skip to main content
 msgid "skiplink-main-content"
 msgstr ""
 
 #: components/theme/SkipLinks/SkipLinks
+# defaultMessage: Skip to navigation
 msgid "skiplink-navigation"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: sort
 msgid "sort"
 msgstr "Ordenatu"
 
 #: config/Blocks
+# defaultMessage: Table
 msgid "table"
 msgstr "Taula"
 
 #: config/Blocks
+# defaultMessage: Text
 msgid "text"
 msgstr "Testua"
 
 #: config/Blocks
+# defaultMessage: Title
 msgid "title"
 msgstr "Izenburua"
 
 #: config/Blocks
+# defaultMessage: Table of Contents
 msgid "toc"
 msgstr "Edukien taula"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Input must be valid url (www.something.com or http(s)://www.something.com)
 msgid "url"
 msgstr "URL zuzen bat izan behar da (www.zerbait.eus) edo http(s)://www.zerbitzaria.eus)"
 
 #: components/manage/Toolbar/PersonalTools
+# defaultMessage: user avatar
 msgid "user avatar"
 msgstr "Erabiltzailearen argazkia"
 
 #: config/Blocks
+# defaultMessage: Video
 msgid "video"
 msgstr "Bideoa"
 
 #: components/theme/View/EventView
+# defaultMessage: Visit external website
 msgid "visit_external_website"
 msgstr "Webgunea ikusi"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: {count, plural, one {Upload {count} file} other {Upload {count} files}}
 msgid "{count, plural, one {Upload {count} file} other {Upload {count} files}}"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: {count} selected
 msgid "{count} selected"
 msgstr "{count} aukeratu tituzu"
 
 #: components/manage/Controlpanels/ContentType
+# defaultMessage: {id} Content Type
 msgid "{id} Content Type"
 msgstr "{id} elementu-mota"
 
 #: components/manage/Controlpanels/ContentTypeSchema
+# defaultMessage: {id} Schema
 msgid "{id} Schema"
 msgstr "{id} eskema"
 
 #: components/manage/Actions/Actions
+# defaultMessage: {title} copied.
 msgid "{title} copied."
 msgstr "{title} kopiatu egin da."
 
 #: components/manage/Actions/Actions
+# defaultMessage: {title} cut.
 msgid "{title} cut."
 msgstr "{title} moztu egin da."
 
 #: components/manage/Actions/Actions
+# defaultMessage: {title} has been deleted.
 msgid "{title} has been deleted."
 msgstr "{title} ezabatu egin da."

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -29,22 +29,27 @@ msgstr ""
 "X-Generator: Poedit 2.2.3\n"
 
 #: components/manage/Blocks/HTML/Edit
+# defaultMessage: <p>Add some HTML here</p>
 msgid "<p>Add some HTML here</p>"
 msgstr ""
 
 #: components/theme/Footer/Footer
+# defaultMessage: Accessibility
 msgid "Accessibility"
 msgstr "Accessibilité"
 
 #: components/theme/Register/Register
+# defaultMessage: Account Registration Completed
 msgid "Account Registration Completed"
 msgstr "Enregistrement de votre compte terminé"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Account activation completed
 msgid "Account activation completed"
 msgstr "Activation de votre compte terminé"
 
 #: components/manage/Controlpanels/ModerateComments
+# defaultMessage: Action
 msgid "Action"
 msgstr "Action"
 
@@ -53,10 +58,12 @@ msgstr "Action"
 #: components/manage/Controlpanels/ContentTypes
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
+# defaultMessage: Actions
 msgid "Actions"
 msgstr "Actions"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Activate and deactivate add-ons in the lists below.
 msgid "Activate and deactivate"
 msgstr "Activé et désactivé"
 
@@ -64,86 +71,107 @@ msgstr "Activé et désactivé"
 #: components/manage/Toolbar/Toolbar
 #: components/manage/Widgets/SchemaWidget
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add
 msgid "Add"
 msgstr "Ajouter"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: To make new add-ons show up here, add them to your buildout configuration, run buildout, and restart the server process. For detailed instructions see
 msgid "Add Addons"
 msgstr "Ajouter des modules"
 
 #: components/manage/Toolbar/Types
+# defaultMessage: Add Content…
 msgid "Add Content"
 msgstr "Ajouter du contenu"
 
 #: components/manage/Toolbar/Types
+# defaultMessage: Add Translation…
 msgid "Add Translation…"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add User
 msgid "Add User"
 msgstr "Ajouter un utilisateur"
 
 #: components/manage/Blocks/Description/Edit
+# defaultMessage: Add a description…
 msgid "Add a description…"
 msgstr "Ajouter une description"
 
 #: components/manage/BlockChooser/BlockChooserButton
+# defaultMessage: Add block
 msgid "Add block"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add block…
 msgid "Add block…"
 msgstr ""
 
 #: components/manage/Widgets/QueryWidget
+# defaultMessage: Add criteria
 msgid "Add criteria"
 msgstr "Ajouter un critère"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Add date
 msgid "Add date"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Add field
 msgid "Add field"
 msgstr "Ajouter un champ"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Add fieldset
 msgid "Add fieldset"
 msgstr "Ajouter un groupe de champs"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add group
 msgid "Add group"
 msgstr "Ajouter un groupe"
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Add new content type
 msgid "Add new content type"
 msgstr "Ajouter un nouveau type de contenu"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add new group
 msgid "Add new group"
 msgstr "Ajouter un nouveau groupe"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add new user
 msgid "Add new user"
 msgstr "Ajouter un nouvel utilistateur"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add to Groups
 msgid "Add to Groups"
 msgstr "Ajouter aux groupes"
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Add term
 msgid "Add vocabulary term"
 msgstr ""
 
 #: components/manage/Add/Add
+# defaultMessage: Add {type}
 msgid "Add {type}"
 msgstr "Ajouter {type}"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Add-ons Settings
 msgid "Add-ons Settings"
 msgstr "Paramètres des modules"
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: Additional date
 msgid "Additional date"
 msgstr ""
 
@@ -151,39 +179,48 @@ msgstr ""
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
 #: components/manage/Blocks/Maps/MapsSidebar
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Alignment
 msgid "Alignment"
 msgstr "Allignement"
 
 #: components/manage/Contents/Contents
+# defaultMessage: All
 msgid "All"
 msgstr "Tout"
 
 #: components/theme/Search/Search
+# defaultMessage: Alphabetically
 msgid "Alphabetically"
 msgstr ""
 
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: Alt text
 msgid "Alt text"
 msgstr "Texte pour la balise alt"
 
 #: components/manage/Toolbar/More
+# defaultMessage: Apply working copy
 msgid "Apply working copy"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Are you sure you want to delete this field?
 msgid "Are you sure you want to delete this field?"
 msgstr "Voulez-vous vraiment supprimer ce champ ?"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Are you sure you want to delete this fieldset including all fields?
 msgid "Are you sure you want to delete this fieldset including all fields?"
 msgstr "Voulez-vous vraiment supprimer ce groupe de champs et tous les champs dedans"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Ascending
 msgid "Ascending"
 msgstr "Ascendant"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Available
 msgid "Available"
 msgstr "Disponible"
 
@@ -208,48 +245,59 @@ msgstr "Disponible"
 #: components/manage/Toolbar/Toolbar
 #: components/theme/ContactForm/ContactForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Back
 msgid "Back"
 msgstr "Retour"
 
 #: components/manage/Diff/Diff
+# defaultMessage: Base
 msgid "Base"
 msgstr "Base"
 
 #: components/manage/Sidebar/Sidebar
+# defaultMessage: Block
 msgid "Block"
 msgstr "Bloc"
 
 #: components/theme/Login/Login
+# defaultMessage: Both email address and password are case sensitive, check that caps lock is not enabled.
 msgid "Both email address and password are case sensitive, check that caps lock is not enabled."
 msgstr "L'adresse e-mail et le mot de passe sont sensibles aux majuscules et minuscules, verifier que le verrouillage des majuscules n'est pas activé"
 
 #: components/theme/Breadcrumbs/Breadcrumbs
+# defaultMessage: Breadcrumbs
 msgid "Breadcrumbs"
 msgstr "Fil d'Ariane"
 
 #: components/manage/Blocks/HeroImageLeft/Edit
 #: components/manage/Contents/ContentsUploadModal
 #: components/manage/Sidebar/ObjectBrowserNav
+# defaultMessage: Browse
 msgid "Browse"
 msgstr "Explore"
 
 #: components/manage/Blocks/Image/Edit
+# defaultMessage: Browse the site, drop an image, or type an URL
 msgid "Browse the site, drop an image, or type an URL"
 msgstr "Explorer le site, déposer l'image ou écriver l'URL"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: By default, permissions from the container of this item are inherited. If you disable this, only the explicitly defined sharing permissions will be valid. In the overview, the symbol {inherited} indicates an inherited value. Similarly, the symbol {global} indicates a global role, which is managed by the site administrator.
 msgid "By default, permissions from the container of this item are inherited. If you disable this, only the explicitly defined sharing permissions will be valid. In the overview, the symbol {inherited} indicates an inherited value. Similarly, the symbol {global} indicates a global role, which is managed by the site administrator."
 msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Cache Name
 msgid "Cache Name"
 msgstr "Nom du cache"
 
 #: components/manage/Controlpanels/ContentTypeLayout
+# defaultMessage: Can not edit Layout for <strong>{type}</strong> content-type as it doesn't have support for <strong>Volto Blocks</strong> enabled
 msgid "Can not edit Layout for <strong>{type}</strong> content-type as it doesn't have support for <strong>Volto Blocks</strong> enabled"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypeLayout
+# defaultMessage: Can not edit Layout for <strong>{type}</strong> content-type as the <strong>Blocks behavior</strong> is enabled and <strong>read-only</strong>
 msgid "Can not edit Layout for <strong>{type}</strong> content-type as the <strong>Blocks behavior</strong> is enabled and <strong>read-only</strong>"
 msgstr ""
 
@@ -265,42 +313,51 @@ msgstr ""
 #: components/manage/Sharing/Sharing
 #: components/theme/Login/Login
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Cancel
 msgid "Cancel"
 msgstr "Annuler"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Cell
 msgid "Cell"
 msgstr "Cellule"
 
 #: components/manage/Blocks/Image/ImageSizeWidget
 #: components/manage/Blocks/Maps/Edit
 #: components/manage/Sidebar/AlignBlock
+# defaultMessage: Center
 msgid "Center"
 msgstr "Centre"
 
 #: components/manage/History/History
+# defaultMessage: Change Note
 msgid "Change Note"
 msgstr "Note de changement"
 
 #: components/manage/Preferences/ChangePassword
+# defaultMessage: Change Password
 msgid "Change Password"
 msgstr "Modifier son mot de passe"
 
 #: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Change State
 msgid "Change State"
 msgstr "Modifier l'état"
 
 #: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Change workflow state recursively
 msgid "Change workflow state recursively"
 msgstr "Modifier le "
 
 #: components/manage/Toolbar/More
+# defaultMessage: Changes applied
 msgid "Changes applied."
 msgstr ""
 
 #: components/manage/Preferences/ChangePassword
 #: components/manage/Preferences/PersonalInformation
 #: components/manage/Preferences/PersonalPreferences
+# defaultMessage: Changes saved
 msgid "Changes saved"
 msgstr "Changements sauvegardés"
 
@@ -308,192 +365,237 @@ msgstr "Changements sauvegardés"
 #: components/manage/Controlpanels/ContentTypeLayout
 #: components/manage/Controlpanels/ContentTypeSchema
 #: components/manage/Controlpanels/Controlpanel
+# defaultMessage: Changes saved.
 msgid "Changes saved."
 msgstr "Changements sauvegardés."
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Checkbox
 msgid "Checkbox"
 msgstr "Case à cocher"
 
 #: components/manage/Widgets/SelectWidget
+# defaultMessage: Choices
 msgid "Choices"
 msgstr "Choix"
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: Choose Image
 msgid "Choose Image"
 msgstr "Choisir une image"
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: Choose Target
 msgid "Choose Target"
 msgstr "Choisir une cible"
 
 #: components/manage/Widgets/FileWidget
+# defaultMessage: Choose a file
 msgid "Choose a file"
 msgstr ""
 
 #: components/manage/Blocks/HTML/Edit
+# defaultMessage: Clear
 msgid "Clear"
 msgstr ""
 
 #: components/theme/View/ImageView
+# defaultMessage: Click to download full sized image
 msgid "Click to download full sized image"
 msgstr "Cliquer pour télécharger l'image en taille réelle"
 
 #: components/manage/Widgets/SelectWidget
+# defaultMessage: Close
 msgid "Close"
 msgstr "Fermer"
 
 #: components/theme/Navigation/Navigation
+# defaultMessage: Close menu
 msgid "Close menu"
 msgstr "Fermer le menu"
 
 #: components/manage/Blocks/HTML/Edit
+# defaultMessage: Code
 msgid "Code"
 msgstr ""
 
 #: components/manage/Widgets/ObjectListWidget
+# defaultMessage: Collapse item
 msgid "Collapse item"
 msgstr ""
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Collection
 msgid "Collection"
 msgstr "Collection"
 
 #: components/manage/Controlpanels/ModerateComments
 #: components/theme/Comments/CommentEditModal
 #: components/theme/Comments/Comments
+# defaultMessage: Comment
 msgid "Comment"
 msgstr "Commentaire"
 
 #: components/manage/Controlpanels/ModerateComments
+# defaultMessage: Commenter
 msgid "Commenter"
 msgstr "Commenter"
 
 #: components/theme/Comments/Comments
+# defaultMessage: Comments
 msgid "Comments"
 msgstr ""
 
 #: components/manage/Diff/Diff
+# defaultMessage: Compare
 msgid "Compare"
 msgstr "Comparer"
 
 #: components/manage/Preferences/ChangePassword
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Confirm password
 msgid "Confirm password"
 msgstr "Confirmer le mot de passe"
 
 #: components/theme/ConnectionRefused/ConnectionRefused
+# defaultMessage: Connection refused
 msgid "Connection refused"
 msgstr "Connexion refusée"
 
 #: components/theme/Footer/Footer
+# defaultMessage: Contact
 msgid "Contact"
 msgstr "Contact"
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Contact form
 msgid "Contact form"
 msgstr "Formulaire de contact"
 
 #: components/manage/Blocks/Listing/Edit
+# defaultMessage: Contained items
 msgid "Contained items"
 msgstr "Eléments contenants"
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Content type created
 msgid "Content type created"
 msgstr "Type de contenu créé"
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Content type deleted
 msgid "Content type deleted"
 msgstr "Type de contenu supprimé"
 
 #: components/manage/Contents/Contents
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Contents
 msgid "Contents"
 msgstr "Contenus"
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Copy
 msgid "Copy"
 msgstr "Copier"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: undefined
 msgid "Copy blocks"
 msgstr ""
 
 #: components/theme/Footer/Footer
+# defaultMessage: Copyright
 msgid "Copyright"
 msgstr "Droits d'auteur"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Copyright statement or other rights information on this item.
 msgid "Copyright statement or other rights information on this item."
 msgstr "Droits d'auteur ou autres informations sur les droits sur cet élément"
 
 #: components/manage/Toolbar/More
+# defaultMessage: Create working copy
 msgid "Create working copy"
 msgstr ""
 
 #: components/manage/WorkingCopyToastsFactory/WorkingCopyToastsFactory
+# defaultMessage: Created by {creator} on {date}
 msgid "Created by {creator} on {date}"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Created on
 msgid "Created on"
 msgstr "Créé le"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Creator
 msgid "Creator"
 msgstr "Créateur"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Creators
 msgid "Creators"
 msgstr "Créateurs"
 
 #: components/manage/Widgets/QuerystringWidget
 #: components/manage/Widgets/QueryWidget
+# defaultMessage: Criteria
 msgid "Criteria"
 msgstr "Critère"
 
 #: components/manage/Preferences/ChangePassword
+# defaultMessage: Current password
 msgid "Current password"
 msgstr "Mot de passe actuel"
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Cut
 msgid "Cut"
 msgstr "Couper"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: undefined
 msgid "Cut blocks"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Daily
 msgid "Daily"
 msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Database Information
 msgid "Database Information"
 msgstr "Information sur la base de donnée"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Database Location
 msgid "Database Location"
 msgstr "Localisation de la base de donnée"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Database Size
 msgid "Database Size"
 msgstr "Taille de la basse de donnée"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Database main
 msgid "Database main"
 msgstr "Base de donnée principale"
 
 #: components/manage/Controlpanels/ModerateComments
 #: components/manage/Widgets/DatetimeWidget
+# defaultMessage: Date
 msgid "Date"
 msgstr "Date"
 
 #: components/theme/Search/Search
+# defaultMessage: Date (newest first)
 msgid "Date (newest first)"
 msgstr ""
 
@@ -513,6 +615,7 @@ msgstr ""
 #: components/theme/PasswordReset/PasswordReset
 #: components/theme/PasswordReset/RequestPasswordReset
 #: components/theme/Register/Register
+# defaultMessage: Default
 msgid "Default"
 msgstr "Défaut"
 
@@ -527,38 +630,47 @@ msgstr "Défaut"
 #: components/manage/Widgets/ObjectBrowserWidget
 #: components/manage/Widgets/WysiwygWidget
 #: components/theme/Comments/Comments
+# defaultMessage: Delete
 msgid "Delete"
 msgstr "Supprimer"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Delete Group
 msgid "Delete Group"
 msgstr "Supprimer le groupe"
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Delete Type
 msgid "Delete Type"
 msgstr "Supprimer le type"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Delete User
 msgid "Delete User"
 msgstr "Supprimer l'utilisateur"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: undefined
 msgid "Delete blocks"
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Delete col
 msgid "Delete col"
 msgstr "Supprimer la colonne"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Delete row
 msgid "Delete row"
 msgstr "Supprimer la ligne"
 
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: Depth
 msgid "Depth"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Descending
 msgid "Descending"
 msgstr "Descendant"
 
@@ -569,72 +681,89 @@ msgstr "Descendant"
 #: components/manage/Widgets/WysiwygWidget
 #: components/theme/View/TabularView
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Description
 msgid "Description"
 msgstr "Déscription"
 
 #: components/manage/Diff/Diff
+# defaultMessage: Diff
 msgid "Diff"
 msgstr "Différence"
 
 #: components/manage/Diff/Diff
+# defaultMessage: Difference between revision {one} and {two} of {title}
 msgid "Difference between revision {one} and {two} of {title}"
 msgstr "Différence entre le révision {one] et {two} de {title}"
 
 #: components/theme/Footer/Footer
+# defaultMessage: Distributed under the {license}.
 msgid "Distributed under the {license}."
 msgstr "Distribué sous la {license}."
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Add border to inner columns
 msgid "Divide each row into separate cells"
 msgstr "Diviser chaque colonnes en cellules séparées"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Do you really want to delete the following items?
 msgid "Do you really want to delete the following items?"
 msgstr "Voulez-vous vraiment supprimer les éléments suivants ?"
 
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
+# defaultMessage: Do you really want to delete the group {groupname}?
 msgid "Do you really want to delete the group {groupname}?"
 msgstr "Voulez-vous vraiment supprimer le groupe {groupname} ?"
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Do you really want to delete type {typename}?
 msgid "Do you really want to delete the type {typename}?"
 msgstr "Voulez-vous vraiment supprimer le type {typename} ?"
 
 #: components/manage/Controlpanels/Users/UsersControlpanel
+# defaultMessage: Do you really want to delete the user {username}?
 msgid "Do you really want to delete the user {username}?"
 msgstr "Voulez-vous vraiment supprimer l'utilisateur {username} ?"
 
 #: components/manage/Delete/Delete
+# defaultMessage: Do you really want to delete this item?
 msgid "Do you really want to delete this item?"
 msgstr "Voulez-vous vraiment supprimer cet élément ?"
 
 #: components/manage/Multilingual/TranslationObject
 #: components/manage/Sidebar/Sidebar
+# defaultMessage: Document
 msgid "Document"
 msgstr "Document"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Drag and drop files from your computer onto this area or click the “Browse” button.
 msgid "Drag and drop files from your computer onto this area or click the “Browse” button."
 msgstr "Glisser et déposer les fichiers depuis votre ordinateur dans la zone ou cliquer sur le bouton “Explore“"
 
 #: components/manage/Widgets/FileWidget
+# defaultMessage: Drop file here to replace the existing file
 msgid "Drop file here to replace the existing file"
 msgstr ""
 
 #: components/manage/Widgets/FileWidget
+# defaultMessage: Drop file here to upload a new file
 msgid "Drop file here to upload a new file"
 msgstr ""
 
 #: components/manage/Widgets/FileWidget
+# defaultMessage: Drop files here ...
 msgid "Drop files here ..."
 msgstr ""
 
 #: components/manage/Preferences/PersonalInformation
 #: components/theme/Register/Register
+# defaultMessage: E-mail
 msgid "E-mail"
 msgstr "E-mail"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: E-mail addresses do not match.
 msgid "E-mail addresses do not match."
 msgstr "Les adresses e-mails ne correspondent pas."
 
@@ -645,93 +774,115 @@ msgstr "Les adresses e-mails ne correspondent pas."
 #: components/manage/Widgets/FormFieldWrapper
 #: components/manage/Widgets/ObjectBrowserWidget
 #: components/theme/Comments/Comments
+# defaultMessage: Edit
 msgid "Edit"
 msgstr "Modifier"
 
 #: components/theme/Comments/CommentEditModal
+# defaultMessage: Edit comment
 msgid "Edit comment"
 msgstr "Modifier le commentaire"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Edit field
 msgid "Edit field"
 msgstr "Modifier le champ"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Edit fieldset
 msgid "Edit fieldset"
 msgstr "Modifier le groupe de champs"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Edit recurrence
 msgid "Edit recurrence"
 msgstr ""
 
 #: components/manage/Form/InlineForm
+# defaultMessage: Edit values
 msgid "Edit values"
 msgstr "Modifier les valeurs"
 
 #: components/manage/Edit/Edit
+# defaultMessage: Edit {title}
 msgid "Edit {title}"
 msgstr "Modifier {title}"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Email
 msgid "Email"
 msgstr "E-mail"
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Email sent
 msgid "Email sent"
 msgstr "E-mail envoyé"
 
 #: components/manage/Blocks/Maps/Edit
+# defaultMessage: Embed code error, please follow the instructions and try again.
 msgid "Embed code error, please follow the instructions and try again."
 msgstr "Erreur dans le code intégré, veuillez suivre les instructions et essayez de nouveau."
 
 #: components/manage/Blocks/Maps/View
+# defaultMessage: Embeded Google Maps
 msgid "Embeded Google Maps"
 msgstr "Carte Google intégrée"
 
 #: components/manage/Widgets/ObjectListWidget
+# defaultMessage: Empty object list
 msgid "Empty object list"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypeLayout
+# defaultMessage: Enable editable Blocks
 msgid "Enable editable Blocks"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: End Date
 msgid "End Date"
 msgstr "Date de fin"
 
 #: components/manage/AnchorPlugin/components/LinkButton/AddLinkForm
+# defaultMessage: Enter URL or select an item
 msgid "Enter URL or select an item"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Enter a username above to search or click 'Show All'
 msgid "Enter a username above to search or click 'Show All'"
 msgstr ""
 
 #: components/theme/Register/Register
+# defaultMessage: Enter an email address. This will be your login name. We respect your privacy, and will not give the address away to any third parties or expose it anywhere.
 msgid "Enter an email address. This will be your login name. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr "Entrer votre adresse e-mail. Elle sera votre nom d'utilisateur. Nous respectons votre vie privée, nous ne donnerons pas votre adresse à un tiers et elle ne sera pas exposée."
 
 #: components/manage/Preferences/PersonalInformation
 #: components/theme/PasswordReset/PasswordReset
 #: components/theme/Register/Register
+# defaultMessage: Enter full name, e.g. John Smith.
 msgid "Enter full name, e.g. John Smith."
 msgstr "Entrer votre nom complet (par exemple : John Smith)"
 
 #: components/manage/Blocks/Maps/Edit
+# defaultMessage: Enter map Embed Code
 msgid "Enter map Embed Code"
 msgstr "Entrer le code intégré de la carte"
 
 #: components/manage/Preferences/ChangePassword
+# defaultMessage: Enter your current password.
 msgid "Enter your current password."
 msgstr "Entrer votre mot de passe actuel."
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Enter your email address for verification.
 msgid "Enter your email address for verification."
 msgstr "Entrer votre adresse e-mail pour la vérification."
 
 #: components/manage/Preferences/ChangePassword
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Enter your new password. Minimum 5 characters.
 msgid "Enter your new password. Minimum 5 characters."
 msgstr "Entrer votre nouveau mot de passe. Minimum 5 caractères."
 
@@ -743,199 +894,245 @@ msgstr "Entrer votre nouveau mot de passe. Minimum 5 caractères."
 #: components/theme/ContactForm/ContactForm
 #: components/theme/Login/Login
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Error
 msgid "Error"
 msgstr "Erreur"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Exclude from navigation
 msgid "Exclude from navigation"
 msgstr "Exclure de la navigation"
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: Exclude this occurence
 msgid "Exclude this occurence"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Excluded from navigation
 msgid "Excluded from navigation"
 msgstr "Exclut de la navigation"
 
 #: components/manage/Sidebar/Sidebar
+# defaultMessage: Expand sidebar
 msgid "Expand sidebar"
 msgstr "Etendre la barre latérale"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Expiration Date
 msgid "Expiration Date"
 msgstr "Date d'expiration"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Expiration date
 msgid "Expiration date"
 msgstr "Date d'expiration"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Expired
 msgid "Expired"
 msgstr "Expiré"
 
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: External URL
 msgid "External URL"
 msgstr "URL externe"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: File
 msgid "File"
 msgstr "Fichier"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: File size
 msgid "File size"
 msgstr "Taille du fichier"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Filename
 msgid "Filename"
 msgstr "Nom du fichier"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Filter…
 msgid "Filter…"
 msgstr "Filtre..."
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: First
 msgid "First"
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Fixed width columns
 msgid "Fixed width table cells"
 msgstr "Taille de la cellule de la table fixé"
 
 #: components/manage/BlockChooser/BlockChooser
+# defaultMessage: Fold
 msgid "Fold"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Folder
 msgid "Folder"
 msgstr "Dossier"
 
 #: components/theme/Forbidden/Forbidden
+# defaultMessage: Forbidden
 msgid "Forbidden"
 msgstr "Interdit"
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: Fourth
 msgid "Fourth"
 msgstr ""
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: From
 msgid "From"
 msgstr "De"
 
 #: components/manage/Blocks/Maps/Edit
 #: components/manage/Sidebar/AlignBlock
+# defaultMessage: Full
 msgid "Full"
 msgstr "Complet"
 
 #: components/manage/Preferences/PersonalInformation
 #: components/theme/PasswordReset/PasswordReset
 #: components/theme/Register/Register
+# defaultMessage: Full Name
 msgid "Full Name"
 msgstr "Nom complet"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Fullname
 msgid "Fullname"
 msgstr "Nom complet"
 
 #: components/theme/Footer/Footer
+# defaultMessage: GNU GPL license
 msgid "GNU GPL license"
 msgstr "License GNU GPL"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Global role
 msgid "Global role"
 msgstr "Rôle global"
 
 #: components/manage/Blocks/Maps/Edit
+# defaultMessage: Google Maps Embedded Block
 msgid "Google Maps Embedded Block"
 msgstr "Bloc intégré de la carte Google"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Group
 msgid "Group"
 msgstr "Groupe"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Group created
 msgid "Group created"
 msgstr "Groupe créé"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Group roles updated
 msgid "Group roles updated"
 msgstr ""
 
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Groupname
 msgid "Groupname"
 msgstr "Nom du groupe"
 
 #: components/manage/Controlpanels/Controlpanels
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Groups
 msgid "Groups"
 msgstr "Groupes"
 
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
+# defaultMessage: Groups are logical collections of users, such as departments and business units. Groups are not directly related to permissions on a global level, you normally use Roles for that - and let certain Groups have a particular role. The symbol{plone_svg}indicates a role inherited from membership in another group.
 msgid "Groups are logical collections of users, such as departments and business units. Groups are not directly related to permissions on a global level, you normally use Roles for that - and let certain Groups have a particular role. The symbol{plone_svg}indicates a role inherited from membership in another group."
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Header cell
 msgid "Header cell"
 msgstr ""
 
 #: components/theme/Comments/Comments
+# defaultMessage: Hide Replies
 msgid "Hide Replies"
 msgstr ""
 
 #: components/manage/History/History
 #: components/manage/Toolbar/More
+# defaultMessage: History
 msgid "History"
 msgstr "Historique"
 
 #: components/manage/History/History
+# defaultMessage: #
 msgid "History Version Number"
 msgstr ""
 
 #: components/manage/History/History
+# defaultMessage: History of {title}
 msgid "History of {title}"
 msgstr "Historique de {title}"
 
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsBreadcrumbs
 #: components/theme/Breadcrumbs/Breadcrumbs
+# defaultMessage: Home
 msgid "Home"
 msgstr "Accueil"
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: Home page
 msgid "Home page"
 msgstr "Page d'accueil"
 
 #: components/manage/Contents/Contents
+# defaultMessage: ID
 msgid "ID"
 msgstr "ID"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: If selected, this item will not appear in the navigation tree
 msgid "If selected, this item will not appear in the navigation tree"
 msgstr "Si sélectionné, cet élément n'apparaitera pas dans la navigation."
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: If this date is in the future, the content will not show up in listings and searches until this date.
 msgid "If this date is in the future, the content will not show up in listings and searches until this date."
 msgstr "Si cette date est dans l'avenir, le contenu n'apparaîtera pas dans les listes et dans les recherches jusqu'à cette date."
 
 #: components/manage/LockingToastsFactory/LockingToastsFactory
+# defaultMessage: If you are certain this user has abandoned the object, you may unlock the object. You will then be able to edit it.
 msgid "If you are certain this user has abandoned the object, you may unlock the object. You will then be able to edit it."
 msgstr ""
 
 #: components/theme/NotFound/NotFound
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: If you are certain you have the correct web address but are encountering an error, please contact the {site_admin}.
 msgid "If you are certain you have the correct web address but are encountering an error, please contact the {site_admin}."
 msgstr "Si vous êtes certain que l'adresse est bonne, mais que vous avez un erreur, veuillez contacter le {site_admin}."
 
 #: components/manage/Blocks/HeroImageLeft/Edit
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: Image
 msgid "Image"
 msgstr "Image"
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: Include this occurence
 msgid "Include this occurence"
 msgstr ""
 
@@ -943,142 +1140,176 @@ msgstr ""
 #: components/manage/Controlpanels/ContentTypeLayout
 #: components/manage/Controlpanels/ContentTypeSchema
 #: components/manage/Controlpanels/Controlpanel
+# defaultMessage: Info
 msgid "Info"
 msgstr "Info"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Inherit permissions from higher levels
 msgid "Inherit permissions from higher levels"
 msgstr "Hériter des permissions depuis un niveau supérieur"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Inherited value
 msgid "Inherited value"
 msgstr "Hériter de la valeur"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Insert col after
 msgid "Insert col after"
 msgstr "Insérer une colonne après"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Insert col before
 msgid "Insert col before"
 msgstr "Insérer une colonne avant"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Insert row after
 msgid "Insert row after"
 msgstr "Insérer une ligne après"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Insert row before
 msgid "Insert row before"
 msgstr "Insérer une ligne avant"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Install
 msgid "Install"
 msgstr "Installer"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Installed
 msgid "Installed"
 msgstr "Installé"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Installed version
 msgid "Installed version"
 msgstr "Version instalée"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: days
 msgid "Interval Daily"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Month(s)
 msgid "Interval Monthly"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: week(s)
 msgid "Interval Weekly"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: year(s)
 msgid "Interval Yearly"
 msgstr ""
 
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: Item batch size
 msgid "Item batch size"
 msgstr "Nombre d'éléments du lot"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Item succesfully moved.
 msgid "Item succesfully moved."
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Item(s) copied.
 msgid "Item(s) copied."
 msgstr "Elément(s) copié(s)"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Item(s) cut.
 msgid "Item(s) cut."
 msgstr "Elément(s) coupé(s)"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Item(s) has been updated.
 msgid "Item(s) has been updated."
 msgstr ""
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
+# defaultMessage: Item(s) pasted.
 msgid "Item(s) pasted."
 msgstr "Elément(s) collé(s)"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Item(s) state has been updated.
 msgid "Item(s) state has been updated."
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Items
 msgid "Items"
 msgstr "Eléments"
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Items must be unique.
 msgid "Items must be unique."
 msgstr "Les éléments doivent être unique."
 
 #: components/manage/Preferences/PersonalPreferences
+# defaultMessage: Language
 msgid "Language"
 msgstr "Langage"
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: Last
 msgid "Last"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Last comment date
 msgid "Last comment date"
 msgstr "Date du dernier commentaire"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Last modified
 msgid "Last modified"
 msgstr "Dernier modifié"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Latest version
 msgid "Latest version"
 msgstr "Dernière version"
 
 #: components/manage/Controlpanels/ContentTypesActions
+# defaultMessage: Layout
 msgid "Layout"
 msgstr ""
 
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: Lead Image
 msgid "Lead Image"
 msgstr "Image de garde"
 
 #: components/manage/Blocks/Image/ImageSizeWidget
 #: components/manage/Blocks/Maps/Edit
 #: components/manage/Sidebar/AlignBlock
+# defaultMessage: Left
 msgid "Left"
 msgstr "Gauche"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Link
 msgid "Link"
 msgstr "Lien"
 
 #: components/manage/Blocks/Listing/schema
+# defaultMessage: Link more
 msgid "Link more"
 msgstr "Lier plus"
 
 #: components/manage/Blocks/Listing/schema
+# defaultMessage: Link Title
 msgid "Link title"
 msgstr "Titre du lien"
 
@@ -1087,212 +1318,262 @@ msgstr "Titre du lien"
 #: components/manage/Blocks/Listing/schema
 #: components/manage/Blocks/Maps/MapsSidebar
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Link to
 msgid "Link to"
 msgstr "Lien vers"
 
 #: components/manage/Multilingual/ManageTranslations
+# defaultMessage: Link translation for
 msgid "Link translation for"
 msgstr ""
 
 #: components/manage/Blocks/Listing/schema
+# defaultMessage: Listing
 msgid "Listing"
 msgstr "Listing"
 
 #: components/theme/Comments/Comments
+# defaultMessage: Load more...
 msgid "Load more"
 msgstr ""
 
 #: components/manage/Form/ModalForm
+# defaultMessage: Loading.
 msgid "Loading"
 msgstr ""
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: Location
 msgid "Location"
 msgstr "Localisation"
 
 #: components/theme/Login/Login
+# defaultMessage: Login
 msgid "Log In"
 msgstr "Se connecter"
 
 #: components/theme/Anontools/Anontools
 #: components/theme/Login/Login
+# defaultMessage: Log in
 msgid "Log in"
 msgstr "Se connecter"
 
 #: components/theme/Login/Login
+# defaultMessage: Login
 msgid "Login"
 msgstr "Se connecter"
 
 #: components/theme/Login/Login
+# defaultMessage: Login Failed
 msgid "Login Failed"
 msgstr "Echec de la connexion"
 
 #: components/theme/Login/Login
+# defaultMessage: Login Name
 msgid "Login Name"
 msgstr "Identifiant"
 
 #: components/manage/Toolbar/PersonalTools
+# defaultMessage: Logout
 msgid "Logout"
 msgstr ""
 
 #: components/manage/Toolbar/More
+# defaultMessage: Made by {creator} on {date}. This is not a working copy anymore, but the main content.
 msgid "Made by {creator} on {date}. This is not a working copy anymore, but the main content."
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Reduce cell padding
 msgid "Make the table compact"
 msgstr "Faire une table compacte"
 
 #: components/manage/Multilingual/ManageTranslations
 #: components/manage/Toolbar/More
+# defaultMessage: Manage Translations
 msgid "Manage Translations"
 msgstr ""
 
 #: components/manage/Multilingual/ManageTranslations
+# defaultMessage: Manage translations for {title}
 msgid "Manage translations for {title}"
 msgstr ""
 
 #: components/manage/Blocks/Maps/MapsSidebar
+# defaultMessage: Map
 msgid "Map"
 msgstr "Carte"
 
 #: components/manage/Blocks/Maps/MapsSidebar
+# defaultMessage: Maps URL
 msgid "Maps URL"
 msgstr "URL de la carte"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Maximum length is {len}.
 msgid "Maximum length is {len}."
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Maximum value is {len}.
 msgid "Maximum value is {len}."
 msgstr ""
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Message
 msgid "Message"
 msgstr "Message"
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Minimum length is {len}.
 msgid "Minimum length is {len}."
 msgstr "La longueur minimum est {len}."
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Minimum value is {len}.
 msgid "Minimum value is {len}."
 msgstr ""
 
 #: components/manage/Controlpanels/Controlpanels
+# defaultMessage: Moderate Comments
 msgid "Moderate Comments"
 msgstr "Modérer les commentaires"
 
 #: components/manage/Controlpanels/ModerateComments
+# defaultMessage: Moderate comments
 msgid "Moderate comments"
 msgstr "Modérer les commentaires"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Monday and Friday
 msgid "Monday and Friday"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/ByMonthDayField
+# defaultMessage: Day
 msgid "Month day"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Monthly
 msgid "Monthly"
 msgstr ""
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: More
 msgid "More"
 msgstr "Plus"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Move to bottom of folder
 msgid "Move to bottom of folder"
 msgstr "Déplacer à la fin du dossier"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Move to top of folder
 msgid "Move to top of folder"
 msgstr "Déplace au début du dossier"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: My email address is
 msgid "My email address is"
 msgstr "Mon adresse e-mail est"
 
 #: components/manage/Sharing/Sharing
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Name
 msgid "Name"
 msgstr "Nom"
 
 #: error
+# defaultMessage: Navigate back
 msgid "Navigate back"
 msgstr "Retour en arrière"
 
 #: components/theme/Navigation/ContextNavigation
+# defaultMessage: Navigation
 msgid "Navigation"
 msgstr ""
 
 #: components/manage/Preferences/ChangePassword
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: New password
 msgid "New password"
 msgstr "Nouveau mot de passe"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: News Item
 msgid "News Item"
 msgstr "Actualité"
 
 #: components/manage/Contents/ContentsItem
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: No
 msgid "No"
 msgstr "Non"
 
 #: components/manage/Blocks/Image/ImageSidebar
+# defaultMessage: No image selected
 msgid "No image selected"
 msgstr "Aucune image sélectionée"
 
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: No image set in Lead Image content field
 msgid "No image set in Lead Image content field"
 msgstr "Aucune image pour le champ de l'image de garde"
 
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: No image set in image content field
 msgid "No image set in image content field"
 msgstr "Aucune image pour le champ image"
 
 #: components/manage/Blocks/Listing/ListingBody
+# defaultMessage: No items found in this container.
 msgid "No items found in this container."
 msgstr "Aucun élément trouvé dans ce conteneur"
 
 #: components/manage/Widgets/ObjectBrowserWidget
+# defaultMessage: No items selected
 msgid "No items selected"
 msgstr "Aucun élément sélectionné"
 
 #: components/manage/Blocks/Maps/MapsSidebar
+# defaultMessage: No map selected
 msgid "No map selected"
 msgstr "Aucune carte sélectionnée"
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: No occurences set
 msgid "No occurences set"
 msgstr ""
 
 #: components/manage/Widgets/ArrayWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/TokenWidget
+# defaultMessage: No options
 msgid "No options"
 msgstr ""
 
 #: components/theme/Search/Search
+# defaultMessage: No results found
 msgid "No results found"
 msgstr ""
 
 #: components/manage/Blocks/Listing/ListingBody
 #: components/manage/Widgets/ReferenceWidget
+# defaultMessage: No results found.
 msgid "No results found."
 msgstr "Aucun resultat trouvé"
 
 #: components/manage/Widgets/QuerySortOnWidget
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: No selection
 msgid "No selection"
 msgstr "Aucune sélection"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: This addon does not provide an uninstall profile.
 msgid "No uninstall profile"
 msgstr "Aucun profile de désinstalation"
 
@@ -1300,39 +1581,48 @@ msgstr "Aucun profile de désinstalation"
 #: components/manage/Widgets/ReferenceWidget
 #: components/manage/Widgets/SelectUtils
 #: components/manage/Widgets/SelectWidget
+# defaultMessage: No value
 msgid "No value"
 msgstr "Aucune valeur"
 
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: No video selected
 msgid "No video selected"
 msgstr "Aucune vidéo selectionnée"
 
 #: components/manage/Workflow/Workflow
+# defaultMessage: No workflow
 msgid "No workflow"
 msgstr "Aucun workflow"
 
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsItem
+# defaultMessage: None
 msgid "None"
 msgstr "Aucun"
 
 #: components/manage/Controlpanels/Users/UsersControlpanel
+# defaultMessage: Note that roles set here apply directly to a user. The symbol{plone_svg}indicates a role inherited from membership in a group.
 msgid "Note that roles set here apply directly to a user. The symbol{plone_svg}indicates a role inherited from membership in a group."
 msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Number of active objects
 msgid "Number of active objects"
 msgstr "Nombre d'objets actifs"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Object Size
 msgid "Object Size"
 msgstr "Taille de l'objet"
 
 #: components/manage/Widgets/RecurrenceWidget/EndField
+# defaultMessage: occurrence(s)
 msgid "Occurences"
 msgstr ""
 
 #: components/manage/Delete/Delete
+# defaultMessage: Ok
 msgid "Ok"
 msgstr "Ok"
 
@@ -1340,301 +1630,371 @@ msgstr "Ok"
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
 #: components/manage/Blocks/Maps/MapsSidebar
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Open in a new tab
 msgid "Open in a new tab"
 msgstr "Ouvrir dans un nouvel onglet"
 
 #: components/theme/Navigation/Navigation
+# defaultMessage: Open menu
 msgid "Open menu"
 msgstr "Ouvrir le menu"
 
 #: components/manage/Widgets/ObjectBrowserWidget
+# defaultMessage: Open object browser
 msgid "Open object browser"
 msgstr ""
 
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: Origin
 msgid "Origin"
 msgstr "Origine"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Page
 msgid "Page"
 msgstr "Page"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Parent fieldset
 msgid "Parent fieldset"
 msgstr ""
 
 #: components/theme/Login/Login
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Password
 msgid "Password"
 msgstr "Mot de passe"
 
 #: components/theme/PasswordReset/PasswordReset
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Password reset
 msgid "Password reset"
 msgstr "Réinitialisation du mot de passe"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Passwords do not match.
 msgid "Passwords do not match."
 msgstr "Les mots de passe ne correspondent pas."
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
+# defaultMessage: Paste
 msgid "Paste"
 msgstr "Coller"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: undefined
 msgid "Paste blocks"
 msgstr ""
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Permissions have been updated successfully
 msgid "Permissions have been updated successfully"
 msgstr ""
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Permissions updated
 msgid "Permissions updated"
 msgstr ""
 
 #: components/manage/Preferences/PersonalInformation
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Personal Information
 msgid "Personal Information"
 msgstr "Informations personnelles"
 
 #: components/manage/Preferences/PersonalPreferences
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Personal Preferences
 msgid "Personal Preferences"
 msgstr "Préférences personnelles"
 
 #: components/manage/Toolbar/More
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Personal tools
 msgid "Personal tools"
 msgstr "Outils personnelles"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Persons responsible for creating the content of this item. Please enter a list of user names, one per line. The principal creator should come first.
 msgid "Persons responsible for creating the content of this item. Please enter a list of user names, one per line. The principal creator should come first."
 msgstr "Personnes responsables de la création du contenu de cet article. Veuillez entrer une liste de noms d'utilisateurs, un par ligne. Le créateur principal doit venir en premier."
 
 #: components/manage/Blocks/Video/Edit
+# defaultMessage: Please enter a valid URL by deleting the block and adding a new video block.
 msgid "Please enter a valid URL by deleting the block and adding a new video block."
 msgstr "Veuillez saisir une URL valide en supprimant le bloc et en ajoutant un nouveau bloc vidéo."
 
 #: components/manage/Blocks/Maps/Edit
+# defaultMessage: Please enter the Embed Code provided by Google Maps -> Share -> Embed map. It should contain the <iframe> code on it.
 msgid "Please enter the Embed Code provided by Google Maps -> Share -> Embed map. It should contain the <iframe> code on it."
 msgstr "Veuillez saisir le code d'intégration fourni par Google Maps -> Partager -> Intégrer une carte. Il doit contenir le code <iframe> dessus."
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Please fill out the form below to set your password.
 msgid "Please fill out the form below to set your password."
 msgstr "Veuillez remplir le formulaire ci-dessous pour définir votre mot de passe."
 
 #: components/theme/Footer/Footer
+# defaultMessage: Plone Foundation
 msgid "Plone Foundation"
 msgstr "Fondation Plone"
 
 #: components/theme/Logo/Logo
+# defaultMessage: Plone Site
 msgid "Plone Site"
 msgstr "Site Plone"
 
 #: components/theme/Footer/Footer
+# defaultMessage: Plone{reg} Open Source CMS/WCM
 msgid "Plone{reg} Open Source CMS/WCM"
 msgstr "Plone{reg} Open Source CMS/WCM"
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: Portrait
 msgid "Portrait"
 msgstr "Portrait"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Possible values (Enter allowed choices one per line).
 msgid "Possible values"
 msgstr ""
 
 #: components/theme/Footer/Footer
+# defaultMessage: Powered by Plone & Python
 msgid "Powered by Plone & Python"
 msgstr "Alimenté par Plone & Python"
 
 #: components/manage/Toolbar/PersonalTools
+# defaultMessage: Preferences
 msgid "Preferences"
 msgstr "Préférences"
 
 #: components/manage/Blocks/HTML/Edit
+# defaultMessage: Prettify your code
 msgid "Prettify your code"
 msgstr ""
 
 #: components/manage/Blocks/HTML/Edit
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Preview
 msgid "Preview"
 msgstr "Aperçu"
 
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Preview Image URL
 msgid "Preview Image URL"
 msgstr ""
 
 #: components/manage/Toolbar/PersonalTools
+# defaultMessage: Profile
 msgid "Profile"
 msgstr "Profile"
 
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Properties
 msgid "Properties"
 msgstr "Propriétés"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Publication date
 msgid "Publication date"
 msgstr "Date de publication"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Publishing Date
 msgid "Publishing Date"
 msgstr "Date de publication"
 
 #: components/manage/Blocks/Listing/schema
+# defaultMessage: Query
 msgid "Query"
 msgstr ""
 
 #: components/manage/Preferences/ChangePassword
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Re-enter the password. Make sure the passwords are identical.
 msgid "Re-enter the password. Make sure the passwords are identical."
 msgstr "Entrez à nouveau le mot de passe. Assurez-vous que les mots de passe sont identiques."
 
 #: components/theme/Search/Search
 #: components/theme/View/SummaryView
+# defaultMessage: Read More…
 msgid "Read More…"
 msgstr "Lire la suite..."
 
 #: components/manage/Contents/Contents
+# defaultMessage: Rearrange items by…
 msgid "Rearrange items by…"
 msgstr "Réorganiser les éléments par…"
 
 #: components/manage/Widgets/RecurrenceWidget/EndField
+# defaultMessage: Ends
 msgid "Recurrence ends"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/EndField
+# defaultMessage: after
 msgid "Recurrence ends after"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/EndField
+# defaultMessage: on
 msgid "Recurrence ends on"
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Minimalistic table design
 msgid "Reduce complexity"
 msgstr "Réduisez la complexité"
 
 #: components/theme/Anontools/Anontools
 #: components/theme/Login/Login
 #: components/theme/Register/Register
+# defaultMessage: Register
 msgid "Register"
 msgstr "S'enregistrer"
 
 #: components/theme/Register/Register
+# defaultMessage: Registration form
 msgid "Registration form"
 msgstr "Formulaire d'enregistrement"
 
 #: components/theme/Search/Search
+# defaultMessage: Relevance
 msgid "Relevance"
 msgstr ""
 
 #: components/manage/Widgets/ObjectListWidget
+# defaultMessage: Remove item
 msgid "Remove item"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Remove
 msgid "Remove recurrence"
 msgstr ""
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Remove term
 msgid "Remove term"
 msgstr ""
 
 #: components/manage/Toolbar/More
+# defaultMessage: Remove working copy
 msgid "Remove working copy"
 msgstr ""
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
+# defaultMessage: Rename
 msgid "Rename"
 msgstr "Renomer"
 
 #: components/manage/Contents/ContentsRenameModal
+# defaultMessage: Renaming items...
 msgid "Rename Items Loading Message"
 msgstr ""
 
 #: components/manage/Contents/ContentsRenameModal
+# defaultMessage: Rename items
 msgid "Rename items"
 msgstr "Renommer les éléments"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Repeat
 msgid "Repeat"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Repeat every
 msgid "Repeat every"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Repeat on
 msgid "Repeat on"
 msgstr ""
 
 #: components/manage/Widgets/FileWidget
+# defaultMessage: Replace existing file
 msgid "Replace existing file"
 msgstr ""
 
 #: components/theme/Comments/Comments
+# defaultMessage: Reply
 msgid "Reply"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/WysiwygWidget
+# defaultMessage: Required
 msgid "Required"
 msgstr "Obligatoire"
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Required input is missing.
 msgid "Required input is missing."
 msgstr "Un champ obligatoire est manquant"
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Reset title
 msgid "Reset term title"
 msgstr ""
 
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: Results limit
 msgid "Results limit"
 msgstr "Limiter les résultats"
 
 #: components/manage/Blocks/Listing/Edit
+# defaultMessage: Results preview
 msgid "Results preview"
 msgstr "Aperçu des résultats"
 
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: Reversed order
 msgid "Reversed order"
 msgstr "Ordre inversé"
 
 #: components/manage/History/History
+# defaultMessage: Revert to this revision
 msgid "Revert to this revision"
 msgstr "Revenir à cette révision"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Review state
 msgid "Review state"
 msgstr "Etat de révision"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Richtext
 msgid "Richtext"
 msgstr "Texte riche"
 
 #: components/manage/Blocks/Image/ImageSizeWidget
 #: components/manage/Blocks/Maps/Edit
 #: components/manage/Sidebar/AlignBlock
+# defaultMessage: Right
 msgid "Right"
 msgstr "Droit"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Rights
 msgid "Rights"
 msgstr "Droits"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Roles
 msgid "Roles"
 msgstr "Rôles"
 
 #: components/manage/Contents/ContentsBreadcrumbs
+# defaultMessage: Root
 msgid "Root"
 msgstr ""
 
@@ -1647,90 +2007,112 @@ msgstr ""
 #: components/manage/Form/ModalForm
 #: components/manage/Sharing/Sharing
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Save
 msgid "Save"
 msgstr "Sauvegarder"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Save
 msgid "Save recurrence"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypesActions
+# defaultMessage: Schema
 msgid "Schema"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypeSchema
+# defaultMessage: Schema updates
 msgid "Schema updates"
 msgstr ""
 
 #: components/theme/SearchWidget/SearchWidget
+# defaultMessage: Search
 msgid "Search"
 msgstr "Recherche"
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: Search SVG
 msgid "Search SVG"
 msgstr ""
 
 #: components/theme/SearchWidget/SearchWidget
+# defaultMessage: Search Site
 msgid "Search Site"
 msgstr "Site de recherche"
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: Search content
 msgid "Search content"
 msgstr "Recherche de contenu"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Search for user or group
 msgid "Search for user or group"
 msgstr "Recherche d'un utilisateur ou un groupe"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Search group…
 msgid "Search group…"
 msgstr ""
 
 #: components/theme/Search/Search
+# defaultMessage: Search results
 msgid "Search results"
 msgstr "Résultats de recherche"
 
 #: components/theme/Search/Search
+# defaultMessage: Search results for {term}
 msgid "Search results for {term}"
 msgstr "Résultats de recherche pour {term}"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Search users…
 msgid "Search users…"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: Second
 msgid "Second"
 msgstr ""
 
 #: components/manage/Sidebar/ObjectBrowserNav
+# defaultMessage: Select
 msgid "Select"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Select a date to add to recurrence
 msgid "Select a date to add to recurrence"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Select columns to show
 msgid "Select columns to show"
 msgstr "Sélectionnez les colonnes à afficher"
 
 #: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Select the transition to be used for modifying the items state.
 msgid "Select the transition to be used for modifying the items state."
 msgstr "Sélectionnez la transition à utiliser pour modifier l'état des éléments."
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: Selected dates
 msgid "Selected dates"
 msgstr ""
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: Selected items
 msgid "Selected items"
 msgstr "Éléments sélectionnés"
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: of
 msgid "Selected items - x of y"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Selection
 msgid "Selection"
 msgstr "Sélection"
 
@@ -1738,158 +2120,195 @@ msgstr "Sélection"
 #: components/manage/Widgets/ArrayWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/TokenWidget
+# defaultMessage: Select…
 msgid "Select…"
 msgstr "Sélectionner..."
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Send
 msgid "Send"
 msgstr "Envoyer"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Set my password
 msgid "Set my password"
 msgstr "Définir mon mot de passe"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Set your password
 msgid "Set your password"
 msgstr "Définir votre mot de passe"
 
 #: components/manage/Sidebar/Sidebar
+# defaultMessage: Settings
 msgid "Settings"
 msgstr ""
 
 #: components/manage/Sharing/Sharing
 #: components/manage/Toolbar/More
+# defaultMessage: Sharing
 msgid "Sharing"
 msgstr "Partager"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Sharing for {title}
 msgid "Sharing for {title}"
 msgstr "Partage pour {title}"
 
 #: components/manage/Widgets/SchemaWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/WysiwygWidget
+# defaultMessage: Short Name
 msgid "Short Name"
 msgstr "Nom court"
 
 #: components/manage/Contents/ContentsRenameModal
+# defaultMessage: Short name
 msgid "Short name"
 msgstr "Nom court"
 
 #: components/theme/Pagination/Pagination
+# defaultMessage: Show
 msgid "Show"
 msgstr "Voir"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Show All
 msgid "Show All"
 msgstr ""
 
 #: components/theme/Comments/Comments
+# defaultMessage: Show Replies
 msgid "Show Replies"
 msgstr ""
 
 #: components/manage/Widgets/ObjectListWidget
+# defaultMessage: Show item
 msgid "Show item"
 msgstr ""
 
 #: components/manage/Sidebar/Sidebar
+# defaultMessage: Shrink sidebar
 msgid "Shrink sidebar"
 msgstr "Rétrécir la barre latérale"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Shrink toolbar
 msgid "Shrink toolbar"
 msgstr "Réduire la barre d'outils"
 
 #: components/theme/Login/Login
+# defaultMessage: Sign in to start session
 msgid "Sign in to start session"
 msgstr "Connectez-vous pour démarrer la session"
 
 #: components/theme/Logo/Logo
+# defaultMessage: Site
 msgid "Site"
 msgstr "Site"
 
 #: components/theme/NotFound/NotFound
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: Site Administration
 msgid "Site Administration"
 msgstr "Administration du site"
 
 #: components/theme/Footer/Footer
+# defaultMessage: Site Map
 msgid "Site Map"
 msgstr "Plan du site"
 
 #: components/manage/Controlpanels/Controlpanels
 #: components/manage/Toolbar/PersonalTools
+# defaultMessage: Site Setup
 msgid "Site Setup"
 msgstr "Configuration du site"
 
 #: components/theme/Sitemap/Sitemap
+# defaultMessage: Sitemap
 msgid "Sitemap"
 msgstr "Plan du site"
 
 #: components/manage/Blocks/Image/ImageSidebar
+# defaultMessage: Size
 msgid "Size"
 msgstr "Taille"
 
 #: components/theme/View/ImageView
+# defaultMessage: Size: {size}
 msgid "Size: {size}"
 msgstr "Taille : {size}"
 
 #: error
+# defaultMessage: Sorry, something went wrong with your request
 msgid "Sorry, something went wrong with your request"
 msgstr "Désolé, quelque chose s'est mal passé avec votre demande"
 
 #: components/theme/Search/Search
+# defaultMessage: Sort by:
 msgid "Sort By:"
 msgstr ""
 
 #: components/manage/Widgets/QuerySortOnWidget
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: Sort on
 msgid "Sort on"
 msgstr "Trier sur"
 
 #: components/manage/Blocks/HTML/Edit
+# defaultMessage: Source
 msgid "Source"
 msgstr "Source"
 
 #: components/manage/Blocks/Video/Edit
+# defaultMessage: Specify a youtube video or playlist url
 msgid "Specify a youtube video or playlist url"
 msgstr "Spécifiez une URL de vidéo ou de playlist YouTube"
 
 #: components/manage/Diff/Diff
+# defaultMessage: Split
 msgid "Split"
 msgstr "Divisé"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Start Date
 msgid "Start Date"
 msgstr "Date de début"
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: Start of the recurrence
 msgid "Start of the recurrence"
 msgstr ""
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Start password reset
 msgid "Start password reset"
 msgstr "Lancer la réinitialisation du mot de passe"
 
 #: components/manage/Contents/Contents
 #: components/manage/Workflow/Workflow
 #: components/theme/View/TabularView
+# defaultMessage: State
 msgid "State"
 msgstr "Etat"
 
 #: components/manage/Multilingual/CompareLanguages
+# defaultMessage: Stop compare
 msgid "Stop compare"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: String
 msgid "String"
 msgstr "Chaîne"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Alternate row background color
 msgid "Stripe alternate rows with color"
 msgstr "Rayez les rangées paires/impaires avec la couleur"
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Subject
 msgid "Subject"
 msgstr "Sujet"
 
@@ -1903,43 +2322,53 @@ msgstr "Sujet"
 #: components/manage/Preferences/PersonalPreferences
 #: components/theme/ContactForm/ContactForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Success
 msgid "Success"
 msgstr "Succès"
 
 #: components/theme/LanguageSelector/LanguageSelector
+# defaultMessage: Switch to
 msgid "Switch to"
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Table
 msgid "Table"
 msgstr "Table"
 
 #: components/manage/Blocks/ToC/View
+# defaultMessage: Table of Contents
 msgid "Table of Contents"
 msgstr "Table des matières"
 
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsTagsModal
+# defaultMessage: Tags
 msgid "Tags"
 msgstr "Mots clés"
 
 #: components/manage/Contents/ContentsTagsModal
+# defaultMessage: Tags to add
 msgid "Tags to add"
 msgstr "Mots clés à ajouter"
 
 #: components/manage/Contents/ContentsTagsModal
+# defaultMessage: Tags to remove
 msgid "Tags to remove"
 msgstr "Mots clés à supprimer"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Target memory size per cache in bytes
 msgid "Target memory size per cache in bytes"
 msgstr "Taille de la mémoire par cache en octets"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Target number of objects in memory per cache
 msgid "Target number of objects in memory per cache"
 msgstr "Nombre d'objets en mémoire par cache"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Text
 msgid "Text"
 msgstr "Texte"
 
@@ -1947,87 +2376,108 @@ msgstr "Texte"
 #: components/theme/CorsError/CorsError
 #: components/theme/NotFound/NotFound
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: Thank you.
 msgid "Thank you."
 msgstr "Merci."
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: The Database Manager allow you to view database status information
 msgid "The Database Manager allow you to view database status information"
 msgstr "Le gestionnaire de base de données vous permet d'afficher les informations d'état de la base de données"
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: The URL for your external home page, if you have one.
 msgid "The URL for your external home page, if you have one."
 msgstr "L'URL de votre page d'accueil externe, si vous en avez une."
 
 #: components/theme/ConnectionRefused/ConnectionRefused
+# defaultMessage: The backend is not responding, please check if you have started Plone, check your project's configuration object apiPath (or if you are using the internal proxy, devProxyToApiPath) or the RAZZLE_API_PATH Volto's environment variable.
 msgid "The backend is not responding, please check if you have started Plone, check your project's configuration object apiPath (or if you are using the internal proxy, devProxyToApiPath) or the RAZZLE_API_PATH Volto's environment variable."
 msgstr "Le backend ne répond pas, veuillez vérifier si vous avez démarré Plone, vérifiez l'objet de configuration de votre projet apiPath (ou si vous utilisez le proxy interne, devProxyToApiPath) ou la variable d'environnement RAZZLE_API_ PATH de Volto."
 
 #: components/theme/CorsError/CorsError
+# defaultMessage: The backend is responding, but the CORS headers are not configured properly and the browser has denied the access to the backend resources.
 msgid "The backend is responding, but the CORS headers are not configured properly and the browser has denied the access to the backend resources."
 msgstr "Le backend répond, mais les en-têtes CORS ne sont pas configurés correctement et le navigateur a refusé l'accès aux ressources du backend."
 
 #: components/theme/CorsError/CorsError
+# defaultMessage: The backend server of your website is not anwering, we apologize for the inconvenience. Please try to re-load the page and try again. If the problem persists please contact the site administrators.
 msgid "The backend server of your website is not anwering, we apologize for the inconvenience. Please try to re-load the page and try again. If the problem persists please contact the site administrators."
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: The item could not be deleted.
 msgid "The item could not be deleted."
 msgstr ""
 
 #: components/theme/Register/Register
+# defaultMessage: The registration process has been successful. Please check your e-mail inbox for information on how activate your account.
 msgid "The registration process has been successful. Please check your e-mail inbox for information on how activate your account."
 msgstr "Le processus d'inscription a réussi. Veuillez vérifier votre boîte e-mail pour savoir comment activer votre compte."
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: The user portrait/avatar
 msgid "The user portrait/avatar"
 msgstr "Portrait / avatar de l'utilisateur"
 
 #: components/manage/Toolbar/More
+# defaultMessage: The working copy was discarded
 msgid "The working copy was discarded"
 msgstr ""
 
 #: components/theme/Footer/Footer
+# defaultMessage: The {plonecms} is {copyright} 2000-{current_year} by the {plonefoundation} and friends.
 msgid "The {plonecms} is {copyright} 2000-{current_year} by the {plonefoundation} and friends."
 msgstr "Le {plonecms} est {copyright} 2000-{current_year} par la {plonefoundation} et ses amis."
 
 #: components/theme/CorsError/CorsError
+# defaultMessage: There is a configuration problem on the backend
 msgid "There is a configuration problem on the backend"
 msgstr "Il y a un problème de configuration sur le backend"
 
 #: components/manage/Form/InlineForm
+# defaultMessage: There were some errors
 msgid "There were some errors"
 msgstr "Il y a eu quelques erreurs"
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: There were some errors.
 msgid "There were some errors."
 msgstr "Il y a eu quelques erreurs."
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: Third
 msgid "Third"
 msgstr ""
 
 #: components/manage/WorkingCopyToastsFactory/WorkingCopyToastsFactory
+# defaultMessage: This has an ongoing working copy in {title}
 msgid "This has an ongoing working copy in {title}"
 msgstr ""
 
 #: components/manage/WorkingCopyToastsFactory/WorkingCopyToastsFactory
+# defaultMessage: This is a working copy of {title}
 msgid "This is a working copy of {title}"
 msgstr ""
 
 #: components/manage/LockingToastsFactory/LockingToastsFactory
+# defaultMessage: This item was locked by {creator} on {date}
 msgid "This item was locked by {creator} on {date}"
 msgstr ""
 
 #: components/manage/Contents/ContentsRenameModal
+# defaultMessage: This name will be displayed in the URL.
 msgid "This name will be displayed in the URL."
 msgstr "Ce nom sera affiché dans l'URL."
 
 #: components/theme/NotFound/NotFound
+# defaultMessage: This page does not seem to exist…
 msgid "This page does not seem to exist…"
 msgstr "Cette page ne semble pas exister…"
 
 #: components/manage/Widgets/DatetimeWidget
+# defaultMessage: Time
 msgid "Time"
 msgstr "Temps"
 
@@ -2040,714 +2490,889 @@ msgstr "Temps"
 #: components/manage/Widgets/WysiwygWidget
 #: components/theme/View/TabularView
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Title
 msgid "Title"
 msgstr "Titre"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Total active and non-active objects
 msgid "Total active and non-active objects"
 msgstr "Total des objets actifs et non actifs"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Total comments
 msgid "Total comments"
 msgstr "Nombre de commentaires"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Total number of objects in each cache
 msgid "Total number of objects in each cache"
 msgstr "Nombre total d'objets dans chaque cache"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Total number of objects in memory from all caches
 msgid "Total number of objects in memory from all caches"
 msgstr "Nombre total d'objets en mémoire de tous les caches"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Total number of objects in the database
 msgid "Total number of objects in the database"
 msgstr "Nombre total d'objets dans la base de données"
 
 #: components/manage/Add/Add
 #: components/manage/Toolbar/Types
+# defaultMessage: Translate to {lang}
 msgid "Translate to {lang}"
 msgstr "Traduire en {lang}"
 
 #: components/manage/Multilingual/ManageTranslations
+# defaultMessage: Translation linked
 msgid "Translation linked"
 msgstr ""
 
 #: components/manage/Multilingual/ManageTranslations
+# defaultMessage: Translation linking removed
 msgid "Translation linking removed"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypes
 #: components/manage/Widgets/SchemaWidget
 #: components/theme/View/TabularView
+# defaultMessage: Type
 msgid "Type"
 msgstr "Type"
 
 #: components/manage/Blocks/Video/Edit
+# defaultMessage: Type a Video (YouTube, Vimeo or mp4) URL
 msgid "Type a Video (YouTube, Vimeo or mp4) URL"
 msgstr "Saisissez une URL de vidéo (YouTube, Vimeo ou mp4)"
 
 #: components/manage/Blocks/Text/Edit
+# defaultMessage: Type text…
 msgid "Type text…"
 msgstr "Saisissez du texte…"
 
 #: components/manage/Blocks/Title/Edit
+# defaultMessage: Type the title…
 msgid "Type the title…"
 msgstr "Tapez le titre…"
 
 #: components/manage/Contents/Contents
+# defaultMessage: UID
 msgid "UID"
 msgstr "UID"
 
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: Unauthorized
 msgid "Unauthorized"
 msgstr "Non autorisé"
 
 #: components/manage/BlockChooser/BlockChooser
+# defaultMessage: Unfold
 msgid "Unfold"
 msgstr ""
 
 #: components/manage/Diff/Diff
+# defaultMessage: Unified
 msgid "Unified"
 msgstr "Unifié"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Uninstall
 msgid "Uninstall"
 msgstr "Désinstaller"
 
 #: components/manage/Blocks/Block/Edit
 #: components/theme/View/DefaultView
 #: components/theme/View/RenderBlocks
+# defaultMessage: Unknown Block {block}
 msgid "Unknown Block"
 msgstr "Bloc inconnu"
 
 #: components/manage/Multilingual/ManageTranslations
+# defaultMessage: Unlink translation for
 msgid "Unlink translation for"
 msgstr ""
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Unlock
 msgid "Unlock"
 msgstr ""
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Update
 msgid "Update"
 msgstr "Mise à jour"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Update installed addons
 msgid "Update installed addons"
 msgstr "Mettre à jour les modules installés"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Update installed addons:
 msgid "Update installed addons:"
 msgstr "Mettre à jour les modules installés :"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Updates available
 msgid "Updates available"
 msgstr "Mises à jour disponibles"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Upload
 msgid "Upload"
 msgstr "Téléchargé"
 
 #: components/manage/Blocks/LeadImage/Edit
+# defaultMessage: Upload a lead image in the 'Lead Image' content field.
 msgid "Upload a lead image in the 'Lead Image' content field."
 msgstr "Téléchargez une image de garde dans le champ «Image de garde»."
 
 #: components/manage/Blocks/HeroImageLeft/Edit
+# defaultMessage: Upload a new image
 msgid "Upload a new image"
 msgstr ""
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Upload files
 msgid "Upload files"
 msgstr "Télécharger des fichiers"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Uploading files
 msgid "Uploading files"
 msgstr "Téléchargement de fichiers"
 
 #: components/manage/Blocks/HeroImageLeft/Edit
+# defaultMessage: Uploading image
 msgid "Uploading image"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/WysiwygWidget
+# defaultMessage: Used for programmatic access to the fieldset.
 msgid "Used for programmatic access to the fieldset."
 msgstr "Utilisé pour l'accès programmatique au groupe de champs."
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: User
 msgid "User"
 msgstr "Utilisateur"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: User created
 msgid "User created"
 msgstr "Utilisateur créé"
 
 #: components/manage/Controlpanels/Users/UsersControlpanel
+# defaultMessage: User name
 msgid "User name"
 msgstr "Nom d'utilisateur"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: User roles updated
 msgid "User roles updated"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Username
 msgid "Username"
 msgstr "Nom d'utilisateur"
 
 #: components/manage/Controlpanels/Controlpanels
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Users
 msgid "Users"
 msgstr "Utilisateurs"
 
 #: components/manage/Controlpanels/Controlpanels
+# defaultMessage: Users and Groups
 msgid "Users and Groups"
 msgstr "Utilisateurs et groupes"
 
 #: helpers/Extensions/withBlockSchemaEnhancer
+# defaultMessage: Variation
 msgid "Variation"
 msgstr ""
 
 #: components/manage/Controlpanels/Controlpanels
+# defaultMessage: Version Overview
 msgid "Version Overview"
 msgstr "Présentation de la version"
 
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Video
 msgid "Video"
 msgstr "Vidéo"
 
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Video URL
 msgid "Video URL"
 msgstr "URL de la vidéo"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: View
 msgid "View"
 msgstr "Vue"
 
 #: components/manage/History/History
+# defaultMessage: View changes
 msgid "View changes"
 msgstr "Voir les changements"
 
 #: components/manage/History/History
+# defaultMessage: View this revision
 msgid "View this revision"
 msgstr "Voir cette révision"
 
 #: components/manage/Toolbar/More
+# defaultMessage: View working copy
 msgid "View working copy"
 msgstr ""
 
 #: components/manage/Display/Display
+# defaultMessage: View
 msgid "Viewmode"
 msgstr "Mode d'affichage"
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Vocabulary term
 msgid "Vocabulary term"
 msgstr ""
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Title
 msgid "Vocabulary term title"
 msgstr ""
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Vocabulary terms
 msgid "Vocabulary terms"
 msgstr ""
 
 #: components/manage/Controlpanels/VersionOverview
+# defaultMessage: You are running in 'debug mode'. This mode is intended for sites that are under development. This allows many configuration changes to be immediately visible, but will make your site run more slowly. To turn off debug mode, stop the server, set 'debug-mode=off' in your buildout.cfg, re-run bin/buildout and then restart the server process.
 msgid "Warning Regarding debug mode"
 msgstr "Avertissement concernant le mode de débogage"
 
 #: components/theme/ConnectionRefused/ConnectionRefused
+# defaultMessage: We apologize for the inconvenience, but the backend of the site you are accessing is not available right now. Please, try again later.
 msgid "We apologize for the inconvenience, but the backend of the site you are accessing is not available right now. Please, try again later."
 msgstr "Nous nous excusons pour la gêne occasionnée, mais le backend du site auquel vous accédez n'est pas disponible pour le moment. Veuillez réessayer plus tard."
 
 #: components/theme/NotFound/NotFound
+# defaultMessage: We apologize for the inconvenience, but the page you were trying to access is not at this address. You can use the links below to help you find what you are looking for.
 msgid "We apologize for the inconvenience, but the page you were trying to access is not at this address. You can use the links below to help you find what you are looking for."
 msgstr "Nous nous excusons pour la gêne occasionnée, mais la page à laquelle vous tentiez d'accéder n'est pas à cette adresse. Vous pouvez utiliser les liens ci-dessous pour vous aider à trouver ce que vous recherchez."
 
 #: components/theme/Forbidden/Forbidden
+# defaultMessage: We apologize for the inconvenience, but you don't have permissions on this resource.
 msgid "We apologize for the inconvenience, but you don't have permissions on this resource."
 msgstr "Nous nous excusons pour la gêne occasionnée, mais vous ne disposez pas des autorisations sur cette ressource."
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: We will use this address if you need to recover your password
 msgid "We will use this address if you need to recover your password"
 msgstr "Nous utiliserons cette adresse si vous avez besoin de récupérer votre mot de passe"
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: The
 msgid "Weeek day of month"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Weekday
 msgid "Weekday"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Weekly
 msgid "Weekly"
 msgstr ""
 
 #: components/manage/History/History
+# defaultMessage: What
 msgid "What"
 msgstr "Quoi"
 
 #: components/manage/History/History
+# defaultMessage: When
 msgid "When"
 msgstr "Quand"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: When this date is reached, the content will nolonger be visible in listings and searches.
 msgid "When this date is reached, the content will nolonger be visible in listings and searches."
 msgstr "Lorsque cette date est atteinte, le contenu ne sera plus visible dans les listes et les recherches."
 
 #: components/manage/History/History
+# defaultMessage: Who
 msgid "Who"
 msgstr "Qui"
 
 #: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Updating workflow states...
 msgid "Workflow Change Loading Message"
 msgstr ""
 
 #: components/manage/Workflow/Workflow
+# defaultMessage: Workflow updated.
 msgid "Workflow updated."
 msgstr "Workflow mis à jour."
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Yearly
 msgid "Yearly"
 msgstr ""
 
 #: components/manage/Contents/ContentsItem
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Yes
 msgid "Yes"
 msgstr "Oui"
 
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: You are trying to access a protected resource, please {login} first.
 msgid "You are trying to access a protected resource, please {login} first."
 msgstr "Vous essayez d'accéder à une ressource protégée, veuillez d'abord {login}."
 
 #: components/theme/OutdatedBrowser/OutdatedBrowser
+# defaultMessage: You are using an outdated browser
 msgid "You are using an outdated browser"
 msgstr "Vous utilisez un navigateur obsolète"
 
 #: components/theme/Comments/Comments
+# defaultMessage: You can add a comment by filling out the form below. Plain text formatting.
 msgid "You can add a comment by filling out the form below. Plain text formatting."
 msgstr "Vous pouvez ajouter un commentaire en remplissant le formulaire ci-dessous. Formatage de texte brut."
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: You can control who can view and edit your item using the list below.
 msgid "You can control who can view and edit your item using the list below."
 msgstr "Vous pouvez contrôler qui peut afficher et modifier votre élément à l'aide de la liste ci-dessous."
 
 #: components/manage/Diff/Diff
+# defaultMessage: You can view the difference of the revisions below.
 msgid "You can view the difference of the revisions below."
 msgstr "Vous pouvez voir la différence des révisions ci-dessous."
 
 #: components/manage/History/History
+# defaultMessage: You can view the history of your item below.
 msgid "You can view the history of your item below."
 msgstr "Vous pouvez consulter l'historique de votre élément ci-dessous."
 
 #: components/manage/Contents/Contents
+# defaultMessage: You can't paste this content here
 msgid "You can't paste this content here"
 msgstr ""
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Your email is required for reset your password.
 msgid "Your email is required for reset your password."
 msgstr "Votre e-mail est nécessaire pour réinitialiser votre mot de passe."
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: Your location - either city and country - or in a company setting, where your office is located.
 msgid "Your location - either city and country - or in a company setting, where your office is located."
 msgstr "L'emplacement, ville et pays, ou nom de l'entreprise, où se trouve votre bureau."
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Your password has been set successfully. You may now {link} with your new password.
 msgid "Your password has been set successfully. You may now {link} with your new password."
 msgstr "Votre mot de passe a été défini avec succès. Vous pouvez maintenant {link} avec votre nouveau mot de passe."
 
 #: components/manage/Preferences/PersonalPreferences
+# defaultMessage: Your preferred language
 msgid "Your preferred language"
 msgstr "Votre langue préférée"
 
 #: components/theme/Login/Login
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Forgot your password?
 msgid "box_forgot_password_option"
 msgstr "Mot de passe oublié"
 
 #: config/Blocks
+# defaultMessage: Common
 msgid "common"
 msgstr "commun"
 
 #: components/manage/Multilingual/CompareLanguages
+# defaultMessage: Compare to language
 msgid "compare_to"
 msgstr ""
 
 #: components/manage/Blocks/Block/EditBlockWrapper
+# defaultMessage: delete
 msgid "delete"
 msgstr "supprimer"
 
 #: components/theme/OutdatedBrowser/OutdatedBrowser
+# defaultMessage: You are using {browsername} {browserversion} which is deprecated by its vendor. That means that it does not get security updates and it is not ready for current modern web features, which deteriorates the user experience. Please upgrade to a modern browser.
 msgid "deprecated_browser_notice_message"
 msgstr "Votre navigateur est obslète"
 
 #: config/Blocks
+# defaultMessage: Description
 msgid "description"
 msgstr "description"
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: For security reasons, we store your password encrypted, and cannot mail it to you. If you would like to reset your password, fill out the form below and we will send you an email at the address you gave when you registered to start the process of resetting your password.
 msgid "description_lost_password"
 msgstr "Mot de passe perdu"
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Your password reset request has been mailed. It should arrive in your mailbox shortly. When you receive the message, visit the address it contains to reset your password.
 msgid "description_sent_password"
 msgstr "Mot de passe envoyé"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Draft
 msgid "draft"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Input must be valid email (something@domain.com)
 msgid "email"
 msgstr ""
 
 #: components/theme/View/EventView
+# defaultMessage: All dates
 msgid "event_alldates"
 msgstr "Toutes les dates"
 
 #: components/theme/View/EventView
+# defaultMessage: Attendees
 msgid "event_attendees"
 msgstr "Participants"
 
 #: components/theme/View/EventView
+# defaultMessage: Contact Name
 msgid "event_contactname"
 msgstr "Nom du contact"
 
 #: components/theme/View/EventView
+# defaultMessage: Contact Phone
 msgid "event_contactphone"
 msgstr "Téléphone du contact"
 
 #: components/theme/View/EventView
+# defaultMessage: Website
 msgid "event_website"
 msgstr "Site de l'événement"
 
 #: components/theme/View/EventView
+# defaultMessage: What
 msgid "event_what"
 msgstr "Quoi"
 
 #: components/theme/View/EventView
+# defaultMessage: When
 msgid "event_when"
 msgstr "Quand"
 
 #: components/theme/View/EventView
+# defaultMessage: Where
 msgid "event_where"
 msgstr "Où"
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Password reset confirmation sent
 msgid "heading_sent_password"
 msgstr ""
 
 #: config/Blocks
+# defaultMessage: Hero
 msgid "hero"
 msgstr "hero"
 
 #: config/Blocks
+# defaultMessage: HTML
 msgid "html"
 msgstr "html"
 
 #: config/Blocks
+# defaultMessage: Image
 msgid "image"
 msgstr "image"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Input must be integer
 msgid "integer"
 msgstr ""
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Intranet
 msgid "intranet"
 msgstr ""
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: My email address is
 msgid "label_my_email_address_is"
 msgstr "Mon adresse e-mail est"
 
 #: config/Blocks
+# defaultMessage: Lead Image Field
 msgid "leadimage"
 msgstr "image de garde"
 
 #: config/Blocks
+# defaultMessage: Listing
 msgid "listing"
 msgstr "listing"
 
 #: components/manage/Blocks/Listing/ListingBody
 #: components/manage/Contents/Contents
+# defaultMessage: Loading
 msgid "loading"
 msgstr ""
 
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: log in
 msgid "log in"
 msgstr "se connecter"
 
 #: config/Blocks
+# defaultMessage: Maps
 msgid "maps"
 msgstr "cartes"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Maximum Length
 msgid "maxLength"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: End of the range (including the value itself)
 msgid "maximum"
 msgstr ""
 
 #: config/Blocks
+# defaultMessage: Media
 msgid "media"
 msgstr "média"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Minimum Length
 msgid "minLength"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Start of the range
 msgid "minimum"
 msgstr ""
 
 #: config/Blocks
+# defaultMessage: Most used
 msgid "mostUsed"
 msgstr "souvent utilisé"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: No workflow state
 msgid "no workflow state"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Input must be number
 msgid "number"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/ByMonthDayField
 #: components/manage/Widgets/RecurrenceWidget/ByYearField
+# defaultMessage: of the month
 msgid "of the month"
 msgstr ""
 
 #: error
+# defaultMessage: or try a different page.
 msgid "or try a different page."
 msgstr "ou essayez une autre page."
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: others
 msgid "others"
 msgstr ""
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Private
 msgid "private"
 msgstr ""
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Published
 msgid "published"
 msgstr ""
 
 #: components/manage/Widgets/QueryWidget
+# defaultMessage: Select…
 msgid "querystring-widget-select"
 msgstr ""
 
 #: components/theme/Search/Search
+# defaultMessage: results
 msgid "results found"
 msgstr "résultats trouvés"
 
 #: error
+# defaultMessage: return to the site root
 msgid "return to the site root"
 msgstr "retour à la racine du site"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: and
 msgid "rrule_and"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: (~approximate)
 msgid "rrule_approximate"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: at
 msgid "rrule_at"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: [month] [day], [year]
 msgid "rrule_dateFormat"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: day
 msgid "rrule_day"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: days
 msgid "rrule_days"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: every
 msgid "rrule_every"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: for
 msgid "rrule_for"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: hour
 msgid "rrule_hour"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: hours
 msgid "rrule_hours"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: in
 msgid "rrule_in"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: last
 msgid "rrule_last"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: minutes
 msgid "rrule_minutes"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: month
 msgid "rrule_month"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: months
 msgid "rrule_months"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: nd
 msgid "rrule_nd"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: on
 msgid "rrule_on"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: on the
 msgid "rrule_on the"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: or
 msgid "rrule_or"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: rd
 msgid "rrule_rd"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: st
 msgid "rrule_st"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: th
 msgid "rrule_th"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: the
 msgid "rrule_the"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: time
 msgid "rrule_time"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: times
 msgid "rrule_times"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: until
 msgid "rrule_until"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: week
 msgid "rrule_week"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: weekday
 msgid "rrule_weekday"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: weekdays
 msgid "rrule_weekdays"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: weeks
 msgid "rrule_weeks"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: year
 msgid "rrule_year"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: years
 msgid "rrule_years"
 msgstr ""
 
 #: components/theme/SkipLinks/SkipLinks
+# defaultMessage: Skip to footer
 msgid "skiplink-footer"
 msgstr ""
 
 #: components/theme/SkipLinks/SkipLinks
+# defaultMessage: Skip to main content
 msgid "skiplink-main-content"
 msgstr ""
 
 #: components/theme/SkipLinks/SkipLinks
+# defaultMessage: Skip to navigation
 msgid "skiplink-navigation"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: sort
 msgid "sort"
 msgstr "trier"
 
 #: config/Blocks
+# defaultMessage: Table
 msgid "table"
 msgstr "table"
 
 #: config/Blocks
+# defaultMessage: Text
 msgid "text"
 msgstr "texte"
 
 #: config/Blocks
+# defaultMessage: Title
 msgid "title"
 msgstr "titre"
 
 #: config/Blocks
+# defaultMessage: Table of Contents
 msgid "toc"
 msgstr "toc"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Input must be valid url (www.something.com or http(s)://www.something.com)
 msgid "url"
 msgstr ""
 
 #: components/manage/Toolbar/PersonalTools
+# defaultMessage: user avatar
 msgid "user avatar"
 msgstr "Avatar de l'utilisateur"
 
 #: config/Blocks
+# defaultMessage: Video
 msgid "video"
 msgstr "vidéo"
 
 #: components/theme/View/EventView
+# defaultMessage: Visit external website
 msgid "visit_external_website"
 msgstr ""
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: {count, plural, one {Upload {count} file} other {Upload {count} files}}
 msgid "{count, plural, one {Upload {count} file} other {Upload {count} files}}"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: {count} selected
 msgid "{count} selected"
 msgstr "{count} sélectionné"
 
 #: components/manage/Controlpanels/ContentType
+# defaultMessage: {id} Content Type
 msgid "{id} Content Type"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypeSchema
+# defaultMessage: {id} Schema
 msgid "{id} Schema"
 msgstr ""
 
 #: components/manage/Actions/Actions
+# defaultMessage: {title} copied.
 msgid "{title} copied."
 msgstr "{title} copié."
 
 #: components/manage/Actions/Actions
+# defaultMessage: {title} cut.
 msgid "{title} cut."
 msgstr "{title} coupé."
 
 #: components/manage/Actions/Actions
+# defaultMessage: {title} has been deleted.
 msgid "{title} has been deleted."
 msgstr "{title} a été supprimé"

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -12,22 +12,27 @@ msgstr ""
 "Plural-Forms: \n"
 
 #: components/manage/Blocks/HTML/Edit
+# defaultMessage: <p>Add some HTML here</p>
 msgid "<p>Add some HTML here</p>"
 msgstr "<p>Aggiungi dell'HTML qui</p>"
 
 #: components/theme/Footer/Footer
+# defaultMessage: Accessibility
 msgid "Accessibility"
 msgstr "Accessibilità"
 
 #: components/theme/Register/Register
+# defaultMessage: Account Registration Completed
 msgid "Account Registration Completed"
 msgstr "Registrazione account completata"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Account activation completed
 msgid "Account activation completed"
 msgstr "Attivazione account completata"
 
 #: components/manage/Controlpanels/ModerateComments
+# defaultMessage: Action
 msgid "Action"
 msgstr "Azione"
 
@@ -36,10 +41,12 @@ msgstr "Azione"
 #: components/manage/Controlpanels/ContentTypes
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
+# defaultMessage: Actions
 msgid "Actions"
 msgstr "Azioni"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Activate and deactivate add-ons in the lists below.
 msgid "Activate and deactivate"
 msgstr "Attiva e disattiva"
 
@@ -47,86 +54,107 @@ msgstr "Attiva e disattiva"
 #: components/manage/Toolbar/Toolbar
 #: components/manage/Widgets/SchemaWidget
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add
 msgid "Add"
 msgstr "Aggiungi"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: To make new add-ons show up here, add them to your buildout configuration, run buildout, and restart the server process. For detailed instructions see
 msgid "Add Addons"
 msgstr "Aggiungi Add-ons"
 
 #: components/manage/Toolbar/Types
+# defaultMessage: Add Content…
 msgid "Add Content"
 msgstr "Aggiungi un contenuto"
 
 #: components/manage/Toolbar/Types
+# defaultMessage: Add Translation…
 msgid "Add Translation…"
 msgstr "Aggiungi traduzione…"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add User
 msgid "Add User"
 msgstr "Aggiungi un utente"
 
 #: components/manage/Blocks/Description/Edit
+# defaultMessage: Add a description…
 msgid "Add a description…"
 msgstr "Aggiungi una descrizione…"
 
 #: components/manage/BlockChooser/BlockChooserButton
+# defaultMessage: Add block
 msgid "Add block"
 msgstr "Aggiungi blocco"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add block…
 msgid "Add block…"
 msgstr "Aggiungi un blocco…"
 
 #: components/manage/Widgets/QueryWidget
+# defaultMessage: Add criteria
 msgid "Add criteria"
 msgstr "Aggiungi un criterio"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Add date
 msgid "Add date"
 msgstr "Aggiungi una data"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Add field
 msgid "Add field"
 msgstr "Aggiungi campo"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Add fieldset
 msgid "Add fieldset"
 msgstr "Aggiungi un nuovo insieme di campi"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add group
 msgid "Add group"
 msgstr "Aggiungi un gruppo"
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Add new content type
 msgid "Add new content type"
 msgstr "Aggiungi un nuovo tipo di contenuto"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add new group
 msgid "Add new group"
 msgstr "Aggiungi un nuovo gruppo"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add new user
 msgid "Add new user"
 msgstr "Aggiungi nuovo utente"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add to Groups
 msgid "Add to Groups"
 msgstr "Aggiungi ai gruppi"
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Add term
 msgid "Add vocabulary term"
 msgstr "Aggiungi termine"
 
 #: components/manage/Add/Add
+# defaultMessage: Add {type}
 msgid "Add {type}"
 msgstr "Aggiungi {type}"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Add-ons Settings
 msgid "Add-ons Settings"
 msgstr "Impostazioni Add-ons"
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: Additional date
 msgid "Additional date"
 msgstr "Data aggiuntiva"
 
@@ -134,39 +162,48 @@ msgstr "Data aggiuntiva"
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
 #: components/manage/Blocks/Maps/MapsSidebar
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Alignment
 msgid "Alignment"
 msgstr "Allineamento"
 
 #: components/manage/Contents/Contents
+# defaultMessage: All
 msgid "All"
 msgstr "Tutti"
 
 #: components/theme/Search/Search
+# defaultMessage: Alphabetically
 msgid "Alphabetically"
 msgstr "Alfabetico"
 
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: Alt text
 msgid "Alt text"
 msgstr "Testo alternativo"
 
 #: components/manage/Toolbar/More
+# defaultMessage: Apply working copy
 msgid "Apply working copy"
 msgstr "Applica la copia di lavoro"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Are you sure you want to delete this field?
 msgid "Are you sure you want to delete this field?"
 msgstr "Sicuro di voler eliminare questo campo?"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Are you sure you want to delete this fieldset including all fields?
 msgid "Are you sure you want to delete this fieldset including all fields?"
 msgstr "Sicuro di voler eliminare questo insieme di campi compresi tutti i campi contenuti?"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Ascending
 msgid "Ascending"
 msgstr "Crescente"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Available
 msgid "Available"
 msgstr "Disponibile"
 
@@ -191,48 +228,59 @@ msgstr "Disponibile"
 #: components/manage/Toolbar/Toolbar
 #: components/theme/ContactForm/ContactForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Back
 msgid "Back"
 msgstr "Indietro"
 
 #: components/manage/Diff/Diff
+# defaultMessage: Base
 msgid "Base"
 msgstr "Base"
 
 #: components/manage/Sidebar/Sidebar
+# defaultMessage: Block
 msgid "Block"
 msgstr "Blocco"
 
 #: components/theme/Login/Login
+# defaultMessage: Both email address and password are case sensitive, check that caps lock is not enabled.
 msgid "Both email address and password are case sensitive, check that caps lock is not enabled."
 msgstr "E-mail e password distinguono entrambi le maiuscole dalle minuscole, verifica di non avere il Blocco maiuscole attivato."
 
 #: components/theme/Breadcrumbs/Breadcrumbs
+# defaultMessage: Breadcrumbs
 msgid "Breadcrumbs"
 msgstr "Briciole di pane"
 
 #: components/manage/Blocks/HeroImageLeft/Edit
 #: components/manage/Contents/ContentsUploadModal
 #: components/manage/Sidebar/ObjectBrowserNav
+# defaultMessage: Browse
 msgid "Browse"
 msgstr "Sfoglia"
 
 #: components/manage/Blocks/Image/Edit
+# defaultMessage: Browse the site, drop an image, or type an URL
 msgid "Browse the site, drop an image, or type an URL"
 msgstr "Sfoglia i contenuti, rilascia un'immagine o digita un URL"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: By default, permissions from the container of this item are inherited. If you disable this, only the explicitly defined sharing permissions will be valid. In the overview, the symbol {inherited} indicates an inherited value. Similarly, the symbol {global} indicates a global role, which is managed by the site administrator.
 msgid "By default, permissions from the container of this item are inherited. If you disable this, only the explicitly defined sharing permissions will be valid. In the overview, the symbol {inherited} indicates an inherited value. Similarly, the symbol {global} indicates a global role, which is managed by the site administrator."
 msgstr "Di norma, i permessi di questo elemento vengono ereditati dal contenitore. Se disabiliti questa opzione, verranno considerati solo i permessi di condivisione definiti esplicitamente. Nel sommario, il simbolo {inherited} indica una impostazione ereditata. Analogamente, il simbolo {global} indica un ruolo globale, che è gestito dall'amministratore del sito"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Cache Name
 msgid "Cache Name"
 msgstr "Nome della cache"
 
 #: components/manage/Controlpanels/ContentTypeLayout
+# defaultMessage: Can not edit Layout for <strong>{type}</strong> content-type as it doesn't have support for <strong>Volto Blocks</strong> enabled
 msgid "Can not edit Layout for <strong>{type}</strong> content-type as it doesn't have support for <strong>Volto Blocks</strong> enabled"
 msgstr "Non è possibile modificare il Layout per il tipo <strong>{type}</strong> poichè non ha abilitato il supporto per i <strong>blocchi</strong>"
 
 #: components/manage/Controlpanels/ContentTypeLayout
+# defaultMessage: Can not edit Layout for <strong>{type}</strong> content-type as the <strong>Blocks behavior</strong> is enabled and <strong>read-only</strong>
 msgid "Can not edit Layout for <strong>{type}</strong> content-type as the <strong>Blocks behavior</strong> is enabled and <strong>read-only</strong>"
 msgstr "Non è possibile modificare il Layout per il tipo <strong>{type}</strong> poichè il <strong>Blocks behavior</strong> è abilitato ma in <strong>sola lettura</strong>"
 
@@ -248,42 +296,51 @@ msgstr "Non è possibile modificare il Layout per il tipo <strong>{type}</strong
 #: components/manage/Sharing/Sharing
 #: components/theme/Login/Login
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Cancel
 msgid "Cancel"
 msgstr "Annulla"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Cell
 msgid "Cell"
 msgstr "Cella"
 
 #: components/manage/Blocks/Image/ImageSizeWidget
 #: components/manage/Blocks/Maps/Edit
 #: components/manage/Sidebar/AlignBlock
+# defaultMessage: Center
 msgid "Center"
 msgstr "Centrato"
 
 #: components/manage/History/History
+# defaultMessage: Change Note
 msgid "Change Note"
 msgstr "Cambia Nota"
 
 #: components/manage/Preferences/ChangePassword
+# defaultMessage: Change Password
 msgid "Change Password"
 msgstr "Cambia Password"
 
 #: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Change State
 msgid "Change State"
 msgstr "Cambia Stato"
 
 #: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Change workflow state recursively
 msgid "Change workflow state recursively"
 msgstr "Cambia stato di workflow ricorsivamente"
 
 #: components/manage/Toolbar/More
+# defaultMessage: Changes applied
 msgid "Changes applied."
 msgstr "Modifiche applicate."
 
 #: components/manage/Preferences/ChangePassword
 #: components/manage/Preferences/PersonalInformation
 #: components/manage/Preferences/PersonalPreferences
+# defaultMessage: Changes saved
 msgid "Changes saved"
 msgstr "Modifiche salvate"
 
@@ -291,192 +348,237 @@ msgstr "Modifiche salvate"
 #: components/manage/Controlpanels/ContentTypeLayout
 #: components/manage/Controlpanels/ContentTypeSchema
 #: components/manage/Controlpanels/Controlpanel
+# defaultMessage: Changes saved.
 msgid "Changes saved."
 msgstr "Modifiche salvate."
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Checkbox
 msgid "Checkbox"
 msgstr "Checkbox"
 
 #: components/manage/Widgets/SelectWidget
+# defaultMessage: Choices
 msgid "Choices"
 msgstr "Scelta multipla"
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: Choose Image
 msgid "Choose Image"
 msgstr "Seleziona un'immagine"
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: Choose Target
 msgid "Choose Target"
 msgstr "Seleziona la destinazione"
 
 #: components/manage/Widgets/FileWidget
+# defaultMessage: Choose a file
 msgid "Choose a file"
 msgstr "Scegli un file"
 
 #: components/manage/Blocks/HTML/Edit
+# defaultMessage: Clear
 msgid "Clear"
 msgstr "Annulla"
 
 #: components/theme/View/ImageView
+# defaultMessage: Click to download full sized image
 msgid "Click to download full sized image"
 msgstr "Clicca per scaricare l'immagine in dimensione originale"
 
 #: components/manage/Widgets/SelectWidget
+# defaultMessage: Close
 msgid "Close"
 msgstr "Chiudi"
 
 #: components/theme/Navigation/Navigation
+# defaultMessage: Close menu
 msgid "Close menu"
 msgstr "Chiudi menu"
 
 #: components/manage/Blocks/HTML/Edit
+# defaultMessage: Code
 msgid "Code"
 msgstr "Codice"
 
 #: components/manage/Widgets/ObjectListWidget
+# defaultMessage: Collapse item
 msgid "Collapse item"
 msgstr "Collassa elemento"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Collection
 msgid "Collection"
 msgstr "Collezione"
 
 #: components/manage/Controlpanels/ModerateComments
 #: components/theme/Comments/CommentEditModal
 #: components/theme/Comments/Comments
+# defaultMessage: Comment
 msgid "Comment"
 msgstr "Commento"
 
 #: components/manage/Controlpanels/ModerateComments
+# defaultMessage: Commenter
 msgid "Commenter"
 msgstr "Autore"
 
 #: components/theme/Comments/Comments
+# defaultMessage: Comments
 msgid "Comments"
 msgstr "Commenti"
 
 #: components/manage/Diff/Diff
+# defaultMessage: Compare
 msgid "Compare"
 msgstr "Confronta"
 
 #: components/manage/Preferences/ChangePassword
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Confirm password
 msgid "Confirm password"
 msgstr "Conferma password"
 
 #: components/theme/ConnectionRefused/ConnectionRefused
+# defaultMessage: Connection refused
 msgid "Connection refused"
 msgstr "Connesione rifiutata"
 
 #: components/theme/Footer/Footer
+# defaultMessage: Contact
 msgid "Contact"
 msgstr "Contatti"
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Contact form
 msgid "Contact form"
 msgstr "Form di contatto"
 
 #: components/manage/Blocks/Listing/Edit
+# defaultMessage: Contained items
 msgid "Contained items"
 msgstr "Elementi contenuti"
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Content type created
 msgid "Content type created"
 msgstr "Il tipo di contenuto è stato creato"
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Content type deleted
 msgid "Content type deleted"
 msgstr "Il tipo di contenuto è stato eliminato"
 
 #: components/manage/Contents/Contents
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Contents
 msgid "Contents"
 msgstr "Contenuti"
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Copy
 msgid "Copy"
 msgstr "Copia"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: undefined
 msgid "Copy blocks"
 msgstr "Copia blocchi"
 
 #: components/theme/Footer/Footer
+# defaultMessage: Copyright
 msgid "Copyright"
 msgstr "Copyright"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Copyright statement or other rights information on this item.
 msgid "Copyright statement or other rights information on this item."
 msgstr "Informazioni sul copyright o su altri diritti dell'elemento."
 
 #: components/manage/Toolbar/More
+# defaultMessage: Create working copy
 msgid "Create working copy"
 msgstr "Crea copia di lavoro"
 
 #: components/manage/WorkingCopyToastsFactory/WorkingCopyToastsFactory
+# defaultMessage: Created by {creator} on {date}
 msgid "Created by {creator} on {date}"
 msgstr "Creato da {creator} il {date}"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Created on
 msgid "Created on"
 msgstr "Creato il"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Creator
 msgid "Creator"
 msgstr "Autore"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Creators
 msgid "Creators"
 msgstr "Autori"
 
 #: components/manage/Widgets/QuerystringWidget
 #: components/manage/Widgets/QueryWidget
+# defaultMessage: Criteria
 msgid "Criteria"
 msgstr "Criteri"
 
 #: components/manage/Preferences/ChangePassword
+# defaultMessage: Current password
 msgid "Current password"
 msgstr "Password corrente"
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Cut
 msgid "Cut"
 msgstr "Taglia"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: undefined
 msgid "Cut blocks"
 msgstr "Taglia blocchi"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Daily
 msgid "Daily"
 msgstr "Giornaliera"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Database Information
 msgid "Database Information"
 msgstr "Informazioni sul database"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Database Location
 msgid "Database Location"
 msgstr "Posizione del database"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Database Size
 msgid "Database Size"
 msgstr "Dimensione del database"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Database main
 msgid "Database main"
 msgstr "Database principale"
 
 #: components/manage/Controlpanels/ModerateComments
 #: components/manage/Widgets/DatetimeWidget
+# defaultMessage: Date
 msgid "Date"
 msgstr "Data"
 
 #: components/theme/Search/Search
+# defaultMessage: Date (newest first)
 msgid "Date (newest first)"
 msgstr "Data (prima i più recenti)"
 
@@ -496,6 +598,7 @@ msgstr "Data (prima i più recenti)"
 #: components/theme/PasswordReset/PasswordReset
 #: components/theme/PasswordReset/RequestPasswordReset
 #: components/theme/Register/Register
+# defaultMessage: Default
 msgid "Default"
 msgstr "Default"
 
@@ -510,38 +613,47 @@ msgstr "Default"
 #: components/manage/Widgets/ObjectBrowserWidget
 #: components/manage/Widgets/WysiwygWidget
 #: components/theme/Comments/Comments
+# defaultMessage: Delete
 msgid "Delete"
 msgstr "Elimina"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Delete Group
 msgid "Delete Group"
 msgstr "Elimina gruppo"
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Delete Type
 msgid "Delete Type"
 msgstr "Rimuovi tipo di contenuto"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Delete User
 msgid "Delete User"
 msgstr "Elimina utente"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: undefined
 msgid "Delete blocks"
 msgstr "Elimina blocchi"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Delete col
 msgid "Delete col"
 msgstr "Elimina colonna"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Delete row
 msgid "Delete row"
 msgstr "Elimina riga"
 
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: Depth
 msgid "Depth"
 msgstr "Profondità di ricerca"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Descending
 msgid "Descending"
 msgstr "Decrescente"
 
@@ -552,72 +664,89 @@ msgstr "Decrescente"
 #: components/manage/Widgets/WysiwygWidget
 #: components/theme/View/TabularView
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Description
 msgid "Description"
 msgstr "Descrizione"
 
 #: components/manage/Diff/Diff
+# defaultMessage: Diff
 msgid "Diff"
 msgstr "Diff"
 
 #: components/manage/Diff/Diff
+# defaultMessage: Difference between revision {one} and {two} of {title}
 msgid "Difference between revision {one} and {two} of {title}"
 msgstr "Differenze tra la revisione {one} e {two} di {title}"
 
 #: components/theme/Footer/Footer
+# defaultMessage: Distributed under the {license}.
 msgid "Distributed under the {license}."
 msgstr "Distribuito sotto {license}"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Add border to inner columns
 msgid "Divide each row into separate cells"
 msgstr "Dividi ogni fila in celle separate"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Do you really want to delete the following items?
 msgid "Do you really want to delete the following items?"
 msgstr "Vuoi veramente eliminare i seguenti elementi?"
 
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
+# defaultMessage: Do you really want to delete the group {groupname}?
 msgid "Do you really want to delete the group {groupname}?"
 msgstr "Vuoi veramente eliminare il gruppo {groupname}?"
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Do you really want to delete type {typename}?
 msgid "Do you really want to delete the type {typename}?"
 msgstr "Vuoi veramente eliminare il tipo di contenuto {typename}?"
 
 #: components/manage/Controlpanels/Users/UsersControlpanel
+# defaultMessage: Do you really want to delete the user {username}?
 msgid "Do you really want to delete the user {username}?"
 msgstr "Vuoi veramente eliminare l'utente {username}?"
 
 #: components/manage/Delete/Delete
+# defaultMessage: Do you really want to delete this item?
 msgid "Do you really want to delete this item?"
 msgstr "Vuoi veramente eliminare questo elemento?"
 
 #: components/manage/Multilingual/TranslationObject
 #: components/manage/Sidebar/Sidebar
+# defaultMessage: Document
 msgid "Document"
 msgstr "Pagina"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Drag and drop files from your computer onto this area or click the “Browse” button.
 msgid "Drag and drop files from your computer onto this area or click the “Browse” button."
 msgstr "Trascina in quest'area i file dal tuo computer o clicca su “Sfoglia”."
 
 #: components/manage/Widgets/FileWidget
+# defaultMessage: Drop file here to replace the existing file
 msgid "Drop file here to replace the existing file"
 msgstr "Rilascia un file qui per sostituire quello esistente"
 
 #: components/manage/Widgets/FileWidget
+# defaultMessage: Drop file here to upload a new file
 msgid "Drop file here to upload a new file"
 msgstr "Rilascia un file qui per caricare un nuovo file"
 
 #: components/manage/Widgets/FileWidget
+# defaultMessage: Drop files here ...
 msgid "Drop files here ..."
 msgstr "Rilascia file qui..."
 
 #: components/manage/Preferences/PersonalInformation
 #: components/theme/Register/Register
+# defaultMessage: E-mail
 msgid "E-mail"
 msgstr "E-mail"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: E-mail addresses do not match.
 msgid "E-mail addresses do not match."
 msgstr "Gli indirizzi e-mail non corrispondono"
 
@@ -628,93 +757,115 @@ msgstr "Gli indirizzi e-mail non corrispondono"
 #: components/manage/Widgets/FormFieldWrapper
 #: components/manage/Widgets/ObjectBrowserWidget
 #: components/theme/Comments/Comments
+# defaultMessage: Edit
 msgid "Edit"
 msgstr "Modifica"
 
 #: components/theme/Comments/CommentEditModal
+# defaultMessage: Edit comment
 msgid "Edit comment"
 msgstr "Modifica commento"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Edit field
 msgid "Edit field"
 msgstr "Modifica campo"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Edit fieldset
 msgid "Edit fieldset"
 msgstr "Modifica insieme di campi"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Edit recurrence
 msgid "Edit recurrence"
 msgstr "Modifica le regole"
 
 #: components/manage/Form/InlineForm
+# defaultMessage: Edit values
 msgid "Edit values"
 msgstr "Modifica i valori"
 
 #: components/manage/Edit/Edit
+# defaultMessage: Edit {title}
 msgid "Edit {title}"
 msgstr "Modifica {title}"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Email
 msgid "Email"
 msgstr "Email"
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Email sent
 msgid "Email sent"
 msgstr "Email inviata"
 
 #: components/manage/Blocks/Maps/Edit
+# defaultMessage: Embed code error, please follow the instructions and try again.
 msgid "Embed code error, please follow the instructions and try again."
 msgstr "Errore del codice incorporato, per favore segui le istruzioni e riprova."
 
 #: components/manage/Blocks/Maps/View
+# defaultMessage: Embeded Google Maps
 msgid "Embeded Google Maps"
 msgstr "Google Maps incorporata"
 
 #: components/manage/Widgets/ObjectListWidget
+# defaultMessage: Empty object list
 msgid "Empty object list"
 msgstr "Lista di oggetti vuota"
 
 #: components/manage/Controlpanels/ContentTypeLayout
+# defaultMessage: Enable editable Blocks
 msgid "Enable editable Blocks"
 msgstr "Abilita i blocchi editabili"
 
 #: components/manage/Contents/Contents
+# defaultMessage: End Date
 msgid "End Date"
 msgstr "Data di fine"
 
 #: components/manage/AnchorPlugin/components/LinkButton/AddLinkForm
+# defaultMessage: Enter URL or select an item
 msgid "Enter URL or select an item"
 msgstr "Inserisci un URL o seleziona un elemento"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Enter a username above to search or click 'Show All'
 msgid "Enter a username above to search or click 'Show All'"
 msgstr "Inserisci uno username da ricercare, oppure clicca su 'Vedi tutto'"
 
 #: components/theme/Register/Register
+# defaultMessage: Enter an email address. This will be your login name. We respect your privacy, and will not give the address away to any third parties or expose it anywhere.
 msgid "Enter an email address. This will be your login name. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr "Inserisci un indirizzo e-mail. Esso sarà il tuo nome utente. Rispettiamo la tua privacy: non daremo l'indirizzo a terzi, né verrà esposto nel portale."
 
 #: components/manage/Preferences/PersonalInformation
 #: components/theme/PasswordReset/PasswordReset
 #: components/theme/Register/Register
+# defaultMessage: Enter full name, e.g. John Smith.
 msgid "Enter full name, e.g. John Smith."
 msgstr "Inserisci il tuo nome completo, ad esempio Mario Rossi."
 
 #: components/manage/Blocks/Maps/Edit
+# defaultMessage: Enter map Embed Code
 msgid "Enter map Embed Code"
 msgstr "Inserisci il codice di incorporamento della mappa"
 
 #: components/manage/Preferences/ChangePassword
+# defaultMessage: Enter your current password.
 msgid "Enter your current password."
 msgstr "Inserisci la tua password attuale."
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Enter your email address for verification.
 msgid "Enter your email address for verification."
 msgstr "Inserisci la tua mail per verifica."
 
 #: components/manage/Preferences/ChangePassword
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Enter your new password. Minimum 5 characters.
 msgid "Enter your new password. Minimum 5 characters."
 msgstr "Inserisci la tua nuova password. Minimo 5 caratteri."
 
@@ -726,199 +877,245 @@ msgstr "Inserisci la tua nuova password. Minimo 5 caratteri."
 #: components/theme/ContactForm/ContactForm
 #: components/theme/Login/Login
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Error
 msgid "Error"
 msgstr "Errore"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Exclude from navigation
 msgid "Exclude from navigation"
 msgstr "Escludi dalla navigazione"
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: Exclude this occurence
 msgid "Exclude this occurence"
 msgstr "Escludi questa data"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Excluded from navigation
 msgid "Excluded from navigation"
 msgstr "Escluso dalla navigazione"
 
 #: components/manage/Sidebar/Sidebar
+# defaultMessage: Expand sidebar
 msgid "Expand sidebar"
 msgstr "Espandi la sidebar"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Expiration Date
 msgid "Expiration Date"
 msgstr "Data di scadenza"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Expiration date
 msgid "Expiration date"
 msgstr "Data di scadenza"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Expired
 msgid "Expired"
 msgstr "Scaduto"
 
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: External URL
 msgid "External URL"
 msgstr "URL esterno"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: File
 msgid "File"
 msgstr "File"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: File size
 msgid "File size"
 msgstr "Dimensione del file"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Filename
 msgid "Filename"
 msgstr "Nome del file"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Filter…
 msgid "Filter…"
 msgstr "Filtra…"
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: First
 msgid "First"
 msgstr "Primo"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Fixed width columns
 msgid "Fixed width table cells"
 msgstr "Celle della tabella a larghezza fissata"
 
 #: components/manage/BlockChooser/BlockChooser
+# defaultMessage: Fold
 msgid "Fold"
 msgstr "Chiudi"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Folder
 msgid "Folder"
 msgstr "Cartella"
 
 #: components/theme/Forbidden/Forbidden
+# defaultMessage: Forbidden
 msgid "Forbidden"
 msgstr "Proibito"
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: Fourth
 msgid "Fourth"
 msgstr "Quarto"
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: From
 msgid "From"
 msgstr "Da"
 
 #: components/manage/Blocks/Maps/Edit
 #: components/manage/Sidebar/AlignBlock
+# defaultMessage: Full
 msgid "Full"
 msgstr "A tutta larghezza"
 
 #: components/manage/Preferences/PersonalInformation
 #: components/theme/PasswordReset/PasswordReset
 #: components/theme/Register/Register
+# defaultMessage: Full Name
 msgid "Full Name"
 msgstr "Nome completo"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Fullname
 msgid "Fullname"
 msgstr "Nome completo"
 
 #: components/theme/Footer/Footer
+# defaultMessage: GNU GPL license
 msgid "GNU GPL license"
 msgstr "licenza GNU GPL"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Global role
 msgid "Global role"
 msgstr "Ruolo globale"
 
 #: components/manage/Blocks/Maps/Edit
+# defaultMessage: Google Maps Embedded Block
 msgid "Google Maps Embedded Block"
 msgstr "Blocco Google Maps incorporata"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Group
 msgid "Group"
 msgstr "Gruppo"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Group created
 msgid "Group created"
 msgstr "Gruppo creato"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Group roles updated
 msgid "Group roles updated"
 msgstr "Ruoli del gruppo aggiornati"
 
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Groupname
 msgid "Groupname"
 msgstr "Nome del gruppo"
 
 #: components/manage/Controlpanels/Controlpanels
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Groups
 msgid "Groups"
 msgstr "Gruppi"
 
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
+# defaultMessage: Groups are logical collections of users, such as departments and business units. Groups are not directly related to permissions on a global level, you normally use Roles for that - and let certain Groups have a particular role. The symbol{plone_svg}indicates a role inherited from membership in another group.
 msgid "Groups are logical collections of users, such as departments and business units. Groups are not directly related to permissions on a global level, you normally use Roles for that - and let certain Groups have a particular role. The symbol{plone_svg}indicates a role inherited from membership in another group."
 msgstr "I gruppi sono raggruppamenti di utenti, come dipartimenti e unità organizzative. I gruppi non sono direttamente collegati a permessi a livello globale, per quello usiamo i ruoli e applichiamo specifici ruoli a certi gruppi. Il simbolo {plong_svg} indica che un ruolo è ereditato dall'appartenenza ad un gruppo."
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Header cell
 msgid "Header cell"
 msgstr "Cella d'intestazione"
 
 #: components/theme/Comments/Comments
+# defaultMessage: Hide Replies
 msgid "Hide Replies"
 msgstr "Nascondi risposte"
 
 #: components/manage/History/History
 #: components/manage/Toolbar/More
+# defaultMessage: History
 msgid "History"
 msgstr "Cronologia"
 
 #: components/manage/History/History
+# defaultMessage: #
 msgid "History Version Number"
 msgstr "Numero di versione della cronologia"
 
 #: components/manage/History/History
+# defaultMessage: History of {title}
 msgid "History of {title}"
 msgstr "Cronologia di {title}"
 
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsBreadcrumbs
 #: components/theme/Breadcrumbs/Breadcrumbs
+# defaultMessage: Home
 msgid "Home"
 msgstr "Home"
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: Home page
 msgid "Home page"
 msgstr "Pagina personale"
 
 #: components/manage/Contents/Contents
+# defaultMessage: ID
 msgid "ID"
 msgstr "ID"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: If selected, this item will not appear in the navigation tree
 msgid "If selected, this item will not appear in the navigation tree"
 msgstr "Se attivi l'opzione, questo elemento non apparirà nell'albero di navigazione del sito."
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: If this date is in the future, the content will not show up in listings and searches until this date.
 msgid "If this date is in the future, the content will not show up in listings and searches until this date."
 msgstr "Se questa data è in futuro, il contenuto non verrà mostrato negli elenchi e nelle ricerche fino a questa data."
 
 #: components/manage/LockingToastsFactory/LockingToastsFactory
+# defaultMessage: If you are certain this user has abandoned the object, you may unlock the object. You will then be able to edit it.
 msgid "If you are certain this user has abandoned the object, you may unlock the object. You will then be able to edit it."
 msgstr ""
 
 #: components/theme/NotFound/NotFound
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: If you are certain you have the correct web address but are encountering an error, please contact the {site_admin}.
 msgid "If you are certain you have the correct web address but are encountering an error, please contact the {site_admin}."
 msgstr "Se sei sicuro di aver inserito l'indirizzo corretto ma ottieni comunque un errore, contatta l' {site_admin}."
 
 #: components/manage/Blocks/HeroImageLeft/Edit
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: Image
 msgid "Image"
 msgstr "Immagine"
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: Include this occurence
 msgid "Include this occurence"
 msgstr "Includi questa data"
 
@@ -926,142 +1123,176 @@ msgstr "Includi questa data"
 #: components/manage/Controlpanels/ContentTypeLayout
 #: components/manage/Controlpanels/ContentTypeSchema
 #: components/manage/Controlpanels/Controlpanel
+# defaultMessage: Info
 msgid "Info"
 msgstr "Info"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Inherit permissions from higher levels
 msgid "Inherit permissions from higher levels"
 msgstr "Eredita i permessi dai livelli superiori"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Inherited value
 msgid "Inherited value"
 msgstr "Valore ereditato"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Insert col after
 msgid "Insert col after"
 msgstr "Inserisci colonna dopo"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Insert col before
 msgid "Insert col before"
 msgstr "Inserisci colonna prima"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Insert row after
 msgid "Insert row after"
 msgstr "Inserisci riga sotto"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Insert row before
 msgid "Insert row before"
 msgstr "Inserisci riga sopra"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Install
 msgid "Install"
 msgstr "Installa"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Installed
 msgid "Installed"
 msgstr "Installato"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Installed version
 msgid "Installed version"
 msgstr "Versione installata"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: days
 msgid "Interval Daily"
 msgstr "giorni"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Month(s)
 msgid "Interval Monthly"
 msgstr "mesi"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: week(s)
 msgid "Interval Weekly"
 msgstr "settimane"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: year(s)
 msgid "Interval Yearly"
 msgstr "anni"
 
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: Item batch size
 msgid "Item batch size"
 msgstr "Risultati per pagina"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Item succesfully moved.
 msgid "Item succesfully moved."
 msgstr "Elemento spostato correttamente."
 
 #: components/manage/Contents/Contents
+# defaultMessage: Item(s) copied.
 msgid "Item(s) copied."
 msgstr "Elemento/i copiato/i."
 
 #: components/manage/Contents/Contents
+# defaultMessage: Item(s) cut.
 msgid "Item(s) cut."
 msgstr "Elemento/i tagliato/i."
 
 #: components/manage/Contents/Contents
+# defaultMessage: Item(s) has been updated.
 msgid "Item(s) has been updated."
 msgstr "Elemento/i aggiornati."
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
+# defaultMessage: Item(s) pasted.
 msgid "Item(s) pasted."
 msgstr "Elemento/i incollato/i."
 
 #: components/manage/Contents/Contents
+# defaultMessage: Item(s) state has been updated.
 msgid "Item(s) state has been updated."
 msgstr "Stato/i aggiornato/i"
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Items
 msgid "Items"
 msgstr "Elementi"
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Items must be unique.
 msgid "Items must be unique."
 msgstr "Gli elementi devono essere unici."
 
 #: components/manage/Preferences/PersonalPreferences
+# defaultMessage: Language
 msgid "Language"
 msgstr "Lingua"
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: Last
 msgid "Last"
 msgstr "Ultimo"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Last comment date
 msgid "Last comment date"
 msgstr "Data ultimo commento"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Last modified
 msgid "Last modified"
 msgstr "Ultima modifica"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Latest version
 msgid "Latest version"
 msgstr "Ultima versione"
 
 #: components/manage/Controlpanels/ContentTypesActions
+# defaultMessage: Layout
 msgid "Layout"
 msgstr "Layout"
 
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: Lead Image
 msgid "Lead Image"
 msgstr "Immagine di testata"
 
 #: components/manage/Blocks/Image/ImageSizeWidget
 #: components/manage/Blocks/Maps/Edit
 #: components/manage/Sidebar/AlignBlock
+# defaultMessage: Left
 msgid "Left"
 msgstr "Sinistra"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Link
 msgid "Link"
 msgstr "Link"
 
 #: components/manage/Blocks/Listing/schema
+# defaultMessage: Link more
 msgid "Link more"
 msgstr "Link ad altro"
 
 #: components/manage/Blocks/Listing/schema
+# defaultMessage: Link Title
 msgid "Link title"
 msgstr "Link al resto"
 
@@ -1070,212 +1301,262 @@ msgstr "Link al resto"
 #: components/manage/Blocks/Listing/schema
 #: components/manage/Blocks/Maps/MapsSidebar
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Link to
 msgid "Link to"
 msgstr "Link a"
 
 #: components/manage/Multilingual/ManageTranslations
+# defaultMessage: Link translation for
 msgid "Link translation for"
 msgstr "Collega traduzione per"
 
 #: components/manage/Blocks/Listing/schema
+# defaultMessage: Listing
 msgid "Listing"
 msgstr "Elenco"
 
 #: components/theme/Comments/Comments
+# defaultMessage: Load more...
 msgid "Load more"
 msgstr "Carica altro"
 
 #: components/manage/Form/ModalForm
+# defaultMessage: Loading.
 msgid "Loading"
 msgstr "Caricamento"
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: Location
 msgid "Location"
 msgstr "Luogo"
 
 #: components/theme/Login/Login
+# defaultMessage: Login
 msgid "Log In"
 msgstr "Log In"
 
 #: components/theme/Anontools/Anontools
 #: components/theme/Login/Login
+# defaultMessage: Log in
 msgid "Log in"
 msgstr "Log in"
 
 #: components/theme/Login/Login
+# defaultMessage: Login
 msgid "Login"
 msgstr "Login"
 
 #: components/theme/Login/Login
+# defaultMessage: Login Failed
 msgid "Login Failed"
 msgstr "Accesso fallito"
 
 #: components/theme/Login/Login
+# defaultMessage: Login Name
 msgid "Login Name"
 msgstr "Nome utente"
 
 #: components/manage/Toolbar/PersonalTools
+# defaultMessage: Logout
 msgid "Logout"
 msgstr "Logout"
 
 #: components/manage/Toolbar/More
+# defaultMessage: Made by {creator} on {date}. This is not a working copy anymore, but the main content.
 msgid "Made by {creator} on {date}. This is not a working copy anymore, but the main content."
 msgstr "Creato da {creator} il {date}. Questa non è più una copia di lavoro, ma il contenuto principale."
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Reduce cell padding
 msgid "Make the table compact"
 msgstr "Rendi la tabella compatta"
 
 #: components/manage/Multilingual/ManageTranslations
 #: components/manage/Toolbar/More
+# defaultMessage: Manage Translations
 msgid "Manage Translations"
 msgstr "Gestisci traduzioni"
 
 #: components/manage/Multilingual/ManageTranslations
+# defaultMessage: Manage translations for {title}
 msgid "Manage translations for {title}"
 msgstr "Gestisci le traduzioni per {title}"
 
 #: components/manage/Blocks/Maps/MapsSidebar
+# defaultMessage: Map
 msgid "Map"
 msgstr "Mappa"
 
 #: components/manage/Blocks/Maps/MapsSidebar
+# defaultMessage: Maps URL
 msgid "Maps URL"
 msgstr "URL di Maps"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Maximum length is {len}.
 msgid "Maximum length is {len}."
 msgstr "La lunghezza massima è {len}."
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Maximum value is {len}.
 msgid "Maximum value is {len}."
 msgstr "Il valore massimo è {len}."
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Message
 msgid "Message"
 msgstr "Messaggio"
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Minimum length is {len}.
 msgid "Minimum length is {len}."
 msgstr "La lunghezza minima è {len}"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Minimum value is {len}.
 msgid "Minimum value is {len}."
 msgstr "Il valore minimo è {len}."
 
 #: components/manage/Controlpanels/Controlpanels
+# defaultMessage: Moderate Comments
 msgid "Moderate Comments"
 msgstr "Modera i commenti"
 
 #: components/manage/Controlpanels/ModerateComments
+# defaultMessage: Moderate comments
 msgid "Moderate comments"
 msgstr "Moderazione dei commenti"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Monday and Friday
 msgid "Monday and Friday"
 msgstr "lunedi e venerdì"
 
 #: components/manage/Widgets/RecurrenceWidget/ByMonthDayField
+# defaultMessage: Day
 msgid "Month day"
 msgstr "Giorno"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Monthly
 msgid "Monthly"
 msgstr "Mensile"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: More
 msgid "More"
 msgstr "Altro"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Move to bottom of folder
 msgid "Move to bottom of folder"
 msgstr "Sposta in fondo alla cartella"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Move to top of folder
 msgid "Move to top of folder"
 msgstr "Sposta in cima alla cartella"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: My email address is
 msgid "My email address is"
 msgstr "Il mio indirizzo email è"
 
 #: components/manage/Sharing/Sharing
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Name
 msgid "Name"
 msgstr "Nome"
 
 #: error
+# defaultMessage: Navigate back
 msgid "Navigate back"
 msgstr "Torna indietro"
 
 #: components/theme/Navigation/ContextNavigation
+# defaultMessage: Navigation
 msgid "Navigation"
 msgstr "Navigazione"
 
 #: components/manage/Preferences/ChangePassword
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: New password
 msgid "New password"
 msgstr "Nuova password"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: News Item
 msgid "News Item"
 msgstr "Notizia"
 
 #: components/manage/Contents/ContentsItem
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: No
 msgid "No"
 msgstr "No"
 
 #: components/manage/Blocks/Image/ImageSidebar
+# defaultMessage: No image selected
 msgid "No image selected"
 msgstr "Nessuna immagine selezionata"
 
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: No image set in Lead Image content field
 msgid "No image set in Lead Image content field"
 msgstr "Nessuna immagine impostata come Immagine di testata"
 
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: No image set in image content field
 msgid "No image set in image content field"
 msgstr "Nessuna immagine impostata"
 
 #: components/manage/Blocks/Listing/ListingBody
+# defaultMessage: No items found in this container.
 msgid "No items found in this container."
 msgstr "Nessun elemento trovato in questo contenitore."
 
 #: components/manage/Widgets/ObjectBrowserWidget
+# defaultMessage: No items selected
 msgid "No items selected"
 msgstr "Nessun elemento selezionato"
 
 #: components/manage/Blocks/Maps/MapsSidebar
+# defaultMessage: No map selected
 msgid "No map selected"
 msgstr "Nessuna mappa selezionata"
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: No occurences set
 msgid "No occurences set"
 msgstr "Nessuna ricorrenza impostata"
 
 #: components/manage/Widgets/ArrayWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/TokenWidget
+# defaultMessage: No options
 msgid "No options"
 msgstr "Nessuna opzione"
 
 #: components/theme/Search/Search
+# defaultMessage: No results found
 msgid "No results found"
 msgstr "Nessun risultato"
 
 #: components/manage/Blocks/Listing/ListingBody
 #: components/manage/Widgets/ReferenceWidget
+# defaultMessage: No results found.
 msgid "No results found."
 msgstr "La ricerca non ha prodotto risultati."
 
 #: components/manage/Widgets/QuerySortOnWidget
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: No selection
 msgid "No selection"
 msgstr "Nessun elemento selezionato"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: This addon does not provide an uninstall profile.
 msgid "No uninstall profile"
 msgstr "Nessun profilo di disinstallazione"
 
@@ -1283,39 +1564,48 @@ msgstr "Nessun profilo di disinstallazione"
 #: components/manage/Widgets/ReferenceWidget
 #: components/manage/Widgets/SelectUtils
 #: components/manage/Widgets/SelectWidget
+# defaultMessage: No value
 msgid "No value"
 msgstr "Nessun valore"
 
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: No video selected
 msgid "No video selected"
 msgstr "Nessun video selezionato"
 
 #: components/manage/Workflow/Workflow
+# defaultMessage: No workflow
 msgid "No workflow"
 msgstr "Nessun flusso"
 
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsItem
+# defaultMessage: None
 msgid "None"
 msgstr "Nessuno"
 
 #: components/manage/Controlpanels/Users/UsersControlpanel
+# defaultMessage: Note that roles set here apply directly to a user. The symbol{plone_svg}indicates a role inherited from membership in a group.
 msgid "Note that roles set here apply directly to a user. The symbol{plone_svg}indicates a role inherited from membership in a group."
 msgstr "Tieni presente che i ruoli qui impostati si applicano direttamente a un utente. Il simbolo {plone_svg} indica un ruolo ereditato dall'appartenenza a un gruppo."
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Number of active objects
 msgid "Number of active objects"
 msgstr "Numero degli oggetti attivi"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Object Size
 msgid "Object Size"
 msgstr "Dimensioni dell'oggetto"
 
 #: components/manage/Widgets/RecurrenceWidget/EndField
+# defaultMessage: occurrence(s)
 msgid "Occurences"
 msgstr "occorrenze"
 
 #: components/manage/Delete/Delete
+# defaultMessage: Ok
 msgid "Ok"
 msgstr "Ok"
 
@@ -1323,301 +1613,371 @@ msgstr "Ok"
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
 #: components/manage/Blocks/Maps/MapsSidebar
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Open in a new tab
 msgid "Open in a new tab"
 msgstr "Apri in un nuovo tab"
 
 #: components/theme/Navigation/Navigation
+# defaultMessage: Open menu
 msgid "Open menu"
 msgstr "Apri menu"
 
 #: components/manage/Widgets/ObjectBrowserWidget
+# defaultMessage: Open object browser
 msgid "Open object browser"
 msgstr "Apri object browser"
 
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: Origin
 msgid "Origin"
 msgstr "Origine"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Page
 msgid "Page"
 msgstr "Pagina"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Parent fieldset
 msgid "Parent fieldset"
 msgstr "Fieldset genitore"
 
 #: components/theme/Login/Login
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Password
 msgid "Password"
 msgstr "Password"
 
 #: components/theme/PasswordReset/PasswordReset
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Password reset
 msgid "Password reset"
 msgstr "Recupera password"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Passwords do not match.
 msgid "Passwords do not match."
 msgstr "Le password non corrispondono."
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
+# defaultMessage: Paste
 msgid "Paste"
 msgstr "Incolla"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: undefined
 msgid "Paste blocks"
 msgstr "Incolla blocchi"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Permissions have been updated successfully
 msgid "Permissions have been updated successfully"
 msgstr "I permesso sono stati aggiornati con successo"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Permissions updated
 msgid "Permissions updated"
 msgstr "Permessi aggiornati"
 
 #: components/manage/Preferences/PersonalInformation
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Personal Information
 msgid "Personal Information"
 msgstr "Informazioni Personali"
 
 #: components/manage/Preferences/PersonalPreferences
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Personal Preferences
 msgid "Personal Preferences"
 msgstr "Preferenze Personali"
 
 #: components/manage/Toolbar/More
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Personal tools
 msgid "Personal tools"
 msgstr "Strumenti"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Persons responsible for creating the content of this item. Please enter a list of user names, one per line. The principal creator should come first.
 msgid "Persons responsible for creating the content of this item. Please enter a list of user names, one per line. The principal creator should come first."
 msgstr "Persone responsabili della creazione del contenuto di questo elemento. Inserisci un elenco di nomi, uno per riga. L'autore principale dovrebbe essere messo al primo posto."
 
 #: components/manage/Blocks/Video/Edit
+# defaultMessage: Please enter a valid URL by deleting the block and adding a new video block.
 msgid "Please enter a valid URL by deleting the block and adding a new video block."
 msgstr "Inserisci un URL valido eliminando il blocco e aggiungendo un nuovo blocco di tipo video."
 
 #: components/manage/Blocks/Maps/Edit
+# defaultMessage: Please enter the Embed Code provided by Google Maps -> Share -> Embed map. It should contain the <iframe> code on it.
 msgid "Please enter the Embed Code provided by Google Maps -> Share -> Embed map. It should contain the <iframe> code on it."
 msgstr "Per favore inserisci il codice di incorporamento fornito da Google Maps. Per incorporare la mappa di un luogo clicca su 'Condividi' -> 'Incorporare una mappa' -> 'Copia HTML'. Se invece vuoi incorporare una mappa con MyMaps clicca su 'Incorpora nel mio sito' -> 'Copia HTML'. Deve contenere un <iframe>."
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Please fill out the form below to set your password.
 msgid "Please fill out the form below to set your password."
 msgstr "Completa il seguente modulo per reimpostare la tua password."
 
 #: components/theme/Footer/Footer
+# defaultMessage: Plone Foundation
 msgid "Plone Foundation"
 msgstr "Plone Foundation"
 
 #: components/theme/Logo/Logo
+# defaultMessage: Plone Site
 msgid "Plone Site"
 msgstr "Sito Plone"
 
 #: components/theme/Footer/Footer
+# defaultMessage: Plone{reg} Open Source CMS/WCM
 msgid "Plone{reg} Open Source CMS/WCM"
 msgstr "Plone{reg} Open Source CMS/WCM"
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: Portrait
 msgid "Portrait"
 msgstr "Ritratto"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Possible values (Enter allowed choices one per line).
 msgid "Possible values"
 msgstr "Valori possibili"
 
 #: components/theme/Footer/Footer
+# defaultMessage: Powered by Plone & Python
 msgid "Powered by Plone & Python"
 msgstr "Realizzato con Plone &amp; Python"
 
 #: components/manage/Toolbar/PersonalTools
+# defaultMessage: Preferences
 msgid "Preferences"
 msgstr "Preferenze"
 
 #: components/manage/Blocks/HTML/Edit
+# defaultMessage: Prettify your code
 msgid "Prettify your code"
 msgstr "Formatta il tuo codice"
 
 #: components/manage/Blocks/HTML/Edit
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Preview
 msgid "Preview"
 msgstr "Anteprima"
 
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Preview Image URL
 msgid "Preview Image URL"
 msgstr "URL dell'immagine di anteprima"
 
 #: components/manage/Toolbar/PersonalTools
+# defaultMessage: Profile
 msgid "Profile"
 msgstr "Profilo"
 
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Properties
 msgid "Properties"
 msgstr "Proprietà"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Publication date
 msgid "Publication date"
 msgstr "Data di pubblicazione"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Publishing Date
 msgid "Publishing Date"
 msgstr "Data di pubblicazione"
 
 #: components/manage/Blocks/Listing/schema
+# defaultMessage: Query
 msgid "Query"
 msgstr "Query"
 
 #: components/manage/Preferences/ChangePassword
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Re-enter the password. Make sure the passwords are identical.
 msgid "Re-enter the password. Make sure the passwords are identical."
 msgstr "Reinserisci la password. Assicurati che le password siano identiche."
 
 #: components/theme/Search/Search
 #: components/theme/View/SummaryView
+# defaultMessage: Read More…
 msgid "Read More…"
 msgstr "Leggi il resto…"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Rearrange items by…
 msgid "Rearrange items by…"
 msgstr "Riordina elementi per…"
 
 #: components/manage/Widgets/RecurrenceWidget/EndField
+# defaultMessage: Ends
 msgid "Recurrence ends"
 msgstr "Termina"
 
 #: components/manage/Widgets/RecurrenceWidget/EndField
+# defaultMessage: after
 msgid "Recurrence ends after"
 msgstr "dopo"
 
 #: components/manage/Widgets/RecurrenceWidget/EndField
+# defaultMessage: on
 msgid "Recurrence ends on"
 msgstr "il"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Minimalistic table design
 msgid "Reduce complexity"
 msgstr "Riduci complessità"
 
 #: components/theme/Anontools/Anontools
 #: components/theme/Login/Login
 #: components/theme/Register/Register
+# defaultMessage: Register
 msgid "Register"
 msgstr "Registrati"
 
 #: components/theme/Register/Register
+# defaultMessage: Registration form
 msgid "Registration form"
 msgstr "Form di iscrizione"
 
 #: components/theme/Search/Search
+# defaultMessage: Relevance
 msgid "Relevance"
 msgstr "Rilevanza"
 
 #: components/manage/Widgets/ObjectListWidget
+# defaultMessage: Remove item
 msgid "Remove item"
 msgstr "Rimuovi elemento"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Remove
 msgid "Remove recurrence"
 msgstr "Rimuovi"
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Remove term
 msgid "Remove term"
 msgstr "Rimuovi termine"
 
 #: components/manage/Toolbar/More
+# defaultMessage: Remove working copy
 msgid "Remove working copy"
 msgstr "Rimuovi copia di lavoro"
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
+# defaultMessage: Rename
 msgid "Rename"
 msgstr "Rinomina"
 
 #: components/manage/Contents/ContentsRenameModal
+# defaultMessage: Renaming items...
 msgid "Rename Items Loading Message"
 msgstr "Aggiornando gli elementi..."
 
 #: components/manage/Contents/ContentsRenameModal
+# defaultMessage: Rename items
 msgid "Rename items"
 msgstr "Rinomina elementi"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Repeat
 msgid "Repeat"
 msgstr "Tipo di ricorrenza"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Repeat every
 msgid "Repeat every"
 msgstr "Ogni"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Repeat on
 msgid "Repeat on"
 msgstr "Ripeti ogni"
 
 #: components/manage/Widgets/FileWidget
+# defaultMessage: Replace existing file
 msgid "Replace existing file"
 msgstr "Sostituisci file esistente"
 
 #: components/theme/Comments/Comments
+# defaultMessage: Reply
 msgid "Reply"
 msgstr "Rispondi"
 
 #: components/manage/Widgets/SchemaWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/WysiwygWidget
+# defaultMessage: Required
 msgid "Required"
 msgstr "Obbligatorio"
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Required input is missing.
 msgid "Required input is missing."
 msgstr "Un campo richiesto è mancante."
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Reset title
 msgid "Reset term title"
 msgstr "Reimposta titolo del termine"
 
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: Results limit
 msgid "Results limit"
 msgstr "Numero massimo di risultati "
 
 #: components/manage/Blocks/Listing/Edit
+# defaultMessage: Results preview
 msgid "Results preview"
 msgstr "Anteprima dei risultati"
 
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: Reversed order
 msgid "Reversed order"
 msgstr "Ordine inverso"
 
 #: components/manage/History/History
+# defaultMessage: Revert to this revision
 msgid "Revert to this revision"
 msgstr "Ripristina questa versione"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Review state
 msgid "Review state"
 msgstr "Stato del workflow"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Richtext
 msgid "Richtext"
 msgstr "Testo formattato"
 
 #: components/manage/Blocks/Image/ImageSizeWidget
 #: components/manage/Blocks/Maps/Edit
 #: components/manage/Sidebar/AlignBlock
+# defaultMessage: Right
 msgid "Right"
 msgstr "Destra"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Rights
 msgid "Rights"
 msgstr "Diritti"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Roles
 msgid "Roles"
 msgstr "Ruoli"
 
 #: components/manage/Contents/ContentsBreadcrumbs
+# defaultMessage: Root
 msgid "Root"
 msgstr "Radice"
 
@@ -1630,90 +1990,112 @@ msgstr "Radice"
 #: components/manage/Form/ModalForm
 #: components/manage/Sharing/Sharing
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Save
 msgid "Save"
 msgstr "Salva"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Save
 msgid "Save recurrence"
 msgstr "Salva la ricorrenza"
 
 #: components/manage/Controlpanels/ContentTypesActions
+# defaultMessage: Schema
 msgid "Schema"
 msgstr "Schema"
 
 #: components/manage/Controlpanels/ContentTypeSchema
+# defaultMessage: Schema updates
 msgid "Schema updates"
 msgstr "Aggiornamenti dello schema"
 
 #: components/theme/SearchWidget/SearchWidget
+# defaultMessage: Search
 msgid "Search"
 msgstr "Ricerca"
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: Search SVG
 msgid "Search SVG"
 msgstr "Cerca"
 
 #: components/theme/SearchWidget/SearchWidget
+# defaultMessage: Search Site
 msgid "Search Site"
 msgstr "Cerca nel sito"
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: Search content
 msgid "Search content"
 msgstr "Cerca contenuto"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Search for user or group
 msgid "Search for user or group"
 msgstr "Ricerca per nome utente o gruppo"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Search group…
 msgid "Search group…"
 msgstr "Cerca gruppo…"
 
 #: components/theme/Search/Search
+# defaultMessage: Search results
 msgid "Search results"
 msgstr "Risultati della ricerca"
 
 #: components/theme/Search/Search
+# defaultMessage: Search results for {term}
 msgid "Search results for {term}"
 msgstr "Risultati per {term}"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Search users…
 msgid "Search users…"
 msgstr "Cerca utenti…"
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: Second
 msgid "Second"
 msgstr "Secondo"
 
 #: components/manage/Sidebar/ObjectBrowserNav
+# defaultMessage: Select
 msgid "Select"
 msgstr "Seleziona"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Select a date to add to recurrence
 msgid "Select a date to add to recurrence"
 msgstr "Seleziona una data da aggiungere alla ricorrenza"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Select columns to show
 msgid "Select columns to show"
 msgstr "Seleziona le colonne da mostrare"
 
 #: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Select the transition to be used for modifying the items state.
 msgid "Select the transition to be used for modifying the items state."
 msgstr "Seleziona la transizione da effettuare per cambiare lo stato del contenuto."
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: Selected dates
 msgid "Selected dates"
 msgstr "Date selezionate"
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: Selected items
 msgid "Selected items"
 msgstr "Elementi selezionati"
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: of
 msgid "Selected items - x of y"
 msgstr "su"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Selection
 msgid "Selection"
 msgstr "Selezione"
 
@@ -1721,158 +2103,195 @@ msgstr "Selezione"
 #: components/manage/Widgets/ArrayWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/TokenWidget
+# defaultMessage: Select…
 msgid "Select…"
 msgstr "Seleziona…"
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Send
 msgid "Send"
 msgstr "Invia"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Set my password
 msgid "Set my password"
 msgstr "Imposta la password"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Set your password
 msgid "Set your password"
 msgstr "Specifica la tua password"
 
 #: components/manage/Sidebar/Sidebar
+# defaultMessage: Settings
 msgid "Settings"
 msgstr "Impostazioni"
 
 #: components/manage/Sharing/Sharing
 #: components/manage/Toolbar/More
+# defaultMessage: Sharing
 msgid "Sharing"
 msgstr "Condivisione"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Sharing for {title}
 msgid "Sharing for {title}"
 msgstr "Condivisioni di {title}"
 
 #: components/manage/Widgets/SchemaWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/WysiwygWidget
+# defaultMessage: Short Name
 msgid "Short Name"
 msgstr "Nome Breve"
 
 #: components/manage/Contents/ContentsRenameModal
+# defaultMessage: Short name
 msgid "Short name"
 msgstr "Nome breve"
 
 #: components/theme/Pagination/Pagination
+# defaultMessage: Show
 msgid "Show"
 msgstr "Mostra"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Show All
 msgid "Show All"
 msgstr "Mostra tutti"
 
 #: components/theme/Comments/Comments
+# defaultMessage: Show Replies
 msgid "Show Replies"
 msgstr "Mostra risposte"
 
 #: components/manage/Widgets/ObjectListWidget
+# defaultMessage: Show item
 msgid "Show item"
 msgstr "Mostra elemento"
 
 #: components/manage/Sidebar/Sidebar
+# defaultMessage: Shrink sidebar
 msgid "Shrink sidebar"
 msgstr "Riduci la sidebar"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Shrink toolbar
 msgid "Shrink toolbar"
 msgstr "Riduci la toolbar"
 
 #: components/theme/Login/Login
+# defaultMessage: Sign in to start session
 msgid "Sign in to start session"
 msgstr "Accedi per iniziare la sessione"
 
 #: components/theme/Logo/Logo
+# defaultMessage: Site
 msgid "Site"
 msgstr "Sito"
 
 #: components/theme/NotFound/NotFound
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: Site Administration
 msgid "Site Administration"
 msgstr "Amministratore del sito"
 
 #: components/theme/Footer/Footer
+# defaultMessage: Site Map
 msgid "Site Map"
 msgstr "Mappa del sito"
 
 #: components/manage/Controlpanels/Controlpanels
 #: components/manage/Toolbar/PersonalTools
+# defaultMessage: Site Setup
 msgid "Site Setup"
 msgstr "Configurazione del sito"
 
 #: components/theme/Sitemap/Sitemap
+# defaultMessage: Sitemap
 msgid "Sitemap"
 msgstr "Mappa del sito"
 
 #: components/manage/Blocks/Image/ImageSidebar
+# defaultMessage: Size
 msgid "Size"
 msgstr "Dimensione"
 
 #: components/theme/View/ImageView
+# defaultMessage: Size: {size}
 msgid "Size: {size}"
 msgstr "Dimensione: {size}"
 
 #: error
+# defaultMessage: Sorry, something went wrong with your request
 msgid "Sorry, something went wrong with your request"
 msgstr "Spiacente, qualcosa è andato storto"
 
 #: components/theme/Search/Search
+# defaultMessage: Sort by:
 msgid "Sort By:"
 msgstr "Ordina per:"
 
 #: components/manage/Widgets/QuerySortOnWidget
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: Sort on
 msgid "Sort on"
 msgstr "Ordina per"
 
 #: components/manage/Blocks/HTML/Edit
+# defaultMessage: Source
 msgid "Source"
 msgstr "Sorgente"
 
 #: components/manage/Blocks/Video/Edit
+# defaultMessage: Specify a youtube video or playlist url
 msgid "Specify a youtube video or playlist url"
 msgstr "Specifica l'URL di un video o una playlist di YouTube"
 
 #: components/manage/Diff/Diff
+# defaultMessage: Split
 msgid "Split"
 msgstr "Dividi"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Start Date
 msgid "Start Date"
 msgstr "Data di inizio"
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: Start of the recurrence
 msgid "Start of the recurrence"
 msgstr "Inizio della ricorrenza"
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Start password reset
 msgid "Start password reset"
 msgstr "Rinnova la password"
 
 #: components/manage/Contents/Contents
 #: components/manage/Workflow/Workflow
 #: components/theme/View/TabularView
+# defaultMessage: State
 msgid "State"
 msgstr "Stato"
 
 #: components/manage/Multilingual/CompareLanguages
+# defaultMessage: Stop compare
 msgid "Stop compare"
 msgstr "Interrompi il confronto"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: String
 msgid "String"
 msgstr "Stringa"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Alternate row background color
 msgid "Stripe alternate rows with color"
 msgstr "Colore delle righe alternato"
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Subject
 msgid "Subject"
 msgstr "Oggetto"
 
@@ -1886,43 +2305,53 @@ msgstr "Oggetto"
 #: components/manage/Preferences/PersonalPreferences
 #: components/theme/ContactForm/ContactForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Success
 msgid "Success"
 msgstr "Successo"
 
 #: components/theme/LanguageSelector/LanguageSelector
+# defaultMessage: Switch to
 msgid "Switch to"
 msgstr "Vai a"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Table
 msgid "Table"
 msgstr "Tabella"
 
 #: components/manage/Blocks/ToC/View
+# defaultMessage: Table of Contents
 msgid "Table of Contents"
 msgstr "Indice dei contenuti"
 
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsTagsModal
+# defaultMessage: Tags
 msgid "Tags"
 msgstr "Categorie"
 
 #: components/manage/Contents/ContentsTagsModal
+# defaultMessage: Tags to add
 msgid "Tags to add"
 msgstr "Categorie da aggiungere"
 
 #: components/manage/Contents/ContentsTagsModal
+# defaultMessage: Tags to remove
 msgid "Tags to remove"
 msgstr "Categorie da rimuovere"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Target memory size per cache in bytes
 msgid "Target memory size per cache in bytes"
 msgstr "Dimensionei target della memoria per cache in byte"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Target number of objects in memory per cache
 msgid "Target number of objects in memory per cache"
 msgstr "Numero target di oggetti in memoria per cache"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Text
 msgid "Text"
 msgstr "Testo"
 
@@ -1930,87 +2359,108 @@ msgstr "Testo"
 #: components/theme/CorsError/CorsError
 #: components/theme/NotFound/NotFound
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: Thank you.
 msgid "Thank you."
 msgstr "Grazie."
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: The Database Manager allow you to view database status information
 msgid "The Database Manager allow you to view database status information"
 msgstr "Il Database Manager ti permette di vedere le informazioni di stato del database"
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: The URL for your external home page, if you have one.
 msgid "The URL for your external home page, if you have one."
 msgstr "L'indirizzo della tua pagina personale esterna, se ne hai una."
 
 #: components/theme/ConnectionRefused/ConnectionRefused
+# defaultMessage: The backend is not responding, please check if you have started Plone, check your project's configuration object apiPath (or if you are using the internal proxy, devProxyToApiPath) or the RAZZLE_API_PATH Volto's environment variable.
 msgid "The backend is not responding, please check if you have started Plone, check your project's configuration object apiPath (or if you are using the internal proxy, devProxyToApiPath) or the RAZZLE_API_PATH Volto's environment variable."
 msgstr "Il backend non sta rispondendo, verifica di avere avviato Plone, controlla la configurazione di apiPath nel tuo progetto (o se stai usando un proxy interno, devProxyToApiPath) oppure la variabile RAZZLE_API_PATH nell'ambiente di Volto."
 
 #: components/theme/CorsError/CorsError
+# defaultMessage: The backend is responding, but the CORS headers are not configured properly and the browser has denied the access to the backend resources.
 msgid "The backend is responding, but the CORS headers are not configured properly and the browser has denied the access to the backend resources."
 msgstr "Il backend sta rispondendo, ma i CORS headers non sono adeguatamente configurati e il browser ha negato l'accesso alle risorse del backend."
 
 #: components/theme/CorsError/CorsError
+# defaultMessage: The backend server of your website is not anwering, we apologize for the inconvenience. Please try to re-load the page and try again. If the problem persists please contact the site administrators.
 msgid "The backend server of your website is not anwering, we apologize for the inconvenience. Please try to re-load the page and try again. If the problem persists please contact the site administrators."
 msgstr "Il server di backend del tuo sito web non risponde, ci scusiamo per l'inconveniente. Prova a ricaricare la pagina e riprova. Se il problema persiste, contattare gli amministratori del sito."
 
 #: components/manage/Contents/Contents
+# defaultMessage: The item could not be deleted.
 msgid "The item could not be deleted."
 msgstr "L'elemento non può essere eliminato."
 
 #: components/theme/Register/Register
+# defaultMessage: The registration process has been successful. Please check your e-mail inbox for information on how activate your account.
 msgid "The registration process has been successful. Please check your e-mail inbox for information on how activate your account."
 msgstr "La registrazione è avvenuta correttamente. Per favore controlla la tua casella di posta per informazioni su come attivare il tuo account."
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: The user portrait/avatar
 msgid "The user portrait/avatar"
 msgstr "L'avatar/ritratto utente"
 
 #: components/manage/Toolbar/More
+# defaultMessage: The working copy was discarded
 msgid "The working copy was discarded"
 msgstr "La copia di lavoro è stata scartata"
 
 #: components/theme/Footer/Footer
+# defaultMessage: The {plonecms} is {copyright} 2000-{current_year} by the {plonefoundation} and friends.
 msgid "The {plonecms} is {copyright} 2000-{current_year} by the {plonefoundation} and friends."
 msgstr "{plonecms} è {copyright} 2000-{current_year} della {plonefoundation} ed amici."
 
 #: components/theme/CorsError/CorsError
+# defaultMessage: There is a configuration problem on the backend
 msgid "There is a configuration problem on the backend"
 msgstr "C'è un problema di configurazione sul backend"
 
 #: components/manage/Form/InlineForm
+# defaultMessage: There were some errors
 msgid "There were some errors"
 msgstr "Si sono verificati degli errori"
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: There were some errors.
 msgid "There were some errors."
 msgstr "Si sono verificati degli errori."
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: Third
 msgid "Third"
 msgstr "Terzo"
 
 #: components/manage/WorkingCopyToastsFactory/WorkingCopyToastsFactory
+# defaultMessage: This has an ongoing working copy in {title}
 msgid "This has an ongoing working copy in {title}"
 msgstr "Questa è una copia di lavoro in corso di {title}"
 
 #: components/manage/WorkingCopyToastsFactory/WorkingCopyToastsFactory
+# defaultMessage: This is a working copy of {title}
 msgid "This is a working copy of {title}"
 msgstr "Questa è una copia di lavoro di {title}"
 
 #: components/manage/LockingToastsFactory/LockingToastsFactory
+# defaultMessage: This item was locked by {creator} on {date}
 msgid "This item was locked by {creator} on {date}"
 msgstr ""
 
 #: components/manage/Contents/ContentsRenameModal
+# defaultMessage: This name will be displayed in the URL.
 msgid "This name will be displayed in the URL."
 msgstr "Questo nome verrà mostrato nell'URL."
 
 #: components/theme/NotFound/NotFound
+# defaultMessage: This page does not seem to exist…
 msgid "This page does not seem to exist…"
 msgstr "Questa pagina non esiste…"
 
 #: components/manage/Widgets/DatetimeWidget
+# defaultMessage: Time
 msgid "Time"
 msgstr "Ora"
 
@@ -2023,714 +2473,889 @@ msgstr "Ora"
 #: components/manage/Widgets/WysiwygWidget
 #: components/theme/View/TabularView
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Title
 msgid "Title"
 msgstr "Titolo"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Total active and non-active objects
 msgid "Total active and non-active objects"
 msgstr "Totale degli oggetti attivi e non attivi"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Total comments
 msgid "Total comments"
 msgstr "Totale dei commenti"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Total number of objects in each cache
 msgid "Total number of objects in each cache"
 msgstr "Numero totale degli oggetti in ogni cache"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Total number of objects in memory from all caches
 msgid "Total number of objects in memory from all caches"
 msgstr "Numero totale degli oggetti di tutte le cache"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Total number of objects in the database
 msgid "Total number of objects in the database"
 msgstr "Numero totale di oggetti nel database"
 
 #: components/manage/Add/Add
 #: components/manage/Toolbar/Types
+# defaultMessage: Translate to {lang}
 msgid "Translate to {lang}"
 msgstr "Traduci in {lang}"
 
 #: components/manage/Multilingual/ManageTranslations
+# defaultMessage: Translation linked
 msgid "Translation linked"
 msgstr "Traduzioni collegate"
 
 #: components/manage/Multilingual/ManageTranslations
+# defaultMessage: Translation linking removed
 msgid "Translation linking removed"
 msgstr "Rimosso il collegamento delle traduzioni"
 
 #: components/manage/Controlpanels/ContentTypes
 #: components/manage/Widgets/SchemaWidget
 #: components/theme/View/TabularView
+# defaultMessage: Type
 msgid "Type"
 msgstr "Tipo"
 
 #: components/manage/Blocks/Video/Edit
+# defaultMessage: Type a Video (YouTube, Vimeo or mp4) URL
 msgid "Type a Video (YouTube, Vimeo or mp4) URL"
 msgstr "Digita l'URL di un Video (YouTube, Vimeo or mp4)"
 
 #: components/manage/Blocks/Text/Edit
+# defaultMessage: Type text…
 msgid "Type text…"
 msgstr "Digita testo…"
 
 #: components/manage/Blocks/Title/Edit
+# defaultMessage: Type the title…
 msgid "Type the title…"
 msgstr "Digita il titolo…"
 
 #: components/manage/Contents/Contents
+# defaultMessage: UID
 msgid "UID"
 msgstr "UID"
 
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: Unauthorized
 msgid "Unauthorized"
 msgstr "Non autorizzato"
 
 #: components/manage/BlockChooser/BlockChooser
+# defaultMessage: Unfold
 msgid "Unfold"
 msgstr "Apri"
 
 #: components/manage/Diff/Diff
+# defaultMessage: Unified
 msgid "Unified"
 msgstr "Unificato"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Uninstall
 msgid "Uninstall"
 msgstr "Disinstalla"
 
 #: components/manage/Blocks/Block/Edit
 #: components/theme/View/DefaultView
 #: components/theme/View/RenderBlocks
+# defaultMessage: Unknown Block {block}
 msgid "Unknown Block"
 msgstr "Blocco sconosciuto"
 
 #: components/manage/Multilingual/ManageTranslations
+# defaultMessage: Unlink translation for
 msgid "Unlink translation for"
 msgstr "Scollega traduzione per"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Unlock
 msgid "Unlock"
 msgstr ""
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Update
 msgid "Update"
 msgstr "Aggiorna"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Update installed addons
 msgid "Update installed addons"
 msgstr "Aggiorna gli addons installati"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Update installed addons:
 msgid "Update installed addons:"
 msgstr "Aggiorna gli addons installati:"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Updates available
 msgid "Updates available"
 msgstr "Aggiornamenti disponibili"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Upload
 msgid "Upload"
 msgstr "Carica"
 
 #: components/manage/Blocks/LeadImage/Edit
+# defaultMessage: Upload a lead image in the 'Lead Image' content field.
 msgid "Upload a lead image in the 'Lead Image' content field."
 msgstr "Carica un'Immagine di testata nel campo del contenuto."
 
 #: components/manage/Blocks/HeroImageLeft/Edit
+# defaultMessage: Upload a new image
 msgid "Upload a new image"
 msgstr "Carica una nuova immagine"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Upload files
 msgid "Upload files"
 msgstr "Carica file"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Uploading files
 msgid "Uploading files"
 msgstr "Caricamento dei files"
 
 #: components/manage/Blocks/HeroImageLeft/Edit
+# defaultMessage: Uploading image
 msgid "Uploading image"
 msgstr "Caricamento dell'immagine"
 
 #: components/manage/Widgets/SchemaWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/WysiwygWidget
+# defaultMessage: Used for programmatic access to the fieldset.
 msgid "Used for programmatic access to the fieldset."
 msgstr "Usato per l'accesso programmatico al set di campi."
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: User
 msgid "User"
 msgstr "Utente"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: User created
 msgid "User created"
 msgstr "Utente creato"
 
 #: components/manage/Controlpanels/Users/UsersControlpanel
+# defaultMessage: User name
 msgid "User name"
 msgstr "Nome utente"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: User roles updated
 msgid "User roles updated"
 msgstr "Ruoli utente aggiornati"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Username
 msgid "Username"
 msgstr "Username"
 
 #: components/manage/Controlpanels/Controlpanels
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Users
 msgid "Users"
 msgstr "Utenti"
 
 #: components/manage/Controlpanels/Controlpanels
+# defaultMessage: Users and Groups
 msgid "Users and Groups"
 msgstr "Utenti e gruppi"
 
 #: helpers/Extensions/withBlockSchemaEnhancer
+# defaultMessage: Variation
 msgid "Variation"
 msgstr "Variazione"
 
 #: components/manage/Controlpanels/Controlpanels
+# defaultMessage: Version Overview
 msgid "Version Overview"
 msgstr "Panoramica delle versioni"
 
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Video
 msgid "Video"
 msgstr "Video"
 
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Video URL
 msgid "Video URL"
 msgstr "URL del video"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: View
 msgid "View"
 msgstr "Visualizza"
 
 #: components/manage/History/History
+# defaultMessage: View changes
 msgid "View changes"
 msgstr "Mostra le modifiche"
 
 #: components/manage/History/History
+# defaultMessage: View this revision
 msgid "View this revision"
 msgstr "Mostra questa revisione"
 
 #: components/manage/Toolbar/More
+# defaultMessage: View working copy
 msgid "View working copy"
 msgstr "Vedi copia di lavoro"
 
 #: components/manage/Display/Display
+# defaultMessage: View
 msgid "Viewmode"
 msgstr "Vista"
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Vocabulary term
 msgid "Vocabulary term"
 msgstr "Termine del vocabolario"
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Title
 msgid "Vocabulary term title"
 msgstr "Titolo del termine del vocabolario"
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Vocabulary terms
 msgid "Vocabulary terms"
 msgstr "Termini del vocabolario"
 
 #: components/manage/Controlpanels/VersionOverview
+# defaultMessage: You are running in 'debug mode'. This mode is intended for sites that are under development. This allows many configuration changes to be immediately visible, but will make your site run more slowly. To turn off debug mode, stop the server, set 'debug-mode=off' in your buildout.cfg, re-run bin/buildout and then restart the server process.
 msgid "Warning Regarding debug mode"
 msgstr "Avviso relativo alla modalità di debug"
 
 #: components/theme/ConnectionRefused/ConnectionRefused
+# defaultMessage: We apologize for the inconvenience, but the backend of the site you are accessing is not available right now. Please, try again later.
 msgid "We apologize for the inconvenience, but the backend of the site you are accessing is not available right now. Please, try again later."
 msgstr "Ci scusiamo per l'inconveniente, ma il backend del sito a cui stai cercando di accedere non è disponibile al momento. Ti preghiamo di riprovare più tardi."
 
 #: components/theme/NotFound/NotFound
+# defaultMessage: We apologize for the inconvenience, but the page you were trying to access is not at this address. You can use the links below to help you find what you are looking for.
 msgid "We apologize for the inconvenience, but the page you were trying to access is not at this address. You can use the links below to help you find what you are looking for."
 msgstr "Ci scusiamo per l'inconveniente, la pagina cui stai provando ad accedere non esiste a questo indirizzo. Puoi usare il link qui sotto per trovare quello che stavi cercando."
 
 #: components/theme/Forbidden/Forbidden
+# defaultMessage: We apologize for the inconvenience, but you don't have permissions on this resource.
 msgid "We apologize for the inconvenience, but you don't have permissions on this resource."
 msgstr "Ci scusiamo per l'inconveniente, ma non hai i permessi per questa risorsa."
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: We will use this address if you need to recover your password
 msgid "We will use this address if you need to recover your password"
 msgstr "Useremo questo indirizzo email nel caso dovessi recuperare la tua password"
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: The
 msgid "Weeek day of month"
 msgstr "Il"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Weekday
 msgid "Weekday"
 msgstr "giorno feriale (lunedì-venerdì)"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Weekly
 msgid "Weekly"
 msgstr "Settimanale"
 
 #: components/manage/History/History
+# defaultMessage: What
 msgid "What"
 msgstr "Cosa"
 
 #: components/manage/History/History
+# defaultMessage: When
 msgid "When"
 msgstr "Quando"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: When this date is reached, the content will nolonger be visible in listings and searches.
 msgid "When this date is reached, the content will nolonger be visible in listings and searches."
 msgstr "Quando questa data sarà raggiunta, il contenuto non sarà più visibile negli elenchi e nelle ricerche."
 
 #: components/manage/History/History
+# defaultMessage: Who
 msgid "Who"
 msgstr "Chi"
 
 #: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Updating workflow states...
 msgid "Workflow Change Loading Message"
 msgstr "Aggiornando gli stati..."
 
 #: components/manage/Workflow/Workflow
+# defaultMessage: Workflow updated.
 msgid "Workflow updated."
 msgstr "Workflow aggiornato."
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Yearly
 msgid "Yearly"
 msgstr "Annuale"
 
 #: components/manage/Contents/ContentsItem
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Yes
 msgid "Yes"
 msgstr "Si"
 
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: You are trying to access a protected resource, please {login} first.
 msgid "You are trying to access a protected resource, please {login} first."
 msgstr "Stai provando ad accedere ad una risorsa protetta, per favore fai prima il {login}."
 
 #: components/theme/OutdatedBrowser/OutdatedBrowser
+# defaultMessage: You are using an outdated browser
 msgid "You are using an outdated browser"
 msgstr "Stai usando un browser obsoleto"
 
 #: components/theme/Comments/Comments
+# defaultMessage: You can add a comment by filling out the form below. Plain text formatting.
 msgid "You can add a comment by filling out the form below. Plain text formatting."
 msgstr "Puoi aggiungere un commento compilando la form sotto. Utilizza il testo semplice."
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: You can control who can view and edit your item using the list below.
 msgid "You can control who can view and edit your item using the list below."
 msgstr "Puoi controllare chi può visualizzare e modificare l'elemento usando l'elenco che segue."
 
 #: components/manage/Diff/Diff
+# defaultMessage: You can view the difference of the revisions below.
 msgid "You can view the difference of the revisions below."
 msgstr "Puoi visualizzare la differenza delle revisioni qui sotto."
 
 #: components/manage/History/History
+# defaultMessage: You can view the history of your item below.
 msgid "You can view the history of your item below."
 msgstr "Puoi visualizzare la cronologia del tuo articolo qui sotto."
 
 #: components/manage/Contents/Contents
+# defaultMessage: You can't paste this content here
 msgid "You can't paste this content here"
 msgstr "Non puoi incollare questo contenuto qui."
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Your email is required for reset your password.
 msgid "Your email is required for reset your password."
 msgstr "La tua email è necessaria per reimpostare la tua password."
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: Your location - either city and country - or in a company setting, where your office is located.
 msgid "Your location - either city and country - or in a company setting, where your office is located."
 msgstr "La località in cui vivi (paese e città) oppure, in ambito aziendale, il luogo in cui si trova il tuo ufficio."
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Your password has been set successfully. You may now {link} with your new password.
 msgid "Your password has been set successfully. You may now {link} with your new password."
 msgstr "La tua password è stata reimpostata correttamente. Ora puoi {link} usando la nuova password."
 
 #: components/manage/Preferences/PersonalPreferences
+# defaultMessage: Your preferred language
 msgid "Your preferred language"
 msgstr "La tua lingua preferita."
 
 #: components/theme/Login/Login
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Forgot your password?
 msgid "box_forgot_password_option"
 msgstr "Hai dimenticato la tua password?"
 
 #: config/Blocks
+# defaultMessage: Common
 msgid "common"
 msgstr "Comuni"
 
 #: components/manage/Multilingual/CompareLanguages
+# defaultMessage: Compare to language
 msgid "compare_to"
 msgstr "Confronta con"
 
 #: components/manage/Blocks/Block/EditBlockWrapper
+# defaultMessage: delete
 msgid "delete"
 msgstr "Elimina"
 
 #: components/theme/OutdatedBrowser/OutdatedBrowser
+# defaultMessage: You are using {browsername} {browserversion} which is deprecated by its vendor. That means that it does not get security updates and it is not ready for current modern web features, which deteriorates the user experience. Please upgrade to a modern browser.
 msgid "deprecated_browser_notice_message"
 msgstr "Stai usando {browsername} {browserversion} che è stato deprecato dal suo fornitore. Questo significa che non riceverà aggiornamenti di sicurezza e che non supporterà le attuali funzionalità del web moderno, danneggiando l'esperienza utente. Esegui l'upgrade a un browser moderno."
 
 #: config/Blocks
+# defaultMessage: Description
 msgid "description"
 msgstr "Descrizione"
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: For security reasons, we store your password encrypted, and cannot mail it to you. If you would like to reset your password, fill out the form below and we will send you an email at the address you gave when you registered to start the process of resetting your password.
 msgid "description_lost_password"
 msgstr "Per ragioni di sicurezza, le password vengono memorizzate in forma crittata e non è quindi possibile spedirtela. Se desideri reimpostare la tua password, completa il modulo sottostante: ti verranno spedite ulteriori istruzioni per completare il processo all'indirizzo e-mail che hai specificato all'iscrizione."
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Your password reset request has been mailed. It should arrive in your mailbox shortly. When you receive the message, visit the address it contains to reset your password.
 msgid "description_sent_password"
 msgstr "La istruzioni per reimpostare la tua password sono state inviate. Dovrebbero arrivare a breve nella tua casella di posta. Una volta ricevuto il messaggio, visita l'indirizzo indicato per reimpostare la password."
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Draft
 msgid "draft"
 msgstr "Bozza"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Input must be valid email (something@domain.com)
 msgid "email"
 msgstr "email"
 
 #: components/theme/View/EventView
+# defaultMessage: All dates
 msgid "event_alldates"
 msgstr "Tutte le date"
 
 #: components/theme/View/EventView
+# defaultMessage: Attendees
 msgid "event_attendees"
 msgstr "Partecipanti"
 
 #: components/theme/View/EventView
+# defaultMessage: Contact Name
 msgid "event_contactname"
 msgstr "Nome del contatto"
 
 #: components/theme/View/EventView
+# defaultMessage: Contact Phone
 msgid "event_contactphone"
 msgstr "Telefono del contatto"
 
 #: components/theme/View/EventView
+# defaultMessage: Website
 msgid "event_website"
 msgstr "Sito web"
 
 #: components/theme/View/EventView
+# defaultMessage: What
 msgid "event_what"
 msgstr "Cosa"
 
 #: components/theme/View/EventView
+# defaultMessage: When
 msgid "event_when"
 msgstr "Quando"
 
 #: components/theme/View/EventView
+# defaultMessage: Where
 msgid "event_where"
 msgstr "Dove"
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Password reset confirmation sent
 msgid "heading_sent_password"
 msgstr "Richiesta di conferma reimpostazione password spedita"
 
 #: config/Blocks
+# defaultMessage: Hero
 msgid "hero"
 msgstr "Hero"
 
 #: config/Blocks
+# defaultMessage: HTML
 msgid "html"
 msgstr "HTML"
 
 #: config/Blocks
+# defaultMessage: Image
 msgid "image"
 msgstr "Immagine"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Input must be integer
 msgid "integer"
 msgstr "intero"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Intranet
 msgid "intranet"
 msgstr "Pubbliato internamente"
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: My email address is
 msgid "label_my_email_address_is"
 msgstr "Il mio indirizzo email è"
 
 #: config/Blocks
+# defaultMessage: Lead Image Field
 msgid "leadimage"
 msgstr "Immagine di testata"
 
 #: config/Blocks
+# defaultMessage: Listing
 msgid "listing"
 msgstr "Elenco"
 
 #: components/manage/Blocks/Listing/ListingBody
 #: components/manage/Contents/Contents
+# defaultMessage: Loading
 msgid "loading"
 msgstr "caricamento"
 
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: log in
 msgid "log in"
 msgstr "log in"
 
 #: config/Blocks
+# defaultMessage: Maps
 msgid "maps"
 msgstr "Mappa"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Maximum Length
 msgid "maxLength"
 msgstr "Lunghezza massima"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: End of the range (including the value itself)
 msgid "maximum"
 msgstr "Fine del range (valore stesso incluso)"
 
 #: config/Blocks
+# defaultMessage: Media
 msgid "media"
 msgstr "media"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Minimum Length
 msgid "minLength"
 msgstr "Lunghezza minima"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Start of the range
 msgid "minimum"
 msgstr "Inizio del range"
 
 #: config/Blocks
+# defaultMessage: Most used
 msgid "mostUsed"
 msgstr "Più usati"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: No workflow state
 msgid "no workflow state"
 msgstr "Nessun stato di workflow"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Input must be number
 msgid "number"
 msgstr "numero"
 
 #: components/manage/Widgets/RecurrenceWidget/ByMonthDayField
 #: components/manage/Widgets/RecurrenceWidget/ByYearField
+# defaultMessage: of the month
 msgid "of the month"
 msgstr "del mese"
 
 #: error
+# defaultMessage: or try a different page.
 msgid "or try a different page."
 msgstr "oppure prova una pagina diversa."
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: others
 msgid "others"
 msgstr "altre"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Private
 msgid "private"
 msgstr "Privato"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Published
 msgid "published"
 msgstr "Pubblicato"
 
 #: components/manage/Widgets/QueryWidget
+# defaultMessage: Select…
 msgid "querystring-widget-select"
 msgstr "Seleziona…"
 
 #: components/theme/Search/Search
+# defaultMessage: results
 msgid "results found"
 msgstr "risultati trovati"
 
 #: error
+# defaultMessage: return to the site root
 msgid "return to the site root"
 msgstr "ritorna alla radice del sito"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: and
 msgid "rrule_and"
 msgstr "e"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: (~approximate)
 msgid "rrule_approximate"
 msgstr "(approssimativamente)"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: at
 msgid "rrule_at"
 msgstr "alle"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: [month] [day], [year]
 msgid "rrule_dateFormat"
 msgstr "[day] [month] [year]"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: day
 msgid "rrule_day"
 msgstr "giorno"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: days
 msgid "rrule_days"
 msgstr "giorni"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: every
 msgid "rrule_every"
 msgstr "ogni"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: for
 msgid "rrule_for"
 msgstr "per"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: hour
 msgid "rrule_hour"
 msgstr "ora"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: hours
 msgid "rrule_hours"
 msgstr "ore"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: in
 msgid "rrule_in"
 msgstr "nel"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: last
 msgid "rrule_last"
 msgstr "ultimo"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: minutes
 msgid "rrule_minutes"
 msgstr "minuti"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: month
 msgid "rrule_month"
 msgstr "mese"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: months
 msgid "rrule_months"
 msgstr "mesi"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: nd
 msgid "rrule_nd"
 msgstr "secondo"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: on
 msgid "rrule_on"
 msgstr "il"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: on the
 msgid "rrule_on the"
 msgstr "nel"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: or
 msgid "rrule_or"
 msgstr "oppure"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: rd
 msgid "rrule_rd"
 msgstr "terzo"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: st
 msgid "rrule_st"
 msgstr "primo"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: th
 msgid "rrule_th"
 msgstr "*"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: the
 msgid "rrule_the"
 msgstr "il"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: time
 msgid "rrule_time"
 msgstr "volta"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: times
 msgid "rrule_times"
 msgstr "volte"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: until
 msgid "rrule_until"
 msgstr "fino al"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: week
 msgid "rrule_week"
 msgstr "settimana"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: weekday
 msgid "rrule_weekday"
 msgstr "giorno"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: weekdays
 msgid "rrule_weekdays"
 msgstr "giorni"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: weeks
 msgid "rrule_weeks"
 msgstr "settimane"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: year
 msgid "rrule_year"
 msgstr "anno"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: years
 msgid "rrule_years"
 msgstr "anni"
 
 #: components/theme/SkipLinks/SkipLinks
+# defaultMessage: Skip to footer
 msgid "skiplink-footer"
 msgstr "Salta al footer"
 
 #: components/theme/SkipLinks/SkipLinks
+# defaultMessage: Skip to main content
 msgid "skiplink-main-content"
 msgstr "Salta al contenuto"
 
 #: components/theme/SkipLinks/SkipLinks
+# defaultMessage: Skip to navigation
 msgid "skiplink-navigation"
 msgstr "Salta alla navigazione"
 
 #: components/manage/Contents/Contents
+# defaultMessage: sort
 msgid "sort"
 msgstr "ordina"
 
 #: config/Blocks
+# defaultMessage: Table
 msgid "table"
 msgstr "Tabella"
 
 #: config/Blocks
+# defaultMessage: Text
 msgid "text"
 msgstr "Testo"
 
 #: config/Blocks
+# defaultMessage: Title
 msgid "title"
 msgstr "Titolo"
 
 #: config/Blocks
+# defaultMessage: Table of Contents
 msgid "toc"
 msgstr "Indice dei contenuti"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Input must be valid url (www.something.com or http(s)://www.something.com)
 msgid "url"
 msgstr "URL"
 
 #: components/manage/Toolbar/PersonalTools
+# defaultMessage: user avatar
 msgid "user avatar"
 msgstr "Avatar dell'utente"
 
 #: config/Blocks
+# defaultMessage: Video
 msgid "video"
 msgstr "Video"
 
 #: components/theme/View/EventView
+# defaultMessage: Visit external website
 msgid "visit_external_website"
 msgstr "Visita il sito web"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: {count, plural, one {Upload {count} file} other {Upload {count} files}}
 msgid "{count, plural, one {Upload {count} file} other {Upload {count} files}}"
 msgstr "{count, plural, one {Carica {count} file} other {Carica {count} file}}"
 
 #: components/manage/Contents/Contents
+# defaultMessage: {count} selected
 msgid "{count} selected"
 msgstr "{count} selezionati."
 
 #: components/manage/Controlpanels/ContentType
+# defaultMessage: {id} Content Type
 msgid "{id} Content Type"
 msgstr "{id} Tipo di Contenuto"
 
 #: components/manage/Controlpanels/ContentTypeSchema
+# defaultMessage: {id} Schema
 msgid "{id} Schema"
 msgstr "{id} Schema"
 
 #: components/manage/Actions/Actions
+# defaultMessage: {title} copied.
 msgid "{title} copied."
 msgstr "{title} copiato."
 
 #: components/manage/Actions/Actions
+# defaultMessage: {title} cut.
 msgid "{title} cut."
 msgstr "{title} tagliato."
 
 #: components/manage/Actions/Actions
+# defaultMessage: {title} has been deleted.
 msgid "{title} has been deleted."
 msgstr "{title} è stato eliminato."

--- a/locales/ja/LC_MESSAGES/volto.po
+++ b/locales/ja/LC_MESSAGES/volto.po
@@ -19,22 +19,27 @@ msgstr ""
 "X-Is-Fallback-For: ja-jp\n"
 
 #: components/manage/Blocks/HTML/Edit
+# defaultMessage: <p>Add some HTML here</p>
 msgid "<p>Add some HTML here</p>"
 msgstr "<p>ここにHTMLを記述</p>"
 
 #: components/theme/Footer/Footer
+# defaultMessage: Accessibility
 msgid "Accessibility"
 msgstr "アクセシビリティ"
 
 #: components/theme/Register/Register
+# defaultMessage: Account Registration Completed
 msgid "Account Registration Completed"
 msgstr "アカウント登録が完了しました"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Account activation completed
 msgid "Account activation completed"
 msgstr "アカウントが有効になりました"
 
 #: components/manage/Controlpanels/ModerateComments
+# defaultMessage: Action
 msgid "Action"
 msgstr "アクション"
 
@@ -43,10 +48,12 @@ msgstr "アクション"
 #: components/manage/Controlpanels/ContentTypes
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
+# defaultMessage: Actions
 msgid "Actions"
 msgstr "アクション"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Activate and deactivate add-ons in the lists below.
 msgid "Activate and deactivate"
 msgstr "以下のリストにあるアドオンを有効にしたり無効にしたりできます。"
 
@@ -54,86 +61,107 @@ msgstr "以下のリストにあるアドオンを有効にしたり無効にし
 #: components/manage/Toolbar/Toolbar
 #: components/manage/Widgets/SchemaWidget
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add
 msgid "Add"
 msgstr "追加"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: To make new add-ons show up here, add them to your buildout configuration, run buildout, and restart the server process. For detailed instructions see
 msgid "Add Addons"
 msgstr "以下のリストに新しいアドオンが表示されるようにするには、それをビルドアウト設定(buildout.cfg)に追加し、ビルドアウトコマンド(bin/buildout)を実行した後に、サーバプロセスを再起動します。"
 
 #: components/manage/Toolbar/Types
+# defaultMessage: Add Content…
 msgid "Add Content"
 msgstr "新規追加"
 
 #: components/manage/Toolbar/Types
+# defaultMessage: Add Translation…
 msgid "Add Translation…"
 msgstr "翻訳を追加…"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add User
 msgid "Add User"
 msgstr "ユーザを追加"
 
 #: components/manage/Blocks/Description/Edit
+# defaultMessage: Add a description…
 msgid "Add a description…"
 msgstr "説明を追加…"
 
 #: components/manage/BlockChooser/BlockChooserButton
+# defaultMessage: Add block
 msgid "Add block"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add block…
 msgid "Add block…"
 msgstr "ブロックを追加…"
 
 #: components/manage/Widgets/QueryWidget
+# defaultMessage: Add criteria
 msgid "Add criteria"
 msgstr "基準を追加"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Add date
 msgid "Add date"
 msgstr "日付を追加"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Add field
 msgid "Add field"
 msgstr "フィールドを追加"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Add fieldset
 msgid "Add fieldset"
 msgstr "フィールドセットを追加"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add group
 msgid "Add group"
 msgstr "グループを追加"
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Add new content type
 msgid "Add new content type"
 msgstr "コンテンツタイプを追加"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add new group
 msgid "Add new group"
 msgstr "新しいグループを追加"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add new user
 msgid "Add new user"
 msgstr "新しいユーザを追加"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add to Groups
 msgid "Add to Groups"
 msgstr "グループに追加"
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Add term
 msgid "Add vocabulary term"
 msgstr ""
 
 #: components/manage/Add/Add
+# defaultMessage: Add {type}
 msgid "Add {type}"
 msgstr "{type} を追加"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Add-ons Settings
 msgid "Add-ons Settings"
 msgstr "アドオン設定"
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: Additional date
 msgid "Additional date"
 msgstr "追加日"
 
@@ -141,39 +169,48 @@ msgstr "追加日"
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
 #: components/manage/Blocks/Maps/MapsSidebar
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Alignment
 msgid "Alignment"
 msgstr "配置"
 
 #: components/manage/Contents/Contents
+# defaultMessage: All
 msgid "All"
 msgstr "すべて"
 
 #: components/theme/Search/Search
+# defaultMessage: Alphabetically
 msgid "Alphabetically"
 msgstr "アルファベット順"
 
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: Alt text
 msgid "Alt text"
 msgstr "代替テキスト"
 
 #: components/manage/Toolbar/More
+# defaultMessage: Apply working copy
 msgid "Apply working copy"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Are you sure you want to delete this field?
 msgid "Are you sure you want to delete this field?"
 msgstr "このフィールドを削除しますか？"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Are you sure you want to delete this fieldset including all fields?
 msgid "Are you sure you want to delete this fieldset including all fields?"
 msgstr "Are you sure you want to delete this fieldset including all fields? (未翻訳)"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Ascending
 msgid "Ascending"
 msgstr "昇順"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Available
 msgid "Available"
 msgstr "利用可能"
 
@@ -198,48 +235,59 @@ msgstr "利用可能"
 #: components/manage/Toolbar/Toolbar
 #: components/theme/ContactForm/ContactForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Back
 msgid "Back"
 msgstr "戻る"
 
 #: components/manage/Diff/Diff
+# defaultMessage: Base
 msgid "Base"
 msgstr "比較元"
 
 #: components/manage/Sidebar/Sidebar
+# defaultMessage: Block
 msgid "Block"
 msgstr "ブロック"
 
 #: components/theme/Login/Login
+# defaultMessage: Both email address and password are case sensitive, check that caps lock is not enabled.
 msgid "Both email address and password are case sensitive, check that caps lock is not enabled."
 msgstr "メールアドレスとパスワードは大文字小文字が区別されます。Caps Lockキーの状態に注意してください。"
 
 #: components/theme/Breadcrumbs/Breadcrumbs
+# defaultMessage: Breadcrumbs
 msgid "Breadcrumbs"
 msgstr "パンくず"
 
 #: components/manage/Blocks/HeroImageLeft/Edit
 #: components/manage/Contents/ContentsUploadModal
 #: components/manage/Sidebar/ObjectBrowserNav
+# defaultMessage: Browse
 msgid "Browse"
 msgstr "参照"
 
 #: components/manage/Blocks/Image/Edit
+# defaultMessage: Browse the site, drop an image, or type an URL
 msgid "Browse the site, drop an image, or type an URL"
 msgstr "参照"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: By default, permissions from the container of this item are inherited. If you disable this, only the explicitly defined sharing permissions will be valid. In the overview, the symbol {inherited} indicates an inherited value. Similarly, the symbol {global} indicates a global role, which is managed by the site administrator.
 msgid "By default, permissions from the container of this item are inherited. If you disable this, only the explicitly defined sharing permissions will be valid. In the overview, the symbol {inherited} indicates an inherited value. Similarly, the symbol {global} indicates a global role, which is managed by the site administrator."
 msgstr "デフォルトでは、このアイテムのコンテナからのパーミッションが継承されます。これを無効にすると、明示的に定義されたパーミッションだけが有効になります。概要画面で {inherited} シンボルが継承された値を示します。同様に、{global} シンボルはグローバルロールを示します。これはサイト管理者によって管理されるものです。"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Cache Name
 msgid "Cache Name"
 msgstr "キャッシュの名前"
 
 #: components/manage/Controlpanels/ContentTypeLayout
+# defaultMessage: Can not edit Layout for <strong>{type}</strong> content-type as it doesn't have support for <strong>Volto Blocks</strong> enabled
 msgid "Can not edit Layout for <strong>{type}</strong> content-type as it doesn't have support for <strong>Volto Blocks</strong> enabled"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypeLayout
+# defaultMessage: Can not edit Layout for <strong>{type}</strong> content-type as the <strong>Blocks behavior</strong> is enabled and <strong>read-only</strong>
 msgid "Can not edit Layout for <strong>{type}</strong> content-type as the <strong>Blocks behavior</strong> is enabled and <strong>read-only</strong>"
 msgstr ""
 
@@ -255,42 +303,51 @@ msgstr ""
 #: components/manage/Sharing/Sharing
 #: components/theme/Login/Login
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Cancel
 msgid "Cancel"
 msgstr "キャンセル"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Cell
 msgid "Cell"
 msgstr "セル"
 
 #: components/manage/Blocks/Image/ImageSizeWidget
 #: components/manage/Blocks/Maps/Edit
 #: components/manage/Sidebar/AlignBlock
+# defaultMessage: Center
 msgid "Center"
 msgstr "中央"
 
 #: components/manage/History/History
+# defaultMessage: Change Note
 msgid "Change Note"
 msgstr "変更メモ"
 
 #: components/manage/Preferences/ChangePassword
+# defaultMessage: Change Password
 msgid "Change Password"
 msgstr "パスワードを変更"
 
 #: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Change State
 msgid "Change State"
 msgstr "状態を変更"
 
 #: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Change workflow state recursively
 msgid "Change workflow state recursively"
 msgstr "下位階層のワークフローの状態も変更する"
 
 #: components/manage/Toolbar/More
+# defaultMessage: Changes applied
 msgid "Changes applied."
 msgstr ""
 
 #: components/manage/Preferences/ChangePassword
 #: components/manage/Preferences/PersonalInformation
 #: components/manage/Preferences/PersonalPreferences
+# defaultMessage: Changes saved
 msgid "Changes saved"
 msgstr "変更が保存されました"
 
@@ -298,192 +355,237 @@ msgstr "変更が保存されました"
 #: components/manage/Controlpanels/ContentTypeLayout
 #: components/manage/Controlpanels/ContentTypeSchema
 #: components/manage/Controlpanels/Controlpanel
+# defaultMessage: Changes saved.
 msgid "Changes saved."
 msgstr "変更が保存されました"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Checkbox
 msgid "Checkbox"
 msgstr "チェックボックス"
 
 #: components/manage/Widgets/SelectWidget
+# defaultMessage: Choices
 msgid "Choices"
 msgstr "選択"
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: Choose Image
 msgid "Choose Image"
 msgstr "イメージを選択"
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: Choose Target
 msgid "Choose Target"
 msgstr "ターゲットを選択"
 
 #: components/manage/Widgets/FileWidget
+# defaultMessage: Choose a file
 msgid "Choose a file"
 msgstr ""
 
 #: components/manage/Blocks/HTML/Edit
+# defaultMessage: Clear
 msgid "Clear"
 msgstr ""
 
 #: components/theme/View/ImageView
+# defaultMessage: Click to download full sized image
 msgid "Click to download full sized image"
 msgstr "クリックしてフルサイズ画像をダウンロード"
 
 #: components/manage/Widgets/SelectWidget
+# defaultMessage: Close
 msgid "Close"
 msgstr "閉じる"
 
 #: components/theme/Navigation/Navigation
+# defaultMessage: Close menu
 msgid "Close menu"
 msgstr "メニューを閉じる"
 
 #: components/manage/Blocks/HTML/Edit
+# defaultMessage: Code
 msgid "Code"
 msgstr ""
 
 #: components/manage/Widgets/ObjectListWidget
+# defaultMessage: Collapse item
 msgid "Collapse item"
 msgstr ""
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Collection
 msgid "Collection"
 msgstr "コレクション"
 
 #: components/manage/Controlpanels/ModerateComments
 #: components/theme/Comments/CommentEditModal
 #: components/theme/Comments/Comments
+# defaultMessage: Comment
 msgid "Comment"
 msgstr "コメント"
 
 #: components/manage/Controlpanels/ModerateComments
+# defaultMessage: Commenter
 msgid "Commenter"
 msgstr "投稿者"
 
 #: components/theme/Comments/Comments
+# defaultMessage: Comments
 msgid "Comments"
 msgstr ""
 
 #: components/manage/Diff/Diff
+# defaultMessage: Compare
 msgid "Compare"
 msgstr "比較"
 
 #: components/manage/Preferences/ChangePassword
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Confirm password
 msgid "Confirm password"
 msgstr "パスワードを確認"
 
 #: components/theme/ConnectionRefused/ConnectionRefused
+# defaultMessage: Connection refused
 msgid "Connection refused"
 msgstr "接続が拒否されました"
 
 #: components/theme/Footer/Footer
+# defaultMessage: Contact
 msgid "Contact"
 msgstr "お問い合わせ"
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Contact form
 msgid "Contact form"
 msgstr "お問い合わせフォーム"
 
 #: components/manage/Blocks/Listing/Edit
+# defaultMessage: Contained items
 msgid "Contained items"
 msgstr "含まれるアイテム"
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Content type created
 msgid "Content type created"
 msgstr "コンテンツタイプが作成されました"
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Content type deleted
 msgid "Content type deleted"
 msgstr "コンテンツタイプが削除されました"
 
 #: components/manage/Contents/Contents
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Contents
 msgid "Contents"
 msgstr "コンテンツ"
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Copy
 msgid "Copy"
 msgstr "コピー"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: undefined
 msgid "Copy blocks"
 msgstr ""
 
 #: components/theme/Footer/Footer
+# defaultMessage: Copyright
 msgid "Copyright"
 msgstr "著作権"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Copyright statement or other rights information on this item.
 msgid "Copyright statement or other rights information on this item."
 msgstr "このアイテムの著作権宣言文または他の権利情報"
 
 #: components/manage/Toolbar/More
+# defaultMessage: Create working copy
 msgid "Create working copy"
 msgstr ""
 
 #: components/manage/WorkingCopyToastsFactory/WorkingCopyToastsFactory
+# defaultMessage: Created by {creator} on {date}
 msgid "Created by {creator} on {date}"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Created on
 msgid "Created on"
 msgstr "作成日"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Creator
 msgid "Creator"
 msgstr "作成者"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Creators
 msgid "Creators"
 msgstr "作成者"
 
 #: components/manage/Widgets/QuerystringWidget
 #: components/manage/Widgets/QueryWidget
+# defaultMessage: Criteria
 msgid "Criteria"
 msgstr "基準"
 
 #: components/manage/Preferences/ChangePassword
+# defaultMessage: Current password
 msgid "Current password"
 msgstr "現在のパスワード"
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Cut
 msgid "Cut"
 msgstr "カット"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: undefined
 msgid "Cut blocks"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Daily
 msgid "Daily"
 msgstr "毎日"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Database Information
 msgid "Database Information"
 msgstr "データベース情報"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Database Location
 msgid "Database Location"
 msgstr "データベースの場所"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Database Size
 msgid "Database Size"
 msgstr "データベースサイズ"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Database main
 msgid "Database main"
 msgstr "主なデータベース情報"
 
 #: components/manage/Controlpanels/ModerateComments
 #: components/manage/Widgets/DatetimeWidget
+# defaultMessage: Date
 msgid "Date"
 msgstr "日付"
 
 #: components/theme/Search/Search
+# defaultMessage: Date (newest first)
 msgid "Date (newest first)"
 msgstr "日付 (新しい順)"
 
@@ -503,6 +605,7 @@ msgstr "日付 (新しい順)"
 #: components/theme/PasswordReset/PasswordReset
 #: components/theme/PasswordReset/RequestPasswordReset
 #: components/theme/Register/Register
+# defaultMessage: Default
 msgid "Default"
 msgstr "基本"
 
@@ -517,38 +620,47 @@ msgstr "基本"
 #: components/manage/Widgets/ObjectBrowserWidget
 #: components/manage/Widgets/WysiwygWidget
 #: components/theme/Comments/Comments
+# defaultMessage: Delete
 msgid "Delete"
 msgstr "削除"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Delete Group
 msgid "Delete Group"
 msgstr "グループを削除"
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Delete Type
 msgid "Delete Type"
 msgstr "コンテンツを削除"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Delete User
 msgid "Delete User"
 msgstr "ユーザを削除"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: undefined
 msgid "Delete blocks"
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Delete col
 msgid "Delete col"
 msgstr "列を削除"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Delete row
 msgid "Delete row"
 msgstr "行を削除"
 
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: Depth
 msgid "Depth"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Descending
 msgid "Descending"
 msgstr "降順"
 
@@ -559,72 +671,89 @@ msgstr "降順"
 #: components/manage/Widgets/WysiwygWidget
 #: components/theme/View/TabularView
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Description
 msgid "Description"
 msgstr "説明"
 
 #: components/manage/Diff/Diff
+# defaultMessage: Diff
 msgid "Diff"
 msgstr "差分"
 
 #: components/manage/Diff/Diff
+# defaultMessage: Difference between revision {one} and {two} of {title}
 msgid "Difference between revision {one} and {two} of {title}"
 msgstr "{title} のリビジョン {one} と {two} の差分"
 
 #: components/theme/Footer/Footer
+# defaultMessage: Distributed under the {license}.
 msgid "Distributed under the {license}."
 msgstr "{license} の下で配布されています。"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Add border to inner columns
 msgid "Divide each row into separate cells"
 msgstr "列の区切り線を表示"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Do you really want to delete the following items?
 msgid "Do you really want to delete the following items?"
 msgstr "以下のアイテムを削除してよろしいですか?"
 
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
+# defaultMessage: Do you really want to delete the group {groupname}?
 msgid "Do you really want to delete the group {groupname}?"
 msgstr "グループ {groupname} を削除してよろしいですか?"
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Do you really want to delete type {typename}?
 msgid "Do you really want to delete the type {typename}?"
 msgstr "本当にコンテンツタイプ {typename} を削除しますか?"
 
 #: components/manage/Controlpanels/Users/UsersControlpanel
+# defaultMessage: Do you really want to delete the user {username}?
 msgid "Do you really want to delete the user {username}?"
 msgstr "ユーザ {username} を削除してよろしいですか?"
 
 #: components/manage/Delete/Delete
+# defaultMessage: Do you really want to delete this item?
 msgid "Do you really want to delete this item?"
 msgstr "このアイテムを削除してよろしいですか?"
 
 #: components/manage/Multilingual/TranslationObject
 #: components/manage/Sidebar/Sidebar
+# defaultMessage: Document
 msgid "Document"
 msgstr "文書"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Drag and drop files from your computer onto this area or click the “Browse” button.
 msgid "Drag and drop files from your computer onto this area or click the “Browse” button."
 msgstr "ここにファイルをドラッグ、または「参照」ボタンをクリック"
 
 #: components/manage/Widgets/FileWidget
+# defaultMessage: Drop file here to replace the existing file
 msgid "Drop file here to replace the existing file"
 msgstr ""
 
 #: components/manage/Widgets/FileWidget
+# defaultMessage: Drop file here to upload a new file
 msgid "Drop file here to upload a new file"
 msgstr ""
 
 #: components/manage/Widgets/FileWidget
+# defaultMessage: Drop files here ...
 msgid "Drop files here ..."
 msgstr ""
 
 #: components/manage/Preferences/PersonalInformation
 #: components/theme/Register/Register
+# defaultMessage: E-mail
 msgid "E-mail"
 msgstr "E-mail"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: E-mail addresses do not match.
 msgid "E-mail addresses do not match."
 msgstr "E-mail アドレスが見つかりません。"
 
@@ -635,93 +764,115 @@ msgstr "E-mail アドレスが見つかりません。"
 #: components/manage/Widgets/FormFieldWrapper
 #: components/manage/Widgets/ObjectBrowserWidget
 #: components/theme/Comments/Comments
+# defaultMessage: Edit
 msgid "Edit"
 msgstr "編集"
 
 #: components/theme/Comments/CommentEditModal
+# defaultMessage: Edit comment
 msgid "Edit comment"
 msgstr "コメントを編集"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Edit field
 msgid "Edit field"
 msgstr "フィールドを編集"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Edit fieldset
 msgid "Edit fieldset"
 msgstr "フィールドセットを編集"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Edit recurrence
 msgid "Edit recurrence"
 msgstr "繰り返しを編集"
 
 #: components/manage/Form/InlineForm
+# defaultMessage: Edit values
 msgid "Edit values"
 msgstr "値を編集"
 
 #: components/manage/Edit/Edit
+# defaultMessage: Edit {title}
 msgid "Edit {title}"
 msgstr "{title} を編集"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Email
 msgid "Email"
 msgstr "メール"
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Email sent
 msgid "Email sent"
 msgstr "メール送信"
 
 #: components/manage/Blocks/Maps/Edit
+# defaultMessage: Embed code error, please follow the instructions and try again.
 msgid "Embed code error, please follow the instructions and try again."
 msgstr "Embedコードがエラーです。説明を読んで再度実行してください。"
 
 #: components/manage/Blocks/Maps/View
+# defaultMessage: Embeded Google Maps
 msgid "Embeded Google Maps"
 msgstr "埋め込まれたGoogle Maps"
 
 #: components/manage/Widgets/ObjectListWidget
+# defaultMessage: Empty object list
 msgid "Empty object list"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypeLayout
+# defaultMessage: Enable editable Blocks
 msgid "Enable editable Blocks"
 msgstr "Block編集を有効化"
 
 #: components/manage/Contents/Contents
+# defaultMessage: End Date
 msgid "End Date"
 msgstr "終了日付"
 
 #: components/manage/AnchorPlugin/components/LinkButton/AddLinkForm
+# defaultMessage: Enter URL or select an item
 msgid "Enter URL or select an item"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Enter a username above to search or click 'Show All'
 msgid "Enter a username above to search or click 'Show All'"
 msgstr ""
 
 #: components/theme/Register/Register
+# defaultMessage: Enter an email address. This will be your login name. We respect your privacy, and will not give the address away to any third parties or expose it anywhere.
 msgid "Enter an email address. This will be your login name. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr "Enter an email address. This will be your login name. We respect your privacy, and will not give the address away to any third parties or expose it anywhere. (未翻訳)"
 
 #: components/manage/Preferences/PersonalInformation
 #: components/theme/PasswordReset/PasswordReset
 #: components/theme/Register/Register
+# defaultMessage: Enter full name, e.g. John Smith.
 msgid "Enter full name, e.g. John Smith."
 msgstr "氏名（フルネーム）を入力。例： Hanako Suzuki や 山田太郎 "
 
 #: components/manage/Blocks/Maps/Edit
+# defaultMessage: Enter map Embed Code
 msgid "Enter map Embed Code"
 msgstr "地図のEmbedコードを入力"
 
 #: components/manage/Preferences/ChangePassword
+# defaultMessage: Enter your current password.
 msgid "Enter your current password."
 msgstr "現在のパスワードを入力"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Enter your email address for verification.
 msgid "Enter your email address for verification."
 msgstr "確認するためにあなたのメールアドレスを入力してください"
 
 #: components/manage/Preferences/ChangePassword
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Enter your new password. Minimum 5 characters.
 msgid "Enter your new password. Minimum 5 characters."
 msgstr "新しいパスワードを入力。（5文字以上）"
 
@@ -733,199 +884,245 @@ msgstr "新しいパスワードを入力。（5文字以上）"
 #: components/theme/ContactForm/ContactForm
 #: components/theme/Login/Login
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Error
 msgid "Error"
 msgstr "エラー"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Exclude from navigation
 msgid "Exclude from navigation"
 msgstr "ナビゲーションに含まない"
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: Exclude this occurence
 msgid "Exclude this occurence"
 msgstr "この繰り返しを削除"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Excluded from navigation
 msgid "Excluded from navigation"
 msgstr "ナビゲーションから除く"
 
 #: components/manage/Sidebar/Sidebar
+# defaultMessage: Expand sidebar
 msgid "Expand sidebar"
 msgstr "サイドバーを開く"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Expiration Date
 msgid "Expiration Date"
 msgstr "満了日付"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Expiration date
 msgid "Expiration date"
 msgstr "満了日付"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Expired
 msgid "Expired"
 msgstr "期間満了"
 
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: External URL
 msgid "External URL"
 msgstr "外部URL"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: File
 msgid "File"
 msgstr "ファイル"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: File size
 msgid "File size"
 msgstr "ファイルサイズ"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Filename
 msgid "Filename"
 msgstr "ファイル名"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Filter…
 msgid "Filter…"
 msgstr "フィルター…"
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: First
 msgid "First"
 msgstr "第1"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Fixed width columns
 msgid "Fixed width table cells"
 msgstr "テーブルのセル幅を固定"
 
 #: components/manage/BlockChooser/BlockChooser
+# defaultMessage: Fold
 msgid "Fold"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Folder
 msgid "Folder"
 msgstr "フォルダ"
 
 #: components/theme/Forbidden/Forbidden
+# defaultMessage: Forbidden
 msgid "Forbidden"
 msgstr "Forbidden(未翻訳)"
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: Fourth
 msgid "Fourth"
 msgstr "第4"
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: From
 msgid "From"
 msgstr "メールアドレス"
 
 #: components/manage/Blocks/Maps/Edit
 #: components/manage/Sidebar/AlignBlock
+# defaultMessage: Full
 msgid "Full"
 msgstr "フルサイズ"
 
 #: components/manage/Preferences/PersonalInformation
 #: components/theme/PasswordReset/PasswordReset
 #: components/theme/Register/Register
+# defaultMessage: Full Name
 msgid "Full Name"
 msgstr "氏名"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Fullname
 msgid "Fullname"
 msgstr "氏名"
 
 #: components/theme/Footer/Footer
+# defaultMessage: GNU GPL license
 msgid "GNU GPL license"
 msgstr "GNU GPL license"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Global role
 msgid "Global role"
 msgstr "グローバルロール"
 
 #: components/manage/Blocks/Maps/Edit
+# defaultMessage: Google Maps Embedded Block
 msgid "Google Maps Embedded Block"
 msgstr "Google Maps Embedded Block (未翻訳)"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Group
 msgid "Group"
 msgstr "グループ"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Group created
 msgid "Group created"
 msgstr "グループが作成されました"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Group roles updated
 msgid "Group roles updated"
 msgstr ""
 
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Groupname
 msgid "Groupname"
 msgstr "グループ名"
 
 #: components/manage/Controlpanels/Controlpanels
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Groups
 msgid "Groups"
 msgstr "グループ"
 
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
+# defaultMessage: Groups are logical collections of users, such as departments and business units. Groups are not directly related to permissions on a global level, you normally use Roles for that - and let certain Groups have a particular role. The symbol{plone_svg}indicates a role inherited from membership in another group.
 msgid "Groups are logical collections of users, such as departments and business units. Groups are not directly related to permissions on a global level, you normally use Roles for that - and let certain Groups have a particular role. The symbol{plone_svg}indicates a role inherited from membership in another group."
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Header cell
 msgid "Header cell"
 msgstr ""
 
 #: components/theme/Comments/Comments
+# defaultMessage: Hide Replies
 msgid "Hide Replies"
 msgstr ""
 
 #: components/manage/History/History
 #: components/manage/Toolbar/More
+# defaultMessage: History
 msgid "History"
 msgstr "履歴"
 
 #: components/manage/History/History
+# defaultMessage: #
 msgid "History Version Number"
 msgstr ""
 
 #: components/manage/History/History
+# defaultMessage: History of {title}
 msgid "History of {title}"
 msgstr "{title} の履歴"
 
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsBreadcrumbs
 #: components/theme/Breadcrumbs/Breadcrumbs
+# defaultMessage: Home
 msgid "Home"
 msgstr "ホーム"
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: Home page
 msgid "Home page"
 msgstr "ホーム"
 
 #: components/manage/Contents/Contents
+# defaultMessage: ID
 msgid "ID"
 msgstr "ID"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: If selected, this item will not appear in the navigation tree
 msgid "If selected, this item will not appear in the navigation tree"
 msgstr "選ばれると、このアイテムはナビゲーションツリー内に現れません。"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: If this date is in the future, the content will not show up in listings and searches until this date.
 msgid "If this date is in the future, the content will not show up in listings and searches until this date."
 msgstr "日時が未来なら、このコンテンツはこの日時までリストアップや検索対象になりません。"
 
 #: components/manage/LockingToastsFactory/LockingToastsFactory
+# defaultMessage: If you are certain this user has abandoned the object, you may unlock the object. You will then be able to edit it.
 msgid "If you are certain this user has abandoned the object, you may unlock the object. You will then be able to edit it."
 msgstr ""
 
 #: components/theme/NotFound/NotFound
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: If you are certain you have the correct web address but are encountering an error, please contact the {site_admin}.
 msgid "If you are certain you have the correct web address but are encountering an error, please contact the {site_admin}."
 msgstr "確かに正しいURLを入力したのにエラーになってしまう場合は、 {site_admin} に連絡してください。"
 
 #: components/manage/Blocks/HeroImageLeft/Edit
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: Image
 msgid "Image"
 msgstr "画像"
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: Include this occurence
 msgid "Include this occurence"
 msgstr ""
 
@@ -933,142 +1130,176 @@ msgstr ""
 #: components/manage/Controlpanels/ContentTypeLayout
 #: components/manage/Controlpanels/ContentTypeSchema
 #: components/manage/Controlpanels/Controlpanel
+# defaultMessage: Info
 msgid "Info"
 msgstr "情報"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Inherit permissions from higher levels
 msgid "Inherit permissions from higher levels"
 msgstr "上位レベルからパーミッションを継承する"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Inherited value
 msgid "Inherited value"
 msgstr "継承された値"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Insert col after
 msgid "Insert col after"
 msgstr "右に列を追加"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Insert col before
 msgid "Insert col before"
 msgstr "左に列を追加"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Insert row after
 msgid "Insert row after"
 msgstr "下に行を追加"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Insert row before
 msgid "Insert row before"
 msgstr "上に行を追加"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Install
 msgid "Install"
 msgstr "インストール"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Installed
 msgid "Installed"
 msgstr "インストール済み"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Installed version
 msgid "Installed version"
 msgstr "インストール済バージョン"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: days
 msgid "Interval Daily"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Month(s)
 msgid "Interval Monthly"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: week(s)
 msgid "Interval Weekly"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: year(s)
 msgid "Interval Yearly"
 msgstr ""
 
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: Item batch size
 msgid "Item batch size"
 msgstr "1ページ表示件数"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Item succesfully moved.
 msgid "Item succesfully moved."
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Item(s) copied.
 msgid "Item(s) copied."
 msgstr "アイテムがコピーされました。"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Item(s) cut.
 msgid "Item(s) cut."
 msgstr "アイテムがカットされました。"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Item(s) has been updated.
 msgid "Item(s) has been updated."
 msgstr ""
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
+# defaultMessage: Item(s) pasted.
 msgid "Item(s) pasted."
 msgstr "アイテムがペーストされました。"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Item(s) state has been updated.
 msgid "Item(s) state has been updated."
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Items
 msgid "Items"
 msgstr "アイテム数"
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Items must be unique.
 msgid "Items must be unique."
 msgstr "アイテムはユニークである必要があります。"
 
 #: components/manage/Preferences/PersonalPreferences
+# defaultMessage: Language
 msgid "Language"
 msgstr "言語"
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: Last
 msgid "Last"
 msgstr "最終"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Last comment date
 msgid "Last comment date"
 msgstr "最終コメント日付"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Last modified
 msgid "Last modified"
 msgstr "最終変更"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Latest version
 msgid "Latest version"
 msgstr "最新バージョン"
 
 #: components/manage/Controlpanels/ContentTypesActions
+# defaultMessage: Layout
 msgid "Layout"
 msgstr "レイアウト"
 
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: Lead Image
 msgid "Lead Image"
 msgstr "リード画像"
 
 #: components/manage/Blocks/Image/ImageSizeWidget
 #: components/manage/Blocks/Maps/Edit
 #: components/manage/Sidebar/AlignBlock
+# defaultMessage: Left
 msgid "Left"
 msgstr "左"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Link
 msgid "Link"
 msgstr "リンク"
 
 #: components/manage/Blocks/Listing/schema
+# defaultMessage: Link more
 msgid "Link more"
 msgstr "「もっと見る」の設定"
 
 #: components/manage/Blocks/Listing/schema
+# defaultMessage: Link Title
 msgid "Link title"
 msgstr "リンクタイトル"
 
@@ -1077,212 +1308,262 @@ msgstr "リンクタイトル"
 #: components/manage/Blocks/Listing/schema
 #: components/manage/Blocks/Maps/MapsSidebar
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Link to
 msgid "Link to"
 msgstr "リンク先"
 
 #: components/manage/Multilingual/ManageTranslations
+# defaultMessage: Link translation for
 msgid "Link translation for"
 msgstr ""
 
 #: components/manage/Blocks/Listing/schema
+# defaultMessage: Listing
 msgid "Listing"
 msgstr "リスティング"
 
 #: components/theme/Comments/Comments
+# defaultMessage: Load more...
 msgid "Load more"
 msgstr ""
 
 #: components/manage/Form/ModalForm
+# defaultMessage: Loading.
 msgid "Loading"
 msgstr ""
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: Location
 msgid "Location"
 msgstr "場所"
 
 #: components/theme/Login/Login
+# defaultMessage: Login
 msgid "Log In"
 msgstr "ログイン"
 
 #: components/theme/Anontools/Anontools
 #: components/theme/Login/Login
+# defaultMessage: Log in
 msgid "Log in"
 msgstr "ログイン"
 
 #: components/theme/Login/Login
+# defaultMessage: Login
 msgid "Login"
 msgstr "ログイン"
 
 #: components/theme/Login/Login
+# defaultMessage: Login Failed
 msgid "Login Failed"
 msgstr "ログインに失敗しました"
 
 #: components/theme/Login/Login
+# defaultMessage: Login Name
 msgid "Login Name"
 msgstr "ログイン名"
 
 #: components/manage/Toolbar/PersonalTools
+# defaultMessage: Logout
 msgid "Logout"
 msgstr ""
 
 #: components/manage/Toolbar/More
+# defaultMessage: Made by {creator} on {date}. This is not a working copy anymore, but the main content.
 msgid "Made by {creator} on {date}. This is not a working copy anymore, but the main content."
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Reduce cell padding
 msgid "Make the table compact"
 msgstr "コンパクトな表示"
 
 #: components/manage/Multilingual/ManageTranslations
 #: components/manage/Toolbar/More
+# defaultMessage: Manage Translations
 msgid "Manage Translations"
 msgstr ""
 
 #: components/manage/Multilingual/ManageTranslations
+# defaultMessage: Manage translations for {title}
 msgid "Manage translations for {title}"
 msgstr ""
 
 #: components/manage/Blocks/Maps/MapsSidebar
+# defaultMessage: Map
 msgid "Map"
 msgstr "地図"
 
 #: components/manage/Blocks/Maps/MapsSidebar
+# defaultMessage: Maps URL
 msgid "Maps URL"
 msgstr "地図URL"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Maximum length is {len}.
 msgid "Maximum length is {len}."
 msgstr "最大の長さは {len} です。"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Maximum value is {len}.
 msgid "Maximum value is {len}."
 msgstr "最大の値は {len} です。"
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Message
 msgid "Message"
 msgstr "メッセージ"
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Minimum length is {len}.
 msgid "Minimum length is {len}."
 msgstr "最小の長さは {len} です。"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Minimum value is {len}.
 msgid "Minimum value is {len}."
 msgstr "最小の値は {len} です。"
 
 #: components/manage/Controlpanels/Controlpanels
+# defaultMessage: Moderate Comments
 msgid "Moderate Comments"
 msgstr "コメントのモデレート"
 
 #: components/manage/Controlpanels/ModerateComments
+# defaultMessage: Moderate comments
 msgid "Moderate comments"
 msgstr "コメントのモデレート"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Monday and Friday
 msgid "Monday and Friday"
 msgstr "月曜日と金曜日"
 
 #: components/manage/Widgets/RecurrenceWidget/ByMonthDayField
+# defaultMessage: Day
 msgid "Month day"
 msgstr "日付"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Monthly
 msgid "Monthly"
 msgstr "毎月"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: More
 msgid "More"
 msgstr "もっと見る"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Move to bottom of folder
 msgid "Move to bottom of folder"
 msgstr "フォルダーの一番下に移動"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Move to top of folder
 msgid "Move to top of folder"
 msgstr "フォルダーの一番上に移動"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: My email address is
 msgid "My email address is"
 msgstr "私のE-mailアドレスは、"
 
 #: components/manage/Sharing/Sharing
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Name
 msgid "Name"
 msgstr "名前"
 
 #: error
+# defaultMessage: Navigate back
 msgid "Navigate back"
 msgstr "元に戻る"
 
 #: components/theme/Navigation/ContextNavigation
+# defaultMessage: Navigation
 msgid "Navigation"
 msgstr ""
 
 #: components/manage/Preferences/ChangePassword
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: New password
 msgid "New password"
 msgstr "新しいパスワード"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: News Item
 msgid "News Item"
 msgstr "ニュース"
 
 #: components/manage/Contents/ContentsItem
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: No
 msgid "No"
 msgstr "No"
 
 #: components/manage/Blocks/Image/ImageSidebar
+# defaultMessage: No image selected
 msgid "No image selected"
 msgstr "画像が選択されていません"
 
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: No image set in Lead Image content field
 msgid "No image set in Lead Image content field"
 msgstr "コンテンツフィールドのリード画像がありません"
 
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: No image set in image content field
 msgid "No image set in image content field"
 msgstr "コンテンツフィールドの画像がありません"
 
 #: components/manage/Blocks/Listing/ListingBody
+# defaultMessage: No items found in this container.
 msgid "No items found in this container."
 msgstr "アイテムが見つかりませんでした"
 
 #: components/manage/Widgets/ObjectBrowserWidget
+# defaultMessage: No items selected
 msgid "No items selected"
 msgstr "未選択"
 
 #: components/manage/Blocks/Maps/MapsSidebar
+# defaultMessage: No map selected
 msgid "No map selected"
 msgstr "マップが選択されていません"
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: No occurences set
 msgid "No occurences set"
 msgstr "未設定"
 
 #: components/manage/Widgets/ArrayWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/TokenWidget
+# defaultMessage: No options
 msgid "No options"
 msgstr "選択肢無し"
 
 #: components/theme/Search/Search
+# defaultMessage: No results found
 msgid "No results found"
 msgstr "該当する結果が見つかりません。"
 
 #: components/manage/Blocks/Listing/ListingBody
 #: components/manage/Widgets/ReferenceWidget
+# defaultMessage: No results found.
 msgid "No results found."
 msgstr "結果が見つかりません"
 
 #: components/manage/Widgets/QuerySortOnWidget
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: No selection
 msgid "No selection"
 msgstr "選択肢無し"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: This addon does not provide an uninstall profile.
 msgid "No uninstall profile"
 msgstr "アンインストール用のプロファイルがありません"
 
@@ -1290,39 +1571,48 @@ msgstr "アンインストール用のプロファイルがありません"
 #: components/manage/Widgets/ReferenceWidget
 #: components/manage/Widgets/SelectUtils
 #: components/manage/Widgets/SelectWidget
+# defaultMessage: No value
 msgid "No value"
 msgstr "値がありません"
 
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: No video selected
 msgid "No video selected"
 msgstr "ビデオが選択されていません"
 
 #: components/manage/Workflow/Workflow
+# defaultMessage: No workflow
 msgid "No workflow"
 msgstr "ワークフローなし"
 
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsItem
+# defaultMessage: None
 msgid "None"
 msgstr "None"
 
 #: components/manage/Controlpanels/Users/UsersControlpanel
+# defaultMessage: Note that roles set here apply directly to a user. The symbol{plone_svg}indicates a role inherited from membership in a group.
 msgid "Note that roles set here apply directly to a user. The symbol{plone_svg}indicates a role inherited from membership in a group."
 msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Number of active objects
 msgid "Number of active objects"
 msgstr "アクティブなオブジェクトの数"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Object Size
 msgid "Object Size"
 msgstr "オブジェクトサイズ"
 
 #: components/manage/Widgets/RecurrenceWidget/EndField
+# defaultMessage: occurrence(s)
 msgid "Occurences"
 msgstr "回"
 
 #: components/manage/Delete/Delete
+# defaultMessage: Ok
 msgid "Ok"
 msgstr "OK"
 
@@ -1330,301 +1620,371 @@ msgstr "OK"
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
 #: components/manage/Blocks/Maps/MapsSidebar
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Open in a new tab
 msgid "Open in a new tab"
 msgstr "新しいタブで開く"
 
 #: components/theme/Navigation/Navigation
+# defaultMessage: Open menu
 msgid "Open menu"
 msgstr "Open menu (未翻訳)"
 
 #: components/manage/Widgets/ObjectBrowserWidget
+# defaultMessage: Open object browser
 msgid "Open object browser"
 msgstr ""
 
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: Origin
 msgid "Origin"
 msgstr "参照元"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Page
 msgid "Page"
 msgstr "ページ"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Parent fieldset
 msgid "Parent fieldset"
 msgstr ""
 
 #: components/theme/Login/Login
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Password
 msgid "Password"
 msgstr "パスワード"
 
 #: components/theme/PasswordReset/PasswordReset
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Password reset
 msgid "Password reset"
 msgstr "パスワードリセット"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Passwords do not match.
 msgid "Passwords do not match."
 msgstr "パスワードが一致しません"
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
+# defaultMessage: Paste
 msgid "Paste"
 msgstr "ペースト"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: undefined
 msgid "Paste blocks"
 msgstr ""
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Permissions have been updated successfully
 msgid "Permissions have been updated successfully"
 msgstr ""
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Permissions updated
 msgid "Permissions updated"
 msgstr ""
 
 #: components/manage/Preferences/PersonalInformation
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Personal Information
 msgid "Personal Information"
 msgstr "個人情報"
 
 #: components/manage/Preferences/PersonalPreferences
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Personal Preferences
 msgid "Personal Preferences"
 msgstr "個人別設定"
 
 #: components/manage/Toolbar/More
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Personal tools
 msgid "Personal tools"
 msgstr "個人設定"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Persons responsible for creating the content of this item. Please enter a list of user names, one per line. The principal creator should come first.
 msgid "Persons responsible for creating the content of this item. Please enter a list of user names, one per line. The principal creator should come first."
 msgstr "Persons responsible for creating the content of this item. Please enter a list of user names, one per line. The principal creator should come first. (未翻訳)"
 
 #: components/manage/Blocks/Video/Edit
+# defaultMessage: Please enter a valid URL by deleting the block and adding a new video block.
 msgid "Please enter a valid URL by deleting the block and adding a new video block."
 msgstr "ブロックを削除して新しいビデオブロックを追加して、正しいURLを入力してください。"
 
 #: components/manage/Blocks/Maps/Edit
+# defaultMessage: Please enter the Embed Code provided by Google Maps -> Share -> Embed map. It should contain the <iframe> code on it.
 msgid "Please enter the Embed Code provided by Google Maps -> Share -> Embed map. It should contain the <iframe> code on it."
 msgstr "「Google Maps -> 共有 -> 地図を埋め込む」で提供されるEmbedコードを入力してください。<iframe>コードが含まれています"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Please fill out the form below to set your password.
 msgid "Please fill out the form below to set your password."
 msgstr "パスワードをフォームに入力してください"
 
 #: components/theme/Footer/Footer
+# defaultMessage: Plone Foundation
 msgid "Plone Foundation"
 msgstr "Plone Foundation"
 
 #: components/theme/Logo/Logo
+# defaultMessage: Plone Site
 msgid "Plone Site"
 msgstr "Ploneサイト"
 
 #: components/theme/Footer/Footer
+# defaultMessage: Plone{reg} Open Source CMS/WCM
 msgid "Plone{reg} Open Source CMS/WCM"
 msgstr "Plone{reg} Open Source CMS/WCM"
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: Portrait
 msgid "Portrait"
 msgstr "顔写真"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Possible values (Enter allowed choices one per line).
 msgid "Possible values"
 msgstr ""
 
 #: components/theme/Footer/Footer
+# defaultMessage: Powered by Plone & Python
 msgid "Powered by Plone & Python"
 msgstr "Powered by Plone & Python"
 
 #: components/manage/Toolbar/PersonalTools
+# defaultMessage: Preferences
 msgid "Preferences"
 msgstr "個別設定"
 
 #: components/manage/Blocks/HTML/Edit
+# defaultMessage: Prettify your code
 msgid "Prettify your code"
 msgstr ""
 
 #: components/manage/Blocks/HTML/Edit
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Preview
 msgid "Preview"
 msgstr "プレビュー"
 
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Preview Image URL
 msgid "Preview Image URL"
 msgstr ""
 
 #: components/manage/Toolbar/PersonalTools
+# defaultMessage: Profile
 msgid "Profile"
 msgstr "プロフィール"
 
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Properties
 msgid "Properties"
 msgstr "プロパティ"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Publication date
 msgid "Publication date"
 msgstr "公開日付"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Publishing Date
 msgid "Publishing Date"
 msgstr "公開日付"
 
 #: components/manage/Blocks/Listing/schema
+# defaultMessage: Query
 msgid "Query"
 msgstr ""
 
 #: components/manage/Preferences/ChangePassword
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Re-enter the password. Make sure the passwords are identical.
 msgid "Re-enter the password. Make sure the passwords are identical."
 msgstr "パスワードを再入力してください。同じパスワードであることを確認してください。"
 
 #: components/theme/Search/Search
 #: components/theme/View/SummaryView
+# defaultMessage: Read More…
 msgid "Read More…"
 msgstr "もっと読む"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Rearrange items by…
 msgid "Rearrange items by…"
 msgstr "何で並べ替えますか"
 
 #: components/manage/Widgets/RecurrenceWidget/EndField
+# defaultMessage: Ends
 msgid "Recurrence ends"
 msgstr "終了条件"
 
 #: components/manage/Widgets/RecurrenceWidget/EndField
+# defaultMessage: after
 msgid "Recurrence ends after"
 msgstr "繰り返し"
 
 #: components/manage/Widgets/RecurrenceWidget/EndField
+# defaultMessage: on
 msgid "Recurrence ends on"
 msgstr "最終日"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Minimalistic table design
 msgid "Reduce complexity"
 msgstr "見出し行の背景色を変更しない"
 
 #: components/theme/Anontools/Anontools
 #: components/theme/Login/Login
 #: components/theme/Register/Register
+# defaultMessage: Register
 msgid "Register"
 msgstr "登録"
 
 #: components/theme/Register/Register
+# defaultMessage: Registration form
 msgid "Registration form"
 msgstr "登録フォーム"
 
 #: components/theme/Search/Search
+# defaultMessage: Relevance
 msgid "Relevance"
 msgstr "関連性"
 
 #: components/manage/Widgets/ObjectListWidget
+# defaultMessage: Remove item
 msgid "Remove item"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Remove
 msgid "Remove recurrence"
 msgstr "繰り返しを削除"
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Remove term
 msgid "Remove term"
 msgstr ""
 
 #: components/manage/Toolbar/More
+# defaultMessage: Remove working copy
 msgid "Remove working copy"
 msgstr ""
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
+# defaultMessage: Rename
 msgid "Rename"
 msgstr "名前の変更"
 
 #: components/manage/Contents/ContentsRenameModal
+# defaultMessage: Renaming items...
 msgid "Rename Items Loading Message"
 msgstr ""
 
 #: components/manage/Contents/ContentsRenameModal
+# defaultMessage: Rename items
 msgid "Rename items"
 msgstr "名前の変更"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Repeat
 msgid "Repeat"
 msgstr "繰り返しの単位"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Repeat every
 msgid "Repeat every"
 msgstr "繰り返す間隔"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Repeat on
 msgid "Repeat on"
 msgstr "日または曜日"
 
 #: components/manage/Widgets/FileWidget
+# defaultMessage: Replace existing file
 msgid "Replace existing file"
 msgstr ""
 
 #: components/theme/Comments/Comments
+# defaultMessage: Reply
 msgid "Reply"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/WysiwygWidget
+# defaultMessage: Required
 msgid "Required"
 msgstr "必須"
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Required input is missing.
 msgid "Required input is missing."
 msgstr "必須"
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Reset title
 msgid "Reset term title"
 msgstr ""
 
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: Results limit
 msgid "Results limit"
 msgstr "最大件数"
 
 #: components/manage/Blocks/Listing/Edit
+# defaultMessage: Results preview
 msgid "Results preview"
 msgstr "結果のプレビュー"
 
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: Reversed order
 msgid "Reversed order"
 msgstr "逆順"
 
 #: components/manage/History/History
+# defaultMessage: Revert to this revision
 msgid "Revert to this revision"
 msgstr "このリビジョンに戻す"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Review state
 msgid "Review state"
 msgstr "審査状態"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Richtext
 msgid "Richtext"
 msgstr "Richtext"
 
 #: components/manage/Blocks/Image/ImageSizeWidget
 #: components/manage/Blocks/Maps/Edit
 #: components/manage/Sidebar/AlignBlock
+# defaultMessage: Right
 msgid "Right"
 msgstr "右"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Rights
 msgid "Rights"
 msgstr "権利"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Roles
 msgid "Roles"
 msgstr "ロール"
 
 #: components/manage/Contents/ContentsBreadcrumbs
+# defaultMessage: Root
 msgid "Root"
 msgstr ""
 
@@ -1637,90 +1997,112 @@ msgstr ""
 #: components/manage/Form/ModalForm
 #: components/manage/Sharing/Sharing
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Save
 msgid "Save"
 msgstr "保存"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Save
 msgid "Save recurrence"
 msgstr "繰り返しを保存"
 
 #: components/manage/Controlpanels/ContentTypesActions
+# defaultMessage: Schema
 msgid "Schema"
 msgstr "スキーマ"
 
 #: components/manage/Controlpanels/ContentTypeSchema
+# defaultMessage: Schema updates
 msgid "Schema updates"
 msgstr ""
 
 #: components/theme/SearchWidget/SearchWidget
+# defaultMessage: Search
 msgid "Search"
 msgstr "検索"
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: Search SVG
 msgid "Search SVG"
 msgstr ""
 
 #: components/theme/SearchWidget/SearchWidget
+# defaultMessage: Search Site
 msgid "Search Site"
 msgstr "検索"
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: Search content
 msgid "Search content"
 msgstr "検索"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Search for user or group
 msgid "Search for user or group"
 msgstr "検索"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Search group…
 msgid "Search group…"
 msgstr "グループを検索…"
 
 #: components/theme/Search/Search
+# defaultMessage: Search results
 msgid "Search results"
 msgstr "検索"
 
 #: components/theme/Search/Search
+# defaultMessage: Search results for {term}
 msgid "Search results for {term}"
 msgstr "検索"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Search users…
 msgid "Search users…"
 msgstr "ユーザーを検索…"
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: Second
 msgid "Second"
 msgstr "第2"
 
 #: components/manage/Sidebar/ObjectBrowserNav
+# defaultMessage: Select
 msgid "Select"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Select a date to add to recurrence
 msgid "Select a date to add to recurrence"
 msgstr "繰り返しに追加する日を選択"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Select columns to show
 msgid "Select columns to show"
 msgstr "表示する列を選択"
 
 #: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Select the transition to be used for modifying the items state.
 msgid "Select the transition to be used for modifying the items state."
 msgstr "アイテムの状態を変更するために遷移を選んでください"
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: Selected dates
 msgid "Selected dates"
 msgstr "選択した日付"
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: Selected items
 msgid "Selected items"
 msgstr "選択中のアイテム"
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: of
 msgid "Selected items - x of y"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Selection
 msgid "Selection"
 msgstr "Selection (未翻訳)"
 
@@ -1728,158 +2110,195 @@ msgstr "Selection (未翻訳)"
 #: components/manage/Widgets/ArrayWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/TokenWidget
+# defaultMessage: Select…
 msgid "Select…"
 msgstr "選択…"
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Send
 msgid "Send"
 msgstr "送る"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Set my password
 msgid "Set my password"
 msgstr "パスワードを設定"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Set your password
 msgid "Set your password"
 msgstr "パスワードを設定"
 
 #: components/manage/Sidebar/Sidebar
+# defaultMessage: Settings
 msgid "Settings"
 msgstr ""
 
 #: components/manage/Sharing/Sharing
 #: components/manage/Toolbar/More
+# defaultMessage: Sharing
 msgid "Sharing"
 msgstr "共有"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Sharing for {title}
 msgid "Sharing for {title}"
 msgstr "「{title}」の共有"
 
 #: components/manage/Widgets/SchemaWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/WysiwygWidget
+# defaultMessage: Short Name
 msgid "Short Name"
 msgstr "ショートネーム"
 
 #: components/manage/Contents/ContentsRenameModal
+# defaultMessage: Short name
 msgid "Short name"
 msgstr "ショートネーム"
 
 #: components/theme/Pagination/Pagination
+# defaultMessage: Show
 msgid "Show"
 msgstr "表示件数"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Show All
 msgid "Show All"
 msgstr ""
 
 #: components/theme/Comments/Comments
+# defaultMessage: Show Replies
 msgid "Show Replies"
 msgstr ""
 
 #: components/manage/Widgets/ObjectListWidget
+# defaultMessage: Show item
 msgid "Show item"
 msgstr ""
 
 #: components/manage/Sidebar/Sidebar
+# defaultMessage: Shrink sidebar
 msgid "Shrink sidebar"
 msgstr "サイドバーを閉じる"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Shrink toolbar
 msgid "Shrink toolbar"
 msgstr "ツールバーを閉じる"
 
 #: components/theme/Login/Login
+# defaultMessage: Sign in to start session
 msgid "Sign in to start session"
 msgstr "ログインしてセッションを開始"
 
 #: components/theme/Logo/Logo
+# defaultMessage: Site
 msgid "Site"
 msgstr "サイト"
 
 #: components/theme/NotFound/NotFound
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: Site Administration
 msgid "Site Administration"
 msgstr "サイト管理"
 
 #: components/theme/Footer/Footer
+# defaultMessage: Site Map
 msgid "Site Map"
 msgstr "サイトマップ"
 
 #: components/manage/Controlpanels/Controlpanels
 #: components/manage/Toolbar/PersonalTools
+# defaultMessage: Site Setup
 msgid "Site Setup"
 msgstr "サイト設定"
 
 #: components/theme/Sitemap/Sitemap
+# defaultMessage: Sitemap
 msgid "Sitemap"
 msgstr "サイトマップ"
 
 #: components/manage/Blocks/Image/ImageSidebar
+# defaultMessage: Size
 msgid "Size"
 msgstr "サイズ"
 
 #: components/theme/View/ImageView
+# defaultMessage: Size: {size}
 msgid "Size: {size}"
 msgstr "サイズ: {size}"
 
 #: error
+# defaultMessage: Sorry, something went wrong with your request
 msgid "Sorry, something went wrong with your request"
 msgstr "申し訳ありません。問題が発生したために処理できませんでした。"
 
 #: components/theme/Search/Search
+# defaultMessage: Sort by:
 msgid "Sort By:"
 msgstr "並び順:"
 
 #: components/manage/Widgets/QuerySortOnWidget
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: Sort on
 msgid "Sort on"
 msgstr "ソート順"
 
 #: components/manage/Blocks/HTML/Edit
+# defaultMessage: Source
 msgid "Source"
 msgstr "ソース"
 
 #: components/manage/Blocks/Video/Edit
+# defaultMessage: Specify a youtube video or playlist url
 msgid "Specify a youtube video or playlist url"
 msgstr "YouTubeビデオまたはプレイリストURLを指定してください。"
 
 #: components/manage/Diff/Diff
+# defaultMessage: Split
 msgid "Split"
 msgstr "分割"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Start Date
 msgid "Start Date"
 msgstr "開始日付"
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: Start of the recurrence
 msgid "Start of the recurrence"
 msgstr "繰り返しの開始日"
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Start password reset
 msgid "Start password reset"
 msgstr "パスワード再設定を開始"
 
 #: components/manage/Contents/Contents
 #: components/manage/Workflow/Workflow
 #: components/theme/View/TabularView
+# defaultMessage: State
 msgid "State"
 msgstr "状態"
 
 #: components/manage/Multilingual/CompareLanguages
+# defaultMessage: Stop compare
 msgid "Stop compare"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: String
 msgid "String"
 msgstr "String (未翻訳)"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Alternate row background color
 msgid "Stripe alternate rows with color"
 msgstr "一行おきに背景色を付加"
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Subject
 msgid "Subject"
 msgstr "件名"
 
@@ -1893,43 +2312,53 @@ msgstr "件名"
 #: components/manage/Preferences/PersonalPreferences
 #: components/theme/ContactForm/ContactForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Success
 msgid "Success"
 msgstr "成功"
 
 #: components/theme/LanguageSelector/LanguageSelector
+# defaultMessage: Switch to
 msgid "Switch to"
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Table
 msgid "Table"
 msgstr "テーブル"
 
 #: components/manage/Blocks/ToC/View
+# defaultMessage: Table of Contents
 msgid "Table of Contents"
 msgstr "目次"
 
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsTagsModal
+# defaultMessage: Tags
 msgid "Tags"
 msgstr "タグ"
 
 #: components/manage/Contents/ContentsTagsModal
+# defaultMessage: Tags to add
 msgid "Tags to add"
 msgstr "追加するタグ"
 
 #: components/manage/Contents/ContentsTagsModal
+# defaultMessage: Tags to remove
 msgid "Tags to remove"
 msgstr "削除をするタグ"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Target memory size per cache in bytes
 msgid "Target memory size per cache in bytes"
 msgstr "キャッシュごとの最大容量(byte単位)"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Target number of objects in memory per cache
 msgid "Target number of objects in memory per cache"
 msgstr "キャッシュごとのメモリー上の最大オブジェクト数"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Text
 msgid "Text"
 msgstr "テキスト"
 
@@ -1937,87 +2366,108 @@ msgstr "テキスト"
 #: components/theme/CorsError/CorsError
 #: components/theme/NotFound/NotFound
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: Thank you.
 msgid "Thank you."
 msgstr "ありがとうございます。"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: The Database Manager allow you to view database status information
 msgid "The Database Manager allow you to view database status information"
 msgstr "この画面でデータベースの状態を確認できます。"
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: The URL for your external home page, if you have one.
 msgid "The URL for your external home page, if you have one."
 msgstr "外部ホームページがあればURLを記載してください。"
 
 #: components/theme/ConnectionRefused/ConnectionRefused
+# defaultMessage: The backend is not responding, please check if you have started Plone, check your project's configuration object apiPath (or if you are using the internal proxy, devProxyToApiPath) or the RAZZLE_API_PATH Volto's environment variable.
 msgid "The backend is not responding, please check if you have started Plone, check your project's configuration object apiPath (or if you are using the internal proxy, devProxyToApiPath) or the RAZZLE_API_PATH Volto's environment variable."
 msgstr "The backend is not responding, please check if you have started Plone, check your project's configuration object apiPath (or if you are using the internal proxy, devProxyToApiPath) or the RAZZLE_API_PATH Volto's environment variable. (未翻訳)"
 
 #: components/theme/CorsError/CorsError
+# defaultMessage: The backend is responding, but the CORS headers are not configured properly and the browser has denied the access to the backend resources.
 msgid "The backend is responding, but the CORS headers are not configured properly and the browser has denied the access to the backend resources."
 msgstr "The backend is responding, but the CORS headers are not configured properly and the browser has denied the access to the backend resources. (未翻訳)"
 
 #: components/theme/CorsError/CorsError
+# defaultMessage: The backend server of your website is not anwering, we apologize for the inconvenience. Please try to re-load the page and try again. If the problem persists please contact the site administrators.
 msgid "The backend server of your website is not anwering, we apologize for the inconvenience. Please try to re-load the page and try again. If the problem persists please contact the site administrators."
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: The item could not be deleted.
 msgid "The item could not be deleted."
 msgstr ""
 
 #: components/theme/Register/Register
+# defaultMessage: The registration process has been successful. Please check your e-mail inbox for information on how activate your account.
 msgid "The registration process has been successful. Please check your e-mail inbox for information on how activate your account."
 msgstr "The registration process has been successful. Please check your e-mail inbox for information on how activate your account. (未翻訳)"
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: The user portrait/avatar
 msgid "The user portrait/avatar"
 msgstr "写真やアバターなどプロフィール画像を登録してください。"
 
 #: components/manage/Toolbar/More
+# defaultMessage: The working copy was discarded
 msgid "The working copy was discarded"
 msgstr ""
 
 #: components/theme/Footer/Footer
+# defaultMessage: The {plonecms} is {copyright} 2000-{current_year} by the {plonefoundation} and friends.
 msgid "The {plonecms} is {copyright} 2000-{current_year} by the {plonefoundation} and friends."
 msgstr "The {plonecms} is {copyright} 2000-{current_year} by the {plonefoundation} and friends."
 
 #: components/theme/CorsError/CorsError
+# defaultMessage: There is a configuration problem on the backend
 msgid "There is a configuration problem on the backend"
 msgstr "バックエンドサーバの設定に問題があります。"
 
 #: components/manage/Form/InlineForm
+# defaultMessage: There were some errors
 msgid "There were some errors"
 msgstr "エラーが発生しました"
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: There were some errors.
 msgid "There were some errors."
 msgstr "いくつかのエラーが発生しました"
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: Third
 msgid "Third"
 msgstr "第3"
 
 #: components/manage/WorkingCopyToastsFactory/WorkingCopyToastsFactory
+# defaultMessage: This has an ongoing working copy in {title}
 msgid "This has an ongoing working copy in {title}"
 msgstr ""
 
 #: components/manage/WorkingCopyToastsFactory/WorkingCopyToastsFactory
+# defaultMessage: This is a working copy of {title}
 msgid "This is a working copy of {title}"
 msgstr ""
 
 #: components/manage/LockingToastsFactory/LockingToastsFactory
+# defaultMessage: This item was locked by {creator} on {date}
 msgid "This item was locked by {creator} on {date}"
 msgstr ""
 
 #: components/manage/Contents/ContentsRenameModal
+# defaultMessage: This name will be displayed in the URL.
 msgid "This name will be displayed in the URL."
 msgstr "この名前はURLの一部として使用されます"
 
 #: components/theme/NotFound/NotFound
+# defaultMessage: This page does not seem to exist…
 msgid "This page does not seem to exist…"
 msgstr "このページは存在しないようです…"
 
 #: components/manage/Widgets/DatetimeWidget
+# defaultMessage: Time
 msgid "Time"
 msgstr "時刻"
 
@@ -2030,714 +2480,889 @@ msgstr "時刻"
 #: components/manage/Widgets/WysiwygWidget
 #: components/theme/View/TabularView
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Title
 msgid "Title"
 msgstr "タイトル"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Total active and non-active objects
 msgid "Total active and non-active objects"
 msgstr "オブジェクトの総数"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Total comments
 msgid "Total comments"
 msgstr "コメント計"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Total number of objects in each cache
 msgid "Total number of objects in each cache"
 msgstr "各キャッシュのオブジェクト総数"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Total number of objects in memory from all caches
 msgid "Total number of objects in memory from all caches"
 msgstr "キャッシュメモリ内のオブジェクト数"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Total number of objects in the database
 msgid "Total number of objects in the database"
 msgstr "データベースの中にあるオブジェクト数"
 
 #: components/manage/Add/Add
 #: components/manage/Toolbar/Types
+# defaultMessage: Translate to {lang}
 msgid "Translate to {lang}"
 msgstr "{lang} に翻訳する"
 
 #: components/manage/Multilingual/ManageTranslations
+# defaultMessage: Translation linked
 msgid "Translation linked"
 msgstr ""
 
 #: components/manage/Multilingual/ManageTranslations
+# defaultMessage: Translation linking removed
 msgid "Translation linking removed"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypes
 #: components/manage/Widgets/SchemaWidget
 #: components/theme/View/TabularView
+# defaultMessage: Type
 msgid "Type"
 msgstr "タイプ"
 
 #: components/manage/Blocks/Video/Edit
+# defaultMessage: Type a Video (YouTube, Vimeo or mp4) URL
 msgid "Type a Video (YouTube, Vimeo or mp4) URL"
 msgstr "ビデオURLを入力 (YouTube, Vimeo or mp4)"
 
 #: components/manage/Blocks/Text/Edit
+# defaultMessage: Type text…
 msgid "Type text…"
 msgstr "テキストを入力…"
 
 #: components/manage/Blocks/Title/Edit
+# defaultMessage: Type the title…
 msgid "Type the title…"
 msgstr "タイトルを入力…"
 
 #: components/manage/Contents/Contents
+# defaultMessage: UID
 msgid "UID"
 msgstr "UID"
 
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: Unauthorized
 msgid "Unauthorized"
 msgstr "Unauthorized(未翻訳)"
 
 #: components/manage/BlockChooser/BlockChooser
+# defaultMessage: Unfold
 msgid "Unfold"
 msgstr ""
 
 #: components/manage/Diff/Diff
+# defaultMessage: Unified
 msgid "Unified"
 msgstr "Unified (未翻訳)"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Uninstall
 msgid "Uninstall"
 msgstr "アンインストール"
 
 #: components/manage/Blocks/Block/Edit
 #: components/theme/View/DefaultView
 #: components/theme/View/RenderBlocks
+# defaultMessage: Unknown Block {block}
 msgid "Unknown Block"
 msgstr "不明なブロック"
 
 #: components/manage/Multilingual/ManageTranslations
+# defaultMessage: Unlink translation for
 msgid "Unlink translation for"
 msgstr ""
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Unlock
 msgid "Unlock"
 msgstr ""
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Update
 msgid "Update"
 msgstr "更新"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Update installed addons
 msgid "Update installed addons"
 msgstr "Update installed addons(未翻訳)"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Update installed addons:
 msgid "Update installed addons:"
 msgstr "Update installed addons:(未翻訳)"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Updates available
 msgid "Updates available"
 msgstr "Updates available(未翻訳)"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Upload
 msgid "Upload"
 msgstr "アップロード"
 
 #: components/manage/Blocks/LeadImage/Edit
+# defaultMessage: Upload a lead image in the 'Lead Image' content field.
 msgid "Upload a lead image in the 'Lead Image' content field."
 msgstr "リード画像をコンテンツのフィールドにアップロード"
 
 #: components/manage/Blocks/HeroImageLeft/Edit
+# defaultMessage: Upload a new image
 msgid "Upload a new image"
 msgstr "画像をアップロード"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Upload files
 msgid "Upload files"
 msgstr "アップロードファイル"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Uploading files
 msgid "Uploading files"
 msgstr "ファイルをアップロードしています"
 
 #: components/manage/Blocks/HeroImageLeft/Edit
+# defaultMessage: Uploading image
 msgid "Uploading image"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/WysiwygWidget
+# defaultMessage: Used for programmatic access to the fieldset.
 msgid "Used for programmatic access to the fieldset."
 msgstr "Used for programmatic access to the fieldset. (未翻訳)"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: User
 msgid "User"
 msgstr "ユーザ"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: User created
 msgid "User created"
 msgstr "ユーザを作成しました"
 
 #: components/manage/Controlpanels/Users/UsersControlpanel
+# defaultMessage: User name
 msgid "User name"
 msgstr "ユーザ名"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: User roles updated
 msgid "User roles updated"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Username
 msgid "Username"
 msgstr "ユーザ名"
 
 #: components/manage/Controlpanels/Controlpanels
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Users
 msgid "Users"
 msgstr "ユーザ"
 
 #: components/manage/Controlpanels/Controlpanels
+# defaultMessage: Users and Groups
 msgid "Users and Groups"
 msgstr "ユーザとグループ"
 
 #: helpers/Extensions/withBlockSchemaEnhancer
+# defaultMessage: Variation
 msgid "Variation"
 msgstr ""
 
 #: components/manage/Controlpanels/Controlpanels
+# defaultMessage: Version Overview
 msgid "Version Overview"
 msgstr "バージョン情報"
 
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Video
 msgid "Video"
 msgstr "ビデオ"
 
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Video URL
 msgid "Video URL"
 msgstr "ビデオURL"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: View
 msgid "View"
 msgstr "表示"
 
 #: components/manage/History/History
+# defaultMessage: View changes
 msgid "View changes"
 msgstr "表示"
 
 #: components/manage/History/History
+# defaultMessage: View this revision
 msgid "View this revision"
 msgstr "この履歴を表示"
 
 #: components/manage/Toolbar/More
+# defaultMessage: View working copy
 msgid "View working copy"
 msgstr ""
 
 #: components/manage/Display/Display
+# defaultMessage: View
 msgid "Viewmode"
 msgstr "表示モード"
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Vocabulary term
 msgid "Vocabulary term"
 msgstr ""
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Title
 msgid "Vocabulary term title"
 msgstr ""
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Vocabulary terms
 msgid "Vocabulary terms"
 msgstr ""
 
 #: components/manage/Controlpanels/VersionOverview
+# defaultMessage: You are running in 'debug mode'. This mode is intended for sites that are under development. This allows many configuration changes to be immediately visible, but will make your site run more slowly. To turn off debug mode, stop the server, set 'debug-mode=off' in your buildout.cfg, re-run bin/buildout and then restart the server process.
 msgid "Warning Regarding debug mode"
 msgstr "デバッグモードに関する警告"
 
 #: components/theme/ConnectionRefused/ConnectionRefused
+# defaultMessage: We apologize for the inconvenience, but the backend of the site you are accessing is not available right now. Please, try again later.
 msgid "We apologize for the inconvenience, but the backend of the site you are accessing is not available right now. Please, try again later."
 msgstr ""
 
 #: components/theme/NotFound/NotFound
+# defaultMessage: We apologize for the inconvenience, but the page you were trying to access is not at this address. You can use the links below to help you find what you are looking for.
 msgid "We apologize for the inconvenience, but the page you were trying to access is not at this address. You can use the links below to help you find what you are looking for."
 msgstr "不便をかけて申し訳ありませんが、アクセスしようとしたページはこのアドレスではありません。"
 
 #: components/theme/Forbidden/Forbidden
+# defaultMessage: We apologize for the inconvenience, but you don't have permissions on this resource.
 msgid "We apologize for the inconvenience, but you don't have permissions on this resource."
 msgstr "We apologize for the inconvenience, but you don't have permissions on this resource.(未翻訳)"
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: We will use this address if you need to recover your password
 msgid "We will use this address if you need to recover your password"
 msgstr "あなたのパスワードを回復する必要がある場合、このアドレスが使われます。"
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: The
 msgid "Weeek day of month"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Weekday
 msgid "Weekday"
 msgstr "平日"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Weekly
 msgid "Weekly"
 msgstr "毎週"
 
 #: components/manage/History/History
+# defaultMessage: What
 msgid "What"
 msgstr "何を"
 
 #: components/manage/History/History
+# defaultMessage: When
 msgid "When"
 msgstr "いつ"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: When this date is reached, the content will nolonger be visible in listings and searches.
 msgid "When this date is reached, the content will nolonger be visible in listings and searches."
 msgstr "When this date is reached, the content will nolonger be visible in listings and searches. (未翻訳)"
 
 #: components/manage/History/History
+# defaultMessage: Who
 msgid "Who"
 msgstr "誰が"
 
 #: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Updating workflow states...
 msgid "Workflow Change Loading Message"
 msgstr ""
 
 #: components/manage/Workflow/Workflow
+# defaultMessage: Workflow updated.
 msgid "Workflow updated."
 msgstr "ワークフローがアップデートされました"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Yearly
 msgid "Yearly"
 msgstr "毎年"
 
 #: components/manage/Contents/ContentsItem
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Yes
 msgid "Yes"
 msgstr "Yes"
 
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: You are trying to access a protected resource, please {login} first.
 msgid "You are trying to access a protected resource, please {login} first."
 msgstr "You are trying to access a protected resource, please {login} first.(未翻訳)"
 
 #: components/theme/OutdatedBrowser/OutdatedBrowser
+# defaultMessage: You are using an outdated browser
 msgid "You are using an outdated browser"
 msgstr "このブラウザには対応していません。"
 
 #: components/theme/Comments/Comments
+# defaultMessage: You can add a comment by filling out the form below. Plain text formatting.
 msgid "You can add a comment by filling out the form below. Plain text formatting."
 msgstr "You can add a comment by filling out the form below. Plain text formatting. (未翻訳)"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: You can control who can view and edit your item using the list below.
 msgid "You can control who can view and edit your item using the list below."
 msgstr "You can control who can view and edit your item using the list below. (未翻訳)"
 
 #: components/manage/Diff/Diff
+# defaultMessage: You can view the difference of the revisions below.
 msgid "You can view the difference of the revisions below."
 msgstr "You can view the difference of the revisions below. (未翻訳)"
 
 #: components/manage/History/History
+# defaultMessage: You can view the history of your item below.
 msgid "You can view the history of your item below."
 msgstr "You can view the history of your item below. (未翻訳)"
 
 #: components/manage/Contents/Contents
+# defaultMessage: You can't paste this content here
 msgid "You can't paste this content here"
 msgstr ""
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Your email is required for reset your password.
 msgid "Your email is required for reset your password."
 msgstr "Your email is required for reset your password. (未翻訳)"
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: Your location - either city and country - or in a company setting, where your office is located.
 msgid "Your location - either city and country - or in a company setting, where your office is located."
 msgstr "あなたのいる場所を入力してください。国名や都市名あるいはオフィスの場所など"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Your password has been set successfully. You may now {link} with your new password.
 msgid "Your password has been set successfully. You may now {link} with your new password."
 msgstr "Your password has been set successfully. You may now {link} with your new password. (未翻訳)"
 
 #: components/manage/Preferences/PersonalPreferences
+# defaultMessage: Your preferred language
 msgid "Your preferred language"
 msgstr "優先する言語"
 
 #: components/theme/Login/Login
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Forgot your password?
 msgid "box_forgot_password_option"
 msgstr "パスワードを忘れた？"
 
 #: config/Blocks
+# defaultMessage: Common
 msgid "common"
 msgstr "一般"
 
 #: components/manage/Multilingual/CompareLanguages
+# defaultMessage: Compare to language
 msgid "compare_to"
 msgstr ""
 
 #: components/manage/Blocks/Block/EditBlockWrapper
+# defaultMessage: delete
 msgid "delete"
 msgstr "削除"
 
 #: components/theme/OutdatedBrowser/OutdatedBrowser
+# defaultMessage: You are using {browsername} {browserversion} which is deprecated by its vendor. That means that it does not get security updates and it is not ready for current modern web features, which deteriorates the user experience. Please upgrade to a modern browser.
 msgid "deprecated_browser_notice_message"
 msgstr "サポート対象外のブラウザです"
 
 #: config/Blocks
+# defaultMessage: Description
 msgid "description"
 msgstr "説明"
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: For security reasons, we store your password encrypted, and cannot mail it to you. If you would like to reset your password, fill out the form below and we will send you an email at the address you gave when you registered to start the process of resetting your password.
 msgid "description_lost_password"
 msgstr "安全上の理由で、パスワードは暗号化されて保管されており、それをメールで送ることはできません。パスワードを再設定するには下記のフォームに記入してください。パスワード再設定の処理を開始するように登録すれば、指定されたメールアドレスにＥメールが送られます。"
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Your password reset request has been mailed. It should arrive in your mailbox shortly. When you receive the message, visit the address it contains to reset your password.
 msgid "description_sent_password"
 msgstr "パスワード再設定のお願いをメール送信しました。まもなくあなたのメールボックスに届くはずです。メッセージを受け取ったら、その中にあるパスワード再設定用のURLにアクセスしてください。"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Draft
 msgid "draft"
 msgstr "下書き(draft)"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Input must be valid email (something@domain.com)
 msgid "email"
 msgstr ""
 
 #: components/theme/View/EventView
+# defaultMessage: All dates
 msgid "event_alldates"
 msgstr "すべての日程"
 
 #: components/theme/View/EventView
+# defaultMessage: Attendees
 msgid "event_attendees"
 msgstr "参加者"
 
 #: components/theme/View/EventView
+# defaultMessage: Contact Name
 msgid "event_contactname"
 msgstr "連絡先名称"
 
 #: components/theme/View/EventView
+# defaultMessage: Contact Phone
 msgid "event_contactphone"
 msgstr "連絡先電話番号"
 
 #: components/theme/View/EventView
+# defaultMessage: Website
 msgid "event_website"
 msgstr "イベントURL"
 
 #: components/theme/View/EventView
+# defaultMessage: What
 msgid "event_what"
 msgstr ""
 
 #: components/theme/View/EventView
+# defaultMessage: When
 msgid "event_when"
 msgstr "イベント日時"
 
 #: components/theme/View/EventView
+# defaultMessage: Where
 msgid "event_where"
 msgstr "場所"
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Password reset confirmation sent
 msgid "heading_sent_password"
 msgstr "パスワード再設定の確認が送られました"
 
 #: config/Blocks
+# defaultMessage: Hero
 msgid "hero"
 msgstr "ヒーロー"
 
 #: config/Blocks
+# defaultMessage: HTML
 msgid "html"
 msgstr "HTML"
 
 #: config/Blocks
+# defaultMessage: Image
 msgid "image"
 msgstr "画像"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Input must be integer
 msgid "integer"
 msgstr ""
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Intranet
 msgid "intranet"
 msgstr ""
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: My email address is
 msgid "label_my_email_address_is"
 msgstr "私のメールアドレスは"
 
 #: config/Blocks
+# defaultMessage: Lead Image Field
 msgid "leadimage"
 msgstr "リード画像"
 
 #: config/Blocks
+# defaultMessage: Listing
 msgid "listing"
 msgstr "リスティング"
 
 #: components/manage/Blocks/Listing/ListingBody
 #: components/manage/Contents/Contents
+# defaultMessage: Loading
 msgid "loading"
 msgstr ""
 
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: log in
 msgid "log in"
 msgstr "ログイン"
 
 #: config/Blocks
+# defaultMessage: Maps
 msgid "maps"
 msgstr "地図"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Maximum Length
 msgid "maxLength"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: End of the range (including the value itself)
 msgid "maximum"
 msgstr ""
 
 #: config/Blocks
+# defaultMessage: Media
 msgid "media"
 msgstr "メディア"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Minimum Length
 msgid "minLength"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Start of the range
 msgid "minimum"
 msgstr ""
 
 #: config/Blocks
+# defaultMessage: Most used
 msgid "mostUsed"
 msgstr "よく使う物"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: No workflow state
 msgid "no workflow state"
 msgstr "状態なし"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Input must be number
 msgid "number"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/ByMonthDayField
 #: components/manage/Widgets/RecurrenceWidget/ByYearField
+# defaultMessage: of the month
 msgid "of the month"
 msgstr "(毎月の)"
 
 #: error
+# defaultMessage: or try a different page.
 msgid "or try a different page."
 msgstr "または、他のページを試してください。"
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: others
 msgid "others"
 msgstr ""
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Private
 msgid "private"
 msgstr "非表示"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Published
 msgid "published"
 msgstr "公開中"
 
 #: components/manage/Widgets/QueryWidget
+# defaultMessage: Select…
 msgid "querystring-widget-select"
 msgstr ""
 
 #: components/theme/Search/Search
+# defaultMessage: results
 msgid "results found"
 msgstr "件 見つかりました"
 
 #: error
+# defaultMessage: return to the site root
 msgid "return to the site root"
 msgstr "サイトルートに戻ってください。"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: and
 msgid "rrule_and"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: (~approximate)
 msgid "rrule_approximate"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: at
 msgid "rrule_at"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: [month] [day], [year]
 msgid "rrule_dateFormat"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: day
 msgid "rrule_day"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: days
 msgid "rrule_days"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: every
 msgid "rrule_every"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: for
 msgid "rrule_for"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: hour
 msgid "rrule_hour"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: hours
 msgid "rrule_hours"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: in
 msgid "rrule_in"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: last
 msgid "rrule_last"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: minutes
 msgid "rrule_minutes"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: month
 msgid "rrule_month"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: months
 msgid "rrule_months"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: nd
 msgid "rrule_nd"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: on
 msgid "rrule_on"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: on the
 msgid "rrule_on the"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: or
 msgid "rrule_or"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: rd
 msgid "rrule_rd"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: st
 msgid "rrule_st"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: th
 msgid "rrule_th"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: the
 msgid "rrule_the"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: time
 msgid "rrule_time"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: times
 msgid "rrule_times"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: until
 msgid "rrule_until"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: week
 msgid "rrule_week"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: weekday
 msgid "rrule_weekday"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: weekdays
 msgid "rrule_weekdays"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: weeks
 msgid "rrule_weeks"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: year
 msgid "rrule_year"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: years
 msgid "rrule_years"
 msgstr ""
 
 #: components/theme/SkipLinks/SkipLinks
+# defaultMessage: Skip to footer
 msgid "skiplink-footer"
 msgstr ""
 
 #: components/theme/SkipLinks/SkipLinks
+# defaultMessage: Skip to main content
 msgid "skiplink-main-content"
 msgstr ""
 
 #: components/theme/SkipLinks/SkipLinks
+# defaultMessage: Skip to navigation
 msgid "skiplink-navigation"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: sort
 msgid "sort"
 msgstr "並べ替え"
 
 #: config/Blocks
+# defaultMessage: Table
 msgid "table"
 msgstr "テーブル"
 
 #: config/Blocks
+# defaultMessage: Text
 msgid "text"
 msgstr "テキスト"
 
 #: config/Blocks
+# defaultMessage: Title
 msgid "title"
 msgstr "タイトル"
 
 #: config/Blocks
+# defaultMessage: Table of Contents
 msgid "toc"
 msgstr "目次"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Input must be valid url (www.something.com or http(s)://www.something.com)
 msgid "url"
 msgstr ""
 
 #: components/manage/Toolbar/PersonalTools
+# defaultMessage: user avatar
 msgid "user avatar"
 msgstr "ユーザアイコン"
 
 #: config/Blocks
+# defaultMessage: Video
 msgid "video"
 msgstr "ビデオ"
 
 #: components/theme/View/EventView
+# defaultMessage: Visit external website
 msgid "visit_external_website"
 msgstr "外部サイトを表示"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: {count, plural, one {Upload {count} file} other {Upload {count} files}}
 msgid "{count, plural, one {Upload {count} file} other {Upload {count} files}}"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: {count} selected
 msgid "{count} selected"
 msgstr "{count} 件選択中"
 
 #: components/manage/Controlpanels/ContentType
+# defaultMessage: {id} Content Type
 msgid "{id} Content Type"
 msgstr "{id} コンテンツタイプ"
 
 #: components/manage/Controlpanels/ContentTypeSchema
+# defaultMessage: {id} Schema
 msgid "{id} Schema"
 msgstr "{id} スキーマ"
 
 #: components/manage/Actions/Actions
+# defaultMessage: {title} copied.
 msgid "{title} copied."
 msgstr "「{title}」をコピーしました。"
 
 #: components/manage/Actions/Actions
+# defaultMessage: {title} cut.
 msgid "{title} cut."
 msgstr "「{title}」をカットしました。"
 
 #: components/manage/Actions/Actions
+# defaultMessage: {title} has been deleted.
 msgid "{title} has been deleted."
 msgstr "「{title}」を削除しました。"

--- a/locales/nl/LC_MESSAGES/volto.po
+++ b/locales/nl/LC_MESSAGES/volto.po
@@ -31,22 +31,27 @@ msgstr ""
 "Preferred-Encodings: utf-8\n"
 
 #: components/manage/Blocks/HTML/Edit
+# defaultMessage: <p>Add some HTML here</p>
 msgid "<p>Add some HTML here</p>"
 msgstr ""
 
 #: components/theme/Footer/Footer
+# defaultMessage: Accessibility
 msgid "Accessibility"
 msgstr "Toegankelijkheid"
 
 #: components/theme/Register/Register
+# defaultMessage: Account Registration Completed
 msgid "Account Registration Completed"
 msgstr ""
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Account activation completed
 msgid "Account activation completed"
 msgstr ""
 
 #: components/manage/Controlpanels/ModerateComments
+# defaultMessage: Action
 msgid "Action"
 msgstr ""
 
@@ -55,10 +60,12 @@ msgstr ""
 #: components/manage/Controlpanels/ContentTypes
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
+# defaultMessage: Actions
 msgid "Actions"
 msgstr "Acties"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Activate and deactivate add-ons in the lists below.
 msgid "Activate and deactivate"
 msgstr ""
 
@@ -66,86 +73,107 @@ msgstr ""
 #: components/manage/Toolbar/Toolbar
 #: components/manage/Widgets/SchemaWidget
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add
 msgid "Add"
 msgstr ""
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: To make new add-ons show up here, add them to your buildout configuration, run buildout, and restart the server process. For detailed instructions see
 msgid "Add Addons"
 msgstr ""
 
 #: components/manage/Toolbar/Types
+# defaultMessage: Add Content…
 msgid "Add Content"
 msgstr ""
 
 #: components/manage/Toolbar/Types
+# defaultMessage: Add Translation…
 msgid "Add Translation…"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add User
 msgid "Add User"
 msgstr ""
 
 #: components/manage/Blocks/Description/Edit
+# defaultMessage: Add a description…
 msgid "Add a description…"
 msgstr ""
 
 #: components/manage/BlockChooser/BlockChooserButton
+# defaultMessage: Add block
 msgid "Add block"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add block…
 msgid "Add block…"
 msgstr ""
 
 #: components/manage/Widgets/QueryWidget
+# defaultMessage: Add criteria
 msgid "Add criteria"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Add date
 msgid "Add date"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Add field
 msgid "Add field"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Add fieldset
 msgid "Add fieldset"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add group
 msgid "Add group"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Add new content type
 msgid "Add new content type"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add new group
 msgid "Add new group"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add new user
 msgid "Add new user"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add to Groups
 msgid "Add to Groups"
 msgstr ""
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Add term
 msgid "Add vocabulary term"
 msgstr ""
 
 #: components/manage/Add/Add
+# defaultMessage: Add {type}
 msgid "Add {type}"
 msgstr "Voeg {type} toe"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Add-ons Settings
 msgid "Add-ons Settings"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: Additional date
 msgid "Additional date"
 msgstr ""
 
@@ -153,39 +181,48 @@ msgstr ""
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
 #: components/manage/Blocks/Maps/MapsSidebar
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Alignment
 msgid "Alignment"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: All
 msgid "All"
 msgstr "Alles"
 
 #: components/theme/Search/Search
+# defaultMessage: Alphabetically
 msgid "Alphabetically"
 msgstr ""
 
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: Alt text
 msgid "Alt text"
 msgstr ""
 
 #: components/manage/Toolbar/More
+# defaultMessage: Apply working copy
 msgid "Apply working copy"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Are you sure you want to delete this field?
 msgid "Are you sure you want to delete this field?"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Are you sure you want to delete this fieldset including all fields?
 msgid "Are you sure you want to delete this fieldset including all fields?"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Ascending
 msgid "Ascending"
 msgstr "Oplopend"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Available
 msgid "Available"
 msgstr ""
 
@@ -210,48 +247,59 @@ msgstr ""
 #: components/manage/Toolbar/Toolbar
 #: components/theme/ContactForm/ContactForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Back
 msgid "Back"
 msgstr ""
 
 #: components/manage/Diff/Diff
+# defaultMessage: Base
 msgid "Base"
 msgstr "Basis"
 
 #: components/manage/Sidebar/Sidebar
+# defaultMessage: Block
 msgid "Block"
 msgstr ""
 
 #: components/theme/Login/Login
+# defaultMessage: Both email address and password are case sensitive, check that caps lock is not enabled.
 msgid "Both email address and password are case sensitive, check that caps lock is not enabled."
 msgstr ""
 
 #: components/theme/Breadcrumbs/Breadcrumbs
+# defaultMessage: Breadcrumbs
 msgid "Breadcrumbs"
 msgstr ""
 
 #: components/manage/Blocks/HeroImageLeft/Edit
 #: components/manage/Contents/ContentsUploadModal
 #: components/manage/Sidebar/ObjectBrowserNav
+# defaultMessage: Browse
 msgid "Browse"
 msgstr "Bladeren"
 
 #: components/manage/Blocks/Image/Edit
+# defaultMessage: Browse the site, drop an image, or type an URL
 msgid "Browse the site, drop an image, or type an URL"
 msgstr ""
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: By default, permissions from the container of this item are inherited. If you disable this, only the explicitly defined sharing permissions will be valid. In the overview, the symbol {inherited} indicates an inherited value. Similarly, the symbol {global} indicates a global role, which is managed by the site administrator.
 msgid "By default, permissions from the container of this item are inherited. If you disable this, only the explicitly defined sharing permissions will be valid. In the overview, the symbol {inherited} indicates an inherited value. Similarly, the symbol {global} indicates a global role, which is managed by the site administrator."
 msgstr "Standaard worden de rechten overgenomen van de bovenliggende map.  Als u dit uitgeschakeld, worden alleen de expliciet toegekende rechten gebruikt. In het overzicht geeft het symbool ${image_confirm_icon} een overgenomen waarde aan. Vergelijkbaar geeft het icoon ${image_link_icon} een globale rol aan, die wordt beheerd door de websitebeheerder."
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Cache Name
 msgid "Cache Name"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypeLayout
+# defaultMessage: Can not edit Layout for <strong>{type}</strong> content-type as it doesn't have support for <strong>Volto Blocks</strong> enabled
 msgid "Can not edit Layout for <strong>{type}</strong> content-type as it doesn't have support for <strong>Volto Blocks</strong> enabled"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypeLayout
+# defaultMessage: Can not edit Layout for <strong>{type}</strong> content-type as the <strong>Blocks behavior</strong> is enabled and <strong>read-only</strong>
 msgid "Can not edit Layout for <strong>{type}</strong> content-type as the <strong>Blocks behavior</strong> is enabled and <strong>read-only</strong>"
 msgstr ""
 
@@ -267,42 +315,51 @@ msgstr ""
 #: components/manage/Sharing/Sharing
 #: components/theme/Login/Login
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Cancel
 msgid "Cancel"
 msgstr "Annuleren"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Cell
 msgid "Cell"
 msgstr ""
 
 #: components/manage/Blocks/Image/ImageSizeWidget
 #: components/manage/Blocks/Maps/Edit
 #: components/manage/Sidebar/AlignBlock
+# defaultMessage: Center
 msgid "Center"
 msgstr ""
 
 #: components/manage/History/History
+# defaultMessage: Change Note
 msgid "Change Note"
 msgstr "Beschrijf de wijzigingen"
 
 #: components/manage/Preferences/ChangePassword
+# defaultMessage: Change Password
 msgid "Change Password"
 msgstr "Wachtwoord wijzigen"
 
 #: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Change State
 msgid "Change State"
 msgstr "Status wijzigen"
 
 #: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Change workflow state recursively
 msgid "Change workflow state recursively"
 msgstr ""
 
 #: components/manage/Toolbar/More
+# defaultMessage: Changes applied
 msgid "Changes applied."
 msgstr ""
 
 #: components/manage/Preferences/ChangePassword
 #: components/manage/Preferences/PersonalInformation
 #: components/manage/Preferences/PersonalPreferences
+# defaultMessage: Changes saved
 msgid "Changes saved"
 msgstr "Wijzigingen zijn opgeslagen"
 
@@ -310,192 +367,237 @@ msgstr "Wijzigingen zijn opgeslagen"
 #: components/manage/Controlpanels/ContentTypeLayout
 #: components/manage/Controlpanels/ContentTypeSchema
 #: components/manage/Controlpanels/Controlpanel
+# defaultMessage: Changes saved.
 msgid "Changes saved."
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Checkbox
 msgid "Checkbox"
 msgstr ""
 
 #: components/manage/Widgets/SelectWidget
+# defaultMessage: Choices
 msgid "Choices"
 msgstr ""
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: Choose Image
 msgid "Choose Image"
 msgstr ""
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: Choose Target
 msgid "Choose Target"
 msgstr ""
 
 #: components/manage/Widgets/FileWidget
+# defaultMessage: Choose a file
 msgid "Choose a file"
 msgstr ""
 
 #: components/manage/Blocks/HTML/Edit
+# defaultMessage: Clear
 msgid "Clear"
 msgstr ""
 
 #: components/theme/View/ImageView
+# defaultMessage: Click to download full sized image
 msgid "Click to download full sized image"
 msgstr ""
 
 #: components/manage/Widgets/SelectWidget
+# defaultMessage: Close
 msgid "Close"
 msgstr ""
 
 #: components/theme/Navigation/Navigation
+# defaultMessage: Close menu
 msgid "Close menu"
 msgstr ""
 
 #: components/manage/Blocks/HTML/Edit
+# defaultMessage: Code
 msgid "Code"
 msgstr ""
 
 #: components/manage/Widgets/ObjectListWidget
+# defaultMessage: Collapse item
 msgid "Collapse item"
 msgstr ""
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Collection
 msgid "Collection"
 msgstr ""
 
 #: components/manage/Controlpanels/ModerateComments
 #: components/theme/Comments/CommentEditModal
 #: components/theme/Comments/Comments
+# defaultMessage: Comment
 msgid "Comment"
 msgstr ""
 
 #: components/manage/Controlpanels/ModerateComments
+# defaultMessage: Commenter
 msgid "Commenter"
 msgstr ""
 
 #: components/theme/Comments/Comments
+# defaultMessage: Comments
 msgid "Comments"
 msgstr ""
 
 #: components/manage/Diff/Diff
+# defaultMessage: Compare
 msgid "Compare"
 msgstr "Vergelijken"
 
 #: components/manage/Preferences/ChangePassword
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Confirm password
 msgid "Confirm password"
 msgstr "Wachtwoord bevestigen"
 
 #: components/theme/ConnectionRefused/ConnectionRefused
+# defaultMessage: Connection refused
 msgid "Connection refused"
 msgstr ""
 
 #: components/theme/Footer/Footer
+# defaultMessage: Contact
 msgid "Contact"
 msgstr "Contact"
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Contact form
 msgid "Contact form"
 msgstr ""
 
 #: components/manage/Blocks/Listing/Edit
+# defaultMessage: Contained items
 msgid "Contained items"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Content type created
 msgid "Content type created"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Content type deleted
 msgid "Content type deleted"
 msgstr ""
 
 #: components/manage/Contents/Contents
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Contents
 msgid "Contents"
 msgstr "Inhoud"
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Copy
 msgid "Copy"
 msgstr "Kopiëren"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: undefined
 msgid "Copy blocks"
 msgstr ""
 
 #: components/theme/Footer/Footer
+# defaultMessage: Copyright
 msgid "Copyright"
 msgstr "Copyright"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Copyright statement or other rights information on this item.
 msgid "Copyright statement or other rights information on this item."
 msgstr "Auteursrechten of andere rechtsinformatie van dit item."
 
 #: components/manage/Toolbar/More
+# defaultMessage: Create working copy
 msgid "Create working copy"
 msgstr ""
 
 #: components/manage/WorkingCopyToastsFactory/WorkingCopyToastsFactory
+# defaultMessage: Created by {creator} on {date}
 msgid "Created by {creator} on {date}"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Created on
 msgid "Created on"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Creator
 msgid "Creator"
 msgstr ""
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Creators
 msgid "Creators"
 msgstr "Auteurs"
 
 #: components/manage/Widgets/QuerystringWidget
 #: components/manage/Widgets/QueryWidget
+# defaultMessage: Criteria
 msgid "Criteria"
 msgstr ""
 
 #: components/manage/Preferences/ChangePassword
+# defaultMessage: Current password
 msgid "Current password"
 msgstr "Huidig wachtwoord"
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Cut
 msgid "Cut"
 msgstr "Knippen"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: undefined
 msgid "Cut blocks"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Daily
 msgid "Daily"
 msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Database Information
 msgid "Database Information"
 msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Database Location
 msgid "Database Location"
 msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Database Size
 msgid "Database Size"
 msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Database main
 msgid "Database main"
 msgstr ""
 
 #: components/manage/Controlpanels/ModerateComments
 #: components/manage/Widgets/DatetimeWidget
+# defaultMessage: Date
 msgid "Date"
 msgstr ""
 
 #: components/theme/Search/Search
+# defaultMessage: Date (newest first)
 msgid "Date (newest first)"
 msgstr ""
 
@@ -515,6 +617,7 @@ msgstr ""
 #: components/theme/PasswordReset/PasswordReset
 #: components/theme/PasswordReset/RequestPasswordReset
 #: components/theme/Register/Register
+# defaultMessage: Default
 msgid "Default"
 msgstr "Standaard"
 
@@ -529,38 +632,47 @@ msgstr "Standaard"
 #: components/manage/Widgets/ObjectBrowserWidget
 #: components/manage/Widgets/WysiwygWidget
 #: components/theme/Comments/Comments
+# defaultMessage: Delete
 msgid "Delete"
 msgstr "Verwijderen"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Delete Group
 msgid "Delete Group"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Delete Type
 msgid "Delete Type"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Delete User
 msgid "Delete User"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: undefined
 msgid "Delete blocks"
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Delete col
 msgid "Delete col"
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Delete row
 msgid "Delete row"
 msgstr ""
 
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: Depth
 msgid "Depth"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Descending
 msgid "Descending"
 msgstr "Aflopend"
 
@@ -571,72 +683,89 @@ msgstr "Aflopend"
 #: components/manage/Widgets/WysiwygWidget
 #: components/theme/View/TabularView
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Description
 msgid "Description"
 msgstr "Beschrijving"
 
 #: components/manage/Diff/Diff
+# defaultMessage: Diff
 msgid "Diff"
 msgstr "Verschil"
 
 #: components/manage/Diff/Diff
+# defaultMessage: Difference between revision {one} and {two} of {title}
 msgid "Difference between revision {one} and {two} of {title}"
 msgstr "Verschil tussen revisie {one} en {two} van {title}"
 
 #: components/theme/Footer/Footer
+# defaultMessage: Distributed under the {license}.
 msgid "Distributed under the {license}."
 msgstr "Gedistribueerd onder de {license}."
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Add border to inner columns
 msgid "Divide each row into separate cells"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Do you really want to delete the following items?
 msgid "Do you really want to delete the following items?"
 msgstr "Weet u zeker dat u de volgende items wilt verwijderen?"
 
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
+# defaultMessage: Do you really want to delete the group {groupname}?
 msgid "Do you really want to delete the group {groupname}?"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Do you really want to delete type {typename}?
 msgid "Do you really want to delete the type {typename}?"
 msgstr ""
 
 #: components/manage/Controlpanels/Users/UsersControlpanel
+# defaultMessage: Do you really want to delete the user {username}?
 msgid "Do you really want to delete the user {username}?"
 msgstr ""
 
 #: components/manage/Delete/Delete
+# defaultMessage: Do you really want to delete this item?
 msgid "Do you really want to delete this item?"
 msgstr "Weet u zeker dat u dit item wilt verwijderen?"
 
 #: components/manage/Multilingual/TranslationObject
 #: components/manage/Sidebar/Sidebar
+# defaultMessage: Document
 msgid "Document"
 msgstr ""
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Drag and drop files from your computer onto this area or click the “Browse” button.
 msgid "Drag and drop files from your computer onto this area or click the “Browse” button."
 msgstr "Drag en drop bestanden van uw computer naar dit gebied of klik op de “Bladeren” knop."
 
 #: components/manage/Widgets/FileWidget
+# defaultMessage: Drop file here to replace the existing file
 msgid "Drop file here to replace the existing file"
 msgstr ""
 
 #: components/manage/Widgets/FileWidget
+# defaultMessage: Drop file here to upload a new file
 msgid "Drop file here to upload a new file"
 msgstr ""
 
 #: components/manage/Widgets/FileWidget
+# defaultMessage: Drop files here ...
 msgid "Drop files here ..."
 msgstr ""
 
 #: components/manage/Preferences/PersonalInformation
 #: components/theme/Register/Register
+# defaultMessage: E-mail
 msgid "E-mail"
 msgstr "E-mailadres"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: E-mail addresses do not match.
 msgid "E-mail addresses do not match."
 msgstr ""
 
@@ -647,93 +776,115 @@ msgstr ""
 #: components/manage/Widgets/FormFieldWrapper
 #: components/manage/Widgets/ObjectBrowserWidget
 #: components/theme/Comments/Comments
+# defaultMessage: Edit
 msgid "Edit"
 msgstr "Bewerken"
 
 #: components/theme/Comments/CommentEditModal
+# defaultMessage: Edit comment
 msgid "Edit comment"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Edit field
 msgid "Edit field"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Edit fieldset
 msgid "Edit fieldset"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Edit recurrence
 msgid "Edit recurrence"
 msgstr ""
 
 #: components/manage/Form/InlineForm
+# defaultMessage: Edit values
 msgid "Edit values"
 msgstr ""
 
 #: components/manage/Edit/Edit
+# defaultMessage: Edit {title}
 msgid "Edit {title}"
 msgstr "{title} bewerken"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Email
 msgid "Email"
 msgstr ""
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Email sent
 msgid "Email sent"
 msgstr ""
 
 #: components/manage/Blocks/Maps/Edit
+# defaultMessage: Embed code error, please follow the instructions and try again.
 msgid "Embed code error, please follow the instructions and try again."
 msgstr ""
 
 #: components/manage/Blocks/Maps/View
+# defaultMessage: Embeded Google Maps
 msgid "Embeded Google Maps"
 msgstr ""
 
 #: components/manage/Widgets/ObjectListWidget
+# defaultMessage: Empty object list
 msgid "Empty object list"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypeLayout
+# defaultMessage: Enable editable Blocks
 msgid "Enable editable Blocks"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: End Date
 msgid "End Date"
 msgstr ""
 
 #: components/manage/AnchorPlugin/components/LinkButton/AddLinkForm
+# defaultMessage: Enter URL or select an item
 msgid "Enter URL or select an item"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Enter a username above to search or click 'Show All'
 msgid "Enter a username above to search or click 'Show All'"
 msgstr ""
 
 #: components/theme/Register/Register
+# defaultMessage: Enter an email address. This will be your login name. We respect your privacy, and will not give the address away to any third parties or expose it anywhere.
 msgid "Enter an email address. This will be your login name. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr ""
 
 #: components/manage/Preferences/PersonalInformation
 #: components/theme/PasswordReset/PasswordReset
 #: components/theme/Register/Register
+# defaultMessage: Enter full name, e.g. John Smith.
 msgid "Enter full name, e.g. John Smith."
 msgstr "Vul de volledige naam in, bijvoorbeeld Jan Smit."
 
 #: components/manage/Blocks/Maps/Edit
+# defaultMessage: Enter map Embed Code
 msgid "Enter map Embed Code"
 msgstr ""
 
 #: components/manage/Preferences/ChangePassword
+# defaultMessage: Enter your current password.
 msgid "Enter your current password."
 msgstr "Voer uw huidige wachtwoord in."
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Enter your email address for verification.
 msgid "Enter your email address for verification."
 msgstr ""
 
 #: components/manage/Preferences/ChangePassword
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Enter your new password. Minimum 5 characters.
 msgid "Enter your new password. Minimum 5 characters."
 msgstr "Geef een nieuw wachtwoord op. Minimaal 5 karakters."
 
@@ -745,199 +896,245 @@ msgstr "Geef een nieuw wachtwoord op. Minimaal 5 karakters."
 #: components/theme/ContactForm/ContactForm
 #: components/theme/Login/Login
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Error
 msgid "Error"
 msgstr ""
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Exclude from navigation
 msgid "Exclude from navigation"
 msgstr "Sluit uit van de navigatiestructuur"
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: Exclude this occurence
 msgid "Exclude this occurence"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Excluded from navigation
 msgid "Excluded from navigation"
 msgstr ""
 
 #: components/manage/Sidebar/Sidebar
+# defaultMessage: Expand sidebar
 msgid "Expand sidebar"
 msgstr ""
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Expiration Date
 msgid "Expiration Date"
 msgstr "Vervaldatum"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Expiration date
 msgid "Expiration date"
 msgstr ""
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Expired
 msgid "Expired"
 msgstr ""
 
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: External URL
 msgid "External URL"
 msgstr ""
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: File
 msgid "File"
 msgstr ""
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: File size
 msgid "File size"
 msgstr "Bestandsgrootte"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Filename
 msgid "Filename"
 msgstr "Bestandsnaam"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Filter…
 msgid "Filter…"
 msgstr "Filter…"
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: First
 msgid "First"
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Fixed width columns
 msgid "Fixed width table cells"
 msgstr ""
 
 #: components/manage/BlockChooser/BlockChooser
+# defaultMessage: Fold
 msgid "Fold"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Folder
 msgid "Folder"
 msgstr ""
 
 #: components/theme/Forbidden/Forbidden
+# defaultMessage: Forbidden
 msgid "Forbidden"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: Fourth
 msgid "Fourth"
 msgstr ""
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: From
 msgid "From"
 msgstr ""
 
 #: components/manage/Blocks/Maps/Edit
 #: components/manage/Sidebar/AlignBlock
+# defaultMessage: Full
 msgid "Full"
 msgstr ""
 
 #: components/manage/Preferences/PersonalInformation
 #: components/theme/PasswordReset/PasswordReset
 #: components/theme/Register/Register
+# defaultMessage: Full Name
 msgid "Full Name"
 msgstr "Volledige naam"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Fullname
 msgid "Fullname"
 msgstr ""
 
 #: components/theme/Footer/Footer
+# defaultMessage: GNU GPL license
 msgid "GNU GPL license"
 msgstr "GNU GPL licentie"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Global role
 msgid "Global role"
 msgstr ""
 
 #: components/manage/Blocks/Maps/Edit
+# defaultMessage: Google Maps Embedded Block
 msgid "Google Maps Embedded Block"
 msgstr ""
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Group
 msgid "Group"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Group created
 msgid "Group created"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Group roles updated
 msgid "Group roles updated"
 msgstr ""
 
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Groupname
 msgid "Groupname"
 msgstr ""
 
 #: components/manage/Controlpanels/Controlpanels
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Groups
 msgid "Groups"
 msgstr ""
 
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
+# defaultMessage: Groups are logical collections of users, such as departments and business units. Groups are not directly related to permissions on a global level, you normally use Roles for that - and let certain Groups have a particular role. The symbol{plone_svg}indicates a role inherited from membership in another group.
 msgid "Groups are logical collections of users, such as departments and business units. Groups are not directly related to permissions on a global level, you normally use Roles for that - and let certain Groups have a particular role. The symbol{plone_svg}indicates a role inherited from membership in another group."
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Header cell
 msgid "Header cell"
 msgstr ""
 
 #: components/theme/Comments/Comments
+# defaultMessage: Hide Replies
 msgid "Hide Replies"
 msgstr ""
 
 #: components/manage/History/History
 #: components/manage/Toolbar/More
+# defaultMessage: History
 msgid "History"
 msgstr ""
 
 #: components/manage/History/History
+# defaultMessage: #
 msgid "History Version Number"
 msgstr ""
 
 #: components/manage/History/History
+# defaultMessage: History of {title}
 msgid "History of {title}"
 msgstr "Geschiedenis van {title}"
 
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsBreadcrumbs
 #: components/theme/Breadcrumbs/Breadcrumbs
+# defaultMessage: Home
 msgid "Home"
 msgstr "Home"
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: Home page
 msgid "Home page"
 msgstr "Homepage"
 
 #: components/manage/Contents/Contents
+# defaultMessage: ID
 msgid "ID"
 msgstr ""
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: If selected, this item will not appear in the navigation tree
 msgid "If selected, this item will not appear in the navigation tree"
 msgstr "Indien geselecteerd, wordt het item niet getoond in de navigatiestructuur"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: If this date is in the future, the content will not show up in listings and searches until this date.
 msgid "If this date is in the future, the content will not show up in listings and searches until this date."
 msgstr "Wanneer deze datum in de toekomst is zal de inhoud niet langer zichtbaar zijn in lijsten en zoekresultaten totdat deze datum bereikt is."
 
 #: components/manage/LockingToastsFactory/LockingToastsFactory
+# defaultMessage: If you are certain this user has abandoned the object, you may unlock the object. You will then be able to edit it.
 msgid "If you are certain this user has abandoned the object, you may unlock the object. You will then be able to edit it."
 msgstr ""
 
 #: components/theme/NotFound/NotFound
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: If you are certain you have the correct web address but are encountering an error, please contact the {site_admin}.
 msgid "If you are certain you have the correct web address but are encountering an error, please contact the {site_admin}."
 msgstr "Indien u er zeker van bent dat u het webadres goed heeft, maar toch een foutmelding krijgt, neem dan contact op met {site_admin}."
 
 #: components/manage/Blocks/HeroImageLeft/Edit
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: Image
 msgid "Image"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: Include this occurence
 msgid "Include this occurence"
 msgstr ""
 
@@ -945,142 +1142,176 @@ msgstr ""
 #: components/manage/Controlpanels/ContentTypeLayout
 #: components/manage/Controlpanels/ContentTypeSchema
 #: components/manage/Controlpanels/Controlpanel
+# defaultMessage: Info
 msgid "Info"
 msgstr ""
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Inherit permissions from higher levels
 msgid "Inherit permissions from higher levels"
 msgstr "Rechten overnemen van bovenliggende map"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Inherited value
 msgid "Inherited value"
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Insert col after
 msgid "Insert col after"
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Insert col before
 msgid "Insert col before"
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Insert row after
 msgid "Insert row after"
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Insert row before
 msgid "Insert row before"
 msgstr ""
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Install
 msgid "Install"
 msgstr ""
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Installed
 msgid "Installed"
 msgstr ""
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Installed version
 msgid "Installed version"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: days
 msgid "Interval Daily"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Month(s)
 msgid "Interval Monthly"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: week(s)
 msgid "Interval Weekly"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: year(s)
 msgid "Interval Yearly"
 msgstr ""
 
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: Item batch size
 msgid "Item batch size"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Item succesfully moved.
 msgid "Item succesfully moved."
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Item(s) copied.
 msgid "Item(s) copied."
 msgstr "Item(s) gekopieerd"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Item(s) cut.
 msgid "Item(s) cut."
 msgstr "Item(d) geknipt."
 
 #: components/manage/Contents/Contents
+# defaultMessage: Item(s) has been updated.
 msgid "Item(s) has been updated."
 msgstr ""
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
+# defaultMessage: Item(s) pasted.
 msgid "Item(s) pasted."
 msgstr "Item(s) geplakt."
 
 #: components/manage/Contents/Contents
+# defaultMessage: Item(s) state has been updated.
 msgid "Item(s) state has been updated."
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Items
 msgid "Items"
 msgstr ""
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Items must be unique.
 msgid "Items must be unique."
 msgstr "Items moeten uniek zijn."
 
 #: components/manage/Preferences/PersonalPreferences
+# defaultMessage: Language
 msgid "Language"
 msgstr "Taal"
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: Last
 msgid "Last"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Last comment date
 msgid "Last comment date"
 msgstr ""
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Last modified
 msgid "Last modified"
 msgstr "Laatst gewijzigd"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Latest version
 msgid "Latest version"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypesActions
+# defaultMessage: Layout
 msgid "Layout"
 msgstr ""
 
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: Lead Image
 msgid "Lead Image"
 msgstr ""
 
 #: components/manage/Blocks/Image/ImageSizeWidget
 #: components/manage/Blocks/Maps/Edit
 #: components/manage/Sidebar/AlignBlock
+# defaultMessage: Left
 msgid "Left"
 msgstr ""
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Link
 msgid "Link"
 msgstr ""
 
 #: components/manage/Blocks/Listing/schema
+# defaultMessage: Link more
 msgid "Link more"
 msgstr ""
 
 #: components/manage/Blocks/Listing/schema
+# defaultMessage: Link Title
 msgid "Link title"
 msgstr ""
 
@@ -1089,212 +1320,262 @@ msgstr ""
 #: components/manage/Blocks/Listing/schema
 #: components/manage/Blocks/Maps/MapsSidebar
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Link to
 msgid "Link to"
 msgstr ""
 
 #: components/manage/Multilingual/ManageTranslations
+# defaultMessage: Link translation for
 msgid "Link translation for"
 msgstr ""
 
 #: components/manage/Blocks/Listing/schema
+# defaultMessage: Listing
 msgid "Listing"
 msgstr ""
 
 #: components/theme/Comments/Comments
+# defaultMessage: Load more...
 msgid "Load more"
 msgstr ""
 
 #: components/manage/Form/ModalForm
+# defaultMessage: Loading.
 msgid "Loading"
 msgstr ""
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: Location
 msgid "Location"
 msgstr "Locatie"
 
 #: components/theme/Login/Login
+# defaultMessage: Login
 msgid "Log In"
 msgstr ""
 
 #: components/theme/Anontools/Anontools
 #: components/theme/Login/Login
+# defaultMessage: Log in
 msgid "Log in"
 msgstr "Inloggen"
 
 #: components/theme/Login/Login
+# defaultMessage: Login
 msgid "Login"
 msgstr ""
 
 #: components/theme/Login/Login
+# defaultMessage: Login Failed
 msgid "Login Failed"
 msgstr ""
 
 #: components/theme/Login/Login
+# defaultMessage: Login Name
 msgid "Login Name"
 msgstr "Gebruikersnaam"
 
 #: components/manage/Toolbar/PersonalTools
+# defaultMessage: Logout
 msgid "Logout"
 msgstr ""
 
 #: components/manage/Toolbar/More
+# defaultMessage: Made by {creator} on {date}. This is not a working copy anymore, but the main content.
 msgid "Made by {creator} on {date}. This is not a working copy anymore, but the main content."
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Reduce cell padding
 msgid "Make the table compact"
 msgstr ""
 
 #: components/manage/Multilingual/ManageTranslations
 #: components/manage/Toolbar/More
+# defaultMessage: Manage Translations
 msgid "Manage Translations"
 msgstr ""
 
 #: components/manage/Multilingual/ManageTranslations
+# defaultMessage: Manage translations for {title}
 msgid "Manage translations for {title}"
 msgstr ""
 
 #: components/manage/Blocks/Maps/MapsSidebar
+# defaultMessage: Map
 msgid "Map"
 msgstr ""
 
 #: components/manage/Blocks/Maps/MapsSidebar
+# defaultMessage: Maps URL
 msgid "Maps URL"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Maximum length is {len}.
 msgid "Maximum length is {len}."
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Maximum value is {len}.
 msgid "Maximum value is {len}."
 msgstr ""
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Message
 msgid "Message"
 msgstr ""
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Minimum length is {len}.
 msgid "Minimum length is {len}."
 msgstr "Minimum lengte is {len}"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Minimum value is {len}.
 msgid "Minimum value is {len}."
 msgstr ""
 
 #: components/manage/Controlpanels/Controlpanels
+# defaultMessage: Moderate Comments
 msgid "Moderate Comments"
 msgstr ""
 
 #: components/manage/Controlpanels/ModerateComments
+# defaultMessage: Moderate comments
 msgid "Moderate comments"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Monday and Friday
 msgid "Monday and Friday"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/ByMonthDayField
+# defaultMessage: Day
 msgid "Month day"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Monthly
 msgid "Monthly"
 msgstr ""
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: More
 msgid "More"
 msgstr ""
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Move to bottom of folder
 msgid "Move to bottom of folder"
 msgstr "Verplaats naar onder in de map"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Move to top of folder
 msgid "Move to top of folder"
 msgstr "Verplaats naar boven in de map"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: My email address is
 msgid "My email address is"
 msgstr ""
 
 #: components/manage/Sharing/Sharing
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Name
 msgid "Name"
 msgstr "Naam"
 
 #: error
+# defaultMessage: Navigate back
 msgid "Navigate back"
 msgstr ""
 
 #: components/theme/Navigation/ContextNavigation
+# defaultMessage: Navigation
 msgid "Navigation"
 msgstr ""
 
 #: components/manage/Preferences/ChangePassword
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: New password
 msgid "New password"
 msgstr "Nieuw wachtwoord"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: News Item
 msgid "News Item"
 msgstr ""
 
 #: components/manage/Contents/ContentsItem
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: No
 msgid "No"
 msgstr ""
 
 #: components/manage/Blocks/Image/ImageSidebar
+# defaultMessage: No image selected
 msgid "No image selected"
 msgstr ""
 
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: No image set in Lead Image content field
 msgid "No image set in Lead Image content field"
 msgstr ""
 
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: No image set in image content field
 msgid "No image set in image content field"
 msgstr ""
 
 #: components/manage/Blocks/Listing/ListingBody
+# defaultMessage: No items found in this container.
 msgid "No items found in this container."
 msgstr ""
 
 #: components/manage/Widgets/ObjectBrowserWidget
+# defaultMessage: No items selected
 msgid "No items selected"
 msgstr ""
 
 #: components/manage/Blocks/Maps/MapsSidebar
+# defaultMessage: No map selected
 msgid "No map selected"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: No occurences set
 msgid "No occurences set"
 msgstr ""
 
 #: components/manage/Widgets/ArrayWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/TokenWidget
+# defaultMessage: No options
 msgid "No options"
 msgstr ""
 
 #: components/theme/Search/Search
+# defaultMessage: No results found
 msgid "No results found"
 msgstr ""
 
 #: components/manage/Blocks/Listing/ListingBody
 #: components/manage/Widgets/ReferenceWidget
+# defaultMessage: No results found.
 msgid "No results found."
 msgstr ""
 
 #: components/manage/Widgets/QuerySortOnWidget
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: No selection
 msgid "No selection"
 msgstr ""
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: This addon does not provide an uninstall profile.
 msgid "No uninstall profile"
 msgstr ""
 
@@ -1302,39 +1583,48 @@ msgstr ""
 #: components/manage/Widgets/ReferenceWidget
 #: components/manage/Widgets/SelectUtils
 #: components/manage/Widgets/SelectWidget
+# defaultMessage: No value
 msgid "No value"
 msgstr ""
 
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: No video selected
 msgid "No video selected"
 msgstr ""
 
 #: components/manage/Workflow/Workflow
+# defaultMessage: No workflow
 msgid "No workflow"
 msgstr ""
 
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsItem
+# defaultMessage: None
 msgid "None"
 msgstr "Niks"
 
 #: components/manage/Controlpanels/Users/UsersControlpanel
+# defaultMessage: Note that roles set here apply directly to a user. The symbol{plone_svg}indicates a role inherited from membership in a group.
 msgid "Note that roles set here apply directly to a user. The symbol{plone_svg}indicates a role inherited from membership in a group."
 msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Number of active objects
 msgid "Number of active objects"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Object Size
 msgid "Object Size"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/EndField
+# defaultMessage: occurrence(s)
 msgid "Occurences"
 msgstr ""
 
 #: components/manage/Delete/Delete
+# defaultMessage: Ok
 msgid "Ok"
 msgstr "Ok"
 
@@ -1342,301 +1632,371 @@ msgstr "Ok"
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
 #: components/manage/Blocks/Maps/MapsSidebar
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Open in a new tab
 msgid "Open in a new tab"
 msgstr ""
 
 #: components/theme/Navigation/Navigation
+# defaultMessage: Open menu
 msgid "Open menu"
 msgstr ""
 
 #: components/manage/Widgets/ObjectBrowserWidget
+# defaultMessage: Open object browser
 msgid "Open object browser"
 msgstr ""
 
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: Origin
 msgid "Origin"
 msgstr ""
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Page
 msgid "Page"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Parent fieldset
 msgid "Parent fieldset"
 msgstr ""
 
 #: components/theme/Login/Login
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Password
 msgid "Password"
 msgstr "Wachtwoord"
 
 #: components/theme/PasswordReset/PasswordReset
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Password reset
 msgid "Password reset"
 msgstr ""
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Passwords do not match.
 msgid "Passwords do not match."
 msgstr ""
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
+# defaultMessage: Paste
 msgid "Paste"
 msgstr "Plakken"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: undefined
 msgid "Paste blocks"
 msgstr ""
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Permissions have been updated successfully
 msgid "Permissions have been updated successfully"
 msgstr ""
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Permissions updated
 msgid "Permissions updated"
 msgstr ""
 
 #: components/manage/Preferences/PersonalInformation
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Personal Information
 msgid "Personal Information"
 msgstr "Persoonlijke gegevens"
 
 #: components/manage/Preferences/PersonalPreferences
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Personal Preferences
 msgid "Personal Preferences"
 msgstr "Persoonlijke voorkeuren"
 
 #: components/manage/Toolbar/More
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Personal tools
 msgid "Personal tools"
 msgstr ""
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Persons responsible for creating the content of this item. Please enter a list of user names, one per line. The principal creator should come first.
 msgid "Persons responsible for creating the content of this item. Please enter a list of user names, one per line. The principal creator should come first."
 msgstr "Gebruikers die verantwoordelijk zijn voor de inhoud van dit item. De eindverantwoordelijke vermeldt u als eerste."
 
 #: components/manage/Blocks/Video/Edit
+# defaultMessage: Please enter a valid URL by deleting the block and adding a new video block.
 msgid "Please enter a valid URL by deleting the block and adding a new video block."
 msgstr ""
 
 #: components/manage/Blocks/Maps/Edit
+# defaultMessage: Please enter the Embed Code provided by Google Maps -> Share -> Embed map. It should contain the <iframe> code on it.
 msgid "Please enter the Embed Code provided by Google Maps -> Share -> Embed map. It should contain the <iframe> code on it."
 msgstr ""
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Please fill out the form below to set your password.
 msgid "Please fill out the form below to set your password."
 msgstr ""
 
 #: components/theme/Footer/Footer
+# defaultMessage: Plone Foundation
 msgid "Plone Foundation"
 msgstr "Plone Foundation"
 
 #: components/theme/Logo/Logo
+# defaultMessage: Plone Site
 msgid "Plone Site"
 msgstr "Plone website"
 
 #: components/theme/Footer/Footer
+# defaultMessage: Plone{reg} Open Source CMS/WCM
 msgid "Plone{reg} Open Source CMS/WCM"
 msgstr "Plone{reg} CMS - Open Source Web Content Management Systeem"
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: Portrait
 msgid "Portrait"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Possible values (Enter allowed choices one per line).
 msgid "Possible values"
 msgstr ""
 
 #: components/theme/Footer/Footer
+# defaultMessage: Powered by Plone & Python
 msgid "Powered by Plone & Python"
 msgstr "Powered by Plone & Python"
 
 #: components/manage/Toolbar/PersonalTools
+# defaultMessage: Preferences
 msgid "Preferences"
 msgstr ""
 
 #: components/manage/Blocks/HTML/Edit
+# defaultMessage: Prettify your code
 msgid "Prettify your code"
 msgstr ""
 
 #: components/manage/Blocks/HTML/Edit
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Preview
 msgid "Preview"
 msgstr "Voorvertoning"
 
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Preview Image URL
 msgid "Preview Image URL"
 msgstr ""
 
 #: components/manage/Toolbar/PersonalTools
+# defaultMessage: Profile
 msgid "Profile"
 msgstr ""
 
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Properties
 msgid "Properties"
 msgstr "Eigenschappen"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Publication date
 msgid "Publication date"
 msgstr ""
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Publishing Date
 msgid "Publishing Date"
 msgstr "Ingangsdatum"
 
 #: components/manage/Blocks/Listing/schema
+# defaultMessage: Query
 msgid "Query"
 msgstr ""
 
 #: components/manage/Preferences/ChangePassword
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Re-enter the password. Make sure the passwords are identical.
 msgid "Re-enter the password. Make sure the passwords are identical."
 msgstr "Voer het wachtwoord nogmaals in. Zorg dat de wachtwoorden identiek zijn."
 
 #: components/theme/Search/Search
 #: components/theme/View/SummaryView
+# defaultMessage: Read More…
 msgid "Read More…"
 msgstr "Lees verder…"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Rearrange items by…
 msgid "Rearrange items by…"
 msgstr "Items rangschikken op…"
 
 #: components/manage/Widgets/RecurrenceWidget/EndField
+# defaultMessage: Ends
 msgid "Recurrence ends"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/EndField
+# defaultMessage: after
 msgid "Recurrence ends after"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/EndField
+# defaultMessage: on
 msgid "Recurrence ends on"
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Minimalistic table design
 msgid "Reduce complexity"
 msgstr ""
 
 #: components/theme/Anontools/Anontools
 #: components/theme/Login/Login
 #: components/theme/Register/Register
+# defaultMessage: Register
 msgid "Register"
 msgstr ""
 
 #: components/theme/Register/Register
+# defaultMessage: Registration form
 msgid "Registration form"
 msgstr ""
 
 #: components/theme/Search/Search
+# defaultMessage: Relevance
 msgid "Relevance"
 msgstr ""
 
 #: components/manage/Widgets/ObjectListWidget
+# defaultMessage: Remove item
 msgid "Remove item"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Remove
 msgid "Remove recurrence"
 msgstr ""
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Remove term
 msgid "Remove term"
 msgstr ""
 
 #: components/manage/Toolbar/More
+# defaultMessage: Remove working copy
 msgid "Remove working copy"
 msgstr ""
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
+# defaultMessage: Rename
 msgid "Rename"
 msgstr "Naam wijzigen"
 
 #: components/manage/Contents/ContentsRenameModal
+# defaultMessage: Renaming items...
 msgid "Rename Items Loading Message"
 msgstr ""
 
 #: components/manage/Contents/ContentsRenameModal
+# defaultMessage: Rename items
 msgid "Rename items"
 msgstr "Naam wijzigen"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Repeat
 msgid "Repeat"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Repeat every
 msgid "Repeat every"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Repeat on
 msgid "Repeat on"
 msgstr ""
 
 #: components/manage/Widgets/FileWidget
+# defaultMessage: Replace existing file
 msgid "Replace existing file"
 msgstr ""
 
 #: components/theme/Comments/Comments
+# defaultMessage: Reply
 msgid "Reply"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/WysiwygWidget
+# defaultMessage: Required
 msgid "Required"
 msgstr ""
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Required input is missing.
 msgid "Required input is missing."
 msgstr "Verplichte waarde mist."
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Reset title
 msgid "Reset term title"
 msgstr ""
 
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: Results limit
 msgid "Results limit"
 msgstr ""
 
 #: components/manage/Blocks/Listing/Edit
+# defaultMessage: Results preview
 msgid "Results preview"
 msgstr ""
 
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: Reversed order
 msgid "Reversed order"
 msgstr ""
 
 #: components/manage/History/History
+# defaultMessage: Revert to this revision
 msgid "Revert to this revision"
 msgstr "Deze rivisie herstellen"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Review state
 msgid "Review state"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Richtext
 msgid "Richtext"
 msgstr ""
 
 #: components/manage/Blocks/Image/ImageSizeWidget
 #: components/manage/Blocks/Maps/Edit
 #: components/manage/Sidebar/AlignBlock
+# defaultMessage: Right
 msgid "Right"
 msgstr ""
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Rights
 msgid "Rights"
 msgstr "Rechten"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Roles
 msgid "Roles"
 msgstr ""
 
 #: components/manage/Contents/ContentsBreadcrumbs
+# defaultMessage: Root
 msgid "Root"
 msgstr ""
 
@@ -1649,90 +2009,112 @@ msgstr ""
 #: components/manage/Form/ModalForm
 #: components/manage/Sharing/Sharing
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Save
 msgid "Save"
 msgstr "Opslaan"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Save
 msgid "Save recurrence"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypesActions
+# defaultMessage: Schema
 msgid "Schema"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypeSchema
+# defaultMessage: Schema updates
 msgid "Schema updates"
 msgstr ""
 
 #: components/theme/SearchWidget/SearchWidget
+# defaultMessage: Search
 msgid "Search"
 msgstr "Zoek"
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: Search SVG
 msgid "Search SVG"
 msgstr ""
 
 #: components/theme/SearchWidget/SearchWidget
+# defaultMessage: Search Site
 msgid "Search Site"
 msgstr "Website doorzoeken"
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: Search content
 msgid "Search content"
 msgstr ""
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Search for user or group
 msgid "Search for user or group"
 msgstr "Zoeken naar gebruiker of groep"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Search group…
 msgid "Search group…"
 msgstr ""
 
 #: components/theme/Search/Search
+# defaultMessage: Search results
 msgid "Search results"
 msgstr ""
 
 #: components/theme/Search/Search
+# defaultMessage: Search results for {term}
 msgid "Search results for {term}"
 msgstr "Zoekresultaten voor ${term}"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Search users…
 msgid "Search users…"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: Second
 msgid "Second"
 msgstr ""
 
 #: components/manage/Sidebar/ObjectBrowserNav
+# defaultMessage: Select
 msgid "Select"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Select a date to add to recurrence
 msgid "Select a date to add to recurrence"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Select columns to show
 msgid "Select columns to show"
 msgstr "Selecteer de te tonen kolommen"
 
 #: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Select the transition to be used for modifying the items state.
 msgid "Select the transition to be used for modifying the items state."
 msgstr "Selecteer welke overgang moet worden gebruikt voor het wijzigen van de status van de items."
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: Selected dates
 msgid "Selected dates"
 msgstr ""
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: Selected items
 msgid "Selected items"
 msgstr ""
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: of
 msgid "Selected items - x of y"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Selection
 msgid "Selection"
 msgstr ""
 
@@ -1740,158 +2122,195 @@ msgstr ""
 #: components/manage/Widgets/ArrayWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/TokenWidget
+# defaultMessage: Select…
 msgid "Select…"
 msgstr "Selecteer…"
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Send
 msgid "Send"
 msgstr ""
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Set my password
 msgid "Set my password"
 msgstr ""
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Set your password
 msgid "Set your password"
 msgstr ""
 
 #: components/manage/Sidebar/Sidebar
+# defaultMessage: Settings
 msgid "Settings"
 msgstr ""
 
 #: components/manage/Sharing/Sharing
 #: components/manage/Toolbar/More
+# defaultMessage: Sharing
 msgid "Sharing"
 msgstr ""
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Sharing for {title}
 msgid "Sharing for {title}"
 msgstr "Delen van {title}"
 
 #: components/manage/Widgets/SchemaWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/WysiwygWidget
+# defaultMessage: Short Name
 msgid "Short Name"
 msgstr ""
 
 #: components/manage/Contents/ContentsRenameModal
+# defaultMessage: Short name
 msgid "Short name"
 msgstr "Korte naam"
 
 #: components/theme/Pagination/Pagination
+# defaultMessage: Show
 msgid "Show"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Show All
 msgid "Show All"
 msgstr ""
 
 #: components/theme/Comments/Comments
+# defaultMessage: Show Replies
 msgid "Show Replies"
 msgstr ""
 
 #: components/manage/Widgets/ObjectListWidget
+# defaultMessage: Show item
 msgid "Show item"
 msgstr ""
 
 #: components/manage/Sidebar/Sidebar
+# defaultMessage: Shrink sidebar
 msgid "Shrink sidebar"
 msgstr ""
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Shrink toolbar
 msgid "Shrink toolbar"
 msgstr ""
 
 #: components/theme/Login/Login
+# defaultMessage: Sign in to start session
 msgid "Sign in to start session"
 msgstr ""
 
 #: components/theme/Logo/Logo
+# defaultMessage: Site
 msgid "Site"
 msgstr "Website"
 
 #: components/theme/NotFound/NotFound
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: Site Administration
 msgid "Site Administration"
 msgstr "Sitebeheerder"
 
 #: components/theme/Footer/Footer
+# defaultMessage: Site Map
 msgid "Site Map"
 msgstr "Sitemap"
 
 #: components/manage/Controlpanels/Controlpanels
 #: components/manage/Toolbar/PersonalTools
+# defaultMessage: Site Setup
 msgid "Site Setup"
 msgstr ""
 
 #: components/theme/Sitemap/Sitemap
+# defaultMessage: Sitemap
 msgid "Sitemap"
 msgstr ""
 
 #: components/manage/Blocks/Image/ImageSidebar
+# defaultMessage: Size
 msgid "Size"
 msgstr ""
 
 #: components/theme/View/ImageView
+# defaultMessage: Size: {size}
 msgid "Size: {size}"
 msgstr ""
 
 #: error
+# defaultMessage: Sorry, something went wrong with your request
 msgid "Sorry, something went wrong with your request"
 msgstr ""
 
 #: components/theme/Search/Search
+# defaultMessage: Sort by:
 msgid "Sort By:"
 msgstr ""
 
 #: components/manage/Widgets/QuerySortOnWidget
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: Sort on
 msgid "Sort on"
 msgstr ""
 
 #: components/manage/Blocks/HTML/Edit
+# defaultMessage: Source
 msgid "Source"
 msgstr ""
 
 #: components/manage/Blocks/Video/Edit
+# defaultMessage: Specify a youtube video or playlist url
 msgid "Specify a youtube video or playlist url"
 msgstr ""
 
 #: components/manage/Diff/Diff
+# defaultMessage: Split
 msgid "Split"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Start Date
 msgid "Start Date"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: Start of the recurrence
 msgid "Start of the recurrence"
 msgstr ""
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Start password reset
 msgid "Start password reset"
 msgstr ""
 
 #: components/manage/Contents/Contents
 #: components/manage/Workflow/Workflow
 #: components/theme/View/TabularView
+# defaultMessage: State
 msgid "State"
 msgstr "Status"
 
 #: components/manage/Multilingual/CompareLanguages
+# defaultMessage: Stop compare
 msgid "Stop compare"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: String
 msgid "String"
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Alternate row background color
 msgid "Stripe alternate rows with color"
 msgstr ""
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Subject
 msgid "Subject"
 msgstr ""
 
@@ -1905,43 +2324,53 @@ msgstr ""
 #: components/manage/Preferences/PersonalPreferences
 #: components/theme/ContactForm/ContactForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Success
 msgid "Success"
 msgstr ""
 
 #: components/theme/LanguageSelector/LanguageSelector
+# defaultMessage: Switch to
 msgid "Switch to"
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Table
 msgid "Table"
 msgstr ""
 
 #: components/manage/Blocks/ToC/View
+# defaultMessage: Table of Contents
 msgid "Table of Contents"
 msgstr ""
 
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsTagsModal
+# defaultMessage: Tags
 msgid "Tags"
 msgstr "Tags"
 
 #: components/manage/Contents/ContentsTagsModal
+# defaultMessage: Tags to add
 msgid "Tags to add"
 msgstr "Toe te voegen tags"
 
 #: components/manage/Contents/ContentsTagsModal
+# defaultMessage: Tags to remove
 msgid "Tags to remove"
 msgstr "Te verwijderen tags"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Target memory size per cache in bytes
 msgid "Target memory size per cache in bytes"
 msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Target number of objects in memory per cache
 msgid "Target number of objects in memory per cache"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Text
 msgid "Text"
 msgstr ""
 
@@ -1949,87 +2378,108 @@ msgstr ""
 #: components/theme/CorsError/CorsError
 #: components/theme/NotFound/NotFound
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: Thank you.
 msgid "Thank you."
 msgstr "Bedankt."
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: The Database Manager allow you to view database status information
 msgid "The Database Manager allow you to view database status information"
 msgstr ""
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: The URL for your external home page, if you have one.
 msgid "The URL for your external home page, if you have one."
 msgstr "Het internet adres van uw externe home page, indien u die heeft."
 
 #: components/theme/ConnectionRefused/ConnectionRefused
+# defaultMessage: The backend is not responding, please check if you have started Plone, check your project's configuration object apiPath (or if you are using the internal proxy, devProxyToApiPath) or the RAZZLE_API_PATH Volto's environment variable.
 msgid "The backend is not responding, please check if you have started Plone, check your project's configuration object apiPath (or if you are using the internal proxy, devProxyToApiPath) or the RAZZLE_API_PATH Volto's environment variable."
 msgstr ""
 
 #: components/theme/CorsError/CorsError
+# defaultMessage: The backend is responding, but the CORS headers are not configured properly and the browser has denied the access to the backend resources.
 msgid "The backend is responding, but the CORS headers are not configured properly and the browser has denied the access to the backend resources."
 msgstr ""
 
 #: components/theme/CorsError/CorsError
+# defaultMessage: The backend server of your website is not anwering, we apologize for the inconvenience. Please try to re-load the page and try again. If the problem persists please contact the site administrators.
 msgid "The backend server of your website is not anwering, we apologize for the inconvenience. Please try to re-load the page and try again. If the problem persists please contact the site administrators."
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: The item could not be deleted.
 msgid "The item could not be deleted."
 msgstr ""
 
 #: components/theme/Register/Register
+# defaultMessage: The registration process has been successful. Please check your e-mail inbox for information on how activate your account.
 msgid "The registration process has been successful. Please check your e-mail inbox for information on how activate your account."
 msgstr ""
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: The user portrait/avatar
 msgid "The user portrait/avatar"
 msgstr ""
 
 #: components/manage/Toolbar/More
+# defaultMessage: The working copy was discarded
 msgid "The working copy was discarded"
 msgstr ""
 
 #: components/theme/Footer/Footer
+# defaultMessage: The {plonecms} is {copyright} 2000-{current_year} by the {plonefoundation} and friends.
 msgid "The {plonecms} is {copyright} 2000-{current_year} by the {plonefoundation} and friends."
 msgstr "Het {plonecms} is {copyright} 2000-{current_year} door de {plonefoundation} et al."
 
 #: components/theme/CorsError/CorsError
+# defaultMessage: There is a configuration problem on the backend
 msgid "There is a configuration problem on the backend"
 msgstr ""
 
 #: components/manage/Form/InlineForm
+# defaultMessage: There were some errors
 msgid "There were some errors"
 msgstr ""
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: There were some errors.
 msgid "There were some errors."
 msgstr "Er zijn fouten opgetreden."
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: Third
 msgid "Third"
 msgstr ""
 
 #: components/manage/WorkingCopyToastsFactory/WorkingCopyToastsFactory
+# defaultMessage: This has an ongoing working copy in {title}
 msgid "This has an ongoing working copy in {title}"
 msgstr ""
 
 #: components/manage/WorkingCopyToastsFactory/WorkingCopyToastsFactory
+# defaultMessage: This is a working copy of {title}
 msgid "This is a working copy of {title}"
 msgstr ""
 
 #: components/manage/LockingToastsFactory/LockingToastsFactory
+# defaultMessage: This item was locked by {creator} on {date}
 msgid "This item was locked by {creator} on {date}"
 msgstr ""
 
 #: components/manage/Contents/ContentsRenameModal
+# defaultMessage: This name will be displayed in the URL.
 msgid "This name will be displayed in the URL."
 msgstr "Deze naam wordt getoond in de URL."
 
 #: components/theme/NotFound/NotFound
+# defaultMessage: This page does not seem to exist…
 msgid "This page does not seem to exist…"
 msgstr "Het spijt ons, maar deze pagina bestaat niet…"
 
 #: components/manage/Widgets/DatetimeWidget
+# defaultMessage: Time
 msgid "Time"
 msgstr ""
 
@@ -2042,714 +2492,889 @@ msgstr ""
 #: components/manage/Widgets/WysiwygWidget
 #: components/theme/View/TabularView
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Title
 msgid "Title"
 msgstr "Titel"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Total active and non-active objects
 msgid "Total active and non-active objects"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Total comments
 msgid "Total comments"
 msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Total number of objects in each cache
 msgid "Total number of objects in each cache"
 msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Total number of objects in memory from all caches
 msgid "Total number of objects in memory from all caches"
 msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Total number of objects in the database
 msgid "Total number of objects in the database"
 msgstr ""
 
 #: components/manage/Add/Add
 #: components/manage/Toolbar/Types
+# defaultMessage: Translate to {lang}
 msgid "Translate to {lang}"
 msgstr ""
 
 #: components/manage/Multilingual/ManageTranslations
+# defaultMessage: Translation linked
 msgid "Translation linked"
 msgstr ""
 
 #: components/manage/Multilingual/ManageTranslations
+# defaultMessage: Translation linking removed
 msgid "Translation linking removed"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypes
 #: components/manage/Widgets/SchemaWidget
 #: components/theme/View/TabularView
+# defaultMessage: Type
 msgid "Type"
 msgstr "Type"
 
 #: components/manage/Blocks/Video/Edit
+# defaultMessage: Type a Video (YouTube, Vimeo or mp4) URL
 msgid "Type a Video (YouTube, Vimeo or mp4) URL"
 msgstr ""
 
 #: components/manage/Blocks/Text/Edit
+# defaultMessage: Type text…
 msgid "Type text…"
 msgstr ""
 
 #: components/manage/Blocks/Title/Edit
+# defaultMessage: Type the title…
 msgid "Type the title…"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: UID
 msgid "UID"
 msgstr ""
 
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: Unauthorized
 msgid "Unauthorized"
 msgstr ""
 
 #: components/manage/BlockChooser/BlockChooser
+# defaultMessage: Unfold
 msgid "Unfold"
 msgstr ""
 
 #: components/manage/Diff/Diff
+# defaultMessage: Unified
 msgid "Unified"
 msgstr ""
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Uninstall
 msgid "Uninstall"
 msgstr ""
 
 #: components/manage/Blocks/Block/Edit
 #: components/theme/View/DefaultView
 #: components/theme/View/RenderBlocks
+# defaultMessage: Unknown Block {block}
 msgid "Unknown Block"
 msgstr ""
 
 #: components/manage/Multilingual/ManageTranslations
+# defaultMessage: Unlink translation for
 msgid "Unlink translation for"
 msgstr ""
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Unlock
 msgid "Unlock"
 msgstr ""
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Update
 msgid "Update"
 msgstr ""
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Update installed addons
 msgid "Update installed addons"
 msgstr ""
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Update installed addons:
 msgid "Update installed addons:"
 msgstr ""
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Updates available
 msgid "Updates available"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Upload
 msgid "Upload"
 msgstr "Upload"
 
 #: components/manage/Blocks/LeadImage/Edit
+# defaultMessage: Upload a lead image in the 'Lead Image' content field.
 msgid "Upload a lead image in the 'Lead Image' content field."
 msgstr ""
 
 #: components/manage/Blocks/HeroImageLeft/Edit
+# defaultMessage: Upload a new image
 msgid "Upload a new image"
 msgstr ""
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Upload files
 msgid "Upload files"
 msgstr "Bestanden uploaden"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Uploading files
 msgid "Uploading files"
 msgstr "Bestanden uploaden"
 
 #: components/manage/Blocks/HeroImageLeft/Edit
+# defaultMessage: Uploading image
 msgid "Uploading image"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/WysiwygWidget
+# defaultMessage: Used for programmatic access to the fieldset.
 msgid "Used for programmatic access to the fieldset."
 msgstr ""
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: User
 msgid "User"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: User created
 msgid "User created"
 msgstr ""
 
 #: components/manage/Controlpanels/Users/UsersControlpanel
+# defaultMessage: User name
 msgid "User name"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: User roles updated
 msgid "User roles updated"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Username
 msgid "Username"
 msgstr ""
 
 #: components/manage/Controlpanels/Controlpanels
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Users
 msgid "Users"
 msgstr ""
 
 #: components/manage/Controlpanels/Controlpanels
+# defaultMessage: Users and Groups
 msgid "Users and Groups"
 msgstr ""
 
 #: helpers/Extensions/withBlockSchemaEnhancer
+# defaultMessage: Variation
 msgid "Variation"
 msgstr ""
 
 #: components/manage/Controlpanels/Controlpanels
+# defaultMessage: Version Overview
 msgid "Version Overview"
 msgstr ""
 
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Video
 msgid "Video"
 msgstr ""
 
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Video URL
 msgid "Video URL"
 msgstr ""
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: View
 msgid "View"
 msgstr "Bekijken"
 
 #: components/manage/History/History
+# defaultMessage: View changes
 msgid "View changes"
 msgstr "Bekijk wijzigingen"
 
 #: components/manage/History/History
+# defaultMessage: View this revision
 msgid "View this revision"
 msgstr "Bekijk deze revisie"
 
 #: components/manage/Toolbar/More
+# defaultMessage: View working copy
 msgid "View working copy"
 msgstr ""
 
 #: components/manage/Display/Display
+# defaultMessage: View
 msgid "Viewmode"
 msgstr ""
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Vocabulary term
 msgid "Vocabulary term"
 msgstr ""
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Title
 msgid "Vocabulary term title"
 msgstr ""
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Vocabulary terms
 msgid "Vocabulary terms"
 msgstr ""
 
 #: components/manage/Controlpanels/VersionOverview
+# defaultMessage: You are running in 'debug mode'. This mode is intended for sites that are under development. This allows many configuration changes to be immediately visible, but will make your site run more slowly. To turn off debug mode, stop the server, set 'debug-mode=off' in your buildout.cfg, re-run bin/buildout and then restart the server process.
 msgid "Warning Regarding debug mode"
 msgstr ""
 
 #: components/theme/ConnectionRefused/ConnectionRefused
+# defaultMessage: We apologize for the inconvenience, but the backend of the site you are accessing is not available right now. Please, try again later.
 msgid "We apologize for the inconvenience, but the backend of the site you are accessing is not available right now. Please, try again later."
 msgstr ""
 
 #: components/theme/NotFound/NotFound
+# defaultMessage: We apologize for the inconvenience, but the page you were trying to access is not at this address. You can use the links below to help you find what you are looking for.
 msgid "We apologize for the inconvenience, but the page you were trying to access is not at this address. You can use the links below to help you find what you are looking for."
 msgstr "Onze excuses voor het ongemak, maar de pagina die u probeerde te bereiken bestaat niet. U kunt onderstaande links gebruiken om proberen te vinden wat u zocht."
 
 #: components/theme/Forbidden/Forbidden
+# defaultMessage: We apologize for the inconvenience, but you don't have permissions on this resource.
 msgid "We apologize for the inconvenience, but you don't have permissions on this resource."
 msgstr ""
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: We will use this address if you need to recover your password
 msgid "We will use this address if you need to recover your password"
 msgstr "Wij gebruiken dit adres wanneer u uw wachtwoord wilt terugkrijgen"
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: The
 msgid "Weeek day of month"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Weekday
 msgid "Weekday"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Weekly
 msgid "Weekly"
 msgstr ""
 
 #: components/manage/History/History
+# defaultMessage: What
 msgid "What"
 msgstr "Wat"
 
 #: components/manage/History/History
+# defaultMessage: When
 msgid "When"
 msgstr "Wanneer"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: When this date is reached, the content will nolonger be visible in listings and searches.
 msgid "When this date is reached, the content will nolonger be visible in listings and searches."
 msgstr "Wanneer deze datum bereikt is zal de inhoud niet langer zichtbaar zijn in lijsten en zoekresultaten."
 
 #: components/manage/History/History
+# defaultMessage: Who
 msgid "Who"
 msgstr "Wie"
 
 #: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Updating workflow states...
 msgid "Workflow Change Loading Message"
 msgstr ""
 
 #: components/manage/Workflow/Workflow
+# defaultMessage: Workflow updated.
 msgid "Workflow updated."
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Yearly
 msgid "Yearly"
 msgstr ""
 
 #: components/manage/Contents/ContentsItem
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Yes
 msgid "Yes"
 msgstr ""
 
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: You are trying to access a protected resource, please {login} first.
 msgid "You are trying to access a protected resource, please {login} first."
 msgstr ""
 
 #: components/theme/OutdatedBrowser/OutdatedBrowser
+# defaultMessage: You are using an outdated browser
 msgid "You are using an outdated browser"
 msgstr ""
 
 #: components/theme/Comments/Comments
+# defaultMessage: You can add a comment by filling out the form below. Plain text formatting.
 msgid "You can add a comment by filling out the form below. Plain text formatting."
 msgstr ""
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: You can control who can view and edit your item using the list below.
 msgid "You can control who can view and edit your item using the list below."
 msgstr "U kunt in de onderstaande lijst beheren wie de content kan bekijken en beheren."
 
 #: components/manage/Diff/Diff
+# defaultMessage: You can view the difference of the revisions below.
 msgid "You can view the difference of the revisions below."
 msgstr "U kunt de verschillen tussen de revisies hieronder bekijken."
 
 #: components/manage/History/History
+# defaultMessage: You can view the history of your item below.
 msgid "You can view the history of your item below."
 msgstr "U kunt de geschiedenis van uw item hieronder bekijken."
 
 #: components/manage/Contents/Contents
+# defaultMessage: You can't paste this content here
 msgid "You can't paste this content here"
 msgstr ""
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Your email is required for reset your password.
 msgid "Your email is required for reset your password."
 msgstr ""
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: Your location - either city and country - or in a company setting, where your office is located.
 msgid "Your location - either city and country - or in a company setting, where your office is located."
 msgstr "Uw woonplaats - stad en land - of als u vanuit een bedrijf werkt, waar uw kantoor is gevestigd."
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Your password has been set successfully. You may now {link} with your new password.
 msgid "Your password has been set successfully. You may now {link} with your new password."
 msgstr ""
 
 #: components/manage/Preferences/PersonalPreferences
+# defaultMessage: Your preferred language
 msgid "Your preferred language"
 msgstr "De taal van uw voorkeur"
 
 #: components/theme/Login/Login
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Forgot your password?
 msgid "box_forgot_password_option"
 msgstr ""
 
 #: config/Blocks
+# defaultMessage: Common
 msgid "common"
 msgstr ""
 
 #: components/manage/Multilingual/CompareLanguages
+# defaultMessage: Compare to language
 msgid "compare_to"
 msgstr ""
 
 #: components/manage/Blocks/Block/EditBlockWrapper
+# defaultMessage: delete
 msgid "delete"
 msgstr ""
 
 #: components/theme/OutdatedBrowser/OutdatedBrowser
+# defaultMessage: You are using {browsername} {browserversion} which is deprecated by its vendor. That means that it does not get security updates and it is not ready for current modern web features, which deteriorates the user experience. Please upgrade to a modern browser.
 msgid "deprecated_browser_notice_message"
 msgstr ""
 
 #: config/Blocks
+# defaultMessage: Description
 msgid "description"
 msgstr ""
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: For security reasons, we store your password encrypted, and cannot mail it to you. If you would like to reset your password, fill out the form below and we will send you an email at the address you gave when you registered to start the process of resetting your password.
 msgid "description_lost_password"
 msgstr ""
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Your password reset request has been mailed. It should arrive in your mailbox shortly. When you receive the message, visit the address it contains to reset your password.
 msgid "description_sent_password"
 msgstr ""
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Draft
 msgid "draft"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Input must be valid email (something@domain.com)
 msgid "email"
 msgstr ""
 
 #: components/theme/View/EventView
+# defaultMessage: All dates
 msgid "event_alldates"
 msgstr ""
 
 #: components/theme/View/EventView
+# defaultMessage: Attendees
 msgid "event_attendees"
 msgstr ""
 
 #: components/theme/View/EventView
+# defaultMessage: Contact Name
 msgid "event_contactname"
 msgstr ""
 
 #: components/theme/View/EventView
+# defaultMessage: Contact Phone
 msgid "event_contactphone"
 msgstr ""
 
 #: components/theme/View/EventView
+# defaultMessage: Website
 msgid "event_website"
 msgstr ""
 
 #: components/theme/View/EventView
+# defaultMessage: What
 msgid "event_what"
 msgstr ""
 
 #: components/theme/View/EventView
+# defaultMessage: When
 msgid "event_when"
 msgstr ""
 
 #: components/theme/View/EventView
+# defaultMessage: Where
 msgid "event_where"
 msgstr ""
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Password reset confirmation sent
 msgid "heading_sent_password"
 msgstr ""
 
 #: config/Blocks
+# defaultMessage: Hero
 msgid "hero"
 msgstr ""
 
 #: config/Blocks
+# defaultMessage: HTML
 msgid "html"
 msgstr ""
 
 #: config/Blocks
+# defaultMessage: Image
 msgid "image"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Input must be integer
 msgid "integer"
 msgstr ""
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Intranet
 msgid "intranet"
 msgstr ""
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: My email address is
 msgid "label_my_email_address_is"
 msgstr ""
 
 #: config/Blocks
+# defaultMessage: Lead Image Field
 msgid "leadimage"
 msgstr ""
 
 #: config/Blocks
+# defaultMessage: Listing
 msgid "listing"
 msgstr ""
 
 #: components/manage/Blocks/Listing/ListingBody
 #: components/manage/Contents/Contents
+# defaultMessage: Loading
 msgid "loading"
 msgstr ""
 
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: log in
 msgid "log in"
 msgstr ""
 
 #: config/Blocks
+# defaultMessage: Maps
 msgid "maps"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Maximum Length
 msgid "maxLength"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: End of the range (including the value itself)
 msgid "maximum"
 msgstr ""
 
 #: config/Blocks
+# defaultMessage: Media
 msgid "media"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Minimum Length
 msgid "minLength"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Start of the range
 msgid "minimum"
 msgstr ""
 
 #: config/Blocks
+# defaultMessage: Most used
 msgid "mostUsed"
 msgstr ""
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: No workflow state
 msgid "no workflow state"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Input must be number
 msgid "number"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/ByMonthDayField
 #: components/manage/Widgets/RecurrenceWidget/ByYearField
+# defaultMessage: of the month
 msgid "of the month"
 msgstr ""
 
 #: error
+# defaultMessage: or try a different page.
 msgid "or try a different page."
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: others
 msgid "others"
 msgstr ""
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Private
 msgid "private"
 msgstr ""
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Published
 msgid "published"
 msgstr ""
 
 #: components/manage/Widgets/QueryWidget
+# defaultMessage: Select…
 msgid "querystring-widget-select"
 msgstr ""
 
 #: components/theme/Search/Search
+# defaultMessage: results
 msgid "results found"
 msgstr ""
 
 #: error
+# defaultMessage: return to the site root
 msgid "return to the site root"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: and
 msgid "rrule_and"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: (~approximate)
 msgid "rrule_approximate"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: at
 msgid "rrule_at"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: [month] [day], [year]
 msgid "rrule_dateFormat"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: day
 msgid "rrule_day"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: days
 msgid "rrule_days"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: every
 msgid "rrule_every"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: for
 msgid "rrule_for"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: hour
 msgid "rrule_hour"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: hours
 msgid "rrule_hours"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: in
 msgid "rrule_in"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: last
 msgid "rrule_last"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: minutes
 msgid "rrule_minutes"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: month
 msgid "rrule_month"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: months
 msgid "rrule_months"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: nd
 msgid "rrule_nd"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: on
 msgid "rrule_on"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: on the
 msgid "rrule_on the"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: or
 msgid "rrule_or"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: rd
 msgid "rrule_rd"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: st
 msgid "rrule_st"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: th
 msgid "rrule_th"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: the
 msgid "rrule_the"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: time
 msgid "rrule_time"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: times
 msgid "rrule_times"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: until
 msgid "rrule_until"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: week
 msgid "rrule_week"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: weekday
 msgid "rrule_weekday"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: weekdays
 msgid "rrule_weekdays"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: weeks
 msgid "rrule_weeks"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: year
 msgid "rrule_year"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: years
 msgid "rrule_years"
 msgstr ""
 
 #: components/theme/SkipLinks/SkipLinks
+# defaultMessage: Skip to footer
 msgid "skiplink-footer"
 msgstr ""
 
 #: components/theme/SkipLinks/SkipLinks
+# defaultMessage: Skip to main content
 msgid "skiplink-main-content"
 msgstr ""
 
 #: components/theme/SkipLinks/SkipLinks
+# defaultMessage: Skip to navigation
 msgid "skiplink-navigation"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: sort
 msgid "sort"
 msgstr ""
 
 #: config/Blocks
+# defaultMessage: Table
 msgid "table"
 msgstr ""
 
 #: config/Blocks
+# defaultMessage: Text
 msgid "text"
 msgstr ""
 
 #: config/Blocks
+# defaultMessage: Title
 msgid "title"
 msgstr ""
 
 #: config/Blocks
+# defaultMessage: Table of Contents
 msgid "toc"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Input must be valid url (www.something.com or http(s)://www.something.com)
 msgid "url"
 msgstr ""
 
 #: components/manage/Toolbar/PersonalTools
+# defaultMessage: user avatar
 msgid "user avatar"
 msgstr ""
 
 #: config/Blocks
+# defaultMessage: Video
 msgid "video"
 msgstr ""
 
 #: components/theme/View/EventView
+# defaultMessage: Visit external website
 msgid "visit_external_website"
 msgstr ""
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: {count, plural, one {Upload {count} file} other {Upload {count} files}}
 msgid "{count, plural, one {Upload {count} file} other {Upload {count} files}}"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: {count} selected
 msgid "{count} selected"
 msgstr "{count} geselecteerd"
 
 #: components/manage/Controlpanels/ContentType
+# defaultMessage: {id} Content Type
 msgid "{id} Content Type"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypeSchema
+# defaultMessage: {id} Schema
 msgid "{id} Schema"
 msgstr ""
 
 #: components/manage/Actions/Actions
+# defaultMessage: {title} copied.
 msgid "{title} copied."
 msgstr "{title} gekopieerd."
 
 #: components/manage/Actions/Actions
+# defaultMessage: {title} cut.
 msgid "{title} cut."
 msgstr "{title} geknipt."
 
 #: components/manage/Actions/Actions
+# defaultMessage: {title} has been deleted.
 msgid "{title} has been deleted."
 msgstr "{title} is verwijderd."

--- a/locales/pt/LC_MESSAGES/volto.po
+++ b/locales/pt/LC_MESSAGES/volto.po
@@ -20,22 +20,27 @@ msgstr ""
 "Preferred-Encodings: utf-8\n"
 
 #: components/manage/Blocks/HTML/Edit
+# defaultMessage: <p>Add some HTML here</p>
 msgid "<p>Add some HTML here</p>"
 msgstr ""
 
 #: components/theme/Footer/Footer
+# defaultMessage: Accessibility
 msgid "Accessibility"
 msgstr "Acessibilidade"
 
 #: components/theme/Register/Register
+# defaultMessage: Account Registration Completed
 msgid "Account Registration Completed"
 msgstr "Registo de Conta Concluído"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Account activation completed
 msgid "Account activation completed"
 msgstr "Activação da conta concluída"
 
 #: components/manage/Controlpanels/ModerateComments
+# defaultMessage: Action
 msgid "Action"
 msgstr "Acção"
 
@@ -44,10 +49,12 @@ msgstr "Acção"
 #: components/manage/Controlpanels/ContentTypes
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
+# defaultMessage: Actions
 msgid "Actions"
 msgstr "Acções"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Activate and deactivate add-ons in the lists below.
 msgid "Activate and deactivate"
 msgstr ""
 
@@ -55,86 +62,107 @@ msgstr ""
 #: components/manage/Toolbar/Toolbar
 #: components/manage/Widgets/SchemaWidget
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add
 msgid "Add"
 msgstr "Adicionar"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: To make new add-ons show up here, add them to your buildout configuration, run buildout, and restart the server process. For detailed instructions see
 msgid "Add Addons"
 msgstr ""
 
 #: components/manage/Toolbar/Types
+# defaultMessage: Add Content…
 msgid "Add Content"
 msgstr "Adicionar Conteúdo"
 
 #: components/manage/Toolbar/Types
+# defaultMessage: Add Translation…
 msgid "Add Translation…"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add User
 msgid "Add User"
 msgstr "Adicionar Utilizador"
 
 #: components/manage/Blocks/Description/Edit
+# defaultMessage: Add a description…
 msgid "Add a description…"
 msgstr "Adicionar uma descrição…"
 
 #: components/manage/BlockChooser/BlockChooserButton
+# defaultMessage: Add block
 msgid "Add block"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add block…
 msgid "Add block…"
 msgstr "Adicionar bloco…"
 
 #: components/manage/Widgets/QueryWidget
+# defaultMessage: Add criteria
 msgid "Add criteria"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Add date
 msgid "Add date"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Add field
 msgid "Add field"
 msgstr "Adicionar campo"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Add fieldset
 msgid "Add fieldset"
 msgstr "Adicionar conjunto de campos"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add group
 msgid "Add group"
 msgstr "Adicionar grupo"
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Add new content type
 msgid "Add new content type"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add new group
 msgid "Add new group"
 msgstr "Adicionar novo grupo"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add new user
 msgid "Add new user"
 msgstr "Adicionar um novo utilizador"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add to Groups
 msgid "Add to Groups"
 msgstr "Adicionar a Grupos"
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Add term
 msgid "Add vocabulary term"
 msgstr ""
 
 #: components/manage/Add/Add
+# defaultMessage: Add {type}
 msgid "Add {type}"
 msgstr "Adicionar {type}"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Add-ons Settings
 msgid "Add-ons Settings"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: Additional date
 msgid "Additional date"
 msgstr ""
 
@@ -142,39 +170,48 @@ msgstr ""
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
 #: components/manage/Blocks/Maps/MapsSidebar
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Alignment
 msgid "Alignment"
 msgstr "Alinhamento"
 
 #: components/manage/Contents/Contents
+# defaultMessage: All
 msgid "All"
 msgstr "Tudo"
 
 #: components/theme/Search/Search
+# defaultMessage: Alphabetically
 msgid "Alphabetically"
 msgstr ""
 
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: Alt text
 msgid "Alt text"
 msgstr "Texto alternativo"
 
 #: components/manage/Toolbar/More
+# defaultMessage: Apply working copy
 msgid "Apply working copy"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Are you sure you want to delete this field?
 msgid "Are you sure you want to delete this field?"
 msgstr "Tem a certeza que quer eliminar este campo?"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Are you sure you want to delete this fieldset including all fields?
 msgid "Are you sure you want to delete this fieldset including all fields?"
 msgstr "Tem a certeza que quer eliminar este conjunto de campos incluindo todos os campos?"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Ascending
 msgid "Ascending"
 msgstr "Ascendente"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Available
 msgid "Available"
 msgstr ""
 
@@ -199,48 +236,59 @@ msgstr ""
 #: components/manage/Toolbar/Toolbar
 #: components/theme/ContactForm/ContactForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Back
 msgid "Back"
 msgstr "Voltar"
 
 #: components/manage/Diff/Diff
+# defaultMessage: Base
 msgid "Base"
 msgstr "Base"
 
 #: components/manage/Sidebar/Sidebar
+# defaultMessage: Block
 msgid "Block"
 msgstr "Bloco"
 
 #: components/theme/Login/Login
+# defaultMessage: Both email address and password are case sensitive, check that caps lock is not enabled.
 msgid "Both email address and password are case sensitive, check that caps lock is not enabled."
 msgstr "Tanto o endereço de email como a senha são sensíveis às diferenças entre maiúsculas e minúsculas. Assegure-se que o `caps lock` não esteja ligado."
 
 #: components/theme/Breadcrumbs/Breadcrumbs
+# defaultMessage: Breadcrumbs
 msgid "Breadcrumbs"
 msgstr "Navegação estrutural"
 
 #: components/manage/Blocks/HeroImageLeft/Edit
 #: components/manage/Contents/ContentsUploadModal
 #: components/manage/Sidebar/ObjectBrowserNav
+# defaultMessage: Browse
 msgid "Browse"
 msgstr "Navegar"
 
 #: components/manage/Blocks/Image/Edit
+# defaultMessage: Browse the site, drop an image, or type an URL
 msgid "Browse the site, drop an image, or type an URL"
 msgstr "Navegue no website, largue uma imagem ou escreva um URL"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: By default, permissions from the container of this item are inherited. If you disable this, only the explicitly defined sharing permissions will be valid. In the overview, the symbol {inherited} indicates an inherited value. Similarly, the symbol {global} indicates a global role, which is managed by the site administrator.
 msgid "By default, permissions from the container of this item are inherited. If you disable this, only the explicitly defined sharing permissions will be valid. In the overview, the symbol {inherited} indicates an inherited value. Similarly, the symbol {global} indicates a global role, which is managed by the site administrator."
 msgstr "Por predefinição, as permissões do contentor deste item são herdadas. Se desactivar isto, apenas serão válidas as permissões de partilha explicitamente definidas. No resumo, o símbolo {inherited} indica um valor herdado. Do mesmo modo, o símbolo {global} indica um papel global, que é gerido pelo administrador do sítio."
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Cache Name
 msgid "Cache Name"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypeLayout
+# defaultMessage: Can not edit Layout for <strong>{type}</strong> content-type as it doesn't have support for <strong>Volto Blocks</strong> enabled
 msgid "Can not edit Layout for <strong>{type}</strong> content-type as it doesn't have support for <strong>Volto Blocks</strong> enabled"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypeLayout
+# defaultMessage: Can not edit Layout for <strong>{type}</strong> content-type as the <strong>Blocks behavior</strong> is enabled and <strong>read-only</strong>
 msgid "Can not edit Layout for <strong>{type}</strong> content-type as the <strong>Blocks behavior</strong> is enabled and <strong>read-only</strong>"
 msgstr ""
 
@@ -256,42 +304,51 @@ msgstr ""
 #: components/manage/Sharing/Sharing
 #: components/theme/Login/Login
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Cancel
 msgid "Cancel"
 msgstr "Cancelar"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Cell
 msgid "Cell"
 msgstr "Célula"
 
 #: components/manage/Blocks/Image/ImageSizeWidget
 #: components/manage/Blocks/Maps/Edit
 #: components/manage/Sidebar/AlignBlock
+# defaultMessage: Center
 msgid "Center"
 msgstr "Centro"
 
 #: components/manage/History/History
+# defaultMessage: Change Note
 msgid "Change Note"
 msgstr "Alterar Nota"
 
 #: components/manage/Preferences/ChangePassword
+# defaultMessage: Change Password
 msgid "Change Password"
 msgstr "Alterar Senha"
 
 #: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Change State
 msgid "Change State"
 msgstr "Alterar Estado"
 
 #: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Change workflow state recursively
 msgid "Change workflow state recursively"
 msgstr ""
 
 #: components/manage/Toolbar/More
+# defaultMessage: Changes applied
 msgid "Changes applied."
 msgstr ""
 
 #: components/manage/Preferences/ChangePassword
 #: components/manage/Preferences/PersonalInformation
 #: components/manage/Preferences/PersonalPreferences
+# defaultMessage: Changes saved
 msgid "Changes saved"
 msgstr "Alterações guardadas"
 
@@ -299,192 +356,237 @@ msgstr "Alterações guardadas"
 #: components/manage/Controlpanels/ContentTypeLayout
 #: components/manage/Controlpanels/ContentTypeSchema
 #: components/manage/Controlpanels/Controlpanel
+# defaultMessage: Changes saved.
 msgid "Changes saved."
 msgstr "Alterações guardadas."
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Checkbox
 msgid "Checkbox"
 msgstr "Caixa de verificação"
 
 #: components/manage/Widgets/SelectWidget
+# defaultMessage: Choices
 msgid "Choices"
 msgstr "Escolhas"
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: Choose Image
 msgid "Choose Image"
 msgstr "Escolha Imagem"
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: Choose Target
 msgid "Choose Target"
 msgstr "Escolha Alvo"
 
 #: components/manage/Widgets/FileWidget
+# defaultMessage: Choose a file
 msgid "Choose a file"
 msgstr ""
 
 #: components/manage/Blocks/HTML/Edit
+# defaultMessage: Clear
 msgid "Clear"
 msgstr ""
 
 #: components/theme/View/ImageView
+# defaultMessage: Click to download full sized image
 msgid "Click to download full sized image"
 msgstr ""
 
 #: components/manage/Widgets/SelectWidget
+# defaultMessage: Close
 msgid "Close"
 msgstr "Fechar"
 
 #: components/theme/Navigation/Navigation
+# defaultMessage: Close menu
 msgid "Close menu"
 msgstr "Fechar menu"
 
 #: components/manage/Blocks/HTML/Edit
+# defaultMessage: Code
 msgid "Code"
 msgstr ""
 
 #: components/manage/Widgets/ObjectListWidget
+# defaultMessage: Collapse item
 msgid "Collapse item"
 msgstr ""
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Collection
 msgid "Collection"
 msgstr ""
 
 #: components/manage/Controlpanels/ModerateComments
 #: components/theme/Comments/CommentEditModal
 #: components/theme/Comments/Comments
+# defaultMessage: Comment
 msgid "Comment"
 msgstr "Comentar"
 
 #: components/manage/Controlpanels/ModerateComments
+# defaultMessage: Commenter
 msgid "Commenter"
 msgstr "Comentador"
 
 #: components/theme/Comments/Comments
+# defaultMessage: Comments
 msgid "Comments"
 msgstr ""
 
 #: components/manage/Diff/Diff
+# defaultMessage: Compare
 msgid "Compare"
 msgstr "Comparar"
 
 #: components/manage/Preferences/ChangePassword
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Confirm password
 msgid "Confirm password"
 msgstr "Confirmar senha"
 
 #: components/theme/ConnectionRefused/ConnectionRefused
+# defaultMessage: Connection refused
 msgid "Connection refused"
 msgstr ""
 
 #: components/theme/Footer/Footer
+# defaultMessage: Contact
 msgid "Contact"
 msgstr "Contacto"
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Contact form
 msgid "Contact form"
 msgstr "Formulário de contacto"
 
 #: components/manage/Blocks/Listing/Edit
+# defaultMessage: Contained items
 msgid "Contained items"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Content type created
 msgid "Content type created"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Content type deleted
 msgid "Content type deleted"
 msgstr ""
 
 #: components/manage/Contents/Contents
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Contents
 msgid "Contents"
 msgstr "Conteúdo"
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Copy
 msgid "Copy"
 msgstr "Copiar"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: undefined
 msgid "Copy blocks"
 msgstr ""
 
 #: components/theme/Footer/Footer
+# defaultMessage: Copyright
 msgid "Copyright"
 msgstr "Copyright"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Copyright statement or other rights information on this item.
 msgid "Copyright statement or other rights information on this item."
 msgstr "Declaração de copyright ou outras informações de direitos sobre este item."
 
 #: components/manage/Toolbar/More
+# defaultMessage: Create working copy
 msgid "Create working copy"
 msgstr ""
 
 #: components/manage/WorkingCopyToastsFactory/WorkingCopyToastsFactory
+# defaultMessage: Created by {creator} on {date}
 msgid "Created by {creator} on {date}"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Created on
 msgid "Created on"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Creator
 msgid "Creator"
 msgstr ""
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Creators
 msgid "Creators"
 msgstr "Criadores"
 
 #: components/manage/Widgets/QuerystringWidget
 #: components/manage/Widgets/QueryWidget
+# defaultMessage: Criteria
 msgid "Criteria"
 msgstr ""
 
 #: components/manage/Preferences/ChangePassword
+# defaultMessage: Current password
 msgid "Current password"
 msgstr "Senha actual"
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Cut
 msgid "Cut"
 msgstr "Cortar"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: undefined
 msgid "Cut blocks"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Daily
 msgid "Daily"
 msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Database Information
 msgid "Database Information"
 msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Database Location
 msgid "Database Location"
 msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Database Size
 msgid "Database Size"
 msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Database main
 msgid "Database main"
 msgstr ""
 
 #: components/manage/Controlpanels/ModerateComments
 #: components/manage/Widgets/DatetimeWidget
+# defaultMessage: Date
 msgid "Date"
 msgstr "Data"
 
 #: components/theme/Search/Search
+# defaultMessage: Date (newest first)
 msgid "Date (newest first)"
 msgstr ""
 
@@ -504,6 +606,7 @@ msgstr ""
 #: components/theme/PasswordReset/PasswordReset
 #: components/theme/PasswordReset/RequestPasswordReset
 #: components/theme/Register/Register
+# defaultMessage: Default
 msgid "Default"
 msgstr "Predefinido"
 
@@ -518,38 +621,47 @@ msgstr "Predefinido"
 #: components/manage/Widgets/ObjectBrowserWidget
 #: components/manage/Widgets/WysiwygWidget
 #: components/theme/Comments/Comments
+# defaultMessage: Delete
 msgid "Delete"
 msgstr "Eliminar"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Delete Group
 msgid "Delete Group"
 msgstr "Eliminar Grupo"
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Delete Type
 msgid "Delete Type"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Delete User
 msgid "Delete User"
 msgstr "Eliminar Utilizador"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: undefined
 msgid "Delete blocks"
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Delete col
 msgid "Delete col"
 msgstr "Eliminar coluna"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Delete row
 msgid "Delete row"
 msgstr "Eliminar linha"
 
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: Depth
 msgid "Depth"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Descending
 msgid "Descending"
 msgstr "Descendente"
 
@@ -560,72 +672,89 @@ msgstr "Descendente"
 #: components/manage/Widgets/WysiwygWidget
 #: components/theme/View/TabularView
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Description
 msgid "Description"
 msgstr "Descrição"
 
 #: components/manage/Diff/Diff
+# defaultMessage: Diff
 msgid "Diff"
 msgstr "Diferenças"
 
 #: components/manage/Diff/Diff
+# defaultMessage: Difference between revision {one} and {two} of {title}
 msgid "Difference between revision {one} and {two} of {title}"
 msgstr "Diferenças entre as revisões {one} e {two} de {title}"
 
 #: components/theme/Footer/Footer
+# defaultMessage: Distributed under the {license}.
 msgid "Distributed under the {license}."
 msgstr "Distribuído sob a licença {license}."
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Add border to inner columns
 msgid "Divide each row into separate cells"
 msgstr "Dividir cada linha em células separadas"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Do you really want to delete the following items?
 msgid "Do you really want to delete the following items?"
 msgstr "Quer mesmo eliminar os itens seguintes?"
 
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
+# defaultMessage: Do you really want to delete the group {groupname}?
 msgid "Do you really want to delete the group {groupname}?"
 msgstr "Quer mesmo eliminar o grupo {groupname}?"
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Do you really want to delete type {typename}?
 msgid "Do you really want to delete the type {typename}?"
 msgstr ""
 
 #: components/manage/Controlpanels/Users/UsersControlpanel
+# defaultMessage: Do you really want to delete the user {username}?
 msgid "Do you really want to delete the user {username}?"
 msgstr "Quer mesmo eliminar o utilizador {username}?"
 
 #: components/manage/Delete/Delete
+# defaultMessage: Do you really want to delete this item?
 msgid "Do you really want to delete this item?"
 msgstr "Quer mesmo eliminar este item?"
 
 #: components/manage/Multilingual/TranslationObject
 #: components/manage/Sidebar/Sidebar
+# defaultMessage: Document
 msgid "Document"
 msgstr "Documento"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Drag and drop files from your computer onto this area or click the “Browse” button.
 msgid "Drag and drop files from your computer onto this area or click the “Browse” button."
 msgstr "Arraste e largue ficheiros do seu computador para esta área ou clique no botão “Procurar”."
 
 #: components/manage/Widgets/FileWidget
+# defaultMessage: Drop file here to replace the existing file
 msgid "Drop file here to replace the existing file"
 msgstr ""
 
 #: components/manage/Widgets/FileWidget
+# defaultMessage: Drop file here to upload a new file
 msgid "Drop file here to upload a new file"
 msgstr ""
 
 #: components/manage/Widgets/FileWidget
+# defaultMessage: Drop files here ...
 msgid "Drop files here ..."
 msgstr ""
 
 #: components/manage/Preferences/PersonalInformation
 #: components/theme/Register/Register
+# defaultMessage: E-mail
 msgid "E-mail"
 msgstr "E-mail"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: E-mail addresses do not match.
 msgid "E-mail addresses do not match."
 msgstr "Os endereços de e-mail não coincidem."
 
@@ -636,93 +765,115 @@ msgstr "Os endereços de e-mail não coincidem."
 #: components/manage/Widgets/FormFieldWrapper
 #: components/manage/Widgets/ObjectBrowserWidget
 #: components/theme/Comments/Comments
+# defaultMessage: Edit
 msgid "Edit"
 msgstr "Editar"
 
 #: components/theme/Comments/CommentEditModal
+# defaultMessage: Edit comment
 msgid "Edit comment"
 msgstr "Editar comentário"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Edit field
 msgid "Edit field"
 msgstr "Editar campo"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Edit fieldset
 msgid "Edit fieldset"
 msgstr "Editar conjunto de campos"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Edit recurrence
 msgid "Edit recurrence"
 msgstr ""
 
 #: components/manage/Form/InlineForm
+# defaultMessage: Edit values
 msgid "Edit values"
 msgstr ""
 
 #: components/manage/Edit/Edit
+# defaultMessage: Edit {title}
 msgid "Edit {title}"
 msgstr "Editar {title}"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Email
 msgid "Email"
 msgstr "Email"
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Email sent
 msgid "Email sent"
 msgstr "Email enviado"
 
 #: components/manage/Blocks/Maps/Edit
+# defaultMessage: Embed code error, please follow the instructions and try again.
 msgid "Embed code error, please follow the instructions and try again."
 msgstr ""
 
 #: components/manage/Blocks/Maps/View
+# defaultMessage: Embeded Google Maps
 msgid "Embeded Google Maps"
 msgstr ""
 
 #: components/manage/Widgets/ObjectListWidget
+# defaultMessage: Empty object list
 msgid "Empty object list"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypeLayout
+# defaultMessage: Enable editable Blocks
 msgid "Enable editable Blocks"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: End Date
 msgid "End Date"
 msgstr ""
 
 #: components/manage/AnchorPlugin/components/LinkButton/AddLinkForm
+# defaultMessage: Enter URL or select an item
 msgid "Enter URL or select an item"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Enter a username above to search or click 'Show All'
 msgid "Enter a username above to search or click 'Show All'"
 msgstr ""
 
 #: components/theme/Register/Register
+# defaultMessage: Enter an email address. This will be your login name. We respect your privacy, and will not give the address away to any third parties or expose it anywhere.
 msgid "Enter an email address. This will be your login name. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr "Escreva um endereço de email. Este será o seu nome de sessão. Respeitamos a sua privacidade e nunca iremos ceder o seu endereço a terceiros ou expô-lo onde quer que seja."
 
 #: components/manage/Preferences/PersonalInformation
 #: components/theme/PasswordReset/PasswordReset
 #: components/theme/Register/Register
+# defaultMessage: Enter full name, e.g. John Smith.
 msgid "Enter full name, e.g. John Smith."
 msgstr "Escreva o nome completo. Por exemplo, José Silva."
 
 #: components/manage/Blocks/Maps/Edit
+# defaultMessage: Enter map Embed Code
 msgid "Enter map Embed Code"
 msgstr ""
 
 #: components/manage/Preferences/ChangePassword
+# defaultMessage: Enter your current password.
 msgid "Enter your current password."
 msgstr "Escreva a senha actual."
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Enter your email address for verification.
 msgid "Enter your email address for verification."
 msgstr "Escreva o seu endereço de email para verificação."
 
 #: components/manage/Preferences/ChangePassword
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Enter your new password. Minimum 5 characters.
 msgid "Enter your new password. Minimum 5 characters."
 msgstr "Escreva uma senha nova. Mínimo de 5 caracteres."
 
@@ -734,199 +885,245 @@ msgstr "Escreva uma senha nova. Mínimo de 5 caracteres."
 #: components/theme/ContactForm/ContactForm
 #: components/theme/Login/Login
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Error
 msgid "Error"
 msgstr "Erro"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Exclude from navigation
 msgid "Exclude from navigation"
 msgstr "Excluir da navegação"
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: Exclude this occurence
 msgid "Exclude this occurence"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Excluded from navigation
 msgid "Excluded from navigation"
 msgstr ""
 
 #: components/manage/Sidebar/Sidebar
+# defaultMessage: Expand sidebar
 msgid "Expand sidebar"
 msgstr "Expandir barra lateral"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Expiration Date
 msgid "Expiration Date"
 msgstr "Data de vencimento"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Expiration date
 msgid "Expiration date"
 msgstr ""
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Expired
 msgid "Expired"
 msgstr ""
 
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: External URL
 msgid "External URL"
 msgstr "URL externo"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: File
 msgid "File"
 msgstr ""
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: File size
 msgid "File size"
 msgstr "Tamanho do ficheiro"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Filename
 msgid "Filename"
 msgstr "Nome de ficheiro"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Filter…
 msgid "Filter…"
 msgstr "Filtro…"
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: First
 msgid "First"
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Fixed width columns
 msgid "Fixed width table cells"
 msgstr "Células de tabela de tamanho fixo."
 
 #: components/manage/BlockChooser/BlockChooser
+# defaultMessage: Fold
 msgid "Fold"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Folder
 msgid "Folder"
 msgstr ""
 
 #: components/theme/Forbidden/Forbidden
+# defaultMessage: Forbidden
 msgid "Forbidden"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: Fourth
 msgid "Fourth"
 msgstr ""
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: From
 msgid "From"
 msgstr "De"
 
 #: components/manage/Blocks/Maps/Edit
 #: components/manage/Sidebar/AlignBlock
+# defaultMessage: Full
 msgid "Full"
 msgstr "Cheio"
 
 #: components/manage/Preferences/PersonalInformation
 #: components/theme/PasswordReset/PasswordReset
 #: components/theme/Register/Register
+# defaultMessage: Full Name
 msgid "Full Name"
 msgstr "Nome Completo"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Fullname
 msgid "Fullname"
 msgstr "Nome completo"
 
 #: components/theme/Footer/Footer
+# defaultMessage: GNU GPL license
 msgid "GNU GPL license"
 msgstr "Licença GNU GPL"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Global role
 msgid "Global role"
 msgstr "Papel global"
 
 #: components/manage/Blocks/Maps/Edit
+# defaultMessage: Google Maps Embedded Block
 msgid "Google Maps Embedded Block"
 msgstr "Bloco Integrado Google Maps"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Group
 msgid "Group"
 msgstr "Grupo"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Group created
 msgid "Group created"
 msgstr "Grupo criado"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Group roles updated
 msgid "Group roles updated"
 msgstr ""
 
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Groupname
 msgid "Groupname"
 msgstr "Nome do grupo"
 
 #: components/manage/Controlpanels/Controlpanels
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Groups
 msgid "Groups"
 msgstr "Grupos"
 
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
+# defaultMessage: Groups are logical collections of users, such as departments and business units. Groups are not directly related to permissions on a global level, you normally use Roles for that - and let certain Groups have a particular role. The symbol{plone_svg}indicates a role inherited from membership in another group.
 msgid "Groups are logical collections of users, such as departments and business units. Groups are not directly related to permissions on a global level, you normally use Roles for that - and let certain Groups have a particular role. The symbol{plone_svg}indicates a role inherited from membership in another group."
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Header cell
 msgid "Header cell"
 msgstr ""
 
 #: components/theme/Comments/Comments
+# defaultMessage: Hide Replies
 msgid "Hide Replies"
 msgstr ""
 
 #: components/manage/History/History
 #: components/manage/Toolbar/More
+# defaultMessage: History
 msgid "History"
 msgstr "Histórico"
 
 #: components/manage/History/History
+# defaultMessage: #
 msgid "History Version Number"
 msgstr ""
 
 #: components/manage/History/History
+# defaultMessage: History of {title}
 msgid "History of {title}"
 msgstr "Histórico de {title}"
 
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsBreadcrumbs
 #: components/theme/Breadcrumbs/Breadcrumbs
+# defaultMessage: Home
 msgid "Home"
 msgstr "Início"
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: Home page
 msgid "Home page"
 msgstr "Página inicial"
 
 #: components/manage/Contents/Contents
+# defaultMessage: ID
 msgid "ID"
 msgstr ""
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: If selected, this item will not appear in the navigation tree
 msgid "If selected, this item will not appear in the navigation tree"
 msgstr "Se este item estiver seleccionado, não irá aparecer na árvore de navegação"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: If this date is in the future, the content will not show up in listings and searches until this date.
 msgid "If this date is in the future, the content will not show up in listings and searches until this date."
 msgstr "Se esta data estiver no futuro, o conteúdo não irá aparecer em listas nem em pesquisas até esta data."
 
 #: components/manage/LockingToastsFactory/LockingToastsFactory
+# defaultMessage: If you are certain this user has abandoned the object, you may unlock the object. You will then be able to edit it.
 msgid "If you are certain this user has abandoned the object, you may unlock the object. You will then be able to edit it."
 msgstr ""
 
 #: components/theme/NotFound/NotFound
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: If you are certain you have the correct web address but are encountering an error, please contact the {site_admin}.
 msgid "If you are certain you have the correct web address but are encountering an error, please contact the {site_admin}."
 msgstr "Se tiver a certeza que tem o endereço web correcto mas está a obter um erro, por favor contacte o {site_admin}."
 
 #: components/manage/Blocks/HeroImageLeft/Edit
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: Image
 msgid "Image"
 msgstr "Imagem"
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: Include this occurence
 msgid "Include this occurence"
 msgstr ""
 
@@ -934,142 +1131,176 @@ msgstr ""
 #: components/manage/Controlpanels/ContentTypeLayout
 #: components/manage/Controlpanels/ContentTypeSchema
 #: components/manage/Controlpanels/Controlpanel
+# defaultMessage: Info
 msgid "Info"
 msgstr "Informação"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Inherit permissions from higher levels
 msgid "Inherit permissions from higher levels"
 msgstr "Herdar permissões de níveis superiores"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Inherited value
 msgid "Inherited value"
 msgstr "Herdar valor"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Insert col after
 msgid "Insert col after"
 msgstr "Inserir coluna após"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Insert col before
 msgid "Insert col before"
 msgstr "Inserir coluna antes"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Insert row after
 msgid "Insert row after"
 msgstr "Inserir linha após"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Insert row before
 msgid "Insert row before"
 msgstr "Inserir linha antes"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Install
 msgid "Install"
 msgstr ""
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Installed
 msgid "Installed"
 msgstr ""
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Installed version
 msgid "Installed version"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: days
 msgid "Interval Daily"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Month(s)
 msgid "Interval Monthly"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: week(s)
 msgid "Interval Weekly"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: year(s)
 msgid "Interval Yearly"
 msgstr ""
 
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: Item batch size
 msgid "Item batch size"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Item succesfully moved.
 msgid "Item succesfully moved."
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Item(s) copied.
 msgid "Item(s) copied."
 msgstr "Item(ns) copiado(s)."
 
 #: components/manage/Contents/Contents
+# defaultMessage: Item(s) cut.
 msgid "Item(s) cut."
 msgstr "Item(ns) cortado(s)."
 
 #: components/manage/Contents/Contents
+# defaultMessage: Item(s) has been updated.
 msgid "Item(s) has been updated."
 msgstr ""
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
+# defaultMessage: Item(s) pasted.
 msgid "Item(s) pasted."
 msgstr "Item(ns) colado(s)."
 
 #: components/manage/Contents/Contents
+# defaultMessage: Item(s) state has been updated.
 msgid "Item(s) state has been updated."
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Items
 msgid "Items"
 msgstr ""
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Items must be unique.
 msgid "Items must be unique."
 msgstr "Os itens têm de ser únicos."
 
 #: components/manage/Preferences/PersonalPreferences
+# defaultMessage: Language
 msgid "Language"
 msgstr "Idioma"
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: Last
 msgid "Last"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Last comment date
 msgid "Last comment date"
 msgstr ""
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Last modified
 msgid "Last modified"
 msgstr "Última modificação"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Latest version
 msgid "Latest version"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypesActions
+# defaultMessage: Layout
 msgid "Layout"
 msgstr ""
 
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: Lead Image
 msgid "Lead Image"
 msgstr ""
 
 #: components/manage/Blocks/Image/ImageSizeWidget
 #: components/manage/Blocks/Maps/Edit
 #: components/manage/Sidebar/AlignBlock
+# defaultMessage: Left
 msgid "Left"
 msgstr "Esquerda"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Link
 msgid "Link"
 msgstr ""
 
 #: components/manage/Blocks/Listing/schema
+# defaultMessage: Link more
 msgid "Link more"
 msgstr ""
 
 #: components/manage/Blocks/Listing/schema
+# defaultMessage: Link Title
 msgid "Link title"
 msgstr ""
 
@@ -1078,212 +1309,262 @@ msgstr ""
 #: components/manage/Blocks/Listing/schema
 #: components/manage/Blocks/Maps/MapsSidebar
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Link to
 msgid "Link to"
 msgstr "Ligar a"
 
 #: components/manage/Multilingual/ManageTranslations
+# defaultMessage: Link translation for
 msgid "Link translation for"
 msgstr ""
 
 #: components/manage/Blocks/Listing/schema
+# defaultMessage: Listing
 msgid "Listing"
 msgstr ""
 
 #: components/theme/Comments/Comments
+# defaultMessage: Load more...
 msgid "Load more"
 msgstr ""
 
 #: components/manage/Form/ModalForm
+# defaultMessage: Loading.
 msgid "Loading"
 msgstr ""
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: Location
 msgid "Location"
 msgstr "Localização"
 
 #: components/theme/Login/Login
+# defaultMessage: Login
 msgid "Log In"
 msgstr "Iniciar sessão"
 
 #: components/theme/Anontools/Anontools
 #: components/theme/Login/Login
+# defaultMessage: Log in
 msgid "Log in"
 msgstr "Iniciar sessão"
 
 #: components/theme/Login/Login
+# defaultMessage: Login
 msgid "Login"
 msgstr "Iniciar sessão"
 
 #: components/theme/Login/Login
+# defaultMessage: Login Failed
 msgid "Login Failed"
 msgstr "Falhou o início de sessão"
 
 #: components/theme/Login/Login
+# defaultMessage: Login Name
 msgid "Login Name"
 msgstr "Nome de utilizador"
 
 #: components/manage/Toolbar/PersonalTools
+# defaultMessage: Logout
 msgid "Logout"
 msgstr ""
 
 #: components/manage/Toolbar/More
+# defaultMessage: Made by {creator} on {date}. This is not a working copy anymore, but the main content.
 msgid "Made by {creator} on {date}. This is not a working copy anymore, but the main content."
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Reduce cell padding
 msgid "Make the table compact"
 msgstr "Compactar a tabela"
 
 #: components/manage/Multilingual/ManageTranslations
 #: components/manage/Toolbar/More
+# defaultMessage: Manage Translations
 msgid "Manage Translations"
 msgstr ""
 
 #: components/manage/Multilingual/ManageTranslations
+# defaultMessage: Manage translations for {title}
 msgid "Manage translations for {title}"
 msgstr ""
 
 #: components/manage/Blocks/Maps/MapsSidebar
+# defaultMessage: Map
 msgid "Map"
 msgstr ""
 
 #: components/manage/Blocks/Maps/MapsSidebar
+# defaultMessage: Maps URL
 msgid "Maps URL"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Maximum length is {len}.
 msgid "Maximum length is {len}."
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Maximum value is {len}.
 msgid "Maximum value is {len}."
 msgstr ""
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Message
 msgid "Message"
 msgstr "Mensagem"
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Minimum length is {len}.
 msgid "Minimum length is {len}."
 msgstr "O comprimento mínimo é {len}."
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Minimum value is {len}.
 msgid "Minimum value is {len}."
 msgstr ""
 
 #: components/manage/Controlpanels/Controlpanels
+# defaultMessage: Moderate Comments
 msgid "Moderate Comments"
 msgstr "Moderar Comentários"
 
 #: components/manage/Controlpanels/ModerateComments
+# defaultMessage: Moderate comments
 msgid "Moderate comments"
 msgstr "Moderar comentários"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Monday and Friday
 msgid "Monday and Friday"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/ByMonthDayField
+# defaultMessage: Day
 msgid "Month day"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Monthly
 msgid "Monthly"
 msgstr ""
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: More
 msgid "More"
 msgstr ""
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Move to bottom of folder
 msgid "Move to bottom of folder"
 msgstr "Mover para o fundo da pasta"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Move to top of folder
 msgid "Move to top of folder"
 msgstr "Mover para o topo da pasta"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: My email address is
 msgid "My email address is"
 msgstr "O meu endereço de email é"
 
 #: components/manage/Sharing/Sharing
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Name
 msgid "Name"
 msgstr "Nome"
 
 #: error
+# defaultMessage: Navigate back
 msgid "Navigate back"
 msgstr ""
 
 #: components/theme/Navigation/ContextNavigation
+# defaultMessage: Navigation
 msgid "Navigation"
 msgstr ""
 
 #: components/manage/Preferences/ChangePassword
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: New password
 msgid "New password"
 msgstr "Nova senha"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: News Item
 msgid "News Item"
 msgstr ""
 
 #: components/manage/Contents/ContentsItem
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: No
 msgid "No"
 msgstr ""
 
 #: components/manage/Blocks/Image/ImageSidebar
+# defaultMessage: No image selected
 msgid "No image selected"
 msgstr "Nenhuma imagem seleccionada"
 
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: No image set in Lead Image content field
 msgid "No image set in Lead Image content field"
 msgstr ""
 
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: No image set in image content field
 msgid "No image set in image content field"
 msgstr ""
 
 #: components/manage/Blocks/Listing/ListingBody
+# defaultMessage: No items found in this container.
 msgid "No items found in this container."
 msgstr ""
 
 #: components/manage/Widgets/ObjectBrowserWidget
+# defaultMessage: No items selected
 msgid "No items selected"
 msgstr ""
 
 #: components/manage/Blocks/Maps/MapsSidebar
+# defaultMessage: No map selected
 msgid "No map selected"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: No occurences set
 msgid "No occurences set"
 msgstr ""
 
 #: components/manage/Widgets/ArrayWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/TokenWidget
+# defaultMessage: No options
 msgid "No options"
 msgstr ""
 
 #: components/theme/Search/Search
+# defaultMessage: No results found
 msgid "No results found"
 msgstr ""
 
 #: components/manage/Blocks/Listing/ListingBody
 #: components/manage/Widgets/ReferenceWidget
+# defaultMessage: No results found.
 msgid "No results found."
 msgstr "Não foram encontrados quaisquer resultados."
 
 #: components/manage/Widgets/QuerySortOnWidget
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: No selection
 msgid "No selection"
 msgstr ""
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: This addon does not provide an uninstall profile.
 msgid "No uninstall profile"
 msgstr ""
 
@@ -1291,39 +1572,48 @@ msgstr ""
 #: components/manage/Widgets/ReferenceWidget
 #: components/manage/Widgets/SelectUtils
 #: components/manage/Widgets/SelectWidget
+# defaultMessage: No value
 msgid "No value"
 msgstr "Sem qualquer valor"
 
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: No video selected
 msgid "No video selected"
 msgstr ""
 
 #: components/manage/Workflow/Workflow
+# defaultMessage: No workflow
 msgid "No workflow"
 msgstr "Sem fluxo de trabalho"
 
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsItem
+# defaultMessage: None
 msgid "None"
 msgstr "Nenhum"
 
 #: components/manage/Controlpanels/Users/UsersControlpanel
+# defaultMessage: Note that roles set here apply directly to a user. The symbol{plone_svg}indicates a role inherited from membership in a group.
 msgid "Note that roles set here apply directly to a user. The symbol{plone_svg}indicates a role inherited from membership in a group."
 msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Number of active objects
 msgid "Number of active objects"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Object Size
 msgid "Object Size"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/EndField
+# defaultMessage: occurrence(s)
 msgid "Occurences"
 msgstr ""
 
 #: components/manage/Delete/Delete
+# defaultMessage: Ok
 msgid "Ok"
 msgstr "Ok"
 
@@ -1331,301 +1621,371 @@ msgstr "Ok"
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
 #: components/manage/Blocks/Maps/MapsSidebar
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Open in a new tab
 msgid "Open in a new tab"
 msgstr "Abrir num novo separador"
 
 #: components/theme/Navigation/Navigation
+# defaultMessage: Open menu
 msgid "Open menu"
 msgstr "Abrir menu"
 
 #: components/manage/Widgets/ObjectBrowserWidget
+# defaultMessage: Open object browser
 msgid "Open object browser"
 msgstr ""
 
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: Origin
 msgid "Origin"
 msgstr "Origem"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Page
 msgid "Page"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Parent fieldset
 msgid "Parent fieldset"
 msgstr ""
 
 #: components/theme/Login/Login
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Password
 msgid "Password"
 msgstr "Senha"
 
 #: components/theme/PasswordReset/PasswordReset
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Password reset
 msgid "Password reset"
 msgstr "Reiniciar senha"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Passwords do not match.
 msgid "Passwords do not match."
 msgstr "As senhas não coincidem."
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
+# defaultMessage: Paste
 msgid "Paste"
 msgstr "Colar"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: undefined
 msgid "Paste blocks"
 msgstr ""
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Permissions have been updated successfully
 msgid "Permissions have been updated successfully"
 msgstr ""
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Permissions updated
 msgid "Permissions updated"
 msgstr ""
 
 #: components/manage/Preferences/PersonalInformation
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Personal Information
 msgid "Personal Information"
 msgstr "Informação Pessoal"
 
 #: components/manage/Preferences/PersonalPreferences
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Personal Preferences
 msgid "Personal Preferences"
 msgstr "Preferências Pessoais"
 
 #: components/manage/Toolbar/More
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Personal tools
 msgid "Personal tools"
 msgstr ""
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Persons responsible for creating the content of this item. Please enter a list of user names, one per line. The principal creator should come first.
 msgid "Persons responsible for creating the content of this item. Please enter a list of user names, one per line. The principal creator should come first."
 msgstr "Pessoas responsáveis pela criação de conteúdo deste item. Pro favor escreva uma lista de nomes de utilizador, um por linha. O criador principal deve estar em primeiro lugar."
 
 #: components/manage/Blocks/Video/Edit
+# defaultMessage: Please enter a valid URL by deleting the block and adding a new video block.
 msgid "Please enter a valid URL by deleting the block and adding a new video block."
 msgstr ""
 
 #: components/manage/Blocks/Maps/Edit
+# defaultMessage: Please enter the Embed Code provided by Google Maps -> Share -> Embed map. It should contain the <iframe> code on it.
 msgid "Please enter the Embed Code provided by Google Maps -> Share -> Embed map. It should contain the <iframe> code on it."
 msgstr ""
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Please fill out the form below to set your password.
 msgid "Please fill out the form below to set your password."
 msgstr "Por favor preencha o formulário abaixo para definir a sua senha."
 
 #: components/theme/Footer/Footer
+# defaultMessage: Plone Foundation
 msgid "Plone Foundation"
 msgstr "Fundação Plone"
 
 #: components/theme/Logo/Logo
+# defaultMessage: Plone Site
 msgid "Plone Site"
 msgstr "Sítio Plone"
 
 #: components/theme/Footer/Footer
+# defaultMessage: Plone{reg} Open Source CMS/WCM
 msgid "Plone{reg} Open Source CMS/WCM"
 msgstr "Plone{reg} Open Source CMS/WCM"
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: Portrait
 msgid "Portrait"
 msgstr "Retrato"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Possible values (Enter allowed choices one per line).
 msgid "Possible values"
 msgstr ""
 
 #: components/theme/Footer/Footer
+# defaultMessage: Powered by Plone & Python
 msgid "Powered by Plone & Python"
 msgstr "Criado com Plone e Python"
 
 #: components/manage/Toolbar/PersonalTools
+# defaultMessage: Preferences
 msgid "Preferences"
 msgstr "Preferências"
 
 #: components/manage/Blocks/HTML/Edit
+# defaultMessage: Prettify your code
 msgid "Prettify your code"
 msgstr ""
 
 #: components/manage/Blocks/HTML/Edit
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Preview
 msgid "Preview"
 msgstr "Pré-visualização"
 
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Preview Image URL
 msgid "Preview Image URL"
 msgstr ""
 
 #: components/manage/Toolbar/PersonalTools
+# defaultMessage: Profile
 msgid "Profile"
 msgstr "Perfil"
 
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Properties
 msgid "Properties"
 msgstr "Propriedades"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Publication date
 msgid "Publication date"
 msgstr ""
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Publishing Date
 msgid "Publishing Date"
 msgstr "Data de Publicação"
 
 #: components/manage/Blocks/Listing/schema
+# defaultMessage: Query
 msgid "Query"
 msgstr ""
 
 #: components/manage/Preferences/ChangePassword
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Re-enter the password. Make sure the passwords are identical.
 msgid "Re-enter the password. Make sure the passwords are identical."
 msgstr "Escreva de novo a senha. Certifique-se que as senhas são idênticas."
 
 #: components/theme/Search/Search
 #: components/theme/View/SummaryView
+# defaultMessage: Read More…
 msgid "Read More…"
 msgstr "Ler Mais…"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Rearrange items by…
 msgid "Rearrange items by…"
 msgstr "Reordenar itens por…"
 
 #: components/manage/Widgets/RecurrenceWidget/EndField
+# defaultMessage: Ends
 msgid "Recurrence ends"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/EndField
+# defaultMessage: after
 msgid "Recurrence ends after"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/EndField
+# defaultMessage: on
 msgid "Recurrence ends on"
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Minimalistic table design
 msgid "Reduce complexity"
 msgstr "Reduzir complexidade"
 
 #: components/theme/Anontools/Anontools
 #: components/theme/Login/Login
 #: components/theme/Register/Register
+# defaultMessage: Register
 msgid "Register"
 msgstr "Registar"
 
 #: components/theme/Register/Register
+# defaultMessage: Registration form
 msgid "Registration form"
 msgstr "Formulário de registo"
 
 #: components/theme/Search/Search
+# defaultMessage: Relevance
 msgid "Relevance"
 msgstr ""
 
 #: components/manage/Widgets/ObjectListWidget
+# defaultMessage: Remove item
 msgid "Remove item"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Remove
 msgid "Remove recurrence"
 msgstr ""
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Remove term
 msgid "Remove term"
 msgstr ""
 
 #: components/manage/Toolbar/More
+# defaultMessage: Remove working copy
 msgid "Remove working copy"
 msgstr ""
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
+# defaultMessage: Rename
 msgid "Rename"
 msgstr "Renomear"
 
 #: components/manage/Contents/ContentsRenameModal
+# defaultMessage: Renaming items...
 msgid "Rename Items Loading Message"
 msgstr ""
 
 #: components/manage/Contents/ContentsRenameModal
+# defaultMessage: Rename items
 msgid "Rename items"
 msgstr "Renomear itens"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Repeat
 msgid "Repeat"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Repeat every
 msgid "Repeat every"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Repeat on
 msgid "Repeat on"
 msgstr ""
 
 #: components/manage/Widgets/FileWidget
+# defaultMessage: Replace existing file
 msgid "Replace existing file"
 msgstr ""
 
 #: components/theme/Comments/Comments
+# defaultMessage: Reply
 msgid "Reply"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/WysiwygWidget
+# defaultMessage: Required
 msgid "Required"
 msgstr "Obrigatório"
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Required input is missing.
 msgid "Required input is missing."
 msgstr "Falta informação obrigatória."
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Reset title
 msgid "Reset term title"
 msgstr ""
 
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: Results limit
 msgid "Results limit"
 msgstr ""
 
 #: components/manage/Blocks/Listing/Edit
+# defaultMessage: Results preview
 msgid "Results preview"
 msgstr ""
 
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: Reversed order
 msgid "Reversed order"
 msgstr ""
 
 #: components/manage/History/History
+# defaultMessage: Revert to this revision
 msgid "Revert to this revision"
 msgstr "Reverter para esta revisão"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Review state
 msgid "Review state"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Richtext
 msgid "Richtext"
 msgstr "Richtext"
 
 #: components/manage/Blocks/Image/ImageSizeWidget
 #: components/manage/Blocks/Maps/Edit
 #: components/manage/Sidebar/AlignBlock
+# defaultMessage: Right
 msgid "Right"
 msgstr "Direita"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Rights
 msgid "Rights"
 msgstr "Permissões"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Roles
 msgid "Roles"
 msgstr "Papéis"
 
 #: components/manage/Contents/ContentsBreadcrumbs
+# defaultMessage: Root
 msgid "Root"
 msgstr ""
 
@@ -1638,90 +1998,112 @@ msgstr ""
 #: components/manage/Form/ModalForm
 #: components/manage/Sharing/Sharing
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Save
 msgid "Save"
 msgstr "Guardar"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Save
 msgid "Save recurrence"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypesActions
+# defaultMessage: Schema
 msgid "Schema"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypeSchema
+# defaultMessage: Schema updates
 msgid "Schema updates"
 msgstr ""
 
 #: components/theme/SearchWidget/SearchWidget
+# defaultMessage: Search
 msgid "Search"
 msgstr "Pesquisar"
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: Search SVG
 msgid "Search SVG"
 msgstr ""
 
 #: components/theme/SearchWidget/SearchWidget
+# defaultMessage: Search Site
 msgid "Search Site"
 msgstr "Pesquisar Sítio"
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: Search content
 msgid "Search content"
 msgstr "Pesquisar conteúdo"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Search for user or group
 msgid "Search for user or group"
 msgstr "Pesquisar utilizador ou grupo"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Search group…
 msgid "Search group…"
 msgstr ""
 
 #: components/theme/Search/Search
+# defaultMessage: Search results
 msgid "Search results"
 msgstr "Resultados da pesquisa"
 
 #: components/theme/Search/Search
+# defaultMessage: Search results for {term}
 msgid "Search results for {term}"
 msgstr "Resultados da pesquisa para {term}"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Search users…
 msgid "Search users…"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: Second
 msgid "Second"
 msgstr ""
 
 #: components/manage/Sidebar/ObjectBrowserNav
+# defaultMessage: Select
 msgid "Select"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Select a date to add to recurrence
 msgid "Select a date to add to recurrence"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Select columns to show
 msgid "Select columns to show"
 msgstr "Seleccione colunas a apresentar"
 
 #: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Select the transition to be used for modifying the items state.
 msgid "Select the transition to be used for modifying the items state."
 msgstr "Seleccione a transição a ser usada para modificar o estado dos itens."
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: Selected dates
 msgid "Selected dates"
 msgstr ""
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: Selected items
 msgid "Selected items"
 msgstr ""
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: of
 msgid "Selected items - x of y"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Selection
 msgid "Selection"
 msgstr "Selecção"
 
@@ -1729,158 +2111,195 @@ msgstr "Selecção"
 #: components/manage/Widgets/ArrayWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/TokenWidget
+# defaultMessage: Select…
 msgid "Select…"
 msgstr "Seleccionar…"
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Send
 msgid "Send"
 msgstr "Enviar"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Set my password
 msgid "Set my password"
 msgstr "Definir a minha senha"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Set your password
 msgid "Set your password"
 msgstr "Defina a sua senha"
 
 #: components/manage/Sidebar/Sidebar
+# defaultMessage: Settings
 msgid "Settings"
 msgstr ""
 
 #: components/manage/Sharing/Sharing
 #: components/manage/Toolbar/More
+# defaultMessage: Sharing
 msgid "Sharing"
 msgstr "Partilha"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Sharing for {title}
 msgid "Sharing for {title}"
 msgstr "Partilha de {title}"
 
 #: components/manage/Widgets/SchemaWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/WysiwygWidget
+# defaultMessage: Short Name
 msgid "Short Name"
 msgstr "Nome Curto"
 
 #: components/manage/Contents/ContentsRenameModal
+# defaultMessage: Short name
 msgid "Short name"
 msgstr "Nome curto"
 
 #: components/theme/Pagination/Pagination
+# defaultMessage: Show
 msgid "Show"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Show All
 msgid "Show All"
 msgstr ""
 
 #: components/theme/Comments/Comments
+# defaultMessage: Show Replies
 msgid "Show Replies"
 msgstr ""
 
 #: components/manage/Widgets/ObjectListWidget
+# defaultMessage: Show item
 msgid "Show item"
 msgstr ""
 
 #: components/manage/Sidebar/Sidebar
+# defaultMessage: Shrink sidebar
 msgid "Shrink sidebar"
 msgstr "Encolher barra lateral"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Shrink toolbar
 msgid "Shrink toolbar"
 msgstr ""
 
 #: components/theme/Login/Login
+# defaultMessage: Sign in to start session
 msgid "Sign in to start session"
 msgstr "Inicie a sessão"
 
 #: components/theme/Logo/Logo
+# defaultMessage: Site
 msgid "Site"
 msgstr "Sítio"
 
 #: components/theme/NotFound/NotFound
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: Site Administration
 msgid "Site Administration"
 msgstr "Administração do Sítio"
 
 #: components/theme/Footer/Footer
+# defaultMessage: Site Map
 msgid "Site Map"
 msgstr "Mapa do Sítio"
 
 #: components/manage/Controlpanels/Controlpanels
 #: components/manage/Toolbar/PersonalTools
+# defaultMessage: Site Setup
 msgid "Site Setup"
 msgstr "Configuração do Sítio"
 
 #: components/theme/Sitemap/Sitemap
+# defaultMessage: Sitemap
 msgid "Sitemap"
 msgstr ""
 
 #: components/manage/Blocks/Image/ImageSidebar
+# defaultMessage: Size
 msgid "Size"
 msgstr ""
 
 #: components/theme/View/ImageView
+# defaultMessage: Size: {size}
 msgid "Size: {size}"
 msgstr ""
 
 #: error
+# defaultMessage: Sorry, something went wrong with your request
 msgid "Sorry, something went wrong with your request"
 msgstr ""
 
 #: components/theme/Search/Search
+# defaultMessage: Sort by:
 msgid "Sort By:"
 msgstr ""
 
 #: components/manage/Widgets/QuerySortOnWidget
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: Sort on
 msgid "Sort on"
 msgstr ""
 
 #: components/manage/Blocks/HTML/Edit
+# defaultMessage: Source
 msgid "Source"
 msgstr ""
 
 #: components/manage/Blocks/Video/Edit
+# defaultMessage: Specify a youtube video or playlist url
 msgid "Specify a youtube video or playlist url"
 msgstr "Especifique um vídeo youtube ou um URL de um repertório (playlist)"
 
 #: components/manage/Diff/Diff
+# defaultMessage: Split
 msgid "Split"
 msgstr "Dividir"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Start Date
 msgid "Start Date"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: Start of the recurrence
 msgid "Start of the recurrence"
 msgstr ""
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Start password reset
 msgid "Start password reset"
 msgstr "Redefinir senha"
 
 #: components/manage/Contents/Contents
 #: components/manage/Workflow/Workflow
 #: components/theme/View/TabularView
+# defaultMessage: State
 msgid "State"
 msgstr "Estado"
 
 #: components/manage/Multilingual/CompareLanguages
+# defaultMessage: Stop compare
 msgid "Stop compare"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: String
 msgid "String"
 msgstr "Texto"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Alternate row background color
 msgid "Stripe alternate rows with color"
 msgstr "Alternar cores das linhas"
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Subject
 msgid "Subject"
 msgstr "Assunto"
 
@@ -1894,43 +2313,53 @@ msgstr "Assunto"
 #: components/manage/Preferences/PersonalPreferences
 #: components/theme/ContactForm/ContactForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Success
 msgid "Success"
 msgstr "Sucesso"
 
 #: components/theme/LanguageSelector/LanguageSelector
+# defaultMessage: Switch to
 msgid "Switch to"
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Table
 msgid "Table"
 msgstr "Tabela"
 
 #: components/manage/Blocks/ToC/View
+# defaultMessage: Table of Contents
 msgid "Table of Contents"
 msgstr ""
 
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsTagsModal
+# defaultMessage: Tags
 msgid "Tags"
 msgstr "Etiquetas"
 
 #: components/manage/Contents/ContentsTagsModal
+# defaultMessage: Tags to add
 msgid "Tags to add"
 msgstr "Etiquetas a adicionar"
 
 #: components/manage/Contents/ContentsTagsModal
+# defaultMessage: Tags to remove
 msgid "Tags to remove"
 msgstr "Etiquetas a remover"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Target memory size per cache in bytes
 msgid "Target memory size per cache in bytes"
 msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Target number of objects in memory per cache
 msgid "Target number of objects in memory per cache"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Text
 msgid "Text"
 msgstr "Texto"
 
@@ -1938,87 +2367,108 @@ msgstr "Texto"
 #: components/theme/CorsError/CorsError
 #: components/theme/NotFound/NotFound
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: Thank you.
 msgid "Thank you."
 msgstr "Obrigado."
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: The Database Manager allow you to view database status information
 msgid "The Database Manager allow you to view database status information"
 msgstr ""
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: The URL for your external home page, if you have one.
 msgid "The URL for your external home page, if you have one."
 msgstr "O URL da sua página inicial externa, se tiver uma."
 
 #: components/theme/ConnectionRefused/ConnectionRefused
+# defaultMessage: The backend is not responding, please check if you have started Plone, check your project's configuration object apiPath (or if you are using the internal proxy, devProxyToApiPath) or the RAZZLE_API_PATH Volto's environment variable.
 msgid "The backend is not responding, please check if you have started Plone, check your project's configuration object apiPath (or if you are using the internal proxy, devProxyToApiPath) or the RAZZLE_API_PATH Volto's environment variable."
 msgstr ""
 
 #: components/theme/CorsError/CorsError
+# defaultMessage: The backend is responding, but the CORS headers are not configured properly and the browser has denied the access to the backend resources.
 msgid "The backend is responding, but the CORS headers are not configured properly and the browser has denied the access to the backend resources."
 msgstr ""
 
 #: components/theme/CorsError/CorsError
+# defaultMessage: The backend server of your website is not anwering, we apologize for the inconvenience. Please try to re-load the page and try again. If the problem persists please contact the site administrators.
 msgid "The backend server of your website is not anwering, we apologize for the inconvenience. Please try to re-load the page and try again. If the problem persists please contact the site administrators."
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: The item could not be deleted.
 msgid "The item could not be deleted."
 msgstr ""
 
 #: components/theme/Register/Register
+# defaultMessage: The registration process has been successful. Please check your e-mail inbox for information on how activate your account.
 msgid "The registration process has been successful. Please check your e-mail inbox for information on how activate your account."
 msgstr "O processo de registo foi bem sucedido. Por favor verifique no seu e-mail a informação sobre como activar a sua conta."
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: The user portrait/avatar
 msgid "The user portrait/avatar"
 msgstr "Retrato/avatar do utilizador"
 
 #: components/manage/Toolbar/More
+# defaultMessage: The working copy was discarded
 msgid "The working copy was discarded"
 msgstr ""
 
 #: components/theme/Footer/Footer
+# defaultMessage: The {plonecms} is {copyright} 2000-{current_year} by the {plonefoundation} and friends.
 msgid "The {plonecms} is {copyright} 2000-{current_year} by the {plonefoundation} and friends."
 msgstr "O {plonecms} tem {copyright} de 2000-{current_year} pela {plonefoundation} e amigos."
 
 #: components/theme/CorsError/CorsError
+# defaultMessage: There is a configuration problem on the backend
 msgid "There is a configuration problem on the backend"
 msgstr ""
 
 #: components/manage/Form/InlineForm
+# defaultMessage: There were some errors
 msgid "There were some errors"
 msgstr ""
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: There were some errors.
 msgid "There were some errors."
 msgstr "Ocorreram alguns erros."
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: Third
 msgid "Third"
 msgstr ""
 
 #: components/manage/WorkingCopyToastsFactory/WorkingCopyToastsFactory
+# defaultMessage: This has an ongoing working copy in {title}
 msgid "This has an ongoing working copy in {title}"
 msgstr ""
 
 #: components/manage/WorkingCopyToastsFactory/WorkingCopyToastsFactory
+# defaultMessage: This is a working copy of {title}
 msgid "This is a working copy of {title}"
 msgstr ""
 
 #: components/manage/LockingToastsFactory/LockingToastsFactory
+# defaultMessage: This item was locked by {creator} on {date}
 msgid "This item was locked by {creator} on {date}"
 msgstr ""
 
 #: components/manage/Contents/ContentsRenameModal
+# defaultMessage: This name will be displayed in the URL.
 msgid "This name will be displayed in the URL."
 msgstr "Este nome será apresentado no URL."
 
 #: components/theme/NotFound/NotFound
+# defaultMessage: This page does not seem to exist…
 msgid "This page does not seem to exist…"
 msgstr "Esta página não parece existir…"
 
 #: components/manage/Widgets/DatetimeWidget
+# defaultMessage: Time
 msgid "Time"
 msgstr ""
 
@@ -2031,714 +2481,889 @@ msgstr ""
 #: components/manage/Widgets/WysiwygWidget
 #: components/theme/View/TabularView
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Title
 msgid "Title"
 msgstr "Título"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Total active and non-active objects
 msgid "Total active and non-active objects"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Total comments
 msgid "Total comments"
 msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Total number of objects in each cache
 msgid "Total number of objects in each cache"
 msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Total number of objects in memory from all caches
 msgid "Total number of objects in memory from all caches"
 msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Total number of objects in the database
 msgid "Total number of objects in the database"
 msgstr ""
 
 #: components/manage/Add/Add
 #: components/manage/Toolbar/Types
+# defaultMessage: Translate to {lang}
 msgid "Translate to {lang}"
 msgstr ""
 
 #: components/manage/Multilingual/ManageTranslations
+# defaultMessage: Translation linked
 msgid "Translation linked"
 msgstr ""
 
 #: components/manage/Multilingual/ManageTranslations
+# defaultMessage: Translation linking removed
 msgid "Translation linking removed"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypes
 #: components/manage/Widgets/SchemaWidget
 #: components/theme/View/TabularView
+# defaultMessage: Type
 msgid "Type"
 msgstr "Tipo"
 
 #: components/manage/Blocks/Video/Edit
+# defaultMessage: Type a Video (YouTube, Vimeo or mp4) URL
 msgid "Type a Video (YouTube, Vimeo or mp4) URL"
 msgstr ""
 
 #: components/manage/Blocks/Text/Edit
+# defaultMessage: Type text…
 msgid "Type text…"
 msgstr "Escreva texto…"
 
 #: components/manage/Blocks/Title/Edit
+# defaultMessage: Type the title…
 msgid "Type the title…"
 msgstr "Escreva o título…"
 
 #: components/manage/Contents/Contents
+# defaultMessage: UID
 msgid "UID"
 msgstr ""
 
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: Unauthorized
 msgid "Unauthorized"
 msgstr ""
 
 #: components/manage/BlockChooser/BlockChooser
+# defaultMessage: Unfold
 msgid "Unfold"
 msgstr ""
 
 #: components/manage/Diff/Diff
+# defaultMessage: Unified
 msgid "Unified"
 msgstr "Unificado"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Uninstall
 msgid "Uninstall"
 msgstr ""
 
 #: components/manage/Blocks/Block/Edit
 #: components/theme/View/DefaultView
 #: components/theme/View/RenderBlocks
+# defaultMessage: Unknown Block {block}
 msgid "Unknown Block"
 msgstr "Bloco Desconhecido"
 
 #: components/manage/Multilingual/ManageTranslations
+# defaultMessage: Unlink translation for
 msgid "Unlink translation for"
 msgstr ""
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Unlock
 msgid "Unlock"
 msgstr ""
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Update
 msgid "Update"
 msgstr ""
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Update installed addons
 msgid "Update installed addons"
 msgstr ""
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Update installed addons:
 msgid "Update installed addons:"
 msgstr ""
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Updates available
 msgid "Updates available"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Upload
 msgid "Upload"
 msgstr "Enviar"
 
 #: components/manage/Blocks/LeadImage/Edit
+# defaultMessage: Upload a lead image in the 'Lead Image' content field.
 msgid "Upload a lead image in the 'Lead Image' content field."
 msgstr ""
 
 #: components/manage/Blocks/HeroImageLeft/Edit
+# defaultMessage: Upload a new image
 msgid "Upload a new image"
 msgstr ""
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Upload files
 msgid "Upload files"
 msgstr "Enviar ficheiros"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Uploading files
 msgid "Uploading files"
 msgstr "Enviando ficheiros"
 
 #: components/manage/Blocks/HeroImageLeft/Edit
+# defaultMessage: Uploading image
 msgid "Uploading image"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/WysiwygWidget
+# defaultMessage: Used for programmatic access to the fieldset.
 msgid "Used for programmatic access to the fieldset."
 msgstr "Usado para aceder programaticamente ao conjunto de campos."
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: User
 msgid "User"
 msgstr "Utilizador"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: User created
 msgid "User created"
 msgstr "Utilizador criado"
 
 #: components/manage/Controlpanels/Users/UsersControlpanel
+# defaultMessage: User name
 msgid "User name"
 msgstr "Nome de utilizador"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: User roles updated
 msgid "User roles updated"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Username
 msgid "Username"
 msgstr "Nome de utilizador"
 
 #: components/manage/Controlpanels/Controlpanels
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Users
 msgid "Users"
 msgstr "Utilizadores"
 
 #: components/manage/Controlpanels/Controlpanels
+# defaultMessage: Users and Groups
 msgid "Users and Groups"
 msgstr "Utilizadores e Grupos"
 
 #: helpers/Extensions/withBlockSchemaEnhancer
+# defaultMessage: Variation
 msgid "Variation"
 msgstr ""
 
 #: components/manage/Controlpanels/Controlpanels
+# defaultMessage: Version Overview
 msgid "Version Overview"
 msgstr "Resumo da Versão"
 
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Video
 msgid "Video"
 msgstr ""
 
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Video URL
 msgid "Video URL"
 msgstr ""
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: View
 msgid "View"
 msgstr "Ver"
 
 #: components/manage/History/History
+# defaultMessage: View changes
 msgid "View changes"
 msgstr "Ver modificações"
 
 #: components/manage/History/History
+# defaultMessage: View this revision
 msgid "View this revision"
 msgstr "Ver esta revisão"
 
 #: components/manage/Toolbar/More
+# defaultMessage: View working copy
 msgid "View working copy"
 msgstr ""
 
 #: components/manage/Display/Display
+# defaultMessage: View
 msgid "Viewmode"
 msgstr "Modo de visualização"
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Vocabulary term
 msgid "Vocabulary term"
 msgstr ""
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Title
 msgid "Vocabulary term title"
 msgstr ""
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Vocabulary terms
 msgid "Vocabulary terms"
 msgstr ""
 
 #: components/manage/Controlpanels/VersionOverview
+# defaultMessage: You are running in 'debug mode'. This mode is intended for sites that are under development. This allows many configuration changes to be immediately visible, but will make your site run more slowly. To turn off debug mode, stop the server, set 'debug-mode=off' in your buildout.cfg, re-run bin/buildout and then restart the server process.
 msgid "Warning Regarding debug mode"
 msgstr ""
 
 #: components/theme/ConnectionRefused/ConnectionRefused
+# defaultMessage: We apologize for the inconvenience, but the backend of the site you are accessing is not available right now. Please, try again later.
 msgid "We apologize for the inconvenience, but the backend of the site you are accessing is not available right now. Please, try again later."
 msgstr ""
 
 #: components/theme/NotFound/NotFound
+# defaultMessage: We apologize for the inconvenience, but the page you were trying to access is not at this address. You can use the links below to help you find what you are looking for.
 msgid "We apologize for the inconvenience, but the page you were trying to access is not at this address. You can use the links below to help you find what you are looking for."
 msgstr "Pedimos desculpa pela inconveniência, mas a página a que está a tentar aceder não está neste endereço. Pode usar as ligações abaixo para ajudar a encontrar o que procura."
 
 #: components/theme/Forbidden/Forbidden
+# defaultMessage: We apologize for the inconvenience, but you don't have permissions on this resource.
 msgid "We apologize for the inconvenience, but you don't have permissions on this resource."
 msgstr ""
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: We will use this address if you need to recover your password
 msgid "We will use this address if you need to recover your password"
 msgstr "Iremos usar este endereço se precisar de recuperar a sua senha"
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: The
 msgid "Weeek day of month"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Weekday
 msgid "Weekday"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Weekly
 msgid "Weekly"
 msgstr ""
 
 #: components/manage/History/History
+# defaultMessage: What
 msgid "What"
 msgstr "O quê"
 
 #: components/manage/History/History
+# defaultMessage: When
 msgid "When"
 msgstr "Quando"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: When this date is reached, the content will nolonger be visible in listings and searches.
 msgid "When this date is reached, the content will nolonger be visible in listings and searches."
 msgstr "Quando chegar a esta data, o conteúdo deixará de ficar visível nas listagens e nas pesquisas."
 
 #: components/manage/History/History
+# defaultMessage: Who
 msgid "Who"
 msgstr "Quem"
 
 #: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Updating workflow states...
 msgid "Workflow Change Loading Message"
 msgstr ""
 
 #: components/manage/Workflow/Workflow
+# defaultMessage: Workflow updated.
 msgid "Workflow updated."
 msgstr "Fluxo de trabalho actualizado."
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Yearly
 msgid "Yearly"
 msgstr ""
 
 #: components/manage/Contents/ContentsItem
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Yes
 msgid "Yes"
 msgstr ""
 
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: You are trying to access a protected resource, please {login} first.
 msgid "You are trying to access a protected resource, please {login} first."
 msgstr ""
 
 #: components/theme/OutdatedBrowser/OutdatedBrowser
+# defaultMessage: You are using an outdated browser
 msgid "You are using an outdated browser"
 msgstr ""
 
 #: components/theme/Comments/Comments
+# defaultMessage: You can add a comment by filling out the form below. Plain text formatting.
 msgid "You can add a comment by filling out the form below. Plain text formatting."
 msgstr "Pode adicionar um comentário ao preencher o formulário abaixo. Formatação simples de texto."
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: You can control who can view and edit your item using the list below.
 msgid "You can control who can view and edit your item using the list below."
 msgstr "Pode controlar quem irá ver e editar o seu item usando a lista abaixo."
 
 #: components/manage/Diff/Diff
+# defaultMessage: You can view the difference of the revisions below.
 msgid "You can view the difference of the revisions below."
 msgstr "Pode ver a diferença das revisões abaixo."
 
 #: components/manage/History/History
+# defaultMessage: You can view the history of your item below.
 msgid "You can view the history of your item below."
 msgstr "Pode ver o histórico do seu item abaixo."
 
 #: components/manage/Contents/Contents
+# defaultMessage: You can't paste this content here
 msgid "You can't paste this content here"
 msgstr ""
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Your email is required for reset your password.
 msgid "Your email is required for reset your password."
 msgstr "O seu email é necessário para reiniciar a sua senha."
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: Your location - either city and country - or in a company setting, where your office is located.
 msgid "Your location - either city and country - or in a company setting, where your office is located."
 msgstr "A sua localização (cidade ou país) ou, no contexto de uma empresa, onde o escritório está localizado."
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Your password has been set successfully. You may now {link} with your new password.
 msgid "Your password has been set successfully. You may now {link} with your new password."
 msgstr "A sua senha foi definida com sucesso. Pode agora {link} com a sua nova senha."
 
 #: components/manage/Preferences/PersonalPreferences
+# defaultMessage: Your preferred language
 msgid "Your preferred language"
 msgstr "O seu idioma preferido"
 
 #: components/theme/Login/Login
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Forgot your password?
 msgid "box_forgot_password_option"
 msgstr "box_forgot_password_option"
 
 #: config/Blocks
+# defaultMessage: Common
 msgid "common"
 msgstr "comum"
 
 #: components/manage/Multilingual/CompareLanguages
+# defaultMessage: Compare to language
 msgid "compare_to"
 msgstr ""
 
 #: components/manage/Blocks/Block/EditBlockWrapper
+# defaultMessage: delete
 msgid "delete"
 msgstr "eliminar"
 
 #: components/theme/OutdatedBrowser/OutdatedBrowser
+# defaultMessage: You are using {browsername} {browserversion} which is deprecated by its vendor. That means that it does not get security updates and it is not ready for current modern web features, which deteriorates the user experience. Please upgrade to a modern browser.
 msgid "deprecated_browser_notice_message"
 msgstr ""
 
 #: config/Blocks
+# defaultMessage: Description
 msgid "description"
 msgstr "descrição"
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: For security reasons, we store your password encrypted, and cannot mail it to you. If you would like to reset your password, fill out the form below and we will send you an email at the address you gave when you registered to start the process of resetting your password.
 msgid "description_lost_password"
 msgstr "descrição_senha_perdida"
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Your password reset request has been mailed. It should arrive in your mailbox shortly. When you receive the message, visit the address it contains to reset your password.
 msgid "description_sent_password"
 msgstr "descrição_senha_enviada"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Draft
 msgid "draft"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Input must be valid email (something@domain.com)
 msgid "email"
 msgstr ""
 
 #: components/theme/View/EventView
+# defaultMessage: All dates
 msgid "event_alldates"
 msgstr ""
 
 #: components/theme/View/EventView
+# defaultMessage: Attendees
 msgid "event_attendees"
 msgstr ""
 
 #: components/theme/View/EventView
+# defaultMessage: Contact Name
 msgid "event_contactname"
 msgstr ""
 
 #: components/theme/View/EventView
+# defaultMessage: Contact Phone
 msgid "event_contactphone"
 msgstr ""
 
 #: components/theme/View/EventView
+# defaultMessage: Website
 msgid "event_website"
 msgstr ""
 
 #: components/theme/View/EventView
+# defaultMessage: What
 msgid "event_what"
 msgstr ""
 
 #: components/theme/View/EventView
+# defaultMessage: When
 msgid "event_when"
 msgstr ""
 
 #: components/theme/View/EventView
+# defaultMessage: Where
 msgid "event_where"
 msgstr ""
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Password reset confirmation sent
 msgid "heading_sent_password"
 msgstr "título_senha_enviada"
 
 #: config/Blocks
+# defaultMessage: Hero
 msgid "hero"
 msgstr "herói"
 
 #: config/Blocks
+# defaultMessage: HTML
 msgid "html"
 msgstr "html"
 
 #: config/Blocks
+# defaultMessage: Image
 msgid "image"
 msgstr "imagem"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Input must be integer
 msgid "integer"
 msgstr ""
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Intranet
 msgid "intranet"
 msgstr ""
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: My email address is
 msgid "label_my_email_address_is"
 msgstr "etiqueta_meu_email_é"
 
 #: config/Blocks
+# defaultMessage: Lead Image Field
 msgid "leadimage"
 msgstr ""
 
 #: config/Blocks
+# defaultMessage: Listing
 msgid "listing"
 msgstr ""
 
 #: components/manage/Blocks/Listing/ListingBody
 #: components/manage/Contents/Contents
+# defaultMessage: Loading
 msgid "loading"
 msgstr ""
 
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: log in
 msgid "log in"
 msgstr ""
 
 #: config/Blocks
+# defaultMessage: Maps
 msgid "maps"
 msgstr "mapas"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Maximum Length
 msgid "maxLength"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: End of the range (including the value itself)
 msgid "maximum"
 msgstr ""
 
 #: config/Blocks
+# defaultMessage: Media
 msgid "media"
 msgstr "média"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Minimum Length
 msgid "minLength"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Start of the range
 msgid "minimum"
 msgstr ""
 
 #: config/Blocks
+# defaultMessage: Most used
 msgid "mostUsed"
 msgstr "maisUsado"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: No workflow state
 msgid "no workflow state"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Input must be number
 msgid "number"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/ByMonthDayField
 #: components/manage/Widgets/RecurrenceWidget/ByYearField
+# defaultMessage: of the month
 msgid "of the month"
 msgstr ""
 
 #: error
+# defaultMessage: or try a different page.
 msgid "or try a different page."
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: others
 msgid "others"
 msgstr ""
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Private
 msgid "private"
 msgstr ""
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Published
 msgid "published"
 msgstr ""
 
 #: components/manage/Widgets/QueryWidget
+# defaultMessage: Select…
 msgid "querystring-widget-select"
 msgstr ""
 
 #: components/theme/Search/Search
+# defaultMessage: results
 msgid "results found"
 msgstr ""
 
 #: error
+# defaultMessage: return to the site root
 msgid "return to the site root"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: and
 msgid "rrule_and"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: (~approximate)
 msgid "rrule_approximate"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: at
 msgid "rrule_at"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: [month] [day], [year]
 msgid "rrule_dateFormat"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: day
 msgid "rrule_day"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: days
 msgid "rrule_days"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: every
 msgid "rrule_every"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: for
 msgid "rrule_for"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: hour
 msgid "rrule_hour"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: hours
 msgid "rrule_hours"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: in
 msgid "rrule_in"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: last
 msgid "rrule_last"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: minutes
 msgid "rrule_minutes"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: month
 msgid "rrule_month"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: months
 msgid "rrule_months"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: nd
 msgid "rrule_nd"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: on
 msgid "rrule_on"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: on the
 msgid "rrule_on the"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: or
 msgid "rrule_or"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: rd
 msgid "rrule_rd"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: st
 msgid "rrule_st"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: th
 msgid "rrule_th"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: the
 msgid "rrule_the"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: time
 msgid "rrule_time"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: times
 msgid "rrule_times"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: until
 msgid "rrule_until"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: week
 msgid "rrule_week"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: weekday
 msgid "rrule_weekday"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: weekdays
 msgid "rrule_weekdays"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: weeks
 msgid "rrule_weeks"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: year
 msgid "rrule_year"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: years
 msgid "rrule_years"
 msgstr ""
 
 #: components/theme/SkipLinks/SkipLinks
+# defaultMessage: Skip to footer
 msgid "skiplink-footer"
 msgstr ""
 
 #: components/theme/SkipLinks/SkipLinks
+# defaultMessage: Skip to main content
 msgid "skiplink-main-content"
 msgstr ""
 
 #: components/theme/SkipLinks/SkipLinks
+# defaultMessage: Skip to navigation
 msgid "skiplink-navigation"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: sort
 msgid "sort"
 msgstr ""
 
 #: config/Blocks
+# defaultMessage: Table
 msgid "table"
 msgstr "tabela"
 
 #: config/Blocks
+# defaultMessage: Text
 msgid "text"
 msgstr "texto"
 
 #: config/Blocks
+# defaultMessage: Title
 msgid "title"
 msgstr "título"
 
 #: config/Blocks
+# defaultMessage: Table of Contents
 msgid "toc"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Input must be valid url (www.something.com or http(s)://www.something.com)
 msgid "url"
 msgstr ""
 
 #: components/manage/Toolbar/PersonalTools
+# defaultMessage: user avatar
 msgid "user avatar"
 msgstr "avatar do utilizador"
 
 #: config/Blocks
+# defaultMessage: Video
 msgid "video"
 msgstr "vídeo"
 
 #: components/theme/View/EventView
+# defaultMessage: Visit external website
 msgid "visit_external_website"
 msgstr ""
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: {count, plural, one {Upload {count} file} other {Upload {count} files}}
 msgid "{count, plural, one {Upload {count} file} other {Upload {count} files}}"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: {count} selected
 msgid "{count} selected"
 msgstr "{count} seleccionados"
 
 #: components/manage/Controlpanels/ContentType
+# defaultMessage: {id} Content Type
 msgid "{id} Content Type"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypeSchema
+# defaultMessage: {id} Schema
 msgid "{id} Schema"
 msgstr ""
 
 #: components/manage/Actions/Actions
+# defaultMessage: {title} copied.
 msgid "{title} copied."
 msgstr "{title} copiado."
 
 #: components/manage/Actions/Actions
+# defaultMessage: {title} cut.
 msgid "{title} cut."
 msgstr "{title} cortado."
 
 #: components/manage/Actions/Actions
+# defaultMessage: {title} has been deleted.
 msgid "{title} has been deleted."
 msgstr "{title} foi eliminado."

--- a/locales/pt_BR/LC_MESSAGES/volto.po
+++ b/locales/pt_BR/LC_MESSAGES/volto.po
@@ -22,22 +22,27 @@ msgstr ""
 "X-Generator: Poedit 3.0\n"
 
 #: components/manage/Blocks/HTML/Edit
+# defaultMessage: <p>Add some HTML here</p>
 msgid "<p>Add some HTML here</p>"
 msgstr "<p>Adicione o HTML aqui</p>"
 
 #: components/theme/Footer/Footer
+# defaultMessage: Accessibility
 msgid "Accessibility"
 msgstr "Acessibilidade"
 
 #: components/theme/Register/Register
+# defaultMessage: Account Registration Completed
 msgid "Account Registration Completed"
 msgstr "Cadastro de Conta Finalizado"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Account activation completed
 msgid "Account activation completed"
 msgstr "Ativação completa"
 
 #: components/manage/Controlpanels/ModerateComments
+# defaultMessage: Action
 msgid "Action"
 msgstr "Ação"
 
@@ -46,10 +51,12 @@ msgstr "Ação"
 #: components/manage/Controlpanels/ContentTypes
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
+# defaultMessage: Actions
 msgid "Actions"
 msgstr "Ações"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Activate and deactivate add-ons in the lists below.
 msgid "Activate and deactivate"
 msgstr "Ativar e desativar"
 
@@ -57,86 +64,107 @@ msgstr "Ativar e desativar"
 #: components/manage/Toolbar/Toolbar
 #: components/manage/Widgets/SchemaWidget
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add
 msgid "Add"
 msgstr "Adicionar"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: To make new add-ons show up here, add them to your buildout configuration, run buildout, and restart the server process. For detailed instructions see
 msgid "Add Addons"
 msgstr "Adicione complementos"
 
 #: components/manage/Toolbar/Types
+# defaultMessage: Add Content…
 msgid "Add Content"
 msgstr "Adicionar conteúdo"
 
 #: components/manage/Toolbar/Types
+# defaultMessage: Add Translation…
 msgid "Add Translation…"
 msgstr "Adicionar tradução…"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add User
 msgid "Add User"
 msgstr "Adicionar usuário"
 
 #: components/manage/Blocks/Description/Edit
+# defaultMessage: Add a description…
 msgid "Add a description…"
 msgstr "Adicionar uma descrição…"
 
 #: components/manage/BlockChooser/BlockChooserButton
+# defaultMessage: Add block
 msgid "Add block"
 msgstr "Adicionar Bloco"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add block…
 msgid "Add block…"
 msgstr "Adicionar bloco…"
 
 #: components/manage/Widgets/QueryWidget
+# defaultMessage: Add criteria
 msgid "Add criteria"
 msgstr "Adicionar critério"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Add date
 msgid "Add date"
 msgstr "Adicionar data"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Add field
 msgid "Add field"
 msgstr "Adicionar campo"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Add fieldset
 msgid "Add fieldset"
 msgstr "Adicionar conjunto de campos"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add group
 msgid "Add group"
 msgstr "Adicionar grupo"
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Add new content type
 msgid "Add new content type"
 msgstr "Adicionar novo tipo de conteúdo"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add new group
 msgid "Add new group"
 msgstr "Adicionar novo grupo"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add new user
 msgid "Add new user"
 msgstr "Adicionar novo usuário"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add to Groups
 msgid "Add to Groups"
 msgstr "Adicionar a grupos"
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Add term
 msgid "Add vocabulary term"
 msgstr "Adicionar termo de vocabulário"
 
 #: components/manage/Add/Add
+# defaultMessage: Add {type}
 msgid "Add {type}"
 msgstr "Adicionar {type}"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Add-ons Settings
 msgid "Add-ons Settings"
 msgstr "Configurações dos complementos"
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: Additional date
 msgid "Additional date"
 msgstr "Outra data"
 
@@ -144,39 +172,48 @@ msgstr "Outra data"
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
 #: components/manage/Blocks/Maps/MapsSidebar
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Alignment
 msgid "Alignment"
 msgstr "Alinhamento"
 
 #: components/manage/Contents/Contents
+# defaultMessage: All
 msgid "All"
 msgstr "Todos"
 
 #: components/theme/Search/Search
+# defaultMessage: Alphabetically
 msgid "Alphabetically"
 msgstr "Alfabeticamente"
 
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: Alt text
 msgid "Alt text"
 msgstr "Descrição Alt"
 
 #: components/manage/Toolbar/More
+# defaultMessage: Apply working copy
 msgid "Apply working copy"
 msgstr "Aplicar a cópia de trabalho"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Are you sure you want to delete this field?
 msgid "Are you sure you want to delete this field?"
 msgstr "Você realmente deseja deletar este campo?"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Are you sure you want to delete this fieldset including all fields?
 msgid "Are you sure you want to delete this fieldset including all fields?"
 msgstr "Você realmente deseja deletar este fieldset com todos os campos?"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Ascending
 msgid "Ascending"
 msgstr "Ascendente"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Available
 msgid "Available"
 msgstr "Disponível"
 
@@ -201,48 +238,59 @@ msgstr "Disponível"
 #: components/manage/Toolbar/Toolbar
 #: components/theme/ContactForm/ContactForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Back
 msgid "Back"
 msgstr "Voltar"
 
 #: components/manage/Diff/Diff
+# defaultMessage: Base
 msgid "Base"
 msgstr "Base"
 
 #: components/manage/Sidebar/Sidebar
+# defaultMessage: Block
 msgid "Block"
 msgstr "Bloco"
 
 #: components/theme/Login/Login
+# defaultMessage: Both email address and password are case sensitive, check that caps lock is not enabled.
 msgid "Both email address and password are case sensitive, check that caps lock is not enabled."
 msgstr "O endereço de e-mail e a senha diferenciam maiúsculas de minúsculas. Certifique-se que o caps lock não está ativado."
 
 #: components/theme/Breadcrumbs/Breadcrumbs
+# defaultMessage: Breadcrumbs
 msgid "Breadcrumbs"
 msgstr "Navegação estrutural"
 
 #: components/manage/Blocks/HeroImageLeft/Edit
 #: components/manage/Contents/ContentsUploadModal
 #: components/manage/Sidebar/ObjectBrowserNav
+# defaultMessage: Browse
 msgid "Browse"
 msgstr "Procurar"
 
 #: components/manage/Blocks/Image/Edit
+# defaultMessage: Browse the site, drop an image, or type an URL
 msgid "Browse the site, drop an image, or type an URL"
 msgstr "Navegue no site, arraste uma imagem ou digite um URL"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: By default, permissions from the container of this item are inherited. If you disable this, only the explicitly defined sharing permissions will be valid. In the overview, the symbol {inherited} indicates an inherited value. Similarly, the symbol {global} indicates a global role, which is managed by the site administrator.
 msgid "By default, permissions from the container of this item are inherited. If you disable this, only the explicitly defined sharing permissions will be valid. In the overview, the symbol {inherited} indicates an inherited value. Similarly, the symbol {global} indicates a global role, which is managed by the site administrator."
 msgstr "Por padrão, as permissões do contêiner deste item são herdadas. Se você desabilitar isso, apenas as permissões de compartilhamento definidas explicitamente serão válidas. Na visão geral, o símbolo {inherited} indica um valor herdado. Da mesma forma, o símbolo {global} indica uma função global que é gerenciada pelo administrador do site."
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Cache Name
 msgid "Cache Name"
 msgstr "Nome do cache"
 
 #: components/manage/Controlpanels/ContentTypeLayout
+# defaultMessage: Can not edit Layout for <strong>{type}</strong> content-type as it doesn't have support for <strong>Volto Blocks</strong> enabled
 msgid "Can not edit Layout for <strong>{type}</strong> content-type as it doesn't have support for <strong>Volto Blocks</strong> enabled"
 msgstr "Não é possível editar layout para o tipo de conteúdo <strong>{type}</strong> , pois não tem suporte para <strong>Blocos Volto</strong> ativados"
 
 #: components/manage/Controlpanels/ContentTypeLayout
+# defaultMessage: Can not edit Layout for <strong>{type}</strong> content-type as the <strong>Blocks behavior</strong> is enabled and <strong>read-only</strong>
 msgid "Can not edit Layout for <strong>{type}</strong> content-type as the <strong>Blocks behavior</strong> is enabled and <strong>read-only</strong>"
 msgstr "Não é possível editar layout para o tipo de conteúdo <strong>{type}</strong>, pois o <strong>comportamento de Blocos</strong> está ativado mas  <strong>somentepara leitura</strong>"
 
@@ -258,42 +306,51 @@ msgstr "Não é possível editar layout para o tipo de conteúdo <strong>{type}<
 #: components/manage/Sharing/Sharing
 #: components/theme/Login/Login
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Cancel
 msgid "Cancel"
 msgstr "Cancelar"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Cell
 msgid "Cell"
 msgstr "Célula"
 
 #: components/manage/Blocks/Image/ImageSizeWidget
 #: components/manage/Blocks/Maps/Edit
 #: components/manage/Sidebar/AlignBlock
+# defaultMessage: Center
 msgid "Center"
 msgstr "Centro"
 
 #: components/manage/History/History
+# defaultMessage: Change Note
 msgid "Change Note"
 msgstr "Alterar Nota"
 
 #: components/manage/Preferences/ChangePassword
+# defaultMessage: Change Password
 msgid "Change Password"
 msgstr "Alterar senha"
 
 #: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Change State
 msgid "Change State"
 msgstr "Alterar estado"
 
 #: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Change workflow state recursively
 msgid "Change workflow state recursively"
 msgstr "Alterar o estado de workflow recursivamente"
 
 #: components/manage/Toolbar/More
+# defaultMessage: Changes applied
 msgid "Changes applied."
 msgstr "Alterações aplicadas."
 
 #: components/manage/Preferences/ChangePassword
 #: components/manage/Preferences/PersonalInformation
 #: components/manage/Preferences/PersonalPreferences
+# defaultMessage: Changes saved
 msgid "Changes saved"
 msgstr "Alterações salvas"
 
@@ -301,192 +358,237 @@ msgstr "Alterações salvas"
 #: components/manage/Controlpanels/ContentTypeLayout
 #: components/manage/Controlpanels/ContentTypeSchema
 #: components/manage/Controlpanels/Controlpanel
+# defaultMessage: Changes saved.
 msgid "Changes saved."
 msgstr "Alterações guardadas."
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Checkbox
 msgid "Checkbox"
 msgstr "Caixa de verificação"
 
 #: components/manage/Widgets/SelectWidget
+# defaultMessage: Choices
 msgid "Choices"
 msgstr "Escolhas"
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: Choose Image
 msgid "Choose Image"
 msgstr "Escolha Imagem"
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: Choose Target
 msgid "Choose Target"
 msgstr "Escolha Alvo"
 
 #: components/manage/Widgets/FileWidget
+# defaultMessage: Choose a file
 msgid "Choose a file"
 msgstr "Escolha um arquivo"
 
 #: components/manage/Blocks/HTML/Edit
+# defaultMessage: Clear
 msgid "Clear"
 msgstr "Limpar"
 
 #: components/theme/View/ImageView
+# defaultMessage: Click to download full sized image
 msgid "Click to download full sized image"
 msgstr "Clique para baixar a imagem em tamanho original"
 
 #: components/manage/Widgets/SelectWidget
+# defaultMessage: Close
 msgid "Close"
 msgstr "Fechar"
 
 #: components/theme/Navigation/Navigation
+# defaultMessage: Close menu
 msgid "Close menu"
 msgstr "Fechar menu"
 
 #: components/manage/Blocks/HTML/Edit
+# defaultMessage: Code
 msgid "Code"
 msgstr "Código"
 
 #: components/manage/Widgets/ObjectListWidget
+# defaultMessage: Collapse item
 msgid "Collapse item"
 msgstr "Colapsar item"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Collection
 msgid "Collection"
 msgstr "Coleção"
 
 #: components/manage/Controlpanels/ModerateComments
 #: components/theme/Comments/CommentEditModal
 #: components/theme/Comments/Comments
+# defaultMessage: Comment
 msgid "Comment"
 msgstr "Comentar"
 
 #: components/manage/Controlpanels/ModerateComments
+# defaultMessage: Commenter
 msgid "Commenter"
 msgstr "Comentador"
 
 #: components/theme/Comments/Comments
+# defaultMessage: Comments
 msgid "Comments"
 msgstr "Comentários"
 
 #: components/manage/Diff/Diff
+# defaultMessage: Compare
 msgid "Compare"
 msgstr "Comparar"
 
 #: components/manage/Preferences/ChangePassword
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Confirm password
 msgid "Confirm password"
 msgstr "Confirmar senha"
 
 #: components/theme/ConnectionRefused/ConnectionRefused
+# defaultMessage: Connection refused
 msgid "Connection refused"
 msgstr "Conexão recusada"
 
 #: components/theme/Footer/Footer
+# defaultMessage: Contact
 msgid "Contact"
 msgstr "Contato"
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Contact form
 msgid "Contact form"
 msgstr "Formulário de contato"
 
 #: components/manage/Blocks/Listing/Edit
+# defaultMessage: Contained items
 msgid "Contained items"
 msgstr "Itens contidos"
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Content type created
 msgid "Content type created"
 msgstr "Tipo de conteúdo criado"
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Content type deleted
 msgid "Content type deleted"
 msgstr "Tipo de conteúdo removido"
 
 #: components/manage/Contents/Contents
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Contents
 msgid "Contents"
 msgstr "Conteúdo"
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Copy
 msgid "Copy"
 msgstr "Copiar"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: undefined
 msgid "Copy blocks"
 msgstr "Copiar blocos"
 
 #: components/theme/Footer/Footer
+# defaultMessage: Copyright
 msgid "Copyright"
 msgstr "Copyright"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Copyright statement or other rights information on this item.
 msgid "Copyright statement or other rights information on this item."
 msgstr "Declaração de copyright ou outras informações de direitos sobre este item."
 
 #: components/manage/Toolbar/More
+# defaultMessage: Create working copy
 msgid "Create working copy"
 msgstr "Criar cópia de trabalho"
 
 #: components/manage/WorkingCopyToastsFactory/WorkingCopyToastsFactory
+# defaultMessage: Created by {creator} on {date}
 msgid "Created by {creator} on {date}"
 msgstr "Criado por {creator} em {date}"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Created on
 msgid "Created on"
 msgstr "Criado em"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Creator
 msgid "Creator"
 msgstr "Autor"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Creators
 msgid "Creators"
 msgstr "Autores"
 
 #: components/manage/Widgets/QuerystringWidget
 #: components/manage/Widgets/QueryWidget
+# defaultMessage: Criteria
 msgid "Criteria"
 msgstr "Critérios"
 
 #: components/manage/Preferences/ChangePassword
+# defaultMessage: Current password
 msgid "Current password"
 msgstr "Senha atual"
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Cut
 msgid "Cut"
 msgstr "Cortar"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: undefined
 msgid "Cut blocks"
 msgstr "Recortar blocos"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Daily
 msgid "Daily"
 msgstr "Diariamente"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Database Information
 msgid "Database Information"
 msgstr "Informações do banco de dados"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Database Location
 msgid "Database Location"
 msgstr "Localização do banco de dados"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Database Size
 msgid "Database Size"
 msgstr "Tamanho do banco de dados"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Database main
 msgid "Database main"
 msgstr "Banco de dados principal"
 
 #: components/manage/Controlpanels/ModerateComments
 #: components/manage/Widgets/DatetimeWidget
+# defaultMessage: Date
 msgid "Date"
 msgstr "Data"
 
 #: components/theme/Search/Search
+# defaultMessage: Date (newest first)
 msgid "Date (newest first)"
 msgstr "Data (mais novo primeiro)"
 
@@ -506,6 +608,7 @@ msgstr "Data (mais novo primeiro)"
 #: components/theme/PasswordReset/PasswordReset
 #: components/theme/PasswordReset/RequestPasswordReset
 #: components/theme/Register/Register
+# defaultMessage: Default
 msgid "Default"
 msgstr "Padrão"
 
@@ -520,38 +623,47 @@ msgstr "Padrão"
 #: components/manage/Widgets/ObjectBrowserWidget
 #: components/manage/Widgets/WysiwygWidget
 #: components/theme/Comments/Comments
+# defaultMessage: Delete
 msgid "Delete"
 msgstr "Excluir"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Delete Group
 msgid "Delete Group"
 msgstr "Excluir Grupo"
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Delete Type
 msgid "Delete Type"
 msgstr "Excluir Tipo"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Delete User
 msgid "Delete User"
 msgstr "Excluir Usuário"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: undefined
 msgid "Delete blocks"
 msgstr "Excluir blocos"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Delete col
 msgid "Delete col"
 msgstr "Excluir coluna"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Delete row
 msgid "Delete row"
 msgstr "Excluir linha"
 
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: Depth
 msgid "Depth"
 msgstr "Profundidade"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Descending
 msgid "Descending"
 msgstr "Descendente"
 
@@ -562,72 +674,89 @@ msgstr "Descendente"
 #: components/manage/Widgets/WysiwygWidget
 #: components/theme/View/TabularView
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Description
 msgid "Description"
 msgstr "Descrição"
 
 #: components/manage/Diff/Diff
+# defaultMessage: Diff
 msgid "Diff"
 msgstr "Diferenças"
 
 #: components/manage/Diff/Diff
+# defaultMessage: Difference between revision {one} and {two} of {title}
 msgid "Difference between revision {one} and {two} of {title}"
 msgstr "Diferenças entre as revisões {one} e {two} de {title}"
 
 #: components/theme/Footer/Footer
+# defaultMessage: Distributed under the {license}.
 msgid "Distributed under the {license}."
 msgstr "Distribuído sob a licença {license}."
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Add border to inner columns
 msgid "Divide each row into separate cells"
 msgstr "Dividir cada linha em células separadas"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Do you really want to delete the following items?
 msgid "Do you really want to delete the following items?"
 msgstr "Você realmente quer  excluir os itens seguintes?"
 
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
+# defaultMessage: Do you really want to delete the group {groupname}?
 msgid "Do you really want to delete the group {groupname}?"
 msgstr "Você realmente quer  excluir o grupo {groupname}?"
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Do you really want to delete type {typename}?
 msgid "Do you really want to delete the type {typename}?"
 msgstr "Você realmente quer excluir o tipo {typename}?"
 
 #: components/manage/Controlpanels/Users/UsersControlpanel
+# defaultMessage: Do you really want to delete the user {username}?
 msgid "Do you really want to delete the user {username}?"
 msgstr "Você realmente quer excluir o usuário {username}?"
 
 #: components/manage/Delete/Delete
+# defaultMessage: Do you really want to delete this item?
 msgid "Do you really want to delete this item?"
 msgstr "Você realmente quer excluir este item?"
 
 #: components/manage/Multilingual/TranslationObject
 #: components/manage/Sidebar/Sidebar
+# defaultMessage: Document
 msgid "Document"
 msgstr "Documento"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Drag and drop files from your computer onto this area or click the “Browse” button.
 msgid "Drag and drop files from your computer onto this area or click the “Browse” button."
 msgstr "Arraste e solte arquivos do seu computador para esta área ou clique no botão "Procurar"."
 
 #: components/manage/Widgets/FileWidget
+# defaultMessage: Drop file here to replace the existing file
 msgid "Drop file here to replace the existing file"
 msgstr "Solte um arquivo aqui para substituir o arquivo existente"
 
 #: components/manage/Widgets/FileWidget
+# defaultMessage: Drop file here to upload a new file
 msgid "Drop file here to upload a new file"
 msgstr "Solte um arquivo aqui para enviar um novo arquivo"
 
 #: components/manage/Widgets/FileWidget
+# defaultMessage: Drop files here ...
 msgid "Drop files here ..."
 msgstr "Soltar aquivos aqui…"
 
 #: components/manage/Preferences/PersonalInformation
 #: components/theme/Register/Register
+# defaultMessage: E-mail
 msgid "E-mail"
 msgstr "E-mail"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: E-mail addresses do not match.
 msgid "E-mail addresses do not match."
 msgstr "Os endereços de e-mail não coincidem."
 
@@ -638,93 +767,115 @@ msgstr "Os endereços de e-mail não coincidem."
 #: components/manage/Widgets/FormFieldWrapper
 #: components/manage/Widgets/ObjectBrowserWidget
 #: components/theme/Comments/Comments
+# defaultMessage: Edit
 msgid "Edit"
 msgstr "Editar"
 
 #: components/theme/Comments/CommentEditModal
+# defaultMessage: Edit comment
 msgid "Edit comment"
 msgstr "Editar comentário"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Edit field
 msgid "Edit field"
 msgstr "Editar campo"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Edit fieldset
 msgid "Edit fieldset"
 msgstr "Editar conjunto de campos"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Edit recurrence
 msgid "Edit recurrence"
 msgstr "Editar recorrência"
 
 #: components/manage/Form/InlineForm
+# defaultMessage: Edit values
 msgid "Edit values"
 msgstr "Editar valores"
 
 #: components/manage/Edit/Edit
+# defaultMessage: Edit {title}
 msgid "Edit {title}"
 msgstr "Editar {title}"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Email
 msgid "Email"
 msgstr "E-mail"
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Email sent
 msgid "Email sent"
 msgstr "E-mail enviado"
 
 #: components/manage/Blocks/Maps/Edit
+# defaultMessage: Embed code error, please follow the instructions and try again.
 msgid "Embed code error, please follow the instructions and try again."
 msgstr "Erro de código Embed, siga as instruções e tente novamente."
 
 #: components/manage/Blocks/Maps/View
+# defaultMessage: Embeded Google Maps
 msgid "Embeded Google Maps"
 msgstr "Google Maps Embed"
 
 #: components/manage/Widgets/ObjectListWidget
+# defaultMessage: Empty object list
 msgid "Empty object list"
 msgstr "Lista de objetos vazia"
 
 #: components/manage/Controlpanels/ContentTypeLayout
+# defaultMessage: Enable editable Blocks
 msgid "Enable editable Blocks"
 msgstr "Habilitar blocos editáveis"
 
 #: components/manage/Contents/Contents
+# defaultMessage: End Date
 msgid "End Date"
 msgstr "Data Final"
 
 #: components/manage/AnchorPlugin/components/LinkButton/AddLinkForm
+# defaultMessage: Enter URL or select an item
 msgid "Enter URL or select an item"
 msgstr "Digite URL ou selecione um item"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Enter a username above to search or click 'Show All'
 msgid "Enter a username above to search or click 'Show All'"
 msgstr "Digite um nome de usuário acima para pesquisar ou clique em 'Mostrar todos'"
 
 #: components/theme/Register/Register
+# defaultMessage: Enter an email address. This will be your login name. We respect your privacy, and will not give the address away to any third parties or expose it anywhere.
 msgid "Enter an email address. This will be your login name. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr "Digite um endereço de e-mail. Este será o seu nome de usuário. Respeitamos a sua privacidade e nunca iremos ceder o seu endereço a terceiros ou expô-lo onde quer que seja."
 
 #: components/manage/Preferences/PersonalInformation
 #: components/theme/PasswordReset/PasswordReset
 #: components/theme/Register/Register
+# defaultMessage: Enter full name, e.g. John Smith.
 msgid "Enter full name, e.g. John Smith."
 msgstr "Digite o nome completo. Por exemplo, José da Silva."
 
 #: components/manage/Blocks/Maps/Edit
+# defaultMessage: Enter map Embed Code
 msgid "Enter map Embed Code"
 msgstr "Informe o código Embed do mapa"
 
 #: components/manage/Preferences/ChangePassword
+# defaultMessage: Enter your current password.
 msgid "Enter your current password."
 msgstr "Digite sua senha atual."
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Enter your email address for verification.
 msgid "Enter your email address for verification."
 msgstr "Digite o seu endereço de e-mail para verificação."
 
 #: components/manage/Preferences/ChangePassword
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Enter your new password. Minimum 5 characters.
 msgid "Enter your new password. Minimum 5 characters."
 msgstr "Digite sua nova senha. Mínimo de 5 caracteres."
 
@@ -736,199 +887,245 @@ msgstr "Digite sua nova senha. Mínimo de 5 caracteres."
 #: components/theme/ContactForm/ContactForm
 #: components/theme/Login/Login
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Error
 msgid "Error"
 msgstr "Erro"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Exclude from navigation
 msgid "Exclude from navigation"
 msgstr "Excluir da navegação"
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: Exclude this occurence
 msgid "Exclude this occurence"
 msgstr "Exclua essa ocorrência"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Excluded from navigation
 msgid "Excluded from navigation"
 msgstr "Excluído da navegação"
 
 #: components/manage/Sidebar/Sidebar
+# defaultMessage: Expand sidebar
 msgid "Expand sidebar"
 msgstr "Expandir barra lateral"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Expiration Date
 msgid "Expiration Date"
 msgstr "Data de expiração"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Expiration date
 msgid "Expiration date"
 msgstr "Data de validade"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Expired
 msgid "Expired"
 msgstr "Expirado"
 
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: External URL
 msgid "External URL"
 msgstr "URL externa"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: File
 msgid "File"
 msgstr "Arquivo"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: File size
 msgid "File size"
 msgstr "Tamanho do arquivo"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Filename
 msgid "Filename"
 msgstr "Nome do arquivo"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Filter…
 msgid "Filter…"
 msgstr "Filtrar…"
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: First
 msgid "First"
 msgstr "Primeiro"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Fixed width columns
 msgid "Fixed width table cells"
 msgstr "Células de tabela de largura fixa"
 
 #: components/manage/BlockChooser/BlockChooser
+# defaultMessage: Fold
 msgid "Fold"
 msgstr "Colapsar"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Folder
 msgid "Folder"
 msgstr "Pasta"
 
 #: components/theme/Forbidden/Forbidden
+# defaultMessage: Forbidden
 msgid "Forbidden"
 msgstr "Restrito"
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: Fourth
 msgid "Fourth"
 msgstr "Quarto"
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: From
 msgid "From"
 msgstr "E-mail"
 
 #: components/manage/Blocks/Maps/Edit
 #: components/manage/Sidebar/AlignBlock
+# defaultMessage: Full
 msgid "Full"
 msgstr "Cheia"
 
 #: components/manage/Preferences/PersonalInformation
 #: components/theme/PasswordReset/PasswordReset
 #: components/theme/Register/Register
+# defaultMessage: Full Name
 msgid "Full Name"
 msgstr "Nome completo"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Fullname
 msgid "Fullname"
 msgstr "Nome completo"
 
 #: components/theme/Footer/Footer
+# defaultMessage: GNU GPL license
 msgid "GNU GPL license"
 msgstr "Licença GNU GPL"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Global role
 msgid "Global role"
 msgstr "Papel global"
 
 #: components/manage/Blocks/Maps/Edit
+# defaultMessage: Google Maps Embedded Block
 msgid "Google Maps Embedded Block"
 msgstr "Bloco Google Maps"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Group
 msgid "Group"
 msgstr "Grupo"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Group created
 msgid "Group created"
 msgstr "Grupo criado"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Group roles updated
 msgid "Group roles updated"
 msgstr ""
 
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Groupname
 msgid "Groupname"
 msgstr "Nome do grupo"
 
 #: components/manage/Controlpanels/Controlpanels
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Groups
 msgid "Groups"
 msgstr "Grupos"
 
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
+# defaultMessage: Groups are logical collections of users, such as departments and business units. Groups are not directly related to permissions on a global level, you normally use Roles for that - and let certain Groups have a particular role. The symbol{plone_svg}indicates a role inherited from membership in another group.
 msgid "Groups are logical collections of users, such as departments and business units. Groups are not directly related to permissions on a global level, you normally use Roles for that - and let certain Groups have a particular role. The symbol{plone_svg}indicates a role inherited from membership in another group."
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Header cell
 msgid "Header cell"
 msgstr "Célula de cabeçalho"
 
 #: components/theme/Comments/Comments
+# defaultMessage: Hide Replies
 msgid "Hide Replies"
 msgstr "Ocultar respostas"
 
 #: components/manage/History/History
 #: components/manage/Toolbar/More
+# defaultMessage: History
 msgid "History"
 msgstr "Histórico"
 
 #: components/manage/History/History
+# defaultMessage: #
 msgid "History Version Number"
 msgstr ""
 
 #: components/manage/History/History
+# defaultMessage: History of {title}
 msgid "History of {title}"
 msgstr "Histórico de {title}"
 
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsBreadcrumbs
 #: components/theme/Breadcrumbs/Breadcrumbs
+# defaultMessage: Home
 msgid "Home"
 msgstr "Início"
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: Home page
 msgid "Home page"
 msgstr "Página inicial"
 
 #: components/manage/Contents/Contents
+# defaultMessage: ID
 msgid "ID"
 msgstr "ID"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: If selected, this item will not appear in the navigation tree
 msgid "If selected, this item will not appear in the navigation tree"
 msgstr "Se selecionado, este item não aparecerá na árvore de navegação"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: If this date is in the future, the content will not show up in listings and searches until this date.
 msgid "If this date is in the future, the content will not show up in listings and searches until this date."
 msgstr "Se essa data for no futuro, o conteúdo não aparecerá em listagens e pesquisas até esta data."
 
 #: components/manage/LockingToastsFactory/LockingToastsFactory
+# defaultMessage: If you are certain this user has abandoned the object, you may unlock the object. You will then be able to edit it.
 msgid "If you are certain this user has abandoned the object, you may unlock the object. You will then be able to edit it."
 msgstr ""
 
 #: components/theme/NotFound/NotFound
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: If you are certain you have the correct web address but are encountering an error, please contact the {site_admin}.
 msgid "If you are certain you have the correct web address but are encountering an error, please contact the {site_admin}."
 msgstr "Se você tiver certeza de que tem o endereço web correto, mas está encontrando um erro, entre em contato com o {site_admin}."
 
 #: components/manage/Blocks/HeroImageLeft/Edit
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: Image
 msgid "Image"
 msgstr "Imagem"
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: Include this occurence
 msgid "Include this occurence"
 msgstr "Inclua esta ocorrência"
 
@@ -936,142 +1133,176 @@ msgstr "Inclua esta ocorrência"
 #: components/manage/Controlpanels/ContentTypeLayout
 #: components/manage/Controlpanels/ContentTypeSchema
 #: components/manage/Controlpanels/Controlpanel
+# defaultMessage: Info
 msgid "Info"
 msgstr "Informação"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Inherit permissions from higher levels
 msgid "Inherit permissions from higher levels"
 msgstr "Herdar permissões de níveis superiores"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Inherited value
 msgid "Inherited value"
 msgstr "Herdar valor"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Insert col after
 msgid "Insert col after"
 msgstr "Inserir coluna após"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Insert col before
 msgid "Insert col before"
 msgstr "Inserir coluna antes"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Insert row after
 msgid "Insert row after"
 msgstr "Inserir linha após"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Insert row before
 msgid "Insert row before"
 msgstr "Inserir linha antes"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Install
 msgid "Install"
 msgstr "Instalar"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Installed
 msgid "Installed"
 msgstr "Instalado"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Installed version
 msgid "Installed version"
 msgstr "Versão instalada"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: days
 msgid "Interval Daily"
 msgstr "Intervalo Diário"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Month(s)
 msgid "Interval Monthly"
 msgstr "Intervalo Mensal"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: week(s)
 msgid "Interval Weekly"
 msgstr "Intervalo Semanal"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: year(s)
 msgid "Interval Yearly"
 msgstr "Intervalo Anual"
 
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: Item batch size
 msgid "Item batch size"
 msgstr "Tamanho do lote de itens"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Item succesfully moved.
 msgid "Item succesfully moved."
 msgstr "Item movido com sucesso."
 
 #: components/manage/Contents/Contents
+# defaultMessage: Item(s) copied.
 msgid "Item(s) copied."
 msgstr "Itens copiados."
 
 #: components/manage/Contents/Contents
+# defaultMessage: Item(s) cut.
 msgid "Item(s) cut."
 msgstr "Itens cortados."
 
 #: components/manage/Contents/Contents
+# defaultMessage: Item(s) has been updated.
 msgid "Item(s) has been updated."
 msgstr "Itens atualizados."
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
+# defaultMessage: Item(s) pasted.
 msgid "Item(s) pasted."
 msgstr "Itens colados."
 
 #: components/manage/Contents/Contents
+# defaultMessage: Item(s) state has been updated.
 msgid "Item(s) state has been updated."
 msgstr "O estado dos itens foi atualizado."
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Items
 msgid "Items"
 msgstr "Itens"
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Items must be unique.
 msgid "Items must be unique."
 msgstr "Os itens devem ser únicos."
 
 #: components/manage/Preferences/PersonalPreferences
+# defaultMessage: Language
 msgid "Language"
 msgstr "Idioma"
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: Last
 msgid "Last"
 msgstr "Último"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Last comment date
 msgid "Last comment date"
 msgstr "Data do último comentário"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Last modified
 msgid "Last modified"
 msgstr "Última modificação"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Latest version
 msgid "Latest version"
 msgstr "Última versão"
 
 #: components/manage/Controlpanels/ContentTypesActions
+# defaultMessage: Layout
 msgid "Layout"
 msgstr "Layout"
 
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: Lead Image
 msgid "Lead Image"
 msgstr "Imagem principal"
 
 #: components/manage/Blocks/Image/ImageSizeWidget
 #: components/manage/Blocks/Maps/Edit
 #: components/manage/Sidebar/AlignBlock
+# defaultMessage: Left
 msgid "Left"
 msgstr "Esquerda"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Link
 msgid "Link"
 msgstr "Link"
 
 #: components/manage/Blocks/Listing/schema
+# defaultMessage: Link more
 msgid "Link more"
 msgstr "Mais"
 
 #: components/manage/Blocks/Listing/schema
+# defaultMessage: Link Title
 msgid "Link title"
 msgstr "Título do link"
 
@@ -1080,212 +1311,262 @@ msgstr "Título do link"
 #: components/manage/Blocks/Listing/schema
 #: components/manage/Blocks/Maps/MapsSidebar
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Link to
 msgid "Link to"
 msgstr "Link para"
 
 #: components/manage/Multilingual/ManageTranslations
+# defaultMessage: Link translation for
 msgid "Link translation for"
 msgstr "Linkar tradução para"
 
 #: components/manage/Blocks/Listing/schema
+# defaultMessage: Listing
 msgid "Listing"
 msgstr "Listagem"
 
 #: components/theme/Comments/Comments
+# defaultMessage: Load more...
 msgid "Load more"
 msgstr "Carregar mais"
 
 #: components/manage/Form/ModalForm
+# defaultMessage: Loading.
 msgid "Loading"
 msgstr "Carregando"
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: Location
 msgid "Location"
 msgstr "Localização"
 
 #: components/theme/Login/Login
+# defaultMessage: Login
 msgid "Log In"
 msgstr "Entrar"
 
 #: components/theme/Anontools/Anontools
 #: components/theme/Login/Login
+# defaultMessage: Log in
 msgid "Log in"
 msgstr "Entrar"
 
 #: components/theme/Login/Login
+# defaultMessage: Login
 msgid "Login"
 msgstr "Entrar"
 
 #: components/theme/Login/Login
+# defaultMessage: Login Failed
 msgid "Login Failed"
 msgstr "Falha na autenticação"
 
 #: components/theme/Login/Login
+# defaultMessage: Login Name
 msgid "Login Name"
 msgstr "Nome de usuário"
 
 #: components/manage/Toolbar/PersonalTools
+# defaultMessage: Logout
 msgid "Logout"
 msgstr "Sair"
 
 #: components/manage/Toolbar/More
+# defaultMessage: Made by {creator} on {date}. This is not a working copy anymore, but the main content.
 msgid "Made by {creator} on {date}. This is not a working copy anymore, but the main content."
 msgstr "Criado por {creator} em {date}. Esta não é mais uma cópia de trabalho, mas sim o conteúdo final."
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Reduce cell padding
 msgid "Make the table compact"
 msgstr "Compactar a tabela"
 
 #: components/manage/Multilingual/ManageTranslations
 #: components/manage/Toolbar/More
+# defaultMessage: Manage Translations
 msgid "Manage Translations"
 msgstr "Gerenciar traduções"
 
 #: components/manage/Multilingual/ManageTranslations
+# defaultMessage: Manage translations for {title}
 msgid "Manage translations for {title}"
 msgstr "Gerenciar traduções para {title}"
 
 #: components/manage/Blocks/Maps/MapsSidebar
+# defaultMessage: Map
 msgid "Map"
 msgstr "Mapa"
 
 #: components/manage/Blocks/Maps/MapsSidebar
+# defaultMessage: Maps URL
 msgid "Maps URL"
 msgstr "Url do Mapa"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Maximum length is {len}.
 msgid "Maximum length is {len}."
 msgstr "O comprimento máximo é {len}."
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Maximum value is {len}.
 msgid "Maximum value is {len}."
 msgstr "O valor máximo é {len}."
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Message
 msgid "Message"
 msgstr "Mensagem"
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Minimum length is {len}.
 msgid "Minimum length is {len}."
 msgstr "O comprimento mínimo é {len}."
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Minimum value is {len}.
 msgid "Minimum value is {len}."
 msgstr "O valor mínimo é {len}."
 
 #: components/manage/Controlpanels/Controlpanels
+# defaultMessage: Moderate Comments
 msgid "Moderate Comments"
 msgstr "Moderar comentários"
 
 #: components/manage/Controlpanels/ModerateComments
+# defaultMessage: Moderate comments
 msgid "Moderate comments"
 msgstr "Moderar comentários"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Monday and Friday
 msgid "Monday and Friday"
 msgstr "Segunda e sexta-feira"
 
 #: components/manage/Widgets/RecurrenceWidget/ByMonthDayField
+# defaultMessage: Day
 msgid "Month day"
 msgstr "Dia do mês"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Monthly
 msgid "Monthly"
 msgstr "Mensalmente"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: More
 msgid "More"
 msgstr "Mais"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Move to bottom of folder
 msgid "Move to bottom of folder"
 msgstr "Mover para o final da pasta"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Move to top of folder
 msgid "Move to top of folder"
 msgstr "Mover para o topo da pasta"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: My email address is
 msgid "My email address is"
 msgstr "O meu endereço de e-mail é"
 
 #: components/manage/Sharing/Sharing
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Name
 msgid "Name"
 msgstr "Nome"
 
 #: error
+# defaultMessage: Navigate back
 msgid "Navigate back"
 msgstr "Voltar"
 
 #: components/theme/Navigation/ContextNavigation
+# defaultMessage: Navigation
 msgid "Navigation"
 msgstr "Navegação"
 
 #: components/manage/Preferences/ChangePassword
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: New password
 msgid "New password"
 msgstr "Nova senha"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: News Item
 msgid "News Item"
 msgstr "Notícia"
 
 #: components/manage/Contents/ContentsItem
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: No
 msgid "No"
 msgstr "Não"
 
 #: components/manage/Blocks/Image/ImageSidebar
+# defaultMessage: No image selected
 msgid "No image selected"
 msgstr "Nenhuma imagem selecionada"
 
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: No image set in Lead Image content field
 msgid "No image set in Lead Image content field"
 msgstr "Nenhuma imagem definida no campo de imagem principal"
 
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: No image set in image content field
 msgid "No image set in image content field"
 msgstr "Nenhuma imagem definida no campo de imagem"
 
 #: components/manage/Blocks/Listing/ListingBody
+# defaultMessage: No items found in this container.
 msgid "No items found in this container."
 msgstr "Não foram encontrados itens nesta pasta."
 
 #: components/manage/Widgets/ObjectBrowserWidget
+# defaultMessage: No items selected
 msgid "No items selected"
 msgstr "Nenhum item selecionado"
 
 #: components/manage/Blocks/Maps/MapsSidebar
+# defaultMessage: No map selected
 msgid "No map selected"
 msgstr "Nenhum mapa selecionado"
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: No occurences set
 msgid "No occurences set"
 msgstr "Sem ocorrências definidas"
 
 #: components/manage/Widgets/ArrayWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/TokenWidget
+# defaultMessage: No options
 msgid "No options"
 msgstr "Sem opções"
 
 #: components/theme/Search/Search
+# defaultMessage: No results found
 msgid "No results found"
 msgstr "Nenhum resultado encontrado"
 
 #: components/manage/Blocks/Listing/ListingBody
 #: components/manage/Widgets/ReferenceWidget
+# defaultMessage: No results found.
 msgid "No results found."
 msgstr "Nenhum resultado encontrado."
 
 #: components/manage/Widgets/QuerySortOnWidget
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: No selection
 msgid "No selection"
 msgstr "Nenhuma seleção"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: This addon does not provide an uninstall profile.
 msgid "No uninstall profile"
 msgstr "Sem perfil de desinstalação"
 
@@ -1293,39 +1574,48 @@ msgstr "Sem perfil de desinstalação"
 #: components/manage/Widgets/ReferenceWidget
 #: components/manage/Widgets/SelectUtils
 #: components/manage/Widgets/SelectWidget
+# defaultMessage: No value
 msgid "No value"
 msgstr "Sem valor"
 
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: No video selected
 msgid "No video selected"
 msgstr "Nenhum vídeo selecionado"
 
 #: components/manage/Workflow/Workflow
+# defaultMessage: No workflow
 msgid "No workflow"
 msgstr "Sem workflow"
 
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsItem
+# defaultMessage: None
 msgid "None"
 msgstr "Nenhum"
 
 #: components/manage/Controlpanels/Users/UsersControlpanel
+# defaultMessage: Note that roles set here apply directly to a user. The symbol{plone_svg}indicates a role inherited from membership in a group.
 msgid "Note that roles set here apply directly to a user. The symbol{plone_svg}indicates a role inherited from membership in a group."
 msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Number of active objects
 msgid "Number of active objects"
 msgstr "Número de objetos ativos"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Object Size
 msgid "Object Size"
 msgstr "Tamanho do objeto"
 
 #: components/manage/Widgets/RecurrenceWidget/EndField
+# defaultMessage: occurrence(s)
 msgid "Occurences"
 msgstr "Ocorrências"
 
 #: components/manage/Delete/Delete
+# defaultMessage: Ok
 msgid "Ok"
 msgstr "Ok"
 
@@ -1333,301 +1623,371 @@ msgstr "Ok"
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
 #: components/manage/Blocks/Maps/MapsSidebar
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Open in a new tab
 msgid "Open in a new tab"
 msgstr "Abrir em uma nova aba"
 
 #: components/theme/Navigation/Navigation
+# defaultMessage: Open menu
 msgid "Open menu"
 msgstr "Abrir menu"
 
 #: components/manage/Widgets/ObjectBrowserWidget
+# defaultMessage: Open object browser
 msgid "Open object browser"
 msgstr "Abrir navegador de objetos"
 
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: Origin
 msgid "Origin"
 msgstr "Origem"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Page
 msgid "Page"
 msgstr "Página"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Parent fieldset
 msgid "Parent fieldset"
 msgstr "Conjunto de campos"
 
 #: components/theme/Login/Login
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Password
 msgid "Password"
 msgstr "Senha"
 
 #: components/theme/PasswordReset/PasswordReset
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Password reset
 msgid "Password reset"
 msgstr "Redefinição de senha"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Passwords do not match.
 msgid "Passwords do not match."
 msgstr "As senhas não coincidem."
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
+# defaultMessage: Paste
 msgid "Paste"
 msgstr "Colar"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: undefined
 msgid "Paste blocks"
 msgstr "Colar blocos"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Permissions have been updated successfully
 msgid "Permissions have been updated successfully"
 msgstr "Permissões atualizadas com sucesso"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Permissions updated
 msgid "Permissions updated"
 msgstr "Permissões atualizadas"
 
 #: components/manage/Preferences/PersonalInformation
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Personal Information
 msgid "Personal Information"
 msgstr "Informações pessoais"
 
 #: components/manage/Preferences/PersonalPreferences
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Personal Preferences
 msgid "Personal Preferences"
 msgstr "Preferências pessoais"
 
 #: components/manage/Toolbar/More
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Personal tools
 msgid "Personal tools"
 msgstr "Ferramentas pessoais"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Persons responsible for creating the content of this item. Please enter a list of user names, one per line. The principal creator should come first.
 msgid "Persons responsible for creating the content of this item. Please enter a list of user names, one per line. The principal creator should come first."
 msgstr "Pessoas responsáveis pela criação do conteúdo deste item. Por favor, insira uma lista de nomes de usuário, um por linha. O autor principal deve vir primeiro."
 
 #: components/manage/Blocks/Video/Edit
+# defaultMessage: Please enter a valid URL by deleting the block and adding a new video block.
 msgid "Please enter a valid URL by deleting the block and adding a new video block."
 msgstr "Digite uma URL válida excluindo o bloco e adicionando um novo bloco de vídeo."
 
 #: components/manage/Blocks/Maps/Edit
+# defaultMessage: Please enter the Embed Code provided by Google Maps -> Share -> Embed map. It should contain the <iframe> code on it.
 msgid "Please enter the Embed Code provided by Google Maps -> Share -> Embed map. It should contain the <iframe> code on it."
 msgstr "Digite o código Embed fornecido pelo google maps -> compartilhar -> mapa Embed. Deve conter o <iframe> código.</iframe>."
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Please fill out the form below to set your password.
 msgid "Please fill out the form below to set your password."
 msgstr "Preencha o formulário abaixo para definir sua senha."
 
 #: components/theme/Footer/Footer
+# defaultMessage: Plone Foundation
 msgid "Plone Foundation"
 msgstr "Fundação Plone"
 
 #: components/theme/Logo/Logo
+# defaultMessage: Plone Site
 msgid "Plone Site"
 msgstr "Site Plone"
 
 #: components/theme/Footer/Footer
+# defaultMessage: Plone{reg} Open Source CMS/WCM
 msgid "Plone{reg} Open Source CMS/WCM"
 msgstr "Plone{reg} Open Source CMS/WCM"
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: Portrait
 msgid "Portrait"
 msgstr "Foto"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Possible values (Enter allowed choices one per line).
 msgid "Possible values"
 msgstr "Valores possíveis"
 
 #: components/theme/Footer/Footer
+# defaultMessage: Powered by Plone & Python
 msgid "Powered by Plone & Python"
 msgstr "Criado com Plone e Python"
 
 #: components/manage/Toolbar/PersonalTools
+# defaultMessage: Preferences
 msgid "Preferences"
 msgstr "Preferências"
 
 #: components/manage/Blocks/HTML/Edit
+# defaultMessage: Prettify your code
 msgid "Prettify your code"
 msgstr "Re-formatar seu código"
 
 #: components/manage/Blocks/HTML/Edit
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Preview
 msgid "Preview"
 msgstr "Pré-visualização"
 
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Preview Image URL
 msgid "Preview Image URL"
 msgstr "Url de imagem de pré-visualização"
 
 #: components/manage/Toolbar/PersonalTools
+# defaultMessage: Profile
 msgid "Profile"
 msgstr "Perfil"
 
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Properties
 msgid "Properties"
 msgstr "Propriedades"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Publication date
 msgid "Publication date"
 msgstr "Data de publicação"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Publishing Date
 msgid "Publishing Date"
 msgstr "Data de publicação"
 
 #: components/manage/Blocks/Listing/schema
+# defaultMessage: Query
 msgid "Query"
 msgstr "Consulta"
 
 #: components/manage/Preferences/ChangePassword
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Re-enter the password. Make sure the passwords are identical.
 msgid "Re-enter the password. Make sure the passwords are identical."
 msgstr "Reinsira a senha. Certifique-se de que as senhas são idênticas."
 
 #: components/theme/Search/Search
 #: components/theme/View/SummaryView
+# defaultMessage: Read More…
 msgid "Read More…"
 msgstr "Leia Mais…"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Rearrange items by…
 msgid "Rearrange items by…"
 msgstr "Reorganize itens por…"
 
 #: components/manage/Widgets/RecurrenceWidget/EndField
+# defaultMessage: Ends
 msgid "Recurrence ends"
 msgstr "Término da recorrência"
 
 #: components/manage/Widgets/RecurrenceWidget/EndField
+# defaultMessage: after
 msgid "Recurrence ends after"
 msgstr "Recorrência se encerra após"
 
 #: components/manage/Widgets/RecurrenceWidget/EndField
+# defaultMessage: on
 msgid "Recurrence ends on"
 msgstr "Recorrência se encerra em"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Minimalistic table design
 msgid "Reduce complexity"
 msgstr "Reduzir complexidade"
 
 #: components/theme/Anontools/Anontools
 #: components/theme/Login/Login
 #: components/theme/Register/Register
+# defaultMessage: Register
 msgid "Register"
 msgstr "Cadastro"
 
 #: components/theme/Register/Register
+# defaultMessage: Registration form
 msgid "Registration form"
 msgstr "Formulário de cadastro"
 
 #: components/theme/Search/Search
+# defaultMessage: Relevance
 msgid "Relevance"
 msgstr "Relevância"
 
 #: components/manage/Widgets/ObjectListWidget
+# defaultMessage: Remove item
 msgid "Remove item"
 msgstr "Remover Item"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Remove
 msgid "Remove recurrence"
 msgstr "Remover a recorrência"
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Remove term
 msgid "Remove term"
 msgstr "Remover o termo"
 
 #: components/manage/Toolbar/More
+# defaultMessage: Remove working copy
 msgid "Remove working copy"
 msgstr "Remover a cópia de trabalho"
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
+# defaultMessage: Rename
 msgid "Rename"
 msgstr "Renomear"
 
 #: components/manage/Contents/ContentsRenameModal
+# defaultMessage: Renaming items...
 msgid "Rename Items Loading Message"
 msgstr "Renomeando os items"
 
 #: components/manage/Contents/ContentsRenameModal
+# defaultMessage: Rename items
 msgid "Rename items"
 msgstr "Renomear itens"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Repeat
 msgid "Repeat"
 msgstr "Repetição"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Repeat every
 msgid "Repeat every"
 msgstr "Repete a cada"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Repeat on
 msgid "Repeat on"
 msgstr "Repete em"
 
 #: components/manage/Widgets/FileWidget
+# defaultMessage: Replace existing file
 msgid "Replace existing file"
 msgstr "Substituir arquivo existente"
 
 #: components/theme/Comments/Comments
+# defaultMessage: Reply
 msgid "Reply"
 msgstr "Responder"
 
 #: components/manage/Widgets/SchemaWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/WysiwygWidget
+# defaultMessage: Required
 msgid "Required"
 msgstr "Obrigatório"
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Required input is missing.
 msgid "Required input is missing."
 msgstr "Falta informação obrigatória."
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Reset title
 msgid "Reset term title"
 msgstr "Redefinir o título do termo"
 
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: Results limit
 msgid "Results limit"
 msgstr "Limite de resultados"
 
 #: components/manage/Blocks/Listing/Edit
+# defaultMessage: Results preview
 msgid "Results preview"
 msgstr "Visualização de resultados"
 
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: Reversed order
 msgid "Reversed order"
 msgstr "Ordem invertida"
 
 #: components/manage/History/History
+# defaultMessage: Revert to this revision
 msgid "Revert to this revision"
 msgstr "Reverter para esta revisão"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Review state
 msgid "Review state"
 msgstr "Estado"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Richtext
 msgid "Richtext"
 msgstr "Texto rico"
 
 #: components/manage/Blocks/Image/ImageSizeWidget
 #: components/manage/Blocks/Maps/Edit
 #: components/manage/Sidebar/AlignBlock
+# defaultMessage: Right
 msgid "Right"
 msgstr "Direita"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Rights
 msgid "Rights"
 msgstr "Direitos"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Roles
 msgid "Roles"
 msgstr "Papéis"
 
 #: components/manage/Contents/ContentsBreadcrumbs
+# defaultMessage: Root
 msgid "Root"
 msgstr "Raiz"
 
@@ -1640,90 +2000,112 @@ msgstr "Raiz"
 #: components/manage/Form/ModalForm
 #: components/manage/Sharing/Sharing
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Save
 msgid "Save"
 msgstr "Salvar"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Save
 msgid "Save recurrence"
 msgstr "Salvar a recorrência"
 
 #: components/manage/Controlpanels/ContentTypesActions
+# defaultMessage: Schema
 msgid "Schema"
 msgstr "Esquema"
 
 #: components/manage/Controlpanels/ContentTypeSchema
+# defaultMessage: Schema updates
 msgid "Schema updates"
 msgstr "Atualizações do esquema"
 
 #: components/theme/SearchWidget/SearchWidget
+# defaultMessage: Search
 msgid "Search"
 msgstr "Pesquisar"
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: Search SVG
 msgid "Search SVG"
 msgstr "SVG de busca"
 
 #: components/theme/SearchWidget/SearchWidget
+# defaultMessage: Search Site
 msgid "Search Site"
 msgstr "Pesquisar no site"
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: Search content
 msgid "Search content"
 msgstr "Pesquisar conteúdo"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Search for user or group
 msgid "Search for user or group"
 msgstr "Pesquisar por usuário ou grupo"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Search group…
 msgid "Search group…"
 msgstr "Pesquisar grupo…"
 
 #: components/theme/Search/Search
+# defaultMessage: Search results
 msgid "Search results"
 msgstr "Resultados da pesquisa"
 
 #: components/theme/Search/Search
+# defaultMessage: Search results for {term}
 msgid "Search results for {term}"
 msgstr "Resultados da pesquisa para {term}"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Search users…
 msgid "Search users…"
 msgstr "Pesquisar usuários…"
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: Second
 msgid "Second"
 msgstr "Segundo"
 
 #: components/manage/Sidebar/ObjectBrowserNav
+# defaultMessage: Select
 msgid "Select"
 msgstr "Selecionar"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Select a date to add to recurrence
 msgid "Select a date to add to recurrence"
 msgstr "Selecione uma data para adicionar à recorrência"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Select columns to show
 msgid "Select columns to show"
 msgstr "Selecione colunas para mostrar"
 
 #: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Select the transition to be used for modifying the items state.
 msgid "Select the transition to be used for modifying the items state."
 msgstr "Selecione a transição a ser usada para modificar o estado dos itens."
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: Selected dates
 msgid "Selected dates"
 msgstr "Datas selecionadas"
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: Selected items
 msgid "Selected items"
 msgstr "Itens selecionados"
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: of
 msgid "Selected items - x of y"
 msgstr "Itens selecionados - x de y"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Selection
 msgid "Selection"
 msgstr "Seleção"
 
@@ -1731,158 +2113,195 @@ msgstr "Seleção"
 #: components/manage/Widgets/ArrayWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/TokenWidget
+# defaultMessage: Select…
 msgid "Select…"
 msgstr "Selecionar…"
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Send
 msgid "Send"
 msgstr "Enviar"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Set my password
 msgid "Set my password"
 msgstr "Defina minha senha"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Set your password
 msgid "Set your password"
 msgstr "Defina sua senha"
 
 #: components/manage/Sidebar/Sidebar
+# defaultMessage: Settings
 msgid "Settings"
 msgstr "Configurações"
 
 #: components/manage/Sharing/Sharing
 #: components/manage/Toolbar/More
+# defaultMessage: Sharing
 msgid "Sharing"
 msgstr "Compartilhamento"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Sharing for {title}
 msgid "Sharing for {title}"
 msgstr "Compartilhamento para {title}"
 
 #: components/manage/Widgets/SchemaWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/WysiwygWidget
+# defaultMessage: Short Name
 msgid "Short Name"
 msgstr "Nome curto"
 
 #: components/manage/Contents/ContentsRenameModal
+# defaultMessage: Short name
 msgid "Short name"
 msgstr "Nome curto"
 
 #: components/theme/Pagination/Pagination
+# defaultMessage: Show
 msgid "Show"
 msgstr "Mostrar"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Show All
 msgid "Show All"
 msgstr "Mostrar tudo"
 
 #: components/theme/Comments/Comments
+# defaultMessage: Show Replies
 msgid "Show Replies"
 msgstr "Mostrar respostas"
 
 #: components/manage/Widgets/ObjectListWidget
+# defaultMessage: Show item
 msgid "Show item"
 msgstr "Mostrar item"
 
 #: components/manage/Sidebar/Sidebar
+# defaultMessage: Shrink sidebar
 msgid "Shrink sidebar"
 msgstr "Recolher barra lateral"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Shrink toolbar
 msgid "Shrink toolbar"
 msgstr "Recolher barra de ferramentas"
 
 #: components/theme/Login/Login
+# defaultMessage: Sign in to start session
 msgid "Sign in to start session"
 msgstr "Faça login para iniciar a sessão"
 
 #: components/theme/Logo/Logo
+# defaultMessage: Site
 msgid "Site"
 msgstr "Site"
 
 #: components/theme/NotFound/NotFound
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: Site Administration
 msgid "Site Administration"
 msgstr "Administração do site"
 
 #: components/theme/Footer/Footer
+# defaultMessage: Site Map
 msgid "Site Map"
 msgstr "Mapa do site"
 
 #: components/manage/Controlpanels/Controlpanels
 #: components/manage/Toolbar/PersonalTools
+# defaultMessage: Site Setup
 msgid "Site Setup"
 msgstr "Configuração do site"
 
 #: components/theme/Sitemap/Sitemap
+# defaultMessage: Sitemap
 msgid "Sitemap"
 msgstr "Mapa do site"
 
 #: components/manage/Blocks/Image/ImageSidebar
+# defaultMessage: Size
 msgid "Size"
 msgstr "Tamanho"
 
 #: components/theme/View/ImageView
+# defaultMessage: Size: {size}
 msgid "Size: {size}"
 msgstr "Tamanho: {size}"
 
 #: error
+# defaultMessage: Sorry, something went wrong with your request
 msgid "Sorry, something went wrong with your request"
 msgstr "Desculpe, algo deu errado com sua requisição"
 
 #: components/theme/Search/Search
+# defaultMessage: Sort by:
 msgid "Sort By:"
 msgstr "Ordenar por:"
 
 #: components/manage/Widgets/QuerySortOnWidget
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: Sort on
 msgid "Sort on"
 msgstr "Ordenado por"
 
 #: components/manage/Blocks/HTML/Edit
+# defaultMessage: Source
 msgid "Source"
 msgstr "Fonte"
 
 #: components/manage/Blocks/Video/Edit
+# defaultMessage: Specify a youtube video or playlist url
 msgid "Specify a youtube video or playlist url"
 msgstr "Informe a url para um vídeo ou uma playlist do YouTube"
 
 #: components/manage/Diff/Diff
+# defaultMessage: Split
 msgid "Split"
 msgstr "Dividir"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Start Date
 msgid "Start Date"
 msgstr "Data de Início"
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: Start of the recurrence
 msgid "Start of the recurrence"
 msgstr "Início da recorrência"
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Start password reset
 msgid "Start password reset"
 msgstr "Redefinir senha"
 
 #: components/manage/Contents/Contents
 #: components/manage/Workflow/Workflow
 #: components/theme/View/TabularView
+# defaultMessage: State
 msgid "State"
 msgstr "Estado"
 
 #: components/manage/Multilingual/CompareLanguages
+# defaultMessage: Stop compare
 msgid "Stop compare"
 msgstr "Pare de comparar"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: String
 msgid "String"
 msgstr "Texto"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Alternate row background color
 msgid "Stripe alternate rows with color"
 msgstr "Alternar cores das linhas"
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Subject
 msgid "Subject"
 msgstr "Assunto"
 
@@ -1896,43 +2315,53 @@ msgstr "Assunto"
 #: components/manage/Preferences/PersonalPreferences
 #: components/theme/ContactForm/ContactForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Success
 msgid "Success"
 msgstr "Sucesso"
 
 #: components/theme/LanguageSelector/LanguageSelector
+# defaultMessage: Switch to
 msgid "Switch to"
 msgstr "Mudar para"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Table
 msgid "Table"
 msgstr "Tabela"
 
 #: components/manage/Blocks/ToC/View
+# defaultMessage: Table of Contents
 msgid "Table of Contents"
 msgstr "Tabela de conteúdos"
 
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsTagsModal
+# defaultMessage: Tags
 msgid "Tags"
 msgstr "Tags"
 
 #: components/manage/Contents/ContentsTagsModal
+# defaultMessage: Tags to add
 msgid "Tags to add"
 msgstr "Tags a serem adicionadas"
 
 #: components/manage/Contents/ContentsTagsModal
+# defaultMessage: Tags to remove
 msgid "Tags to remove"
 msgstr "Tags a serem removidas"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Target memory size per cache in bytes
 msgid "Target memory size per cache in bytes"
 msgstr "Tamanho de memória destinada para o cache em bytes"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Target number of objects in memory per cache
 msgid "Target number of objects in memory per cache"
 msgstr "Número de objetos na memória para o cache"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Text
 msgid "Text"
 msgstr "Texto"
 
@@ -1940,87 +2369,108 @@ msgstr "Texto"
 #: components/theme/CorsError/CorsError
 #: components/theme/NotFound/NotFound
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: Thank you.
 msgid "Thank you."
 msgstr "Obrigado."
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: The Database Manager allow you to view database status information
 msgid "The Database Manager allow you to view database status information"
 msgstr "O Gerenciador de banco de dados permite que você visualize informações de status do banco de dados"
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: The URL for your external home page, if you have one.
 msgid "The URL for your external home page, if you have one."
 msgstr "A URL para seu site, caso tenha um."
 
 #: components/theme/ConnectionRefused/ConnectionRefused
+# defaultMessage: The backend is not responding, please check if you have started Plone, check your project's configuration object apiPath (or if you are using the internal proxy, devProxyToApiPath) or the RAZZLE_API_PATH Volto's environment variable.
 msgid "The backend is not responding, please check if you have started Plone, check your project's configuration object apiPath (or if you are using the internal proxy, devProxyToApiPath) or the RAZZLE_API_PATH Volto's environment variable."
 msgstr "O servidor de backend não está respondendo, verifique se você inicializou o Plone, verifique o apiPath de objeto de configuração do seu projeto (ou se você está usando o proxy interno, devProxyToApiPath) ou a variável ambiente RAZZLE_API_PATH Volto."
 
 #: components/theme/CorsError/CorsError
+# defaultMessage: The backend is responding, but the CORS headers are not configured properly and the browser has denied the access to the backend resources.
 msgid "The backend is responding, but the CORS headers are not configured properly and the browser has denied the access to the backend resources."
 msgstr "O servidor de backend está respondendo, mas os cabeçalhos CORS não estão configurados corretamente e o navegador negou o acesso aos recursos de backend."
 
 #: components/theme/CorsError/CorsError
+# defaultMessage: The backend server of your website is not anwering, we apologize for the inconvenience. Please try to re-load the page and try again. If the problem persists please contact the site administrators.
 msgid "The backend server of your website is not anwering, we apologize for the inconvenience. Please try to re-load the page and try again. If the problem persists please contact the site administrators."
 msgstr "O servidor de backend do seu site não está respondendo, pedimos desculpas pelo inconveniente. Por favor, tente recarregar a página e tente novamente. Se o problema persistir, entre em contato com os administradores do site."
 
 #: components/manage/Contents/Contents
+# defaultMessage: The item could not be deleted.
 msgid "The item could not be deleted."
 msgstr "O item não pôde ser excluído."
 
 #: components/theme/Register/Register
+# defaultMessage: The registration process has been successful. Please check your e-mail inbox for information on how activate your account.
 msgid "The registration process has been successful. Please check your e-mail inbox for information on how activate your account."
 msgstr "O processo de registro foi bem sucedido. Verifique sua caixa de entrada de e-mail para obter informações sobre como ativar sua conta."
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: The user portrait/avatar
 msgid "The user portrait/avatar"
 msgstr "Foto/avatar do usuário"
 
 #: components/manage/Toolbar/More
+# defaultMessage: The working copy was discarded
 msgid "The working copy was discarded"
 msgstr "A cópia de trabalho foi descartada."
 
 #: components/theme/Footer/Footer
+# defaultMessage: The {plonecms} is {copyright} 2000-{current_year} by the {plonefoundation} and friends.
 msgid "The {plonecms} is {copyright} 2000-{current_year} by the {plonefoundation} and friends."
 msgstr "O {plonecms} tem {copyright} de 2000-{current_year} pela {plonefoundation} e amigos."
 
 #: components/theme/CorsError/CorsError
+# defaultMessage: There is a configuration problem on the backend
 msgid "There is a configuration problem on the backend"
 msgstr "Há um problema de configuração no backend"
 
 #: components/manage/Form/InlineForm
+# defaultMessage: There were some errors
 msgid "There were some errors"
 msgstr "Houve alguns erros"
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: There were some errors.
 msgid "There were some errors."
 msgstr "Houve alguns erros."
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: Third
 msgid "Third"
 msgstr "Terceiro"
 
 #: components/manage/WorkingCopyToastsFactory/WorkingCopyToastsFactory
+# defaultMessage: This has an ongoing working copy in {title}
 msgid "This has an ongoing working copy in {title}"
 msgstr "Este conteúdo tem uma cópia de trabalho ativa em {title}"
 
 #: components/manage/WorkingCopyToastsFactory/WorkingCopyToastsFactory
+# defaultMessage: This is a working copy of {title}
 msgid "This is a working copy of {title}"
 msgstr "Esta é uma cópia de trabalho de {title}"
 
 #: components/manage/LockingToastsFactory/LockingToastsFactory
+# defaultMessage: This item was locked by {creator} on {date}
 msgid "This item was locked by {creator} on {date}"
 msgstr ""
 
 #: components/manage/Contents/ContentsRenameModal
+# defaultMessage: This name will be displayed in the URL.
 msgid "This name will be displayed in the URL."
 msgstr "Este nome será exibido na URL."
 
 #: components/theme/NotFound/NotFound
+# defaultMessage: This page does not seem to exist…
 msgid "This page does not seem to exist…"
 msgstr "Esta página parece não existir…"
 
 #: components/manage/Widgets/DatetimeWidget
+# defaultMessage: Time
 msgid "Time"
 msgstr "Hora"
 
@@ -2033,714 +2483,889 @@ msgstr "Hora"
 #: components/manage/Widgets/WysiwygWidget
 #: components/theme/View/TabularView
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Title
 msgid "Title"
 msgstr "Título"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Total active and non-active objects
 msgid "Total active and non-active objects"
 msgstr "Total de objetos ativos e não ativos"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Total comments
 msgid "Total comments"
 msgstr "Total de comentários"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Total number of objects in each cache
 msgid "Total number of objects in each cache"
 msgstr "Número total de objetos em cada cache"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Total number of objects in memory from all caches
 msgid "Total number of objects in memory from all caches"
 msgstr "Número total de objetos na memória de todos os caches"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Total number of objects in the database
 msgid "Total number of objects in the database"
 msgstr "Número total de objetos no banco de dados"
 
 #: components/manage/Add/Add
 #: components/manage/Toolbar/Types
+# defaultMessage: Translate to {lang}
 msgid "Translate to {lang}"
 msgstr "Traduza para {lang}"
 
 #: components/manage/Multilingual/ManageTranslations
+# defaultMessage: Translation linked
 msgid "Translation linked"
 msgstr "Tradução vinculada"
 
 #: components/manage/Multilingual/ManageTranslations
+# defaultMessage: Translation linking removed
 msgid "Translation linking removed"
 msgstr "Vínculo de tradução removido"
 
 #: components/manage/Controlpanels/ContentTypes
 #: components/manage/Widgets/SchemaWidget
 #: components/theme/View/TabularView
+# defaultMessage: Type
 msgid "Type"
 msgstr "Tipo"
 
 #: components/manage/Blocks/Video/Edit
+# defaultMessage: Type a Video (YouTube, Vimeo or mp4) URL
 msgid "Type a Video (YouTube, Vimeo or mp4) URL"
 msgstr "Digite uma URL de vídeo (YouTube, Vimeo ou mp4)"
 
 #: components/manage/Blocks/Text/Edit
+# defaultMessage: Type text…
 msgid "Type text…"
 msgstr "Digite texto…"
 
 #: components/manage/Blocks/Title/Edit
+# defaultMessage: Type the title…
 msgid "Type the title…"
 msgstr "Digite o título…"
 
 #: components/manage/Contents/Contents
+# defaultMessage: UID
 msgid "UID"
 msgstr "UID"
 
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: Unauthorized
 msgid "Unauthorized"
 msgstr "Não autorizado"
 
 #: components/manage/BlockChooser/BlockChooser
+# defaultMessage: Unfold
 msgid "Unfold"
 msgstr "Expandir"
 
 #: components/manage/Diff/Diff
+# defaultMessage: Unified
 msgid "Unified"
 msgstr "Unificado"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Uninstall
 msgid "Uninstall"
 msgstr "Desinstalar"
 
 #: components/manage/Blocks/Block/Edit
 #: components/theme/View/DefaultView
 #: components/theme/View/RenderBlocks
+# defaultMessage: Unknown Block {block}
 msgid "Unknown Block"
 msgstr "Bloco Desconhecido"
 
 #: components/manage/Multilingual/ManageTranslations
+# defaultMessage: Unlink translation for
 msgid "Unlink translation for"
 msgstr "Desvincular a tradução para"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Unlock
 msgid "Unlock"
 msgstr ""
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Update
 msgid "Update"
 msgstr "Atualizar"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Update installed addons
 msgid "Update installed addons"
 msgstr "Atualizar complementos instalados"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Update installed addons:
 msgid "Update installed addons:"
 msgstr "Atualização de complementos instalados:"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Updates available
 msgid "Updates available"
 msgstr "Atualizações disponíveis"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Upload
 msgid "Upload"
 msgstr "Enviar"
 
 #: components/manage/Blocks/LeadImage/Edit
+# defaultMessage: Upload a lead image in the 'Lead Image' content field.
 msgid "Upload a lead image in the 'Lead Image' content field."
 msgstr "Enviar uma imagem para o campo de imagem principal."
 
 #: components/manage/Blocks/HeroImageLeft/Edit
+# defaultMessage: Upload a new image
 msgid "Upload a new image"
 msgstr "Enviar uma nova imagem"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Upload files
 msgid "Upload files"
 msgstr "Enviar arquivos"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Uploading files
 msgid "Uploading files"
 msgstr "Enviando arquivos"
 
 #: components/manage/Blocks/HeroImageLeft/Edit
+# defaultMessage: Uploading image
 msgid "Uploading image"
 msgstr "Enviando imagem"
 
 #: components/manage/Widgets/SchemaWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/WysiwygWidget
+# defaultMessage: Used for programmatic access to the fieldset.
 msgid "Used for programmatic access to the fieldset."
 msgstr "Usado para acesso programático ao conjunto de campos."
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: User
 msgid "User"
 msgstr "Usuário"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: User created
 msgid "User created"
 msgstr "Usuário criado"
 
 #: components/manage/Controlpanels/Users/UsersControlpanel
+# defaultMessage: User name
 msgid "User name"
 msgstr "Nome de usuário"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: User roles updated
 msgid "User roles updated"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Username
 msgid "Username"
 msgstr "Nome de usuário"
 
 #: components/manage/Controlpanels/Controlpanels
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Users
 msgid "Users"
 msgstr "Usuários"
 
 #: components/manage/Controlpanels/Controlpanels
+# defaultMessage: Users and Groups
 msgid "Users and Groups"
 msgstr "Usuários e Grupos"
 
 #: helpers/Extensions/withBlockSchemaEnhancer
+# defaultMessage: Variation
 msgid "Variation"
 msgstr "Variação"
 
 #: components/manage/Controlpanels/Controlpanels
+# defaultMessage: Version Overview
 msgid "Version Overview"
 msgstr "Versões"
 
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Video
 msgid "Video"
 msgstr "Vídeo"
 
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Video URL
 msgid "Video URL"
 msgstr "URL do vídeo"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: View
 msgid "View"
 msgstr "Visão"
 
 #: components/manage/History/History
+# defaultMessage: View changes
 msgid "View changes"
 msgstr "Ver mudanças"
 
 #: components/manage/History/History
+# defaultMessage: View this revision
 msgid "View this revision"
 msgstr "Ver esta revisão"
 
 #: components/manage/Toolbar/More
+# defaultMessage: View working copy
 msgid "View working copy"
 msgstr "Exibir a cópia de trabalho"
 
 #: components/manage/Display/Display
+# defaultMessage: View
 msgid "Viewmode"
 msgstr "Visão"
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Vocabulary term
 msgid "Vocabulary term"
 msgstr "Termo de vocabulário"
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Title
 msgid "Vocabulary term title"
 msgstr "Título do termo de vocabulário"
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Vocabulary terms
 msgid "Vocabulary terms"
 msgstr "Termos de vocabulário"
 
 #: components/manage/Controlpanels/VersionOverview
+# defaultMessage: You are running in 'debug mode'. This mode is intended for sites that are under development. This allows many configuration changes to be immediately visible, but will make your site run more slowly. To turn off debug mode, stop the server, set 'debug-mode=off' in your buildout.cfg, re-run bin/buildout and then restart the server process.
 msgid "Warning Regarding debug mode"
 msgstr "Aviso em relação ao modo de depuração"
 
 #: components/theme/ConnectionRefused/ConnectionRefused
+# defaultMessage: We apologize for the inconvenience, but the backend of the site you are accessing is not available right now. Please, try again later.
 msgid "We apologize for the inconvenience, but the backend of the site you are accessing is not available right now. Please, try again later."
 msgstr "Pedimos desculpas pelo inconveniente, mas o backend do site que você está acessando não está disponível agora. Por favor, tente de novo mais tarde."
 
 #: components/theme/NotFound/NotFound
+# defaultMessage: We apologize for the inconvenience, but the page you were trying to access is not at this address. You can use the links below to help you find what you are looking for.
 msgid "We apologize for the inconvenience, but the page you were trying to access is not at this address. You can use the links below to help you find what you are looking for."
 msgstr "Pedimos desculpas pelo inconveniente, mas a página que você estava tentando acessar não está neste endereço. Você pode usar os links abaixo para ajudá-lo a encontrar o que você está procurando."
 
 #: components/theme/Forbidden/Forbidden
+# defaultMessage: We apologize for the inconvenience, but you don't have permissions on this resource.
 msgid "We apologize for the inconvenience, but you don't have permissions on this resource."
 msgstr "Pedimos desculpas pelo inconveniente, mas você não tem permissões neste recurso."
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: We will use this address if you need to recover your password
 msgid "We will use this address if you need to recover your password"
 msgstr "Usaremos este endereço se você precisar recuperar sua senha"
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: The
 msgid "Weeek day of month"
 msgstr "Dia do mês"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Weekday
 msgid "Weekday"
 msgstr "Dia da semana"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Weekly
 msgid "Weekly"
 msgstr "Semanalmente"
 
 #: components/manage/History/History
+# defaultMessage: What
 msgid "What"
 msgstr "O quê"
 
 #: components/manage/History/History
+# defaultMessage: When
 msgid "When"
 msgstr "Quando"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: When this date is reached, the content will nolonger be visible in listings and searches.
 msgid "When this date is reached, the content will nolonger be visible in listings and searches."
 msgstr "Quando chegar a esta data, o conteúdo deixará de ficar visível nas listagens e nas pesquisas."
 
 #: components/manage/History/History
+# defaultMessage: Who
 msgid "Who"
 msgstr "Quem"
 
 #: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Updating workflow states...
 msgid "Workflow Change Loading Message"
 msgstr "Alterando os estados..."
 
 #: components/manage/Workflow/Workflow
+# defaultMessage: Workflow updated.
 msgid "Workflow updated."
 msgstr "Workflow atualizado."
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Yearly
 msgid "Yearly"
 msgstr "Anualmente"
 
 #: components/manage/Contents/ContentsItem
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Yes
 msgid "Yes"
 msgstr "Sim"
 
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: You are trying to access a protected resource, please {login} first.
 msgid "You are trying to access a protected resource, please {login} first."
 msgstr "Você está tentando acessar um recurso protegido, por favor, {login} primeiro."
 
 #: components/theme/OutdatedBrowser/OutdatedBrowser
+# defaultMessage: You are using an outdated browser
 msgid "You are using an outdated browser"
 msgstr "Você está usando um navegador desatualizado"
 
 #: components/theme/Comments/Comments
+# defaultMessage: You can add a comment by filling out the form below. Plain text formatting.
 msgid "You can add a comment by filling out the form below. Plain text formatting."
 msgstr "Você pode adicionar um comentário preenchendo o formulário abaixo. Formatação de texto simples."
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: You can control who can view and edit your item using the list below.
 msgid "You can control who can view and edit your item using the list below."
 msgstr "Você pode controlar quem pode visualizar e editar seu item usando a lista abaixo."
 
 #: components/manage/Diff/Diff
+# defaultMessage: You can view the difference of the revisions below.
 msgid "You can view the difference of the revisions below."
 msgstr "Você pode ver a diferença das revisões abaixo."
 
 #: components/manage/History/History
+# defaultMessage: You can view the history of your item below.
 msgid "You can view the history of your item below."
 msgstr "Você pode ver o histórico do seu item abaixo."
 
 #: components/manage/Contents/Contents
+# defaultMessage: You can't paste this content here
 msgid "You can't paste this content here"
 msgstr "Você não pode colar este conteúdo aqui"
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Your email is required for reset your password.
 msgid "Your email is required for reset your password."
 msgstr "Seu e-mail é necessário para redefinir sua senha."
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: Your location - either city and country - or in a company setting, where your office is located.
 msgid "Your location - either city and country - or in a company setting, where your office is located."
 msgstr "Sua localização - seja cidade e país - ou em um ambiente de empresa, onde seu escritório está localizado."
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Your password has been set successfully. You may now {link} with your new password.
 msgid "Your password has been set successfully. You may now {link} with your new password."
 msgstr "Sua senha foi definida com sucesso. Agora você pode {link} com sua nova senha."
 
 #: components/manage/Preferences/PersonalPreferences
+# defaultMessage: Your preferred language
 msgid "Your preferred language"
 msgstr "O seu idioma preferido"
 
 #: components/theme/Login/Login
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Forgot your password?
 msgid "box_forgot_password_option"
 msgstr "Esqueceu sua senha?"
 
 #: config/Blocks
+# defaultMessage: Common
 msgid "common"
 msgstr "Padrão"
 
 #: components/manage/Multilingual/CompareLanguages
+# defaultMessage: Compare to language
 msgid "compare_to"
 msgstr "Comparar com"
 
 #: components/manage/Blocks/Block/EditBlockWrapper
+# defaultMessage: delete
 msgid "delete"
 msgstr "excluir"
 
 #: components/theme/OutdatedBrowser/OutdatedBrowser
+# defaultMessage: You are using {browsername} {browserversion} which is deprecated by its vendor. That means that it does not get security updates and it is not ready for current modern web features, which deteriorates the user experience. Please upgrade to a modern browser.
 msgid "deprecated_browser_notice_message"
 msgstr "Você está usando {browsername} {browserversion} que está sem suporte pelo seu desenvolvedor. Isto significa que não existem mais atualizações de segurança e que ele não suporta as funcionalidades atuais da web, Por favor, atualize seu navegador"
 
 #: config/Blocks
+# defaultMessage: Description
 msgid "description"
 msgstr "Descrição"
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: For security reasons, we store your password encrypted, and cannot mail it to you. If you would like to reset your password, fill out the form below and we will send you an email at the address you gave when you registered to start the process of resetting your password.
 msgid "description_lost_password"
 msgstr "Por motivos de segurança, armazenamos sua senha criptografada e não podemos enviá-la para você. Se você deseja redefinir sua senha, preencha o formulário abaixo e enviaremos um e-mail para o endereço que você forneceu quando se cadastrou para iniciar o processo de redefinição de sua senha."
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Your password reset request has been mailed. It should arrive in your mailbox shortly. When you receive the message, visit the address it contains to reset your password.
 msgid "description_sent_password"
 msgstr "Sua solicitação de redefinição de senha foi enviada. Ele deve chegar em sua caixa de correio em breve. Ao receber a mensagem, visite o endereço que ela contém para redefinir sua senha."
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Draft
 msgid "draft"
 msgstr "Rascunho"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Input must be valid email (something@domain.com)
 msgid "email"
 msgstr "E-mail"
 
 #: components/theme/View/EventView
+# defaultMessage: All dates
 msgid "event_alldates"
 msgstr "Todas as datas"
 
 #: components/theme/View/EventView
+# defaultMessage: Attendees
 msgid "event_attendees"
 msgstr "Participantes"
 
 #: components/theme/View/EventView
+# defaultMessage: Contact Name
 msgid "event_contactname"
 msgstr "Pessoa de contato"
 
 #: components/theme/View/EventView
+# defaultMessage: Contact Phone
 msgid "event_contactphone"
 msgstr "Telefone de contato"
 
 #: components/theme/View/EventView
+# defaultMessage: Website
 msgid "event_website"
 msgstr "Site"
 
 #: components/theme/View/EventView
+# defaultMessage: What
 msgid "event_what"
 msgstr "O quê"
 
 #: components/theme/View/EventView
+# defaultMessage: When
 msgid "event_when"
 msgstr "Quando"
 
 #: components/theme/View/EventView
+# defaultMessage: Where
 msgid "event_where"
 msgstr "Onde"
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Password reset confirmation sent
 msgid "heading_sent_password"
 msgstr "Sua solicitação de redefinição de senha foi enviada"
 
 #: config/Blocks
+# defaultMessage: Hero
 msgid "hero"
 msgstr "Herói"
 
 #: config/Blocks
+# defaultMessage: HTML
 msgid "html"
 msgstr "HTML"
 
 #: config/Blocks
+# defaultMessage: Image
 msgid "image"
 msgstr "Imagem"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Input must be integer
 msgid "integer"
 msgstr "Valor deve ser um número inteiro"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Intranet
 msgid "intranet"
 msgstr "Intranet"
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: My email address is
 msgid "label_my_email_address_is"
 msgstr "Meu endereço de e-mail é"
 
 #: config/Blocks
+# defaultMessage: Lead Image Field
 msgid "leadimage"
 msgstr "Imagem principal"
 
 #: config/Blocks
+# defaultMessage: Listing
 msgid "listing"
 msgstr "Listagem"
 
 #: components/manage/Blocks/Listing/ListingBody
 #: components/manage/Contents/Contents
+# defaultMessage: Loading
 msgid "loading"
 msgstr "Carregando"
 
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: log in
 msgid "log in"
 msgstr "acessar"
 
 #: config/Blocks
+# defaultMessage: Maps
 msgid "maps"
 msgstr "mapas"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Maximum Length
 msgid "maxLength"
 msgstr "Comprimento máximo"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: End of the range (including the value itself)
 msgid "maximum"
 msgstr "Valor máximo"
 
 #: config/Blocks
+# defaultMessage: Media
 msgid "media"
 msgstr "Mídia"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Minimum Length
 msgid "minLength"
 msgstr "Comprimento mínimo"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Start of the range
 msgid "minimum"
 msgstr "Valor mínimo"
 
 #: config/Blocks
+# defaultMessage: Most used
 msgid "mostUsed"
 msgstr "Mais usados"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: No workflow state
 msgid "no workflow state"
 msgstr "Sem estado de workflow"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Input must be number
 msgid "number"
 msgstr "Valor deve ser numérico"
 
 #: components/manage/Widgets/RecurrenceWidget/ByMonthDayField
 #: components/manage/Widgets/RecurrenceWidget/ByYearField
+# defaultMessage: of the month
 msgid "of the month"
 msgstr "do mês"
 
 #: error
+# defaultMessage: or try a different page.
 msgid "or try a different page."
 msgstr "ou tente uma página diferente"
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: others
 msgid "others"
 msgstr "outros"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Private
 msgid "private"
 msgstr "privado"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Published
 msgid "published"
 msgstr "publicado"
 
 #: components/manage/Widgets/QueryWidget
+# defaultMessage: Select…
 msgid "querystring-widget-select"
 msgstr "Selecionar"
 
 #: components/theme/Search/Search
+# defaultMessage: results
 msgid "results found"
 msgstr "resultados"
 
 #: error
+# defaultMessage: return to the site root
 msgid "return to the site root"
 msgstr "retornar à raiz do site"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: and
 msgid "rrule_and"
 msgstr "e"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: (~approximate)
 msgid "rrule_approximate"
 msgstr "(~aproximadamente)"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: at
 msgid "rrule_at"
 msgstr "em"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: [month] [day], [year]
 msgid "rrule_dateFormat"
 msgstr "[day], [month], [year]"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: day
 msgid "rrule_day"
 msgstr "dia"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: days
 msgid "rrule_days"
 msgstr "dias"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: every
 msgid "rrule_every"
 msgstr "a cada"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: for
 msgid "rrule_for"
 msgstr "para"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: hour
 msgid "rrule_hour"
 msgstr "hora"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: hours
 msgid "rrule_hours"
 msgstr "horas"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: in
 msgid "rrule_in"
 msgstr "em"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: last
 msgid "rrule_last"
 msgstr "última"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: minutes
 msgid "rrule_minutes"
 msgstr "minutos"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: month
 msgid "rrule_month"
 msgstr "mês"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: months
 msgid "rrule_months"
 msgstr "meses"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: nd
 msgid "rrule_nd"
 msgstr "nd"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: on
 msgid "rrule_on"
 msgstr "em"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: on the
 msgid "rrule_on the"
 msgstr "no"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: or
 msgid "rrule_or"
 msgstr "ou"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: rd
 msgid "rrule_rd"
 msgstr "rd"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: st
 msgid "rrule_st"
 msgstr "st"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: th
 msgid "rrule_th"
 msgstr "th"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: the
 msgid "rrule_the"
 msgstr "o"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: time
 msgid "rrule_time"
 msgstr "vezz"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: times
 msgid "rrule_times"
 msgstr "vezes"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: until
 msgid "rrule_until"
 msgstr "até"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: week
 msgid "rrule_week"
 msgstr "semana"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: weekday
 msgid "rrule_weekday"
 msgstr "dia da semana"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: weekdays
 msgid "rrule_weekdays"
 msgstr "dias da semana"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: weeks
 msgid "rrule_weeks"
 msgstr "semanas"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: year
 msgid "rrule_year"
 msgstr "ano"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: years
 msgid "rrule_years"
 msgstr "anos"
 
 #: components/theme/SkipLinks/SkipLinks
+# defaultMessage: Skip to footer
 msgid "skiplink-footer"
 msgstr "Ir para o rodapé"
 
 #: components/theme/SkipLinks/SkipLinks
+# defaultMessage: Skip to main content
 msgid "skiplink-main-content"
 msgstr "Ir para o conteúdo"
 
 #: components/theme/SkipLinks/SkipLinks
+# defaultMessage: Skip to navigation
 msgid "skiplink-navigation"
 msgstr "Ir para a navegação"
 
 #: components/manage/Contents/Contents
+# defaultMessage: sort
 msgid "sort"
 msgstr "ordenar"
 
 #: config/Blocks
+# defaultMessage: Table
 msgid "table"
 msgstr "tabela"
 
 #: config/Blocks
+# defaultMessage: Text
 msgid "text"
 msgstr "texto"
 
 #: config/Blocks
+# defaultMessage: Title
 msgid "title"
 msgstr "título"
 
 #: config/Blocks
+# defaultMessage: Table of Contents
 msgid "toc"
 msgstr "tabela de conteúdos"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Input must be valid url (www.something.com or http(s)://www.something.com)
 msgid "url"
 msgstr "url"
 
 #: components/manage/Toolbar/PersonalTools
+# defaultMessage: user avatar
 msgid "user avatar"
 msgstr "avatar do usuário"
 
 #: config/Blocks
+# defaultMessage: Video
 msgid "video"
 msgstr "vídeo"
 
 #: components/theme/View/EventView
+# defaultMessage: Visit external website
 msgid "visit_external_website"
 msgstr "Visitar site externo"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: {count, plural, one {Upload {count} file} other {Upload {count} files}}
 msgid "{count, plural, one {Upload {count} file} other {Upload {count} files}}"
 msgstr "{count, plural, one {Enviar {count} arquivo} other {Enviar {count} arquivos}}"
 
 #: components/manage/Contents/Contents
+# defaultMessage: {count} selected
 msgid "{count} selected"
 msgstr "{count} selecionados"
 
 #: components/manage/Controlpanels/ContentType
+# defaultMessage: {id} Content Type
 msgid "{id} Content Type"
 msgstr "Tipo de conteúdo {id}"
 
 #: components/manage/Controlpanels/ContentTypeSchema
+# defaultMessage: {id} Schema
 msgid "{id} Schema"
 msgstr "Esquema {id}"
 
 #: components/manage/Actions/Actions
+# defaultMessage: {title} copied.
 msgid "{title} copied."
 msgstr "{title} copiado."
 
 #: components/manage/Actions/Actions
+# defaultMessage: {title} cut.
 msgid "{title} cut."
 msgstr "{title} cortado."
 
 #: components/manage/Actions/Actions
+# defaultMessage: {title} has been deleted.
 msgid "{title} has been deleted."
 msgstr "{title} foi excluído."

--- a/locales/ro/LC_MESSAGES/volto.po
+++ b/locales/ro/LC_MESSAGES/volto.po
@@ -12,22 +12,27 @@ msgstr ""
 "Plural-Forms: \n"
 
 #: components/manage/Blocks/HTML/Edit
+# defaultMessage: <p>Add some HTML here</p>
 msgid "<p>Add some HTML here</p>"
 msgstr ""
 
 #: components/theme/Footer/Footer
+# defaultMessage: Accessibility
 msgid "Accessibility"
 msgstr "Accesibilitate"
 
 #: components/theme/Register/Register
+# defaultMessage: Account Registration Completed
 msgid "Account Registration Completed"
 msgstr "Înregistrarea contului a fost finalizată"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Account activation completed
 msgid "Account activation completed"
 msgstr "Activarea contului a fost finalizată"
 
 #: components/manage/Controlpanels/ModerateComments
+# defaultMessage: Action
 msgid "Action"
 msgstr "Acțiune"
 
@@ -36,10 +41,12 @@ msgstr "Acțiune"
 #: components/manage/Controlpanels/ContentTypes
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
+# defaultMessage: Actions
 msgid "Actions"
 msgstr "Acțiuni"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Activate and deactivate add-ons in the lists below.
 msgid "Activate and deactivate"
 msgstr "Activare și dezactivare"
 
@@ -47,86 +54,107 @@ msgstr "Activare și dezactivare"
 #: components/manage/Toolbar/Toolbar
 #: components/manage/Widgets/SchemaWidget
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add
 msgid "Add"
 msgstr "Adăugare"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: To make new add-ons show up here, add them to your buildout configuration, run buildout, and restart the server process. For detailed instructions see
 msgid "Add Addons"
 msgstr "Adăugare add-on-uri"
 
 #: components/manage/Toolbar/Types
+# defaultMessage: Add Content…
 msgid "Add Content"
 msgstr "Adăugare conținut"
 
 #: components/manage/Toolbar/Types
+# defaultMessage: Add Translation…
 msgid "Add Translation…"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add User
 msgid "Add User"
 msgstr "Adăugare utilizator"
 
 #: components/manage/Blocks/Description/Edit
+# defaultMessage: Add a description…
 msgid "Add a description…"
 msgstr "Adăugați o descriere …"
 
 #: components/manage/BlockChooser/BlockChooserButton
+# defaultMessage: Add block
 msgid "Add block"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add block…
 msgid "Add block…"
 msgstr "Adăugare bloc …"
 
 #: components/manage/Widgets/QueryWidget
+# defaultMessage: Add criteria
 msgid "Add criteria"
 msgstr "Adăugare criterii"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Add date
 msgid "Add date"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Add field
 msgid "Add field"
 msgstr "Adăugare câmp"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Add fieldset
 msgid "Add fieldset"
 msgstr "Adăugare set de câmpuri"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add group
 msgid "Add group"
 msgstr "Adăugare grup"
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Add new content type
 msgid "Add new content type"
 msgstr "Adăugare tip de conținut nou"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add new group
 msgid "Add new group"
 msgstr "Adăugare grup nou"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add new user
 msgid "Add new user"
 msgstr "Adăugare utilizator nou"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Add to Groups
 msgid "Add to Groups"
 msgstr "Adăugare la grupuri"
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Add term
 msgid "Add vocabulary term"
 msgstr ""
 
 #: components/manage/Add/Add
+# defaultMessage: Add {type}
 msgid "Add {type}"
 msgstr "Adăugare {type}"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Add-ons Settings
 msgid "Add-ons Settings"
 msgstr "Setări add-on-uri"
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: Additional date
 msgid "Additional date"
 msgstr ""
 
@@ -134,39 +162,48 @@ msgstr ""
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
 #: components/manage/Blocks/Maps/MapsSidebar
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Alignment
 msgid "Alignment"
 msgstr "Aliniere"
 
 #: components/manage/Contents/Contents
+# defaultMessage: All
 msgid "All"
 msgstr "Toate"
 
 #: components/theme/Search/Search
+# defaultMessage: Alphabetically
 msgid "Alphabetically"
 msgstr ""
 
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: Alt text
 msgid "Alt text"
 msgstr "Text alternativ"
 
 #: components/manage/Toolbar/More
+# defaultMessage: Apply working copy
 msgid "Apply working copy"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Are you sure you want to delete this field?
 msgid "Are you sure you want to delete this field?"
 msgstr "Sunteți sigur că doriți să ștergeți acest câmp?"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Are you sure you want to delete this fieldset including all fields?
 msgid "Are you sure you want to delete this fieldset including all fields?"
 msgstr "Sunteți sigur că doriți să ștergeți acest set de câmpuri, inclusiv toate câmpurile?"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Ascending
 msgid "Ascending"
 msgstr "Crescător"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Available
 msgid "Available"
 msgstr "Disponibil"
 
@@ -191,48 +228,59 @@ msgstr "Disponibil"
 #: components/manage/Toolbar/Toolbar
 #: components/theme/ContactForm/ContactForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Back
 msgid "Back"
 msgstr "Înapoi"
 
 #: components/manage/Diff/Diff
+# defaultMessage: Base
 msgid "Base"
 msgstr "Baza"
 
 #: components/manage/Sidebar/Sidebar
+# defaultMessage: Block
 msgid "Block"
 msgstr "Bloc"
 
 #: components/theme/Login/Login
+# defaultMessage: Both email address and password are case sensitive, check that caps lock is not enabled.
 msgid "Both email address and password are case sensitive, check that caps lock is not enabled."
 msgstr "Atât adresa de e-mail, cât și parola sunt case-sensitive, verificați dacă tasta 'Caps Lock' nu este activată."
 
 #: components/theme/Breadcrumbs/Breadcrumbs
+# defaultMessage: Breadcrumbs
 msgid "Breadcrumbs"
 msgstr "Breadcrumbs"
 
 #: components/manage/Blocks/HeroImageLeft/Edit
 #: components/manage/Contents/ContentsUploadModal
 #: components/manage/Sidebar/ObjectBrowserNav
+# defaultMessage: Browse
 msgid "Browse"
 msgstr "Răsfoiește"
 
 #: components/manage/Blocks/Image/Edit
+# defaultMessage: Browse the site, drop an image, or type an URL
 msgid "Browse the site, drop an image, or type an URL"
 msgstr "Navigați site-ul, adaugați o imagine sau introduceți o adresă URL"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: By default, permissions from the container of this item are inherited. If you disable this, only the explicitly defined sharing permissions will be valid. In the overview, the symbol {inherited} indicates an inherited value. Similarly, the symbol {global} indicates a global role, which is managed by the site administrator.
 msgid "By default, permissions from the container of this item are inherited. If you disable this, only the explicitly defined sharing permissions will be valid. In the overview, the symbol {inherited} indicates an inherited value. Similarly, the symbol {global} indicates a global role, which is managed by the site administrator."
 msgstr "În mod implicit, permisiunile din containerul acestui articol sunt moștenite. Dacă dezactivați acest lucru, numai permisiunile de partajare definite în mod explicit vor fi valide. În imagine, simbolul {inherited} indică o valoare moștenită. În mod similar, simbolul {global} indică un rol global, care este gestionat de administratorul site-ului. "
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Cache Name
 msgid "Cache Name"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypeLayout
+# defaultMessage: Can not edit Layout for <strong>{type}</strong> content-type as it doesn't have support for <strong>Volto Blocks</strong> enabled
 msgid "Can not edit Layout for <strong>{type}</strong> content-type as it doesn't have support for <strong>Volto Blocks</strong> enabled"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypeLayout
+# defaultMessage: Can not edit Layout for <strong>{type}</strong> content-type as the <strong>Blocks behavior</strong> is enabled and <strong>read-only</strong>
 msgid "Can not edit Layout for <strong>{type}</strong> content-type as the <strong>Blocks behavior</strong> is enabled and <strong>read-only</strong>"
 msgstr ""
 
@@ -248,42 +296,51 @@ msgstr ""
 #: components/manage/Sharing/Sharing
 #: components/theme/Login/Login
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Cancel
 msgid "Cancel"
 msgstr "Anulează"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Cell
 msgid "Cell"
 msgstr "Celulă"
 
 #: components/manage/Blocks/Image/ImageSizeWidget
 #: components/manage/Blocks/Maps/Edit
 #: components/manage/Sidebar/AlignBlock
+# defaultMessage: Center
 msgid "Center"
 msgstr "Centrează"
 
 #: components/manage/History/History
+# defaultMessage: Change Note
 msgid "Change Note"
 msgstr "Schimbă comentariul"
 
 #: components/manage/Preferences/ChangePassword
+# defaultMessage: Change Password
 msgid "Change Password"
 msgstr "Schimbă parola"
 
 #: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Change State
 msgid "Change State"
 msgstr "Schimbă starea"
 
 #: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Change workflow state recursively
 msgid "Change workflow state recursively"
 msgstr "Schimbă starea fluxului de lucru recursiv"
 
 #: components/manage/Toolbar/More
+# defaultMessage: Changes applied
 msgid "Changes applied."
 msgstr ""
 
 #: components/manage/Preferences/ChangePassword
 #: components/manage/Preferences/PersonalInformation
 #: components/manage/Preferences/PersonalPreferences
+# defaultMessage: Changes saved
 msgid "Changes saved"
 msgstr "Modificări salvate"
 
@@ -291,192 +348,237 @@ msgstr "Modificări salvate"
 #: components/manage/Controlpanels/ContentTypeLayout
 #: components/manage/Controlpanels/ContentTypeSchema
 #: components/manage/Controlpanels/Controlpanel
+# defaultMessage: Changes saved.
 msgid "Changes saved."
 msgstr "Modificări salvate."
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Checkbox
 msgid "Checkbox"
 msgstr "Checkbox"
 
 #: components/manage/Widgets/SelectWidget
+# defaultMessage: Choices
 msgid "Choices"
 msgstr "Opțiuni"
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: Choose Image
 msgid "Choose Image"
 msgstr "Alegeți imaginea"
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: Choose Target
 msgid "Choose Target"
 msgstr "Alegeți ținta"
 
 #: components/manage/Widgets/FileWidget
+# defaultMessage: Choose a file
 msgid "Choose a file"
 msgstr ""
 
 #: components/manage/Blocks/HTML/Edit
+# defaultMessage: Clear
 msgid "Clear"
 msgstr ""
 
 #: components/theme/View/ImageView
+# defaultMessage: Click to download full sized image
 msgid "Click to download full sized image"
 msgstr "Faceți clic pentru a descărca imaginea cu dimensiuni complete"
 
 #: components/manage/Widgets/SelectWidget
+# defaultMessage: Close
 msgid "Close"
 msgstr "Închideți"
 
 #: components/theme/Navigation/Navigation
+# defaultMessage: Close menu
 msgid "Close menu"
 msgstr "Închidere meniu"
 
 #: components/manage/Blocks/HTML/Edit
+# defaultMessage: Code
 msgid "Code"
 msgstr ""
 
 #: components/manage/Widgets/ObjectListWidget
+# defaultMessage: Collapse item
 msgid "Collapse item"
 msgstr ""
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Collection
 msgid "Collection"
 msgstr "Colecție"
 
 #: components/manage/Controlpanels/ModerateComments
 #: components/theme/Comments/CommentEditModal
 #: components/theme/Comments/Comments
+# defaultMessage: Comment
 msgid "Comment"
 msgstr "Comentariu"
 
 #: components/manage/Controlpanels/ModerateComments
+# defaultMessage: Commenter
 msgid "Commenter"
 msgstr "Comentator"
 
 #: components/theme/Comments/Comments
+# defaultMessage: Comments
 msgid "Comments"
 msgstr ""
 
 #: components/manage/Diff/Diff
+# defaultMessage: Compare
 msgid "Compare"
 msgstr "Compară"
 
 #: components/manage/Preferences/ChangePassword
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Confirm password
 msgid "Confirm password"
 msgstr "Confirmă parola"
 
 #: components/theme/ConnectionRefused/ConnectionRefused
+# defaultMessage: Connection refused
 msgid "Connection refused"
 msgstr "Conexiune refuzată"
 
 #: components/theme/Footer/Footer
+# defaultMessage: Contact
 msgid "Contact"
 msgstr "Contact"
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Contact form
 msgid "Contact form"
 msgstr "Formular de contact"
 
 #: components/manage/Blocks/Listing/Edit
+# defaultMessage: Contained items
 msgid "Contained items"
 msgstr "Elemente conținute"
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Content type created
 msgid "Content type created"
 msgstr "Tip de conținut creat"
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Content type deleted
 msgid "Content type deleted"
 msgstr "Tip de conținut șters"
 
 #: components/manage/Contents/Contents
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Contents
 msgid "Contents"
 msgstr "Cuprins"
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Copy
 msgid "Copy"
 msgstr "Copiere"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: undefined
 msgid "Copy blocks"
 msgstr ""
 
 #: components/theme/Footer/Footer
+# defaultMessage: Copyright
 msgid "Copyright"
 msgstr "Drepturi de autor"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Copyright statement or other rights information on this item.
 msgid "Copyright statement or other rights information on this item."
 msgstr "Declarație de copyright sau alte informații privind drepturile asupra acestui articol."
 
 #: components/manage/Toolbar/More
+# defaultMessage: Create working copy
 msgid "Create working copy"
 msgstr ""
 
 #: components/manage/WorkingCopyToastsFactory/WorkingCopyToastsFactory
+# defaultMessage: Created by {creator} on {date}
 msgid "Created by {creator} on {date}"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Created on
 msgid "Created on"
 msgstr "Creat pe"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Creator
 msgid "Creator"
 msgstr "Creator"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Creators
 msgid "Creators"
 msgstr "Creatori"
 
 #: components/manage/Widgets/QuerystringWidget
 #: components/manage/Widgets/QueryWidget
+# defaultMessage: Criteria
 msgid "Criteria"
 msgstr "Criterii"
 
 #: components/manage/Preferences/ChangePassword
+# defaultMessage: Current password
 msgid "Current password"
 msgstr "Parolă curentă"
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Cut
 msgid "Cut"
 msgstr "Taie"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: undefined
 msgid "Cut blocks"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Daily
 msgid "Daily"
 msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Database Information
 msgid "Database Information"
 msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Database Location
 msgid "Database Location"
 msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Database Size
 msgid "Database Size"
 msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Database main
 msgid "Database main"
 msgstr ""
 
 #: components/manage/Controlpanels/ModerateComments
 #: components/manage/Widgets/DatetimeWidget
+# defaultMessage: Date
 msgid "Date"
 msgstr "Data"
 
 #: components/theme/Search/Search
+# defaultMessage: Date (newest first)
 msgid "Date (newest first)"
 msgstr ""
 
@@ -496,6 +598,7 @@ msgstr ""
 #: components/theme/PasswordReset/PasswordReset
 #: components/theme/PasswordReset/RequestPasswordReset
 #: components/theme/Register/Register
+# defaultMessage: Default
 msgid "Default"
 msgstr "Implicit"
 
@@ -510,38 +613,47 @@ msgstr "Implicit"
 #: components/manage/Widgets/ObjectBrowserWidget
 #: components/manage/Widgets/WysiwygWidget
 #: components/theme/Comments/Comments
+# defaultMessage: Delete
 msgid "Delete"
 msgstr "Ștergeți"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Delete Group
 msgid "Delete Group"
 msgstr "Ștergeți grupul"
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Delete Type
 msgid "Delete Type"
 msgstr "Ștergeți tipul"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Delete User
 msgid "Delete User"
 msgstr "Ștergeți utilizatorul"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: undefined
 msgid "Delete blocks"
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Delete col
 msgid "Delete col"
 msgstr "Șterge coloană"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Delete row
 msgid "Delete row"
 msgstr "Șterge rând"
 
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: Depth
 msgid "Depth"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Descending
 msgid "Descending"
 msgstr "Descrescător"
 
@@ -552,72 +664,89 @@ msgstr "Descrescător"
 #: components/manage/Widgets/WysiwygWidget
 #: components/theme/View/TabularView
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Description
 msgid "Description"
 msgstr "Descriere"
 
 #: components/manage/Diff/Diff
+# defaultMessage: Diff
 msgid "Diff"
 msgstr "Diff"
 
 #: components/manage/Diff/Diff
+# defaultMessage: Difference between revision {one} and {two} of {title}
 msgid "Difference between revision {one} and {two} of {title}"
 msgstr "Diferența dintre versiunea {one} și {two} din {title}"
 
 #: components/theme/Footer/Footer
+# defaultMessage: Distributed under the {license}.
 msgid "Distributed under the {license}."
 msgstr "Distribuit sub {license}."
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Add border to inner columns
 msgid "Divide each row into separate cells"
 msgstr "Împărțiți fiecare rând în celule separate"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Do you really want to delete the following items?
 msgid "Do you really want to delete the following items?"
 msgstr "Doriți cu adevărat să ștergeți următoarele elemente?"
 
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
+# defaultMessage: Do you really want to delete the group {groupname}?
 msgid "Do you really want to delete the group {groupname}?"
 msgstr "Doriți cu adevărat să ștergeți grupul {groupname}?"
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Do you really want to delete type {typename}?
 msgid "Do you really want to delete the type {typename}?"
 msgstr "Doriți cu adevărat să ștergeți tipul {typename}?"
 
 #: components/manage/Controlpanels/Users/UsersControlpanel
+# defaultMessage: Do you really want to delete the user {username}?
 msgid "Do you really want to delete the user {username}?"
 msgstr "Doriți cu adevărat să ștergeți utilizatorul {username}?"
 
 #: components/manage/Delete/Delete
+# defaultMessage: Do you really want to delete this item?
 msgid "Do you really want to delete this item?"
 msgstr "Doriți cu adevărat să ștergeți acest articol?"
 
 #: components/manage/Multilingual/TranslationObject
 #: components/manage/Sidebar/Sidebar
+# defaultMessage: Document
 msgid "Document"
 msgstr "Document"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Drag and drop files from your computer onto this area or click the “Browse” button.
 msgid "Drag and drop files from your computer onto this area or click the “Browse” button."
 msgstr "Trageți și fixați fișierele de pe computer în această zonă sau faceți clic pe butonul Răsfoiește."
 
 #: components/manage/Widgets/FileWidget
+# defaultMessage: Drop file here to replace the existing file
 msgid "Drop file here to replace the existing file"
 msgstr ""
 
 #: components/manage/Widgets/FileWidget
+# defaultMessage: Drop file here to upload a new file
 msgid "Drop file here to upload a new file"
 msgstr ""
 
 #: components/manage/Widgets/FileWidget
+# defaultMessage: Drop files here ...
 msgid "Drop files here ..."
 msgstr ""
 
 #: components/manage/Preferences/PersonalInformation
 #: components/theme/Register/Register
+# defaultMessage: E-mail
 msgid "E-mail"
 msgstr "E-mail"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: E-mail addresses do not match.
 msgid "E-mail addresses do not match."
 msgstr "Adresele de e-mail nu se potrivesc."
 
@@ -628,93 +757,115 @@ msgstr "Adresele de e-mail nu se potrivesc."
 #: components/manage/Widgets/FormFieldWrapper
 #: components/manage/Widgets/ObjectBrowserWidget
 #: components/theme/Comments/Comments
+# defaultMessage: Edit
 msgid "Edit"
 msgstr "Editează"
 
 #: components/theme/Comments/CommentEditModal
+# defaultMessage: Edit comment
 msgid "Edit comment"
 msgstr "Editează comentariul"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Edit field
 msgid "Edit field"
 msgstr "Editează câmp"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Edit fieldset
 msgid "Edit fieldset"
 msgstr "Editează setul de câmpuri"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Edit recurrence
 msgid "Edit recurrence"
 msgstr ""
 
 #: components/manage/Form/InlineForm
+# defaultMessage: Edit values
 msgid "Edit values"
 msgstr "Editează valori"
 
 #: components/manage/Edit/Edit
+# defaultMessage: Edit {title}
 msgid "Edit {title}"
 msgstr "Editează {title}"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Email
 msgid "Email"
 msgstr "Email"
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Email sent
 msgid "Email sent"
 msgstr "E-mail trimis"
 
 #: components/manage/Blocks/Maps/Edit
+# defaultMessage: Embed code error, please follow the instructions and try again.
 msgid "Embed code error, please follow the instructions and try again."
 msgstr "Eroare de cod integrat, urmați instrucțiunile și încercați din nou."
 
 #: components/manage/Blocks/Maps/View
+# defaultMessage: Embeded Google Maps
 msgid "Embeded Google Maps"
 msgstr "Harti Google integrate"
 
 #: components/manage/Widgets/ObjectListWidget
+# defaultMessage: Empty object list
 msgid "Empty object list"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypeLayout
+# defaultMessage: Enable editable Blocks
 msgid "Enable editable Blocks"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: End Date
 msgid "End Date"
 msgstr "Data de încheiere"
 
 #: components/manage/AnchorPlugin/components/LinkButton/AddLinkForm
+# defaultMessage: Enter URL or select an item
 msgid "Enter URL or select an item"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Enter a username above to search or click 'Show All'
 msgid "Enter a username above to search or click 'Show All'"
 msgstr ""
 
 #: components/theme/Register/Register
+# defaultMessage: Enter an email address. This will be your login name. We respect your privacy, and will not give the address away to any third parties or expose it anywhere.
 msgid "Enter an email address. This will be your login name. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
 msgstr "Introduceți o adresă de e-mail. Acesta va fi numele dvs. de autentificare. Respectăm confidențialitatea dvs. și nu vom oferi adresa niciunui terț și nu o vom expune nicăieri."
 
 #: components/manage/Preferences/PersonalInformation
 #: components/theme/PasswordReset/PasswordReset
 #: components/theme/Register/Register
+# defaultMessage: Enter full name, e.g. John Smith.
 msgid "Enter full name, e.g. John Smith."
 msgstr "Introduceți numele complet, de exemplu, Valentin Popescu."
 
 #: components/manage/Blocks/Maps/Edit
+# defaultMessage: Enter map Embed Code
 msgid "Enter map Embed Code"
 msgstr "Introduceți codul de integrare a hărții"
 
 #: components/manage/Preferences/ChangePassword
+# defaultMessage: Enter your current password.
 msgid "Enter your current password."
 msgstr "Introduceți parola curentă."
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Enter your email address for verification.
 msgid "Enter your email address for verification."
 msgstr "Introduceți adresa dvs. de e-mail pentru verificare."
 
 #: components/manage/Preferences/ChangePassword
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Enter your new password. Minimum 5 characters.
 msgid "Enter your new password. Minimum 5 characters."
 msgstr "Introduceți noua parolă. Minim 5 caractere."
 
@@ -726,199 +877,245 @@ msgstr "Introduceți noua parolă. Minim 5 caractere."
 #: components/theme/ContactForm/ContactForm
 #: components/theme/Login/Login
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Error
 msgid "Error"
 msgstr "Eroare"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Exclude from navigation
 msgid "Exclude from navigation"
 msgstr "Excludeți din navigare"
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: Exclude this occurence
 msgid "Exclude this occurence"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Excluded from navigation
 msgid "Excluded from navigation"
 msgstr "Exclus din navigare"
 
 #: components/manage/Sidebar/Sidebar
+# defaultMessage: Expand sidebar
 msgid "Expand sidebar"
 msgstr "Extinde bara laterală"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Expiration Date
 msgid "Expiration Date"
 msgstr "Data de expirare"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Expiration date
 msgid "Expiration date"
 msgstr "Data de expirare"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Expired
 msgid "Expired"
 msgstr "Expirat"
 
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: External URL
 msgid "External URL"
 msgstr "URL extern"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: File
 msgid "File"
 msgstr "Fișier"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: File size
 msgid "File size"
 msgstr "Mărimea fișierului"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Filename
 msgid "Filename"
 msgstr "Nume fișier"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Filter…
 msgid "Filter…"
 msgstr "Filtru…"
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: First
 msgid "First"
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Fixed width columns
 msgid "Fixed width table cells"
 msgstr "Celule de tabel cu lățimea fixă"
 
 #: components/manage/BlockChooser/BlockChooser
+# defaultMessage: Fold
 msgid "Fold"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Folder
 msgid "Folder"
 msgstr "Director"
 
 #: components/theme/Forbidden/Forbidden
+# defaultMessage: Forbidden
 msgid "Forbidden"
 msgstr "Interzis"
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: Fourth
 msgid "Fourth"
 msgstr ""
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: From
 msgid "From"
 msgstr "Din"
 
 #: components/manage/Blocks/Maps/Edit
 #: components/manage/Sidebar/AlignBlock
+# defaultMessage: Full
 msgid "Full"
 msgstr "Complet"
 
 #: components/manage/Preferences/PersonalInformation
 #: components/theme/PasswordReset/PasswordReset
 #: components/theme/Register/Register
+# defaultMessage: Full Name
 msgid "Full Name"
 msgstr "Numele complet"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Fullname
 msgid "Fullname"
 msgstr "Numele complet"
 
 #: components/theme/Footer/Footer
+# defaultMessage: GNU GPL license
 msgid "GNU GPL license"
 msgstr "Licența GNU GPL"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Global role
 msgid "Global role"
 msgstr "Rolul global"
 
 #: components/manage/Blocks/Maps/Edit
+# defaultMessage: Google Maps Embedded Block
 msgid "Google Maps Embedded Block"
 msgstr "Bloc te tip Google Maps"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Group
 msgid "Group"
 msgstr "Grup"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Group created
 msgid "Group created"
 msgstr "Grup creat"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Group roles updated
 msgid "Group roles updated"
 msgstr ""
 
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Groupname
 msgid "Groupname"
 msgstr "Nume de grup"
 
 #: components/manage/Controlpanels/Controlpanels
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Groups
 msgid "Groups"
 msgstr "Grupuri"
 
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
+# defaultMessage: Groups are logical collections of users, such as departments and business units. Groups are not directly related to permissions on a global level, you normally use Roles for that - and let certain Groups have a particular role. The symbol{plone_svg}indicates a role inherited from membership in another group.
 msgid "Groups are logical collections of users, such as departments and business units. Groups are not directly related to permissions on a global level, you normally use Roles for that - and let certain Groups have a particular role. The symbol{plone_svg}indicates a role inherited from membership in another group."
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Header cell
 msgid "Header cell"
 msgstr ""
 
 #: components/theme/Comments/Comments
+# defaultMessage: Hide Replies
 msgid "Hide Replies"
 msgstr ""
 
 #: components/manage/History/History
 #: components/manage/Toolbar/More
+# defaultMessage: History
 msgid "History"
 msgstr "Istoric"
 
 #: components/manage/History/History
+# defaultMessage: #
 msgid "History Version Number"
 msgstr ""
 
 #: components/manage/History/History
+# defaultMessage: History of {title}
 msgid "History of {title}"
 msgstr "Istoricul {title}"
 
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsBreadcrumbs
 #: components/theme/Breadcrumbs/Breadcrumbs
+# defaultMessage: Home
 msgid "Home"
 msgstr "Acasă"
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: Home page
 msgid "Home page"
 msgstr "Pagina de pornire"
 
 #: components/manage/Contents/Contents
+# defaultMessage: ID
 msgid "ID"
 msgstr "ID"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: If selected, this item will not appear in the navigation tree
 msgid "If selected, this item will not appear in the navigation tree"
 msgstr "Dacă este selectat, acest element nu va apărea în arborele de navigare"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: If this date is in the future, the content will not show up in listings and searches until this date.
 msgid "If this date is in the future, the content will not show up in listings and searches until this date."
 msgstr "Dacă această dată va fi în viitor, conținutul nu va apărea în listări și căutări până la această dată."
 
 #: components/manage/LockingToastsFactory/LockingToastsFactory
+# defaultMessage: If you are certain this user has abandoned the object, you may unlock the object. You will then be able to edit it.
 msgid "If you are certain this user has abandoned the object, you may unlock the object. You will then be able to edit it."
 msgstr ""
 
 #: components/theme/NotFound/NotFound
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: If you are certain you have the correct web address but are encountering an error, please contact the {site_admin}.
 msgid "If you are certain you have the correct web address but are encountering an error, please contact the {site_admin}."
 msgstr "Dacă sunteți sigur că aveți adresa web corectă, dar întâmpinați o eroare, vă rugăm să contactați {site_admin}."
 
 #: components/manage/Blocks/HeroImageLeft/Edit
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: Image
 msgid "Image"
 msgstr "Imagine"
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: Include this occurence
 msgid "Include this occurence"
 msgstr ""
 
@@ -926,142 +1123,176 @@ msgstr ""
 #: components/manage/Controlpanels/ContentTypeLayout
 #: components/manage/Controlpanels/ContentTypeSchema
 #: components/manage/Controlpanels/Controlpanel
+# defaultMessage: Info
 msgid "Info"
 msgstr "Info"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Inherit permissions from higher levels
 msgid "Inherit permissions from higher levels"
 msgstr "Permisiuni mostenite de la niveluri superioare"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Inherited value
 msgid "Inherited value"
 msgstr "Valoarea moștenită"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Insert col after
 msgid "Insert col after"
 msgstr "Introduceți col. după"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Insert col before
 msgid "Insert col before"
 msgstr "Introduceți coloana înainte"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Insert row after
 msgid "Insert row after"
 msgstr "Introduceți rândul după"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Insert row before
 msgid "Insert row before"
 msgstr "Introduceți rândul înainte"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Install
 msgid "Install"
 msgstr "Instalare"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Installed
 msgid "Installed"
 msgstr "Instalat"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Installed version
 msgid "Installed version"
 msgstr "Versiunea instalată"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: days
 msgid "Interval Daily"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Month(s)
 msgid "Interval Monthly"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: week(s)
 msgid "Interval Weekly"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: year(s)
 msgid "Interval Yearly"
 msgstr ""
 
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: Item batch size
 msgid "Item batch size"
 msgstr "Dimensiunea lotului obiectului"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Item succesfully moved.
 msgid "Item succesfully moved."
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Item(s) copied.
 msgid "Item(s) copied."
 msgstr "Obiect(e) copiat."
 
 #: components/manage/Contents/Contents
+# defaultMessage: Item(s) cut.
 msgid "Item(s) cut."
 msgstr "Obiect(e) tăiat(e)."
 
 #: components/manage/Contents/Contents
+# defaultMessage: Item(s) has been updated.
 msgid "Item(s) has been updated."
 msgstr ""
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
+# defaultMessage: Item(s) pasted.
 msgid "Item(s) pasted."
 msgstr "Obiect(e) lipit(e)."
 
 #: components/manage/Contents/Contents
+# defaultMessage: Item(s) state has been updated.
 msgid "Item(s) state has been updated."
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Items
 msgid "Items"
 msgstr "Obiecte"
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Items must be unique.
 msgid "Items must be unique."
 msgstr "Obiectele trebuie să fie unice."
 
 #: components/manage/Preferences/PersonalPreferences
+# defaultMessage: Language
 msgid "Language"
 msgstr "Limba"
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: Last
 msgid "Last"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Last comment date
 msgid "Last comment date"
 msgstr "Data ultimului comentariu"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Last modified
 msgid "Last modified"
 msgstr "Ultima modificare"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Latest version
 msgid "Latest version"
 msgstr "Ultima versiune"
 
 #: components/manage/Controlpanels/ContentTypesActions
+# defaultMessage: Layout
 msgid "Layout"
 msgstr ""
 
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: Lead Image
 msgid "Lead Image"
 msgstr "Imaginea de start"
 
 #: components/manage/Blocks/Image/ImageSizeWidget
 #: components/manage/Blocks/Maps/Edit
 #: components/manage/Sidebar/AlignBlock
+# defaultMessage: Left
 msgid "Left"
 msgstr "Stânga"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Link
 msgid "Link"
 msgstr "Legătură"
 
 #: components/manage/Blocks/Listing/schema
+# defaultMessage: Link more
 msgid "Link more"
 msgstr "Legătură către mai multe"
 
 #: components/manage/Blocks/Listing/schema
+# defaultMessage: Link Title
 msgid "Link title"
 msgstr "Legătură la titlu"
 
@@ -1070,212 +1301,262 @@ msgstr "Legătură la titlu"
 #: components/manage/Blocks/Listing/schema
 #: components/manage/Blocks/Maps/MapsSidebar
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Link to
 msgid "Link to"
 msgstr "Legătură către"
 
 #: components/manage/Multilingual/ManageTranslations
+# defaultMessage: Link translation for
 msgid "Link translation for"
 msgstr ""
 
 #: components/manage/Blocks/Listing/schema
+# defaultMessage: Listing
 msgid "Listing"
 msgstr "Listare"
 
 #: components/theme/Comments/Comments
+# defaultMessage: Load more...
 msgid "Load more"
 msgstr ""
 
 #: components/manage/Form/ModalForm
+# defaultMessage: Loading.
 msgid "Loading"
 msgstr ""
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: Location
 msgid "Location"
 msgstr "Locație"
 
 #: components/theme/Login/Login
+# defaultMessage: Login
 msgid "Log In"
 msgstr "Autentificare"
 
 #: components/theme/Anontools/Anontools
 #: components/theme/Login/Login
+# defaultMessage: Log in
 msgid "Log in"
 msgstr "Autentificare"
 
 #: components/theme/Login/Login
+# defaultMessage: Login
 msgid "Login"
 msgstr "Autentificare"
 
 #: components/theme/Login/Login
+# defaultMessage: Login Failed
 msgid "Login Failed"
 msgstr "Autentificare eșuată"
 
 #: components/theme/Login/Login
+# defaultMessage: Login Name
 msgid "Login Name"
 msgstr "Nume de autentificare"
 
 #: components/manage/Toolbar/PersonalTools
+# defaultMessage: Logout
 msgid "Logout"
 msgstr ""
 
 #: components/manage/Toolbar/More
+# defaultMessage: Made by {creator} on {date}. This is not a working copy anymore, but the main content.
 msgid "Made by {creator} on {date}. This is not a working copy anymore, but the main content."
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Reduce cell padding
 msgid "Make the table compact"
 msgstr "Compactati tabelul"
 
 #: components/manage/Multilingual/ManageTranslations
 #: components/manage/Toolbar/More
+# defaultMessage: Manage Translations
 msgid "Manage Translations"
 msgstr ""
 
 #: components/manage/Multilingual/ManageTranslations
+# defaultMessage: Manage translations for {title}
 msgid "Manage translations for {title}"
 msgstr ""
 
 #: components/manage/Blocks/Maps/MapsSidebar
+# defaultMessage: Map
 msgid "Map"
 msgstr "Hartă"
 
 #: components/manage/Blocks/Maps/MapsSidebar
+# defaultMessage: Maps URL
 msgid "Maps URL"
 msgstr "URL Hartă"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Maximum length is {len}.
 msgid "Maximum length is {len}."
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Maximum value is {len}.
 msgid "Maximum value is {len}."
 msgstr ""
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Message
 msgid "Message"
 msgstr "Mesaj"
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Minimum length is {len}.
 msgid "Minimum length is {len}."
 msgstr "Lungimea minimă este {len}."
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Minimum value is {len}.
 msgid "Minimum value is {len}."
 msgstr ""
 
 #: components/manage/Controlpanels/Controlpanels
+# defaultMessage: Moderate Comments
 msgid "Moderate Comments"
 msgstr "Moderati comentarii"
 
 #: components/manage/Controlpanels/ModerateComments
+# defaultMessage: Moderate comments
 msgid "Moderate comments"
 msgstr "Moderati comentarii"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Monday and Friday
 msgid "Monday and Friday"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/ByMonthDayField
+# defaultMessage: Day
 msgid "Month day"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Monthly
 msgid "Monthly"
 msgstr ""
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: More
 msgid "More"
 msgstr "Mai mult"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Move to bottom of folder
 msgid "Move to bottom of folder"
 msgstr "Mutați în partea de jos a folderului"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Move to top of folder
 msgid "Move to top of folder"
 msgstr "Mutați în partea de sus a folderului"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: My email address is
 msgid "My email address is"
 msgstr "Adresa mea de e-mail este"
 
 #: components/manage/Sharing/Sharing
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Name
 msgid "Name"
 msgstr "Nume"
 
 #: error
+# defaultMessage: Navigate back
 msgid "Navigate back"
 msgstr "Navigați înapoi"
 
 #: components/theme/Navigation/ContextNavigation
+# defaultMessage: Navigation
 msgid "Navigation"
 msgstr ""
 
 #: components/manage/Preferences/ChangePassword
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: New password
 msgid "New password"
 msgstr "Parolă nouă"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: News Item
 msgid "News Item"
 msgstr "Articol de știri"
 
 #: components/manage/Contents/ContentsItem
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: No
 msgid "No"
 msgstr "Nu"
 
 #: components/manage/Blocks/Image/ImageSidebar
+# defaultMessage: No image selected
 msgid "No image selected"
 msgstr "Nici o imagine selectată"
 
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: No image set in Lead Image content field
 msgid "No image set in Lead Image content field"
 msgstr "Nicio imagine setată în câmpul de conținut imagine de start"
 
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: No image set in image content field
 msgid "No image set in image content field"
 msgstr "Nicio imagine setată în câmpul imagine de continut"
 
 #: components/manage/Blocks/Listing/ListingBody
+# defaultMessage: No items found in this container.
 msgid "No items found in this container."
 msgstr "Nu s-au găsit articole în acest container."
 
 #: components/manage/Widgets/ObjectBrowserWidget
+# defaultMessage: No items selected
 msgid "No items selected"
 msgstr "Niciun element selectat"
 
 #: components/manage/Blocks/Maps/MapsSidebar
+# defaultMessage: No map selected
 msgid "No map selected"
 msgstr "Nicio hartă selectată"
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: No occurences set
 msgid "No occurences set"
 msgstr ""
 
 #: components/manage/Widgets/ArrayWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/TokenWidget
+# defaultMessage: No options
 msgid "No options"
 msgstr ""
 
 #: components/theme/Search/Search
+# defaultMessage: No results found
 msgid "No results found"
 msgstr ""
 
 #: components/manage/Blocks/Listing/ListingBody
 #: components/manage/Widgets/ReferenceWidget
+# defaultMessage: No results found.
 msgid "No results found."
 msgstr "Nu s-au găsit rezultate."
 
 #: components/manage/Widgets/QuerySortOnWidget
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: No selection
 msgid "No selection"
 msgstr "Fără selecție"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: This addon does not provide an uninstall profile.
 msgid "No uninstall profile"
 msgstr "Niciun profil de dezinstalare"
 
@@ -1283,39 +1564,48 @@ msgstr "Niciun profil de dezinstalare"
 #: components/manage/Widgets/ReferenceWidget
 #: components/manage/Widgets/SelectUtils
 #: components/manage/Widgets/SelectWidget
+# defaultMessage: No value
 msgid "No value"
 msgstr "Fără valoare"
 
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: No video selected
 msgid "No video selected"
 msgstr "Niciun videoclip selectat"
 
 #: components/manage/Workflow/Workflow
+# defaultMessage: No workflow
 msgid "No workflow"
 msgstr "Fără flux de lucru"
 
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsItem
+# defaultMessage: None
 msgid "None"
 msgstr "Niciuna"
 
 #: components/manage/Controlpanels/Users/UsersControlpanel
+# defaultMessage: Note that roles set here apply directly to a user. The symbol{plone_svg}indicates a role inherited from membership in a group.
 msgid "Note that roles set here apply directly to a user. The symbol{plone_svg}indicates a role inherited from membership in a group."
 msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Number of active objects
 msgid "Number of active objects"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Object Size
 msgid "Object Size"
 msgstr "Dimensiunea obiectului"
 
 #: components/manage/Widgets/RecurrenceWidget/EndField
+# defaultMessage: occurrence(s)
 msgid "Occurences"
 msgstr ""
 
 #: components/manage/Delete/Delete
+# defaultMessage: Ok
 msgid "Ok"
 msgstr "Ok"
 
@@ -1323,301 +1613,371 @@ msgstr "Ok"
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
 #: components/manage/Blocks/Maps/MapsSidebar
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Open in a new tab
 msgid "Open in a new tab"
 msgstr "Deschideți într-o fereastra nouă"
 
 #: components/theme/Navigation/Navigation
+# defaultMessage: Open menu
 msgid "Open menu"
 msgstr "Deschideți meniul"
 
 #: components/manage/Widgets/ObjectBrowserWidget
+# defaultMessage: Open object browser
 msgid "Open object browser"
 msgstr ""
 
 #: components/manage/Blocks/Image/ImageSidebar
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
+# defaultMessage: Origin
 msgid "Origin"
 msgstr "Origine"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Page
 msgid "Page"
 msgstr "Pagina"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Parent fieldset
 msgid "Parent fieldset"
 msgstr ""
 
 #: components/theme/Login/Login
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Password
 msgid "Password"
 msgstr "Parolă"
 
 #: components/theme/PasswordReset/PasswordReset
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Password reset
 msgid "Password reset"
 msgstr "Resetare parolă"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Passwords do not match.
 msgid "Passwords do not match."
 msgstr "Parolele nu se potrivesc."
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
+# defaultMessage: Paste
 msgid "Paste"
 msgstr "Lipire"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: undefined
 msgid "Paste blocks"
 msgstr ""
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Permissions have been updated successfully
 msgid "Permissions have been updated successfully"
 msgstr ""
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Permissions updated
 msgid "Permissions updated"
 msgstr ""
 
 #: components/manage/Preferences/PersonalInformation
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Personal Information
 msgid "Personal Information"
 msgstr "Informații personale"
 
 #: components/manage/Preferences/PersonalPreferences
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Personal Preferences
 msgid "Personal Preferences"
 msgstr "Preferințe personale"
 
 #: components/manage/Toolbar/More
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Personal tools
 msgid "Personal tools"
 msgstr "Instrumente personale"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Persons responsible for creating the content of this item. Please enter a list of user names, one per line. The principal creator should come first.
 msgid "Persons responsible for creating the content of this item. Please enter a list of user names, one per line. The principal creator should come first."
 msgstr "Persoane responsabile de crearea conținutului acestui articol. Vă rugăm să introduceți o listă cu numele de utilizator, unul pe fiecare linie. Creatorul principal ar trebui să vină pe primul loc."
 
 #: components/manage/Blocks/Video/Edit
+# defaultMessage: Please enter a valid URL by deleting the block and adding a new video block.
 msgid "Please enter a valid URL by deleting the block and adding a new video block."
 msgstr "Vă rugăm să introduceți o adresă URL validă ștergând blocul și adăugând un nou bloc video."
 
 #: components/manage/Blocks/Maps/Edit
+# defaultMessage: Please enter the Embed Code provided by Google Maps -> Share -> Embed map. It should contain the <iframe> code on it.
 msgid "Please enter the Embed Code provided by Google Maps -> Share -> Embed map. It should contain the <iframe> code on it."
 msgstr "Vă rugăm să introduceți codul de integrare furnizat de Google Maps -> Partajare -> Integrare harta. Acesta trebuie să conțină codul <iframe>."
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Please fill out the form below to set your password.
 msgid "Please fill out the form below to set your password."
 msgstr "Vă rugăm să completați formularul de mai jos pentru a seta parola."
 
 #: components/theme/Footer/Footer
+# defaultMessage: Plone Foundation
 msgid "Plone Foundation"
 msgstr "Fundația Plone"
 
 #: components/theme/Logo/Logo
+# defaultMessage: Plone Site
 msgid "Plone Site"
 msgstr "Site Plone"
 
 #: components/theme/Footer/Footer
+# defaultMessage: Plone{reg} Open Source CMS/WCM
 msgid "Plone{reg} Open Source CMS/WCM"
 msgstr "Plone{reg} CMS/WCM Open Source"
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: Portrait
 msgid "Portrait"
 msgstr "Portret"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Possible values (Enter allowed choices one per line).
 msgid "Possible values"
 msgstr ""
 
 #: components/theme/Footer/Footer
+# defaultMessage: Powered by Plone & Python
 msgid "Powered by Plone & Python"
 msgstr "Powered by Plone & Python"
 
 #: components/manage/Toolbar/PersonalTools
+# defaultMessage: Preferences
 msgid "Preferences"
 msgstr "Preferințe"
 
 #: components/manage/Blocks/HTML/Edit
+# defaultMessage: Prettify your code
 msgid "Prettify your code"
 msgstr ""
 
 #: components/manage/Blocks/HTML/Edit
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Preview
 msgid "Preview"
 msgstr "Previzualizare"
 
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Preview Image URL
 msgid "Preview Image URL"
 msgstr ""
 
 #: components/manage/Toolbar/PersonalTools
+# defaultMessage: Profile
 msgid "Profile"
 msgstr "Profil"
 
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Properties
 msgid "Properties"
 msgstr "Proprietăți"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Publication date
 msgid "Publication date"
 msgstr "Data publicării"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Publishing Date
 msgid "Publishing Date"
 msgstr "Data publicării"
 
 #: components/manage/Blocks/Listing/schema
+# defaultMessage: Query
 msgid "Query"
 msgstr ""
 
 #: components/manage/Preferences/ChangePassword
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Re-enter the password. Make sure the passwords are identical.
 msgid "Re-enter the password. Make sure the passwords are identical."
 msgstr "Reintroduceți parola. Asigurați-vă că parolele sunt identice."
 
 #: components/theme/Search/Search
 #: components/theme/View/SummaryView
+# defaultMessage: Read More…
 msgid "Read More…"
 msgstr "Citește mai mult …"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Rearrange items by…
 msgid "Rearrange items by…"
 msgstr "Reorganizați elementele in functie de …"
 
 #: components/manage/Widgets/RecurrenceWidget/EndField
+# defaultMessage: Ends
 msgid "Recurrence ends"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/EndField
+# defaultMessage: after
 msgid "Recurrence ends after"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/EndField
+# defaultMessage: on
 msgid "Recurrence ends on"
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Minimalistic table design
 msgid "Reduce complexity"
 msgstr "Reduce complexitatea"
 
 #: components/theme/Anontools/Anontools
 #: components/theme/Login/Login
 #: components/theme/Register/Register
+# defaultMessage: Register
 msgid "Register"
 msgstr "Înregistrare"
 
 #: components/theme/Register/Register
+# defaultMessage: Registration form
 msgid "Registration form"
 msgstr "Formular de înregistrare"
 
 #: components/theme/Search/Search
+# defaultMessage: Relevance
 msgid "Relevance"
 msgstr ""
 
 #: components/manage/Widgets/ObjectListWidget
+# defaultMessage: Remove item
 msgid "Remove item"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Remove
 msgid "Remove recurrence"
 msgstr ""
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Remove term
 msgid "Remove term"
 msgstr ""
 
 #: components/manage/Toolbar/More
+# defaultMessage: Remove working copy
 msgid "Remove working copy"
 msgstr ""
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
+# defaultMessage: Rename
 msgid "Rename"
 msgstr "Redenumește"
 
 #: components/manage/Contents/ContentsRenameModal
+# defaultMessage: Renaming items...
 msgid "Rename Items Loading Message"
 msgstr ""
 
 #: components/manage/Contents/ContentsRenameModal
+# defaultMessage: Rename items
 msgid "Rename items"
 msgstr "Redenumirea articolelor"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Repeat
 msgid "Repeat"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Repeat every
 msgid "Repeat every"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Repeat on
 msgid "Repeat on"
 msgstr ""
 
 #: components/manage/Widgets/FileWidget
+# defaultMessage: Replace existing file
 msgid "Replace existing file"
 msgstr ""
 
 #: components/theme/Comments/Comments
+# defaultMessage: Reply
 msgid "Reply"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/WysiwygWidget
+# defaultMessage: Required
 msgid "Required"
 msgstr "Obligatoriu"
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Required input is missing.
 msgid "Required input is missing."
 msgstr "Câmpul este obligatoriu."
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Reset title
 msgid "Reset term title"
 msgstr ""
 
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: Results limit
 msgid "Results limit"
 msgstr "Limita rezultatelor"
 
 #: components/manage/Blocks/Listing/Edit
+# defaultMessage: Results preview
 msgid "Results preview"
 msgstr "Previzualizare rezultate"
 
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: Reversed order
 msgid "Reversed order"
 msgstr "Ordine inversată"
 
 #: components/manage/History/History
+# defaultMessage: Revert to this revision
 msgid "Revert to this revision"
 msgstr "Reveniți la această revizuire"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Review state
 msgid "Review state"
 msgstr "Stare de revizuire"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Richtext
 msgid "Richtext"
 msgstr "Richtext"
 
 #: components/manage/Blocks/Image/ImageSizeWidget
 #: components/manage/Blocks/Maps/Edit
 #: components/manage/Sidebar/AlignBlock
+# defaultMessage: Right
 msgid "Right"
 msgstr "Dreapta"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: Rights
 msgid "Rights"
 msgstr "Drepturi"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Roles
 msgid "Roles"
 msgstr "Roluri"
 
 #: components/manage/Contents/ContentsBreadcrumbs
+# defaultMessage: Root
 msgid "Root"
 msgstr ""
 
@@ -1630,90 +1990,112 @@ msgstr ""
 #: components/manage/Form/ModalForm
 #: components/manage/Sharing/Sharing
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Save
 msgid "Save"
 msgstr "Salvare"
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Save
 msgid "Save recurrence"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypesActions
+# defaultMessage: Schema
 msgid "Schema"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypeSchema
+# defaultMessage: Schema updates
 msgid "Schema updates"
 msgstr ""
 
 #: components/theme/SearchWidget/SearchWidget
+# defaultMessage: Search
 msgid "Search"
 msgstr "Căutare"
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: Search SVG
 msgid "Search SVG"
 msgstr ""
 
 #: components/theme/SearchWidget/SearchWidget
+# defaultMessage: Search Site
 msgid "Search Site"
 msgstr "Căutare pe site"
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: Search content
 msgid "Search content"
 msgstr "Căutare conținut"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Search for user or group
 msgid "Search for user or group"
 msgstr "Căutare utilizator sau grup"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Search group…
 msgid "Search group…"
 msgstr ""
 
 #: components/theme/Search/Search
+# defaultMessage: Search results
 msgid "Search results"
 msgstr "Rezultatele căutării"
 
 #: components/theme/Search/Search
+# defaultMessage: Search results for {term}
 msgid "Search results for {term}"
 msgstr "Rezultatele căutării pentru {term}"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Search users…
 msgid "Search users…"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: Second
 msgid "Second"
 msgstr ""
 
 #: components/manage/Sidebar/ObjectBrowserNav
+# defaultMessage: Select
 msgid "Select"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Select a date to add to recurrence
 msgid "Select a date to add to recurrence"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Select columns to show
 msgid "Select columns to show"
 msgstr "Selectați coloane de afișat"
 
 #: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Select the transition to be used for modifying the items state.
 msgid "Select the transition to be used for modifying the items state."
 msgstr "Selectați tranziția care va fi utilizată pentru modificarea stării elementelor."
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: Selected dates
 msgid "Selected dates"
 msgstr ""
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: Selected items
 msgid "Selected items"
 msgstr "Articole selectate"
 
 #: components/manage/Sidebar/ObjectBrowserBody
+# defaultMessage: of
 msgid "Selected items - x of y"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Selection
 msgid "Selection"
 msgstr "Selecție"
 
@@ -1721,158 +2103,195 @@ msgstr "Selecție"
 #: components/manage/Widgets/ArrayWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/TokenWidget
+# defaultMessage: Select…
 msgid "Select…"
 msgstr "Selectați …"
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Send
 msgid "Send"
 msgstr "Trimite"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Set my password
 msgid "Set my password"
 msgstr "Setați parola mea"
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Set your password
 msgid "Set your password"
 msgstr "Setați parola"
 
 #: components/manage/Sidebar/Sidebar
+# defaultMessage: Settings
 msgid "Settings"
 msgstr ""
 
 #: components/manage/Sharing/Sharing
 #: components/manage/Toolbar/More
+# defaultMessage: Sharing
 msgid "Sharing"
 msgstr "Partajare"
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: Sharing for {title}
 msgid "Sharing for {title}"
 msgstr "Partajare pentru {title}"
 
 #: components/manage/Widgets/SchemaWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/WysiwygWidget
+# defaultMessage: Short Name
 msgid "Short Name"
 msgstr "Nume"
 
 #: components/manage/Contents/ContentsRenameModal
+# defaultMessage: Short name
 msgid "Short name"
 msgstr "Nume"
 
 #: components/theme/Pagination/Pagination
+# defaultMessage: Show
 msgid "Show"
 msgstr "Afișați"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Show All
 msgid "Show All"
 msgstr ""
 
 #: components/theme/Comments/Comments
+# defaultMessage: Show Replies
 msgid "Show Replies"
 msgstr ""
 
 #: components/manage/Widgets/ObjectListWidget
+# defaultMessage: Show item
 msgid "Show item"
 msgstr ""
 
 #: components/manage/Sidebar/Sidebar
+# defaultMessage: Shrink sidebar
 msgid "Shrink sidebar"
 msgstr "Reduceți bara laterală"
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Shrink toolbar
 msgid "Shrink toolbar"
 msgstr "Reduceti bara de instrumente"
 
 #: components/theme/Login/Login
+# defaultMessage: Sign in to start session
 msgid "Sign in to start session"
 msgstr "Conectați-vă pentru a începe sesiunea"
 
 #: components/theme/Logo/Logo
+# defaultMessage: Site
 msgid "Site"
 msgstr "Site"
 
 #: components/theme/NotFound/NotFound
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: Site Administration
 msgid "Site Administration"
 msgstr "Administrare site"
 
 #: components/theme/Footer/Footer
+# defaultMessage: Site Map
 msgid "Site Map"
 msgstr "Harta site-ului"
 
 #: components/manage/Controlpanels/Controlpanels
 #: components/manage/Toolbar/PersonalTools
+# defaultMessage: Site Setup
 msgid "Site Setup"
 msgstr "Configurare site"
 
 #: components/theme/Sitemap/Sitemap
+# defaultMessage: Sitemap
 msgid "Sitemap"
 msgstr "Sitemap"
 
 #: components/manage/Blocks/Image/ImageSidebar
+# defaultMessage: Size
 msgid "Size"
 msgstr ""
 
 #: components/theme/View/ImageView
+# defaultMessage: Size: {size}
 msgid "Size: {size}"
 msgstr "Mărime: {size}"
 
 #: error
+# defaultMessage: Sorry, something went wrong with your request
 msgid "Sorry, something went wrong with your request"
 msgstr "Ne pare rău, a apârut o eroare"
 
 #: components/theme/Search/Search
+# defaultMessage: Sort by:
 msgid "Sort By:"
 msgstr ""
 
 #: components/manage/Widgets/QuerySortOnWidget
 #: components/manage/Widgets/QuerystringWidget
+# defaultMessage: Sort on
 msgid "Sort on"
 msgstr "Sortare pe"
 
 #: components/manage/Blocks/HTML/Edit
+# defaultMessage: Source
 msgid "Source"
 msgstr "Sursa"
 
 #: components/manage/Blocks/Video/Edit
+# defaultMessage: Specify a youtube video or playlist url
 msgid "Specify a youtube video or playlist url"
 msgstr "Specificați un URL YouTube sau url de playlist"
 
 #: components/manage/Diff/Diff
+# defaultMessage: Split
 msgid "Split"
 msgstr "Împărțire"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Start Date
 msgid "Start Date"
 msgstr "Data de început"
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: Start of the recurrence
 msgid "Start of the recurrence"
 msgstr ""
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Start password reset
 msgid "Start password reset"
 msgstr "Start resetare parolă"
 
 #: components/manage/Contents/Contents
 #: components/manage/Workflow/Workflow
 #: components/theme/View/TabularView
+# defaultMessage: State
 msgid "State"
 msgstr "Stare"
 
 #: components/manage/Multilingual/CompareLanguages
+# defaultMessage: Stop compare
 msgid "Stop compare"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: String
 msgid "String"
 msgstr "String"
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Alternate row background color
 msgid "Stripe alternate rows with color"
 msgstr "Colorati randurile alternativ"
 
 #: components/theme/ContactForm/ContactForm
+# defaultMessage: Subject
 msgid "Subject"
 msgstr "Subiect"
 
@@ -1886,43 +2305,53 @@ msgstr "Subiect"
 #: components/manage/Preferences/PersonalPreferences
 #: components/theme/ContactForm/ContactForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Success
 msgid "Success"
 msgstr "Succes"
 
 #: components/theme/LanguageSelector/LanguageSelector
+# defaultMessage: Switch to
 msgid "Switch to"
 msgstr ""
 
 #: components/manage/Blocks/Table/Edit
+# defaultMessage: Table
 msgid "Table"
 msgstr "Tabel"
 
 #: components/manage/Blocks/ToC/View
+# defaultMessage: Table of Contents
 msgid "Table of Contents"
 msgstr "Cuprins"
 
 #: components/manage/Contents/Contents
 #: components/manage/Contents/ContentsTagsModal
+# defaultMessage: Tags
 msgid "Tags"
 msgstr "Etichete"
 
 #: components/manage/Contents/ContentsTagsModal
+# defaultMessage: Tags to add
 msgid "Tags to add"
 msgstr "Etichete de adăugat"
 
 #: components/manage/Contents/ContentsTagsModal
+# defaultMessage: Tags to remove
 msgid "Tags to remove"
 msgstr "Etichete de eliminat"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Target memory size per cache in bytes
 msgid "Target memory size per cache in bytes"
 msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Target number of objects in memory per cache
 msgid "Target number of objects in memory per cache"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Text
 msgid "Text"
 msgstr "Text"
 
@@ -1930,87 +2359,108 @@ msgstr "Text"
 #: components/theme/CorsError/CorsError
 #: components/theme/NotFound/NotFound
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: Thank you.
 msgid "Thank you."
 msgstr "Mulțumesc."
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: The Database Manager allow you to view database status information
 msgid "The Database Manager allow you to view database status information"
 msgstr ""
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: The URL for your external home page, if you have one.
 msgid "The URL for your external home page, if you have one."
 msgstr "Adresa URL a paginii de start externe, dacă aveți una."
 
 #: components/theme/ConnectionRefused/ConnectionRefused
+# defaultMessage: The backend is not responding, please check if you have started Plone, check your project's configuration object apiPath (or if you are using the internal proxy, devProxyToApiPath) or the RAZZLE_API_PATH Volto's environment variable.
 msgid "The backend is not responding, please check if you have started Plone, check your project's configuration object apiPath (or if you are using the internal proxy, devProxyToApiPath) or the RAZZLE_API_PATH Volto's environment variable."
 msgstr "Backendul nu răspunde. Vă rugăm să verificați dacă ați pornit Plone, verificați obiectul apiPath de configurare al proiectului dvs. (sau dacă utilizați proxy intern, devProxyToApiPath) sau variabila de mediu RAZZLE_API_PATH Volto."
 
 #: components/theme/CorsError/CorsError
+# defaultMessage: The backend is responding, but the CORS headers are not configured properly and the browser has denied the access to the backend resources.
 msgid "The backend is responding, but the CORS headers are not configured properly and the browser has denied the access to the backend resources."
 msgstr "Backendul răspunde, dar anteturile CORS nu sunt configurate corect și browserul a refuzat accesul la resursele de backend."
 
 #: components/theme/CorsError/CorsError
+# defaultMessage: The backend server of your website is not anwering, we apologize for the inconvenience. Please try to re-load the page and try again. If the problem persists please contact the site administrators.
 msgid "The backend server of your website is not anwering, we apologize for the inconvenience. Please try to re-load the page and try again. If the problem persists please contact the site administrators."
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: The item could not be deleted.
 msgid "The item could not be deleted."
 msgstr ""
 
 #: components/theme/Register/Register
+# defaultMessage: The registration process has been successful. Please check your e-mail inbox for information on how activate your account.
 msgid "The registration process has been successful. Please check your e-mail inbox for information on how activate your account."
 msgstr "Procesul de înregistrare a avut succes. Vă rugăm să verificați căsuța de e-mail pentru informații despre modul de activare a contului dvs."
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: The user portrait/avatar
 msgid "The user portrait/avatar"
 msgstr "Portretul / avatarul utilizatorului"
 
 #: components/manage/Toolbar/More
+# defaultMessage: The working copy was discarded
 msgid "The working copy was discarded"
 msgstr ""
 
 #: components/theme/Footer/Footer
+# defaultMessage: The {plonecms} is {copyright} 2000-{current_year} by the {plonefoundation} and friends.
 msgid "The {plonecms} is {copyright} 2000-{current_year} by the {plonefoundation} and friends."
 msgstr "{plonecms} este {copyright} 2000- {current_year} de {plonefoundation} și prieteni."
 
 #: components/theme/CorsError/CorsError
+# defaultMessage: There is a configuration problem on the backend
 msgid "There is a configuration problem on the backend"
 msgstr "Există o problemă de configurare pe backend"
 
 #: components/manage/Form/InlineForm
+# defaultMessage: There were some errors
 msgid "There were some errors"
 msgstr "Au aparut unele erori"
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: There were some errors.
 msgid "There were some errors."
 msgstr "Au aparut unele erori."
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: Third
 msgid "Third"
 msgstr ""
 
 #: components/manage/WorkingCopyToastsFactory/WorkingCopyToastsFactory
+# defaultMessage: This has an ongoing working copy in {title}
 msgid "This has an ongoing working copy in {title}"
 msgstr ""
 
 #: components/manage/WorkingCopyToastsFactory/WorkingCopyToastsFactory
+# defaultMessage: This is a working copy of {title}
 msgid "This is a working copy of {title}"
 msgstr ""
 
 #: components/manage/LockingToastsFactory/LockingToastsFactory
+# defaultMessage: This item was locked by {creator} on {date}
 msgid "This item was locked by {creator} on {date}"
 msgstr ""
 
 #: components/manage/Contents/ContentsRenameModal
+# defaultMessage: This name will be displayed in the URL.
 msgid "This name will be displayed in the URL."
 msgstr "Acest nume va fi afișat în adresa URL."
 
 #: components/theme/NotFound/NotFound
+# defaultMessage: This page does not seem to exist…
 msgid "This page does not seem to exist…"
 msgstr "Se pare că această pagină nu există …"
 
 #: components/manage/Widgets/DatetimeWidget
+# defaultMessage: Time
 msgid "Time"
 msgstr ""
 
@@ -2023,714 +2473,889 @@ msgstr ""
 #: components/manage/Widgets/WysiwygWidget
 #: components/theme/View/TabularView
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Title
 msgid "Title"
 msgstr "Titlu"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Total active and non-active objects
 msgid "Total active and non-active objects"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: Total comments
 msgid "Total comments"
 msgstr "Total comentarii"
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Total number of objects in each cache
 msgid "Total number of objects in each cache"
 msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Total number of objects in memory from all caches
 msgid "Total number of objects in memory from all caches"
 msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
+# defaultMessage: Total number of objects in the database
 msgid "Total number of objects in the database"
 msgstr ""
 
 #: components/manage/Add/Add
 #: components/manage/Toolbar/Types
+# defaultMessage: Translate to {lang}
 msgid "Translate to {lang}"
 msgstr "Traduceți în {lang}"
 
 #: components/manage/Multilingual/ManageTranslations
+# defaultMessage: Translation linked
 msgid "Translation linked"
 msgstr ""
 
 #: components/manage/Multilingual/ManageTranslations
+# defaultMessage: Translation linking removed
 msgid "Translation linking removed"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypes
 #: components/manage/Widgets/SchemaWidget
 #: components/theme/View/TabularView
+# defaultMessage: Type
 msgid "Type"
 msgstr "Tip"
 
 #: components/manage/Blocks/Video/Edit
+# defaultMessage: Type a Video (YouTube, Vimeo or mp4) URL
 msgid "Type a Video (YouTube, Vimeo or mp4) URL"
 msgstr "Introduceți un URL video (YouTube, Vimeo sau mp4)"
 
 #: components/manage/Blocks/Text/Edit
+# defaultMessage: Type text…
 msgid "Type text…"
 msgstr "Tastați textul …"
 
 #: components/manage/Blocks/Title/Edit
+# defaultMessage: Type the title…
 msgid "Type the title…"
 msgstr "Tastați titlul …"
 
 #: components/manage/Contents/Contents
+# defaultMessage: UID
 msgid "UID"
 msgstr "UID"
 
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: Unauthorized
 msgid "Unauthorized"
 msgstr "Neautorizat"
 
 #: components/manage/BlockChooser/BlockChooser
+# defaultMessage: Unfold
 msgid "Unfold"
 msgstr ""
 
 #: components/manage/Diff/Diff
+# defaultMessage: Unified
 msgid "Unified"
 msgstr "Unificat"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Uninstall
 msgid "Uninstall"
 msgstr "Dezinstalare"
 
 #: components/manage/Blocks/Block/Edit
 #: components/theme/View/DefaultView
 #: components/theme/View/RenderBlocks
+# defaultMessage: Unknown Block {block}
 msgid "Unknown Block"
 msgstr "Bloc necunoscut"
 
 #: components/manage/Multilingual/ManageTranslations
+# defaultMessage: Unlink translation for
 msgid "Unlink translation for"
 msgstr ""
 
 #: components/manage/Toolbar/Toolbar
+# defaultMessage: Unlock
 msgid "Unlock"
 msgstr ""
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Update
 msgid "Update"
 msgstr "Actualizare"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Update installed addons
 msgid "Update installed addons"
 msgstr "Actualizați suplimentele instalate"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Update installed addons:
 msgid "Update installed addons:"
 msgstr "Actualizați suplimentele instalate:"
 
 #: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Updates available
 msgid "Updates available"
 msgstr "Actualizări disponibile"
 
 #: components/manage/Contents/Contents
+# defaultMessage: Upload
 msgid "Upload"
 msgstr "Încărcare"
 
 #: components/manage/Blocks/LeadImage/Edit
+# defaultMessage: Upload a lead image in the 'Lead Image' content field.
 msgid "Upload a lead image in the 'Lead Image' content field."
 msgstr "Încărcați o imagine de start în câmpul de conținut 'Imagine de start'."
 
 #: components/manage/Blocks/HeroImageLeft/Edit
+# defaultMessage: Upload a new image
 msgid "Upload a new image"
 msgstr ""
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Upload files
 msgid "Upload files"
 msgstr "Încărcați fișiere"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: Uploading files
 msgid "Uploading files"
 msgstr "Încărcarea fișierelor"
 
 #: components/manage/Blocks/HeroImageLeft/Edit
+# defaultMessage: Uploading image
 msgid "Uploading image"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
 #: components/manage/Widgets/SelectWidget
 #: components/manage/Widgets/WysiwygWidget
+# defaultMessage: Used for programmatic access to the fieldset.
 msgid "Used for programmatic access to the fieldset."
 msgstr "Folosit pentru acces programatic la setul de câmpuri."
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: User
 msgid "User"
 msgstr "Utilizator"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: User created
 msgid "User created"
 msgstr "Utilizator creat"
 
 #: components/manage/Controlpanels/Users/UsersControlpanel
+# defaultMessage: User name
 msgid "User name"
 msgstr "Nume utilizator"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: User roles updated
 msgid "User roles updated"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Username
 msgid "Username"
 msgstr "Nume utilizator"
 
 #: components/manage/Controlpanels/Controlpanels
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Users
 msgid "Users"
 msgstr "Utilizatori"
 
 #: components/manage/Controlpanels/Controlpanels
+# defaultMessage: Users and Groups
 msgid "Users and Groups"
 msgstr "Utilizatori și grupuri"
 
 #: helpers/Extensions/withBlockSchemaEnhancer
+# defaultMessage: Variation
 msgid "Variation"
 msgstr ""
 
 #: components/manage/Controlpanels/Controlpanels
+# defaultMessage: Version Overview
 msgid "Version Overview"
 msgstr "Prezentare generală a versiunii"
 
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Video
 msgid "Video"
 msgstr "Video"
 
 #: components/manage/Blocks/Video/VideoSidebar
+# defaultMessage: Video URL
 msgid "Video URL"
 msgstr "URL-ul video"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: View
 msgid "View"
 msgstr "Vizualizare"
 
 #: components/manage/History/History
+# defaultMessage: View changes
 msgid "View changes"
 msgstr "Vizualizare modificări"
 
 #: components/manage/History/History
+# defaultMessage: View this revision
 msgid "View this revision"
 msgstr "Vizualizați această revizuire"
 
 #: components/manage/Toolbar/More
+# defaultMessage: View working copy
 msgid "View working copy"
 msgstr ""
 
 #: components/manage/Display/Display
+# defaultMessage: View
 msgid "Viewmode"
 msgstr "Mod vizualizare"
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Vocabulary term
 msgid "Vocabulary term"
 msgstr ""
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Title
 msgid "Vocabulary term title"
 msgstr ""
 
 #: components/manage/Widgets/VocabularyTermsWidget
+# defaultMessage: Vocabulary terms
 msgid "Vocabulary terms"
 msgstr ""
 
 #: components/manage/Controlpanels/VersionOverview
+# defaultMessage: You are running in 'debug mode'. This mode is intended for sites that are under development. This allows many configuration changes to be immediately visible, but will make your site run more slowly. To turn off debug mode, stop the server, set 'debug-mode=off' in your buildout.cfg, re-run bin/buildout and then restart the server process.
 msgid "Warning Regarding debug mode"
 msgstr "Avertisment cu privire la modul de depanare"
 
 #: components/theme/ConnectionRefused/ConnectionRefused
+# defaultMessage: We apologize for the inconvenience, but the backend of the site you are accessing is not available right now. Please, try again later.
 msgid "We apologize for the inconvenience, but the backend of the site you are accessing is not available right now. Please, try again later."
 msgstr "Ne cerem scuze pentru neplăceri, dar backend-ul site-ului pe care îl accesați nu este disponibil în acest moment. Vă rugăm, încercați din nou mai târziu."
 
 #: components/theme/NotFound/NotFound
+# defaultMessage: We apologize for the inconvenience, but the page you were trying to access is not at this address. You can use the links below to help you find what you are looking for.
 msgid "We apologize for the inconvenience, but the page you were trying to access is not at this address. You can use the links below to help you find what you are looking for."
 msgstr "Ne cerem scuze pentru neplăceri, dar pagina pe care încercați să o accesați nu se află la această adresă. Puteți utiliza linkurile de mai jos pentru a vă ajuta să găsiți ceea ce căutați."
 
 #: components/theme/Forbidden/Forbidden
+# defaultMessage: We apologize for the inconvenience, but you don't have permissions on this resource.
 msgid "We apologize for the inconvenience, but you don't have permissions on this resource."
 msgstr "Ne cerem scuze pentru neplăceri, dar nu aveți permisiuni pentru a accesa această resursă."
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: We will use this address if you need to recover your password
 msgid "We will use this address if you need to recover your password"
 msgstr "Vom folosi această adresă în cazul în care trebuie să vă recuperați parola"
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
+# defaultMessage: The
 msgid "Weeek day of month"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Weekday
 msgid "Weekday"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Weekly
 msgid "Weekly"
 msgstr ""
 
 #: components/manage/History/History
+# defaultMessage: What
 msgid "What"
 msgstr "Ce"
 
 #: components/manage/History/History
+# defaultMessage: When
 msgid "When"
 msgstr "Când"
 
 #: components/manage/Contents/ContentsPropertiesModal
+# defaultMessage: When this date is reached, the content will nolonger be visible in listings and searches.
 msgid "When this date is reached, the content will nolonger be visible in listings and searches."
 msgstr "Când se ajunge la această dată, conținutul nu va fi mai vizibil în listări și căutări."
 
 #: components/manage/History/History
+# defaultMessage: Who
 msgid "Who"
 msgstr "Cine"
 
 #: components/manage/Contents/ContentsWorkflowModal
+# defaultMessage: Updating workflow states...
 msgid "Workflow Change Loading Message"
 msgstr ""
 
 #: components/manage/Workflow/Workflow
+# defaultMessage: Workflow updated.
 msgid "Workflow updated."
 msgstr "Fluxul de lucru a fost actualizat."
 
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
+# defaultMessage: Yearly
 msgid "Yearly"
 msgstr ""
 
 #: components/manage/Contents/ContentsItem
 #: components/manage/Controlpanels/ContentTypes
+# defaultMessage: Yes
 msgid "Yes"
 msgstr "Da"
 
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: You are trying to access a protected resource, please {login} first.
 msgid "You are trying to access a protected resource, please {login} first."
 msgstr "Încercați să accesați o resursă protejată, vă rugăm mai întâi {login}."
 
 #: components/theme/OutdatedBrowser/OutdatedBrowser
+# defaultMessage: You are using an outdated browser
 msgid "You are using an outdated browser"
 msgstr "Utilizați un browser învechit"
 
 #: components/theme/Comments/Comments
+# defaultMessage: You can add a comment by filling out the form below. Plain text formatting.
 msgid "You can add a comment by filling out the form below. Plain text formatting."
 msgstr "Puteți adăuga un comentariu completând formularul de mai jos. Formatare text simplu."
 
 #: components/manage/Sharing/Sharing
+# defaultMessage: You can control who can view and edit your item using the list below.
 msgid "You can control who can view and edit your item using the list below."
 msgstr "Puteți controla cine vă poate vizualiza și edita elementul folosind lista de mai jos."
 
 #: components/manage/Diff/Diff
+# defaultMessage: You can view the difference of the revisions below.
 msgid "You can view the difference of the revisions below."
 msgstr "Puteți vedea diferența reviziilor de mai jos."
 
 #: components/manage/History/History
+# defaultMessage: You can view the history of your item below.
 msgid "You can view the history of your item below."
 msgstr "Puteți vedea istoricul articolului dvs. mai jos."
 
 #: components/manage/Contents/Contents
+# defaultMessage: You can't paste this content here
 msgid "You can't paste this content here"
 msgstr ""
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Your email is required for reset your password.
 msgid "Your email is required for reset your password."
 msgstr "E-mailul dvs. este necesar pentru resetarea parolei."
 
 #: components/manage/Preferences/PersonalInformation
+# defaultMessage: Your location - either city and country - or in a company setting, where your office is located.
 msgid "Your location - either city and country - or in a company setting, where your office is located."
 msgstr "Locația dvs. - fie orașul, fie țara - fie într-un cadru al companiei, unde se află biroul dvs."
 
 #: components/theme/PasswordReset/PasswordReset
+# defaultMessage: Your password has been set successfully. You may now {link} with your new password.
 msgid "Your password has been set successfully. You may now {link} with your new password."
 msgstr "Parola dvs. a fost setată cu succes. Acum puteți {link} cu noua dvs. parolă."
 
 #: components/manage/Preferences/PersonalPreferences
+# defaultMessage: Your preferred language
 msgid "Your preferred language"
 msgstr "Limba dvs. preferată"
 
 #: components/theme/Login/Login
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Forgot your password?
 msgid "box_forgot_password_option"
 msgstr "Ați uitat parola?"
 
 #: config/Blocks
+# defaultMessage: Common
 msgid "common"
 msgstr "Comun"
 
 #: components/manage/Multilingual/CompareLanguages
+# defaultMessage: Compare to language
 msgid "compare_to"
 msgstr ""
 
 #: components/manage/Blocks/Block/EditBlockWrapper
+# defaultMessage: delete
 msgid "delete"
 msgstr "Ștergeți"
 
 #: components/theme/OutdatedBrowser/OutdatedBrowser
+# defaultMessage: You are using {browsername} {browserversion} which is deprecated by its vendor. That means that it does not get security updates and it is not ready for current modern web features, which deteriorates the user experience. Please upgrade to a modern browser.
 msgid "deprecated_browser_notice_message"
 msgstr "Browser-ul dvs. {browsername} {browserversion} este învechit. Actualizați browser-ul pentru o mai mare siguranță, viteză și cea mai bună experiență pe acest site."
 
 #: config/Blocks
+# defaultMessage: Description
 msgid "description"
 msgstr "Descriere"
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: For security reasons, we store your password encrypted, and cannot mail it to you. If you would like to reset your password, fill out the form below and we will send you an email at the address you gave when you registered to start the process of resetting your password.
 msgid "description_lost_password"
 msgstr "Din motive de securitate, parola dvs. este criptată și nu poate fi recuperată. Dacă doriți să o schimbați, completați formularul de mai jos și veți primi instrucțiunile la adresa de e-mail cu care v-ați înregistrat"
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Your password reset request has been mailed. It should arrive in your mailbox shortly. When you receive the message, visit the address it contains to reset your password.
 msgid "description_sent_password"
 msgstr "Parola este în curs de schimbare. Urmați instrucțiunile primite pe adresa de e-mail pentru a finaliza procesul de schimbare a parolei."
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Draft
 msgid "draft"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Input must be valid email (something@domain.com)
 msgid "email"
 msgstr ""
 
 #: components/theme/View/EventView
+# defaultMessage: All dates
 msgid "event_alldates"
 msgstr "Toate"
 
 #: components/theme/View/EventView
+# defaultMessage: Attendees
 msgid "event_attendees"
 msgstr "Participanți"
 
 #: components/theme/View/EventView
+# defaultMessage: Contact Name
 msgid "event_contactname"
 msgstr "Nume"
 
 #: components/theme/View/EventView
+# defaultMessage: Contact Phone
 msgid "event_contactphone"
 msgstr "Telefon"
 
 #: components/theme/View/EventView
+# defaultMessage: Website
 msgid "event_website"
 msgstr "Website"
 
 #: components/theme/View/EventView
+# defaultMessage: What
 msgid "event_what"
 msgstr "Despre"
 
 #: components/theme/View/EventView
+# defaultMessage: When
 msgid "event_when"
 msgstr "Data"
 
 #: components/theme/View/EventView
+# defaultMessage: Where
 msgid "event_where"
 msgstr "Locație"
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: Password reset confirmation sent
 msgid "heading_sent_password"
 msgstr "Confirmare schimbare parolă trimisă cu succes"
 
 #: config/Blocks
+# defaultMessage: Hero
 msgid "hero"
 msgstr "Hero"
 
 #: config/Blocks
+# defaultMessage: HTML
 msgid "html"
 msgstr "HTML"
 
 #: config/Blocks
+# defaultMessage: Image
 msgid "image"
 msgstr "Imagine"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Input must be integer
 msgid "integer"
 msgstr ""
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Intranet
 msgid "intranet"
 msgstr ""
 
 #: components/theme/PasswordReset/RequestPasswordReset
+# defaultMessage: My email address is
 msgid "label_my_email_address_is"
 msgstr "Adresa e-mail"
 
 #: config/Blocks
+# defaultMessage: Lead Image Field
 msgid "leadimage"
 msgstr "Imagine (copertă)"
 
 #: config/Blocks
+# defaultMessage: Listing
 msgid "listing"
 msgstr "Listare"
 
 #: components/manage/Blocks/Listing/ListingBody
 #: components/manage/Contents/Contents
+# defaultMessage: Loading
 msgid "loading"
 msgstr ""
 
 #: components/theme/Unauthorized/Unauthorized
+# defaultMessage: log in
 msgid "log in"
 msgstr "autentificați-vă"
 
 #: config/Blocks
+# defaultMessage: Maps
 msgid "maps"
 msgstr "Harta"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Maximum Length
 msgid "maxLength"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: End of the range (including the value itself)
 msgid "maximum"
 msgstr ""
 
 #: config/Blocks
+# defaultMessage: Media
 msgid "media"
 msgstr "Media"
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Minimum Length
 msgid "minLength"
 msgstr ""
 
 #: components/manage/Widgets/SchemaWidget
+# defaultMessage: Start of the range
 msgid "minimum"
 msgstr ""
 
 #: config/Blocks
+# defaultMessage: Most used
 msgid "mostUsed"
 msgstr "Cele mai utilizate"
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: No workflow state
 msgid "no workflow state"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Input must be number
 msgid "number"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/ByMonthDayField
 #: components/manage/Widgets/RecurrenceWidget/ByYearField
+# defaultMessage: of the month
 msgid "of the month"
 msgstr ""
 
 #: error
+# defaultMessage: or try a different page.
 msgid "or try a different page."
 msgstr "sau încercați o altă pagină."
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
+# defaultMessage: others
 msgid "others"
 msgstr ""
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Private
 msgid "private"
 msgstr ""
 
 #: components/manage/Contents/ContentsItem
+# defaultMessage: Published
 msgid "published"
 msgstr ""
 
 #: components/manage/Widgets/QueryWidget
+# defaultMessage: Select…
 msgid "querystring-widget-select"
 msgstr ""
 
 #: components/theme/Search/Search
+# defaultMessage: results
 msgid "results found"
 msgstr "rezultate găsite"
 
 #: error
+# defaultMessage: return to the site root
 msgid "return to the site root"
 msgstr "revenire la prima pagină"
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: and
 msgid "rrule_and"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: (~approximate)
 msgid "rrule_approximate"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: at
 msgid "rrule_at"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: [month] [day], [year]
 msgid "rrule_dateFormat"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: day
 msgid "rrule_day"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: days
 msgid "rrule_days"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: every
 msgid "rrule_every"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: for
 msgid "rrule_for"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: hour
 msgid "rrule_hour"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: hours
 msgid "rrule_hours"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: in
 msgid "rrule_in"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: last
 msgid "rrule_last"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: minutes
 msgid "rrule_minutes"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: month
 msgid "rrule_month"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: months
 msgid "rrule_months"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: nd
 msgid "rrule_nd"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: on
 msgid "rrule_on"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: on the
 msgid "rrule_on the"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: or
 msgid "rrule_or"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: rd
 msgid "rrule_rd"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: st
 msgid "rrule_st"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: th
 msgid "rrule_th"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: the
 msgid "rrule_the"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: time
 msgid "rrule_time"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: times
 msgid "rrule_times"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: until
 msgid "rrule_until"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: week
 msgid "rrule_week"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: weekday
 msgid "rrule_weekday"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: weekdays
 msgid "rrule_weekdays"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: weeks
 msgid "rrule_weeks"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: year
 msgid "rrule_year"
 msgstr ""
 
 #: components/manage/Widgets/RecurrenceWidget/Utils
+# defaultMessage: years
 msgid "rrule_years"
 msgstr ""
 
 #: components/theme/SkipLinks/SkipLinks
+# defaultMessage: Skip to footer
 msgid "skiplink-footer"
 msgstr ""
 
 #: components/theme/SkipLinks/SkipLinks
+# defaultMessage: Skip to main content
 msgid "skiplink-main-content"
 msgstr ""
 
 #: components/theme/SkipLinks/SkipLinks
+# defaultMessage: Skip to navigation
 msgid "skiplink-navigation"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: sort
 msgid "sort"
 msgstr "sortare"
 
 #: config/Blocks
+# defaultMessage: Table
 msgid "table"
 msgstr "Tabel"
 
 #: config/Blocks
+# defaultMessage: Text
 msgid "text"
 msgstr "Text"
 
 #: config/Blocks
+# defaultMessage: Title
 msgid "title"
 msgstr "Titlu"
 
 #: config/Blocks
+# defaultMessage: Table of Contents
 msgid "toc"
 msgstr "Cuprins"
 
 #: helpers/MessageLabels/MessageLabels
+# defaultMessage: Input must be valid url (www.something.com or http(s)://www.something.com)
 msgid "url"
 msgstr ""
 
 #: components/manage/Toolbar/PersonalTools
+# defaultMessage: user avatar
 msgid "user avatar"
 msgstr "avatarul utilizatorului"
 
 #: config/Blocks
+# defaultMessage: Video
 msgid "video"
 msgstr "Video"
 
 #: components/theme/View/EventView
+# defaultMessage: Visit external website
 msgid "visit_external_website"
 msgstr "Vizitează site extern"
 
 #: components/manage/Contents/ContentsUploadModal
+# defaultMessage: {count, plural, one {Upload {count} file} other {Upload {count} files}}
 msgid "{count, plural, one {Upload {count} file} other {Upload {count} files}}"
 msgstr ""
 
 #: components/manage/Contents/Contents
+# defaultMessage: {count} selected
 msgid "{count} selected"
 msgstr "{count} selectat"
 
 #: components/manage/Controlpanels/ContentType
+# defaultMessage: {id} Content Type
 msgid "{id} Content Type"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypeSchema
+# defaultMessage: {id} Schema
 msgid "{id} Schema"
 msgstr ""
 
 #: components/manage/Actions/Actions
+# defaultMessage: {title} copied.
 msgid "{title} copied."
 msgstr "copiat {title}."
 
 #: components/manage/Actions/Actions
+# defaultMessage: {title} cut.
 msgid "{title} cut."
 msgstr "{title} tăiat."
 
 #: components/manage/Actions/Actions
+# defaultMessage: {title} has been deleted.
 msgid "{title} has been deleted."
 msgstr "{title} a fost șters."

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2021-09-18T11:47:19.291Z\n"
+"POT-Creation-Date: 2021-09-18T11:58:59.711Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -2739,7 +2739,7 @@ msgid "Vocabulary terms"
 msgstr ""
 
 #: components/manage/Controlpanels/VersionOverview
-# defaultMessage: You are running in \"debug mode\". This mode is intended for sites that are under development. This allows many configuration changes to be immediately visible, but will make your site run more slowly. To turn off debug mode, stop the server, set \"debug-mode=off\" in your buildout.cfg, re-run bin/buildout and then restart the server process.
+# defaultMessage: You are running in 'debug mode'. This mode is intended for sites that are under development. This allows many configuration changes to be immediately visible, but will make your site run more slowly. To turn off debug mode, stop the server, set 'debug-mode=off' in your buildout.cfg, re-run bin/buildout and then restart the server process.
 msgid "Warning Regarding debug mode"
 msgstr ""
 

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2021-09-03T08:05:09.647Z\n"
+"POT-Creation-Date: 2021-09-18T11:47:19.291Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -2739,11 +2739,7 @@ msgid "Vocabulary terms"
 msgstr ""
 
 #: components/manage/Controlpanels/VersionOverview
-# defaultMessage: You are running in "debug mode". This mode is intended for sites that
-        are under development. This allows many configuration changes to be
-        immediately visible, but will make your site run more slowly. To turn
-        off debug mode, stop the server, set "debug-mode=off" in your
-        buildout.cfg, re-run bin/buildout and then restart the server process.
+# defaultMessage: You are running in \"debug mode\". This mode is intended for sites that are under development. This allows many configuration changes to be immediately visible, but will make your site run more slowly. To turn off debug mode, stop the server, set \"debug-mode=off\" in your buildout.cfg, re-run bin/buildout and then restart the server process.
 msgid "Warning Regarding debug mode"
 msgstr ""
 

--- a/packages/generator-volto/generators/addon/templates/src/i18n.js
+++ b/packages/generator-volto/generators/addon/templates/src/i18n.js
@@ -148,6 +148,7 @@ ${map(pot.items, (item) => {
   const poItem = find(po.items, { msgid: item.msgid });
   return [
     `${map(item.references, (ref) => `#: ${ref}`).join('\n')}`,
+    `# ${item.comments[0]}`,
     `msgid "${item.msgid}"`,
     `msgstr "${poItem ? poItem.msgstr : ''}"`,
   ].join('\n');

--- a/src/components/manage/Controlpanels/VersionOverview.jsx
+++ b/src/components/manage/Controlpanels/VersionOverview.jsx
@@ -34,7 +34,7 @@ const VersionOverview = ({
       <p>
         <FormattedMessage
           id="Warning Regarding debug mode"
-          defaultMessage='You are running in \"debug mode\". This mode is intended for sites that are under development. This allows many configuration changes to be immediately visible, but will make your site run more slowly. To turn off debug mode, stop the server, set \"debug-mode=off\" in your buildout.cfg, re-run bin/buildout and then restart the server process.'
+          defaultMessage="You are running in 'debug mode'. This mode is intended for sites that are under development. This allows many configuration changes to be immediately visible, but will make your site run more slowly. To turn off debug mode, stop the server, set 'debug-mode=off' in your buildout.cfg, re-run bin/buildout and then restart the server process."
         />
       </p>
     </>

--- a/src/components/manage/Controlpanels/VersionOverview.jsx
+++ b/src/components/manage/Controlpanels/VersionOverview.jsx
@@ -34,11 +34,7 @@ const VersionOverview = ({
       <p>
         <FormattedMessage
           id="Warning Regarding debug mode"
-          defaultMessage='You are running in "debug mode". This mode is intended for sites that
-        are under development. This allows many configuration changes to be
-        immediately visible, but will make your site run more slowly. To turn
-        off debug mode, stop the server, set "debug-mode=off" in your
-        buildout.cfg, re-run bin/buildout and then restart the server process.'
+          defaultMessage='You are running in \"debug mode\". This mode is intended for sites that are under development. This allows many configuration changes to be immediately visible, but will make your site run more slowly. To turn off debug mode, stop the server, set \"debug-mode=off\" in your buildout.cfg, re-run bin/buildout and then restart the server process.'
         />
       </p>
     </>

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -210,6 +210,7 @@ function formatHeader(comments, headers) {
  */
 function syncPoByPot() {
   const pot = Pofile.parse(fs.readFileSync('locales/volto.pot', 'utf8'));
+
   map(glob('locales/**/*.po'), (filename) => {
     const po = Pofile.parse(fs.readFileSync(filename, 'utf8'));
 

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -204,7 +204,6 @@ function formatHeader(comments, headers) {
  */
 function syncPoByPot() {
   const pot = Pofile.parse(fs.readFileSync('locales/volto.pot', 'utf8'));
-
   map(glob('locales/**/*.po'), (filename) => {
     const po = Pofile.parse(fs.readFileSync(filename, 'utf8'));
 
@@ -215,6 +214,7 @@ ${map(pot.items, (item) => {
   const poItem = find(po.items, { msgid: item.msgid });
   return [
     `${map(item.references, (ref) => `#: ${ref}`).join('\n')}`,
+    `${item.comments[0]}`,
     `msgid "${item.msgid}"`,
     `msgstr "${poItem ? poItem.msgstr : ''}"`,
   ].join('\n');
@@ -271,8 +271,8 @@ function main() {
   }
   console.log('Synchronizing messages to po files...');
   syncPoByPot();
-  console.log('Applying defaults to EN po file...');
-  syncENPoFileWithDefaults();
+  // console.log('Applying defaults to EN po file...');
+  // syncENPoFileWithDefaults();
   console.log('Generating the json files...');
   poToJson();
   console.log('done!');


### PR DESCRIPTION
I might be wrong, but I have a hunch that this is the cause of the unchained `Cannot format message: "X", using message id as fallback` message.

It was a difficult one, to decide the behaviour. So I opted for not touching the JSON, but act on the po, because of the add-on use case. So we do not get JSON language files from addons, but POs. So, we need to act at PO level.

Also, there was the alternative to not act on anything, just translate manually every time in the EN PO, but I would have sucked. Like this is automatic and it's aware of custom translations that might happen there anyways.

Problem could be that if we ever, change defaults in JS, then we need to act on the EN PO.

Not an easy one... 