### PR TITLE
add a custom schema to the listing block default template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Feature
 
+- add a custom schema to the listing block default template @ionlizarazu
+
 ### Bugfix
 
 ### Internal

--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -2309,9 +2309,9 @@ msgstr ""
 msgid "Show sorting?"
 msgstr ""
 
-#: components/manage/Blocks/Listing/schema
+#: components/manage/Blocks/Listing/defaultTemplateSchema
 # defaultMessage: undefined
-msgid "Show variation configuration"
+msgid "Show variation config"
 msgstr ""
 
 #: components/manage/Sidebar/Sidebar

--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -705,6 +705,11 @@ msgstr "Absteigend"
 msgid "Description"
 msgstr "Beschreibung"
 
+#: components/manage/Blocks/Listing/defaultTemplateSchema
+# defaultMessage: Description field
+msgid "Description field"
+msgstr ""
+
 #: components/manage/Diff/Diff
 # defaultMessage: Diff
 msgid "Diff"
@@ -2304,6 +2309,11 @@ msgstr ""
 msgid "Show sorting?"
 msgstr ""
 
+#: components/manage/Blocks/Listing/schema
+# defaultMessage: undefined
+msgid "Show variation configuration"
+msgstr ""
+
 #: components/manage/Sidebar/Sidebar
 # defaultMessage: Shrink sidebar
 msgid "Shrink sidebar"
@@ -2626,6 +2636,11 @@ msgstr "Zeit"
 # defaultMessage: Title
 msgid "Title"
 msgstr "Titel"
+
+#: components/manage/Blocks/Listing/defaultTemplateSchema
+# defaultMessage: Title field
+msgid "Title field"
+msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
 # defaultMessage: Total active and non-active objects

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -690,6 +690,11 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
+#: components/manage/Blocks/Listing/defaultTemplateSchema
+# defaultMessage: Description field
+msgid "Description field"
+msgstr ""
+
 #: components/manage/Diff/Diff
 # defaultMessage: Diff
 msgid "Diff"
@@ -2289,6 +2294,11 @@ msgstr ""
 msgid "Show sorting?"
 msgstr ""
 
+#: components/manage/Blocks/Listing/schema
+# defaultMessage: undefined
+msgid "Show variation configuration"
+msgstr ""
+
 #: components/manage/Sidebar/Sidebar
 # defaultMessage: Shrink sidebar
 msgid "Shrink sidebar"
@@ -2610,6 +2620,11 @@ msgstr ""
 #: helpers/MessageLabels/MessageLabels
 # defaultMessage: Title
 msgid "Title"
+msgstr ""
+
+#: components/manage/Blocks/Listing/defaultTemplateSchema
+# defaultMessage: Title field
+msgid "Title field"
 msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -2294,9 +2294,9 @@ msgstr ""
 msgid "Show sorting?"
 msgstr ""
 
-#: components/manage/Blocks/Listing/schema
+#: components/manage/Blocks/Listing/defaultTemplateSchema
 # defaultMessage: undefined
-msgid "Show variation configuration"
+msgid "Show variation config"
 msgstr ""
 
 #: components/manage/Sidebar/Sidebar

--- a/locales/es/LC_MESSAGES/volto.po
+++ b/locales/es/LC_MESSAGES/volto.po
@@ -2304,9 +2304,9 @@ msgstr ""
 msgid "Show sorting?"
 msgstr ""
 
-#: components/manage/Blocks/Listing/schema
+#: components/manage/Blocks/Listing/defaultTemplateSchema
 # defaultMessage: undefined
-msgid "Show variation configuration"
+msgid "Show variation config"
 msgstr ""
 
 #: components/manage/Sidebar/Sidebar

--- a/locales/es/LC_MESSAGES/volto.po
+++ b/locales/es/LC_MESSAGES/volto.po
@@ -700,6 +700,11 @@ msgstr "Descendente"
 msgid "Description"
 msgstr "Descripción"
 
