### PR TITLE
Do not show lead image block when the content type does not have the …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Do not show lead image block when the content type does not have the behavior enabled @sneridagh
+
 ### Internal
 
 ## 14.0.0-alpha.7 (2021-09-20)

--- a/src/config/Blocks.jsx
+++ b/src/config/Blocks.jsx
@@ -202,7 +202,7 @@ const blocksConfig = {
     view: ViewLeadImageBlock,
     edit: EditLeadImageBlock,
     schema: BlockSettingsSchema,
-    restricted: false,
+    restricted: ({ properties }) => !properties.hasOwnProperty('image'),
     mostUsed: false,
     sidebarTab: 1,
     security: {


### PR DESCRIPTION
…behavior enabled