### PR TITLE
Fix: Fixed SelectWidget: when there was a selected value, the selecti…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### Bugfix
 
+- Fixed SelectWidget: when there was a selected value, the selection was lost when the tab was changed. @giuliaghisini
+
 ### Internal
 
 ## 14.0.0-alpha.18 (2021-10-11)

--- a/src/components/manage/Widgets/SelectWidget.jsx
+++ b/src/components/manage/Widgets/SelectWidget.jsx
@@ -155,8 +155,23 @@ class SelectWidget extends Component {
    * @returns {undefined}
    */
   componentDidMount() {
-    if (!this.props.choices?.length && this.props.vocabBaseUrl) {
+    if (
+      (!this.props.choices || this.props.choices?.length === 0) &&
+      this.props.vocabBaseUrl
+    ) {
       this.props.getVocabulary(this.props.vocabBaseUrl);
+    }
+  }
+
+  componentDidUpdate() {
+    if (
+      !this.state.selectedOption &&
+      this.props.value &&
+      this.props.choices?.length > 0
+    ) {
+      this.setState({
+        selectedOption: normalizeValue(this.props.choices, this.props.value),
+      });
     }
   }
 


### PR DESCRIPTION
…on was lost when the tab was changed

Fixes: https://github.com/plone/volto/issues/2742