+#: components/manage/Blocks/Listing/defaultTemplateSchema
+# defaultMessage: Description field
+msgid "Description field"
+msgstr ""
+
 #: components/manage/Diff/Diff
 # defaultMessage: Diff
 msgid "Diff"
@@ -2299,6 +2304,11 @@ msgstr ""
 msgid "Show sorting?"
 msgstr ""
 
+#: components/manage/Blocks/Listing/schema
+# defaultMessage: undefined
+msgid "Show variation configuration"
+msgstr ""
+
 #: components/manage/Sidebar/Sidebar
 # defaultMessage: Shrink sidebar
 msgid "Shrink sidebar"
@@ -2621,6 +2631,11 @@ msgstr "Hora"
 # defaultMessage: Title
 msgid "Title"
 msgstr "Título"
+
+#: components/manage/Blocks/Listing/defaultTemplateSchema
+# defaultMessage: Title field
+msgid "Title field"
+msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
 # defaultMessage: Total active and non-active objects

--- a/locales/eu/LC_MESSAGES/volto.po
+++ b/locales/eu/LC_MESSAGES/volto.po
@@ -2301,9 +2301,9 @@ msgstr ""
 msgid "Show sorting?"
 msgstr ""
 
-#: components/manage/Blocks/Listing/schema
+#: components/manage/Blocks/Listing/defaultTemplateSchema
 # defaultMessage: undefined
-msgid "Show variation configuration"
+msgid "Show variation config"
 msgstr ""
 
 #: components/manage/Sidebar/Sidebar

--- a/locales/eu/LC_MESSAGES/volto.po
+++ b/locales/eu/LC_MESSAGES/volto.po
@@ -697,6 +697,11 @@ msgstr "Beheraka"
 msgid "Description"
 msgstr "Deskribapena"
 
+#: components/manage/Blocks/Listing/defaultTemplateSchema
+# defaultMessage: Description field
+msgid "Description field"
+msgstr ""
+
 #: components/manage/Diff/Diff
 # defaultMessage: Diff
 msgid "Diff"
@@ -2296,6 +2301,11 @@ msgstr ""
 msgid "Show sorting?"
 msgstr ""
 
+#: components/manage/Blocks/Listing/schema
+# defaultMessage: undefined
+msgid "Show variation configuration"
+msgstr ""
+
 #: components/manage/Sidebar/Sidebar
 # defaultMessage: Shrink sidebar
 msgid "Shrink sidebar"
@@ -2618,6 +2628,11 @@ msgstr "Ordua"
 # defaultMessage: Title
 msgid "Title"
 msgstr "Izenburua"
+
+#: components/manage/Blocks/Listing/defaultTemplateSchema
+# defaultMessage: Title field
+msgid "Title field"
+msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
 # defaultMessage: Total active and non-active objects

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -2311,9 +2311,9 @@ msgstr ""
 msgid "Show sorting?"
 msgstr ""
 
-#: components/manage/Blocks/Listing/schema
+#: components/manage/Blocks/Listing/defaultTemplateSchema
 # defaultMessage: undefined
-msgid "Show variation configuration"
+msgid "Show variation config"
 msgstr ""
 
 #: components/manage/Sidebar/Sidebar

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -707,6 +707,11 @@ msgstr "Descendant"
 msgid "Description"
 msgstr "Déscription"
 
+#: components/manage/Blocks/Listing/defaultTemplateSchema
+# defaultMessage: Description field
+msgid "Description field"
+msgstr ""
+
 #: components/manage/Diff/Diff
 # defaultMessage: Diff
 msgid "Diff"
@@ -2306,6 +2311,11 @@ msgstr ""
 msgid "Show sorting?"
 msgstr ""
 
+#: components/manage/Blocks/Listing/schema
+# defaultMessage: undefined
+msgid "Show variation configuration"
+msgstr ""
+
 #: components/manage/Sidebar/Sidebar
 # defaultMessage: Shrink sidebar
 msgid "Shrink sidebar"
