### PR TITLE
Use the block `title` as the source of the translation `id` instead o…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Breaking
 
+- Use the block's `title` as the source of the translation `id` instead of using the `id` of the block. See upgrade guide for more information. @sneridagh
+
 ### Feature
 
 ### Bugfix

--- a/docs/source/upgrade-guide/index.md
+++ b/docs/source/upgrade-guide/index.md
@@ -43,6 +43,11 @@ Not really a breaking change, but it's worth noting it. By default, Volto 14 com
     />
 ```
 
+### Blocks chooser now looks uses the title instead of the id of the block as translation source
+
+The `BlockChooser` component now uses the `title` of the block as source for translating
+the block title. Before, it took the `id` of the block, which is utterly wrong. Could be that this change will trigger untranslated blocks titles in your projects and addons.
+
 ## Upgrading to Volto 13.x.x
 
 ## Deprecating NodeJS 10

--- a/src/components/manage/BlockChooser/BlockChooser.jsx
+++ b/src/components/manage/BlockChooser/BlockChooser.jsx
@@ -133,7 +133,7 @@ const BlockChooser = ({
                     >
                       <Icon name={block.icon} size="36px" />
                       {intl.formatMessage({
-                        id: block.id,
+                        id: block.title,
                         defaultMessage: block.title,
                       })}
                     </Button>


### PR DESCRIPTION
…f using the `id` of the block