### PR TITLE
use proper fieldtitle for errormessages in add/edit form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Show correct fieldname and not internal field id in Toast error messages on Add/Edit forms @jackahl
+
 ### Internal
 
 - Use plone.volto instead of kitconcept.volto @tisto

--- a/src/helpers/FormValidation/FormValidation.js
+++ b/src/helpers/FormValidation/FormValidation.js
@@ -208,8 +208,10 @@ const validateRequiredFields = (
       !schema.properties[requiredField].readonly &&
       isEmpty
     ) {
-      errors[requiredField] = [];
-      errors[requiredField].push(formatMessage(messages.required));
+      const requiredFieldName =
+        schema.properties[requiredField].title || requiredField;
+      errors[requiredFieldName] = [];
+      errors[requiredFieldName].push(formatMessage(messages.required));
     }
   });
 

--- a/src/helpers/FormValidation/FormValidation.test.js
+++ b/src/helpers/FormValidation/FormValidation.test.js
@@ -61,7 +61,7 @@ describe('FormValidation', () => {
           formatMessage,
         }),
       ).toEqual({
-        username: [messages.required.defaultMessage],
+        Username: [messages.required.defaultMessage],
       });
     });
 


### PR DESCRIPTION
I noticed that the messages when a required field is not filled out point to the internal id of the field,which might lead to confusion for users, as the internal names might not make much sense to an outsider. I switched to using the field title instead of the id. This should also make the errors better localized when using multilingual.