@@ -2628,6 +2638,11 @@ msgstr "Temps"
 # defaultMessage: Title
 msgid "Title"
 msgstr "Titre"
+
+#: components/manage/Blocks/Listing/defaultTemplateSchema
+# defaultMessage: Title field
+msgid "Title field"
+msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
 # defaultMessage: Total active and non-active objects

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -2294,9 +2294,9 @@ msgstr ""
 msgid "Show sorting?"
 msgstr ""
 
-#: components/manage/Blocks/Listing/schema
+#: components/manage/Blocks/Listing/defaultTemplateSchema
 # defaultMessage: undefined
-msgid "Show variation configuration"
+msgid "Show variation config"
 msgstr ""
 
 #: components/manage/Sidebar/Sidebar

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -690,6 +690,11 @@ msgstr "Decrescente"
 msgid "Description"
 msgstr "Descrizione"
 
+#: components/manage/Blocks/Listing/defaultTemplateSchema
+# defaultMessage: Description field
+msgid "Description field"
+msgstr ""
+
 #: components/manage/Diff/Diff
 # defaultMessage: Diff
 msgid "Diff"
@@ -2289,6 +2294,11 @@ msgstr ""
 msgid "Show sorting?"
 msgstr ""
 
+#: components/manage/Blocks/Listing/schema
+# defaultMessage: undefined
+msgid "Show variation configuration"
+msgstr ""
+
 #: components/manage/Sidebar/Sidebar
 # defaultMessage: Shrink sidebar
 msgid "Shrink sidebar"
@@ -2611,6 +2621,11 @@ msgstr "Ora"
 # defaultMessage: Title
 msgid "Title"
 msgstr "Titolo"
+
+#: components/manage/Blocks/Listing/defaultTemplateSchema
+# defaultMessage: Title field
+msgid "Title field"
+msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
 # defaultMessage: Total active and non-active objects

--- a/locales/ja/LC_MESSAGES/volto.po
+++ b/locales/ja/LC_MESSAGES/volto.po
@@ -2302,9 +2302,9 @@ msgstr ""
 msgid "Show sorting?"
 msgstr ""
 
-#: components/manage/Blocks/Listing/schema
+#: components/manage/Blocks/Listing/defaultTemplateSchema
 # defaultMessage: undefined
-msgid "Show variation configuration"
+msgid "Show variation config"
 msgstr ""
 
 #: components/manage/Sidebar/Sidebar

--- a/locales/ja/LC_MESSAGES/volto.po
+++ b/locales/ja/LC_MESSAGES/volto.po
@@ -698,6 +698,11 @@ msgstr "降順"
 msgid "Description"
 msgstr "説明"
 
+#: components/manage/Blocks/Listing/defaultTemplateSchema
+# defaultMessage: Description field
+msgid "Description field"
+msgstr ""
+
 #: components/manage/Diff/Diff
 # defaultMessage: Diff
 msgid "Diff"
@@ -2297,6 +2302,11 @@ msgstr ""
 msgid "Show sorting?"
 msgstr ""
 
+#: components/manage/Blocks/Listing/schema
+# defaultMessage: undefined
+msgid "Show variation configuration"
+msgstr ""
+
 #: components/manage/Sidebar/Sidebar
 # defaultMessage: Shrink sidebar
 msgid "Shrink sidebar"
@@ -2619,6 +2629,11 @@ msgstr "時刻"
 # defaultMessage: Title
 msgid "Title"
 msgstr "タイトル"
+
+#: components/manage/Blocks/Listing/defaultTemplateSchema
+# defaultMessage: Title field
+msgid "Title field"
+msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
 # defaultMessage: Total active and non-active objects

--- a/locales/nl/LC_MESSAGES/volto.po
+++ b/locales/nl/LC_MESSAGES/volto.po
@@ -709,6 +709,11 @@ msgstr "Aflopend"
 msgid "Description"
 msgstr "Beschrijving"
 
