### PR TITLE
Get `blocks` and `blocks_layout` defaults from existing behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Get `blocks` and `blocks_layout` defaults from existing behavior when enabling TTW editable DX Layout @avoinea
+
 ### Internal
 
 ## 14.0.0-alpha.13 (2021-09-30)

--- a/src/components/manage/Controlpanels/ContentTypeLayout.jsx
+++ b/src/components/manage/Controlpanels/ContentTypeLayout.jsx
@@ -159,11 +159,10 @@ class ContentTypeLayout extends Component {
 
     // Schema GET
     if (this.props.schemaRequest.loading && nextProps.schemaRequest.loaded) {
-      let properties = nextProps.schema?.properties || {};
-      let content = {};
-      let value, key;
-      for (key in properties) {
-        value = properties[key].default;
+      const properties = nextProps.schema?.properties || {};
+      const content = {};
+      for (const key in properties) {
+        const value = properties[key].default;
         if (value) {
           content[key] = value;
         }
@@ -229,7 +228,7 @@ class ContentTypeLayout extends Component {
    * @returns {undefined}
    */
   onSubmit(data) {
-    let schema = { properties: {} };
+    const schema = { properties: {} };
     Object.keys(data)
       .filter((k) => data[k])
       .forEach((k) => (schema.properties[k] = { default: data[k] }));
@@ -242,7 +241,7 @@ class ContentTypeLayout extends Component {
    * @returns {undefined}
    */
   onCancel() {
-    let url = getParentUrl(this.props.pathname);
+    const url = getParentUrl(this.props.pathname);
     this.props.history.push(getParentUrl(url));
   }
 
@@ -252,7 +251,10 @@ class ContentTypeLayout extends Component {
    * @returns {undefined}
    */
   onEnableBlocks() {
-    let schema = {
+    const { properties = {} } = this.props.schema;
+    const blocksFieldName = getBlocksFieldname(properties);
+    const blocksLayoutFieldname = getBlocksLayoutFieldname(properties);
+    const schema = {
       fieldsets: [
         {
           id: 'layout',
@@ -266,12 +268,14 @@ class ContentTypeLayout extends Component {
           type: 'dict',
           widget: 'json',
           factory: 'JSONField',
+          default: properties[blocksFieldName]?.default || {},
         },
         blocks_layout: {
           title: 'Blocks Layout',
           type: 'dict',
           widget: 'json',
           factory: 'JSONField',
+          default: properties[blocksLayoutFieldname]?.default || { items: [] },
         },
       },
     };


### PR DESCRIPTION
- when enabling TTW editable DX Layout