+#: components/manage/Blocks/Listing/defaultTemplateSchema
+# defaultMessage: Description field
+msgid "Description field"
+msgstr ""
+
 #: components/manage/Diff/Diff
 # defaultMessage: Diff
 msgid "Diff"
@@ -2308,6 +2313,11 @@ msgstr ""
 msgid "Show sorting?"
 msgstr ""
 
+#: components/manage/Blocks/Listing/schema
+# defaultMessage: undefined
+msgid "Show variation configuration"
+msgstr ""
+
 #: components/manage/Sidebar/Sidebar
 # defaultMessage: Shrink sidebar
 msgid "Shrink sidebar"
@@ -2630,6 +2640,11 @@ msgstr ""
 # defaultMessage: Title
 msgid "Title"
 msgstr "Titel"
+
+#: components/manage/Blocks/Listing/defaultTemplateSchema
+# defaultMessage: Title field
+msgid "Title field"
+msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
 # defaultMessage: Total active and non-active objects

--- a/locales/nl/LC_MESSAGES/volto.po
+++ b/locales/nl/LC_MESSAGES/volto.po
@@ -2313,9 +2313,9 @@ msgstr ""
 msgid "Show sorting?"
 msgstr ""
 
-#: components/manage/Blocks/Listing/schema
+#: components/manage/Blocks/Listing/defaultTemplateSchema
 # defaultMessage: undefined
-msgid "Show variation configuration"
+msgid "Show variation config"
 msgstr ""
 
 #: components/manage/Sidebar/Sidebar

--- a/locales/pt/LC_MESSAGES/volto.po
+++ b/locales/pt/LC_MESSAGES/volto.po
@@ -2302,9 +2302,9 @@ msgstr ""
 msgid "Show sorting?"
 msgstr ""
 
-#: components/manage/Blocks/Listing/schema
+#: components/manage/Blocks/Listing/defaultTemplateSchema
 # defaultMessage: undefined
-msgid "Show variation configuration"
+msgid "Show variation config"
 msgstr ""
 
 #: components/manage/Sidebar/Sidebar

--- a/locales/pt/LC_MESSAGES/volto.po
+++ b/locales/pt/LC_MESSAGES/volto.po
@@ -698,6 +698,11 @@ msgstr "Descendente"
 msgid "Description"
 msgstr "Descrição"
 
+#: components/manage/Blocks/Listing/defaultTemplateSchema
+# defaultMessage: Description field
+msgid "Description field"
+msgstr ""
+
 #: components/manage/Diff/Diff
 # defaultMessage: Diff
 msgid "Diff"
@@ -2297,6 +2302,11 @@ msgstr ""
 msgid "Show sorting?"
 msgstr ""
 
+#: components/manage/Blocks/Listing/schema
+# defaultMessage: undefined
+msgid "Show variation configuration"
+msgstr ""
+
 #: components/manage/Sidebar/Sidebar
 # defaultMessage: Shrink sidebar
 msgid "Shrink sidebar"
@@ -2619,6 +2629,11 @@ msgstr ""
 # defaultMessage: Title
 msgid "Title"
 msgstr "Título"
+
+#: components/manage/Blocks/Listing/defaultTemplateSchema
+# defaultMessage: Title field
+msgid "Title field"
+msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
 # defaultMessage: Total active and non-active objects

--- a/locales/pt_BR/LC_MESSAGES/volto.po
+++ b/locales/pt_BR/LC_MESSAGES/volto.po
@@ -2304,9 +2304,9 @@ msgstr ""
 msgid "Show sorting?"
 msgstr ""
 
-#: components/manage/Blocks/Listing/schema
+#: components/manage/Blocks/Listing/defaultTemplateSchema
 # defaultMessage: undefined
-msgid "Show variation configuration"
+msgid "Show variation config"
 msgstr ""
 
 #: components/manage/Sidebar/Sidebar

--- a/locales/pt_BR/LC_MESSAGES/volto.po
+++ b/locales/pt_BR/LC_MESSAGES/volto.po
@@ -700,6 +700,11 @@ msgstr "Descendente"
 msgid "Description"
 msgstr "Descrição"
 
+#: components/manage/Blocks/Listing/defaultTemplateSchema
+# defaultMessage: Description field
+msgid "Description field"
+msgstr ""
+
 #: components/manage/Diff/Diff
 # defaultMessage: Diff
 msgid "Diff"
@@ -2299,6 +2304,11 @@ msgstr ""
 msgid "Show sorting?"
 msgstr ""
 
+#: components/manage/Blocks/Listing/schema
+# defaultMessage: undefined
+msgid "Show variation configuration"
+msgstr ""
+
 #: components/manage/Sidebar/Sidebar
 # defaultMessage: Shrink sidebar
 msgid "Shrink sidebar"
@@ -2621,6 +2631,11 @@ msgstr "Hora"
 # defaultMessage: Title
 msgid "Title"
 msgstr "Título"
+
+#: components/manage/Blocks/Listing/defaultTemplateSchema
+# defaultMessage: Title field
+msgid "Title field"
+msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
 # defaultMessage: Total active and non-active objects

--- a/locales/ro/LC_MESSAGES/volto.po
+++ b/locales/ro/LC_MESSAGES/volto.po
@@ -690,6 +690,11 @@ msgstr "Descrescător"
 msgid "Description"
 msgstr "Descriere"
 
+#: components/manage/Blocks/Listing/defaultTemplateSchema
+# defaultMessage: Description field
+msgid "Description field"
+msgstr ""
+
 #: components/manage/Diff/Diff
 # defaultMessage: Diff
 msgid "Diff"
@@ -2289,6 +2294,11 @@ msgstr ""
 msgid "Show sorting?"
 msgstr ""
 
+#: components/manage/Blocks/Listing/schema
+# defaultMessage: undefined
+msgid "Show variation configuration"
+msgstr ""
+
 #: components/manage/Sidebar/Sidebar
 # defaultMessage: Shrink sidebar
 msgid "Shrink sidebar"
@@ -2611,6 +2621,11 @@ msgstr ""
 # defaultMessage: Title
 msgid "Title"
 msgstr "Titlu"
+
+#: components/manage/Blocks/Listing/defaultTemplateSchema
+# defaultMessage: Title field
+msgid "Title field"
+msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation
 # defaultMessage: Total active and non-active objects

--- a/locales/ro/LC_MESSAGES/volto.po
+++ b/locales/ro/LC_MESSAGES/volto.po
@@ -2294,9 +2294,9 @@ msgstr ""
 msgid "Show sorting?"
 msgstr ""
 
-#: components/manage/Blocks/Listing/schema
+#: components/manage/Blocks/Listing/defaultTemplateSchema
 # defaultMessage: undefined
-msgid "Show variation configuration"
+msgid "Show variation config"
 msgstr ""
 
 #: components/manage/Sidebar/Sidebar

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2021-10-18T10:00:31.303Z\n"
+"POT-Creation-Date: 2021-10-18T15:37:49.800Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -2296,9 +2296,9 @@ msgstr ""
 msgid "Show sorting?"
 msgstr ""
 
-#: components/manage/Blocks/Listing/schema
+#: components/manage/Blocks/Listing/defaultTemplateSchema
 # defaultMessage: undefined
-msgid "Show variation configuration"
+msgid "Show variation config"
 msgstr ""
 
 #: components/manage/Sidebar/Sidebar

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2021-10-14T10:05:59.147Z\n"
+"POT-Creation-Date: 2021-10-18T10:00:31.303Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -690,6 +690,11 @@ msgstr ""
 #: helpers/MessageLabels/MessageLabels
 # defaultMessage: Description
 msgid "Description"
+msgstr ""
+
+#: components/manage/Blocks/Listing/defaultTemplateSchema
+# defaultMessage: Description field
+msgid "Description field"
 msgstr ""
 
 #: components/manage/Diff/Diff
@@ -2291,6 +2296,11 @@ msgstr ""
 msgid "Show sorting?"
 msgstr ""
 
+#: components/manage/Blocks/Listing/schema
+# defaultMessage: undefined
+msgid "Show variation configuration"
+msgstr ""
+
 #: components/manage/Sidebar/Sidebar
 # defaultMessage: Shrink sidebar
 msgid "Shrink sidebar"
@@ -2612,6 +2622,11 @@ msgstr ""
 #: helpers/MessageLabels/MessageLabels
 # defaultMessage: Title
 msgid "Title"
+msgstr ""
+
+#: components/manage/Blocks/Listing/defaultTemplateSchema
+# defaultMessage: Title field
+msgid "Title field"
 msgstr ""
 
 #: components/manage/Controlpanels/DatabaseInformation

--- a/src/components/manage/Blocks/Listing/DefaultTemplate.jsx
+++ b/src/components/manage/Blocks/Listing/DefaultTemplate.jsx
@@ -5,7 +5,14 @@ import { flattenToAppURL } from '@plone/volto/helpers';
 
 import { isInternalURL } from '@plone/volto/helpers/Url/Url';
 
-const DefaultTemplate = ({ items, linkTitle, linkHref, isEditMode }) => {
+const DefaultTemplate = ({
+  items,
+  linkTitle,
+  linkHref,
+  isEditMode,
+  variationTitle,
+  variationDescription,
+}) => {
   let link = null;
   let href = linkHref?.[0]?.['@id'] || '';
 
@@ -18,7 +25,6 @@ const DefaultTemplate = ({ items, linkTitle, linkHref, isEditMode }) => {
   } else if (href) {
     link = <a href={href}>{linkTitle || href}</a>;
   }
-
   return (
     <>
       <div className="items">
@@ -26,8 +32,24 @@ const DefaultTemplate = ({ items, linkTitle, linkHref, isEditMode }) => {
           <div className="listing-item" key={item['@id']}>
             <ConditionalLink item={item} condition={!isEditMode}>
               <div className="listing-body">
-                <h4>{item.title ? item.title : item.id}</h4>
-                <p>{item.description}</p>
+                <h4>
+                  {variationTitle &&
+                  typeof item[variationTitle] != 'object' &&
+                  item[variationTitle] != null
+                    ? item[variationTitle]
+                    : item.title
+                    ? item.title
+                    : item.id}
+                </h4>
+                <p>
+                  {variationDescription &&
+                  typeof item[variationDescription] != 'object' &&
+                  item[variationDescription] != null
+                    ? item[variationDescription]
+                    : item.description
+                    ? item.description
+                    : item.id}
+                </p>
               </div>
             </ConditionalLink>
           </div>

--- a/src/components/manage/Blocks/Listing/defaultTemplateSchema.js
+++ b/src/components/manage/Blocks/Listing/defaultTemplateSchema.js
@@ -9,23 +9,45 @@ const messages = defineMessages({
     id: 'Description field',
     defaultMessage: 'Description field',
   },
+  variationConfig: {
+    id: 'Show variation config',
+    defineMessages: 'Show variation config',
+  },
 });
-export default (props) => {
-  const { intl } = props;
+export const defaultTemplateSchema = (props) => {
+  const { intl, schema, formData } = props;
+  schema.fieldsets.map((fieldset) => {
+    if (fieldset.id === 'default') {
+      fieldset.fields = ['variationConfiguration', ...fieldset.fields];
+    }
+    return fieldset;
+  });
   return {
+    ...schema,
     fieldsets: [
-      {
-        id: 'variation',
-        title: 'Variation',
-        fields: ['variationTitle', 'variationDescription'],
-      },
+      ...schema.fieldsets,
+      ...(formData?.variationConfiguration
+        ? [
+            {
+              id: 'variation',
+              title: 'Variation',
+              fields: ['variationTitle', 'variationDescription'],
+            },
+          ]
+        : []),
     ],
     properties: {
+      ...schema.properties,
       variationTitle: {
         title: intl.formatMessage(messages.titleField),
       },
       variationDescription: {
         title: intl.formatMessage(messages.descriptionField),
+      },
+      variationConfiguration: {
+        title: intl.formatMessage(messages.variationConfig),
+        type: 'boolean',
+        default: false,
       },
     },
     required: [],

--- a/src/components/manage/Blocks/Listing/defaultTemplateSchema.js
+++ b/src/components/manage/Blocks/Listing/defaultTemplateSchema.js
@@ -1,0 +1,33 @@
+import { defineMessages } from 'react-intl';
+
+const messages = defineMessages({
+  titleField: {
+    id: 'Title field',
+    defaultMessage: 'Title field',
+  },
+  descriptionField: {
+    id: 'Description field',
+    defaultMessage: 'Description field',
+  },
+});
+export default (props) => {
+  const { intl } = props;
+  return {
+    fieldsets: [
+      {
+        id: 'variation',
+        title: 'Variation',
+        fields: ['variationTitle', 'variationDescription'],
+      },
+    ],
+    properties: {
+      variationTitle: {
+        title: intl.formatMessage(messages.titleField),
+      },
+      variationDescription: {
+        title: intl.formatMessage(messages.descriptionField),
+      },
+    },
+    required: [],
+  };
+};

--- a/src/components/manage/Blocks/Listing/schema.js
+++ b/src/components/manage/Blocks/Listing/schema.js
@@ -22,18 +22,22 @@ const messages = defineMessages({
     id: 'Link to',
     defaultMessage: 'Link to',
   },
+  variationConfiguration: {
+    id: 'Show variation configuration',
+    defineMessages: 'Show variation configuration',
+  },
 });
 
 export const schemaListing = (props) => {
-  const { intl } = props;
-
+  const { intl, variation, data } = props;
+  const vConfig = variation?.schema ? ['variationConfiguration'] : [];
   return {
     title: intl.formatMessage(messages.listing),
     fieldsets: [
       {
         id: 'default',
         title: 'Default',
-        fields: ['querystring'],
+        fields: [...vConfig, 'querystring'],
       },
       ...(config.blocks.blocksConfig.listing.showLinkMore
         ? [
@@ -43,6 +47,9 @@ export const schemaListing = (props) => {
               fields: ['linkTitle', 'linkHref'],
             },
           ]
+        : []),
+      ...(data.variationConfiguration && variation.schema
+        ? variation.schema(props).fieldsets
         : []),
     ],
 
@@ -61,6 +68,12 @@ export const schemaListing = (props) => {
         selectedItemAttrs: ['Title', 'Description'],
         allowExternals: true,
       },
+      variationConfiguration: {
+        type: 'boolean',
+        title: intl.formatMessage(messages.variationConfiguration),
+        default: false,
+      },
+      ...(variation?.schema ? variation.schema(props).properties : ''),
     },
     required: [],
   };

--- a/src/components/manage/Blocks/Listing/schema.js
+++ b/src/components/manage/Blocks/Listing/schema.js
@@ -22,22 +22,18 @@ const messages = defineMessages({
     id: 'Link to',
     defaultMessage: 'Link to',
   },
-  variationConfiguration: {
-    id: 'Show variation configuration',
-    defineMessages: 'Show variation configuration',
-  },
 });
 
 export const schemaListing = (props) => {
-  const { intl, variation, data } = props;
-  const vConfig = variation?.schema ? ['variationConfiguration'] : [];
+  const { intl } = props;
+
   return {
     title: intl.formatMessage(messages.listing),
     fieldsets: [
       {
         id: 'default',
         title: 'Default',
-        fields: [...vConfig, 'querystring'],
+        fields: ['querystring'],
       },
       ...(config.blocks.blocksConfig.listing.showLinkMore
         ? [
@@ -47,9 +43,6 @@ export const schemaListing = (props) => {
               fields: ['linkTitle', 'linkHref'],
             },
           ]
-        : []),
-      ...(data.variationConfiguration && variation.schema
-        ? variation.schema(props).fieldsets
         : []),
     ],
 
@@ -68,12 +61,6 @@ export const schemaListing = (props) => {
         selectedItemAttrs: ['Title', 'Description'],
         allowExternals: true,
       },
-      variationConfiguration: {
-        type: 'boolean',
-        title: intl.formatMessage(messages.variationConfiguration),
-        default: false,
-      },
-      ...(variation?.schema ? variation.schema(props).properties : ''),
     },
     required: [],
   };

--- a/src/config/Blocks.jsx
+++ b/src/config/Blocks.jsx
@@ -21,7 +21,7 @@ import EditImageBlock from '@plone/volto/components/manage/Blocks/Image/Edit';
 import EditLeadImageBlock from '@plone/volto/components/manage/Blocks/LeadImage/Edit';
 import EditListingBlock from '@plone/volto/components/manage/Blocks/Listing/Edit';
 import DefaultListingBlockTemplate from '@plone/volto/components/manage/Blocks/Listing/DefaultTemplate';
-import DefaultTemplateSchema from '@plone/volto/components/manage/Blocks/Listing/defaultTemplateSchema';
+import { defaultTemplateSchema } from '@plone/volto/components/manage/Blocks/Listing/defaultTemplateSchema';
 import SummaryListingBlockTemplate from '@plone/volto/components/manage/Blocks/Listing/SummaryTemplate';
 import EditVideoBlock from '@plone/volto/components/manage/Blocks/Video/Edit';
 import EditHeroImageLeftBlock from '@plone/volto/components/manage/Blocks/HeroImageLeft/Edit';
@@ -245,7 +245,7 @@ const blocksConfig = {
         isDefault: true,
         title: 'Default',
         template: DefaultListingBlockTemplate,
-        schema: DefaultTemplateSchema,
+        schemaEnhancer: defaultTemplateSchema,
       },
       {
         id: 'imageGallery',

--- a/src/config/Blocks.jsx
+++ b/src/config/Blocks.jsx
@@ -21,6 +21,7 @@ import EditImageBlock from '@plone/volto/components/manage/Blocks/Image/Edit';
 import EditLeadImageBlock from '@plone/volto/components/manage/Blocks/LeadImage/Edit';
 import EditListingBlock from '@plone/volto/components/manage/Blocks/Listing/Edit';
 import DefaultListingBlockTemplate from '@plone/volto/components/manage/Blocks/Listing/DefaultTemplate';
+import DefaultTemplateSchema from '@plone/volto/components/manage/Blocks/Listing/defaultTemplateSchema';
 import SummaryListingBlockTemplate from '@plone/volto/components/manage/Blocks/Listing/SummaryTemplate';
 import EditVideoBlock from '@plone/volto/components/manage/Blocks/Video/Edit';
 import EditHeroImageLeftBlock from '@plone/volto/components/manage/Blocks/HeroImageLeft/Edit';
@@ -244,6 +245,7 @@ const blocksConfig = {
         isDefault: true,
         title: 'Default',
         template: DefaultListingBlockTemplate,
+        schema: DefaultTemplateSchema,
       },
       {
         id: 'imageGallery',


### PR DESCRIPTION
I think that with the listing block and the use of the templates we are creating a very powerful tool, so I add this feature that I think can be very powerful.

I've added a schema to the listing block DefaultTemplate, so we can customize the fields wich are comming the now strict "title" and "description". This will be useful for content_types where we don't necessarily want to use the default fields and the default design is perfect for us. I have not added it, but we can also modify some other characteristics in this way such as the number of columns, show image or not...

Here a gif with the functionality added:
![listing block template schema](https://user-images.githubusercontent.com/5443301/137708846-05892f8b-94a8-465c-a929-3d028c160327.gif)

@sneridagh @tiberiuichim 