### PR TITLE
Enable using the internal proxy in production too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Feature
 
+- Enable to be able to use the internal proxy in production as well @sneridagh
+
 ### Bugfix
 
 ### Internal

--- a/docs/source/configuration/internalproxy.md
+++ b/docs/source/configuration/internalproxy.md
@@ -14,8 +14,7 @@ These are the settings that allows you to configure the API and how the proxy wo
 - `devProxyToApiPath` - The real backend URL, used by the proxy. By default, `http://localhost:8080/Plone`
 
 !!! tip
-    You don't want to deal with CORS in your production deployments, so the proxy is only
-    enabled in development mode (e.g `yarn start`)
+    You don't want to deal with CORS in your production deployments, so using the proxy is only meant to be enabled in development mode (e.g `yarn start`). However, for convenience and for testing/demoing using the stock build, it's also enabled in production mode since Volto 14.
 
 !!! note
     You can disable the proxy by redefining a new `apiPath` and redefining an empty
@@ -25,7 +24,7 @@ Here are some examples.
 
 ### Redefining the proxy target
 
-You can redefine the local proxy target by using the `RAZZLE_DEV_PROXY_API_PATH` or `devProxyToApiPath` in the configuration object (`src/config.js`).
+You can redefine the local proxy target by using the `RAZZLE_DEV_PROXY_API_PATH` or setting `devProxyToApiPath` in the configuration object (`src/config.js`).
 
 For example, if the path to your Plone site is `http://localhost:8081/mysite`, add the following to the bottom of the `src/config.js` file:
 
@@ -53,12 +52,12 @@ export const settings = {
 
 or use the environment variable:
 ```bash
-RAZZLE_API_PATH=http://localhost:8081/mysite yarn start
+RAZZLE_DEV_PROXY_API_PATH= RAZZLE_API_PATH=http://localhost:8081/mysite yarn start
 ```
 
 !!! tip
     To view the existing configuration, add console.log(config) to the `applyConfig` function. This dumps the existing config to your terminal console.
-    
+
 ### Advanced usage
 
 It's possible to define the proxy target more accuratelly using the `RAZZLE_PROXY_REWRITE_TARGET` environment variable, or the `proxyRewriteTarget` setting in the configuration object.

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -74,11 +74,12 @@ let config = {
     port,
     // The URL Volto is going to be served (see sensible defaults above)
     publicURL,
-    // Internal proxy to bypass CORS *while developing*. Not intended for production use.
-    // In production, the proxy is disabled, make sure you specify an apiPath that does
-    // not require CORS to work.
     apiPath,
     apiExpanders: [],
+    // Internal proxy to bypass CORS *while developing*. NOT intended for production use.
+    // In production is recommended you use a Seamless mode deployment using a web server in
+    // front of both the frontend and the backend so you can bypass CORS safely.
+    // https://docs.voltocms.com/deploying/seamless-mode/
     devProxyToApiPath:
       process.env.RAZZLE_DEV_PROXY_API_PATH ||
       process.env.RAZZLE_API_PATH ||

--- a/src/express-middleware/devproxy.js
+++ b/src/express-middleware/devproxy.js
@@ -11,11 +11,7 @@ import { parse as parseUrl } from 'url';
 
 const filter = function (pathname, req) {
   // This is the proxy to the API in case the accept header is 'application/json'
-  return (
-    __DEVELOPMENT__ &&
-    config.settings.devProxyToApiPath &&
-    pathname.startsWith('/++api++')
-  );
+  return config.settings.devProxyToApiPath && pathname.startsWith('/++api++');
 };
 
 let _env = null;

--- a/src/server.jsx
+++ b/src/server.jsx
@@ -131,7 +131,7 @@ function setupServer(req, res, next) {
       .send(`<!doctype html> ${renderToString(errorPage)}`);
   }
 
-  if (!__DEVELOPMENT__ && !process.env.RAZZLE_API_PATH && req.headers.host) {
+  if (!process.env.RAZZLE_API_PATH && req.headers.host) {
     req.app.locals.detectedHost = `${
       req.headers['x-forwarded-proto'] || req.protocol
     }://${req.headers.host}`;


### PR DESCRIPTION
Rationale:

- It was a long standing proposal from the community, specially @tiberiuichim ;)
- Although I always thought that for newbies could be confusing (and far too easy to get it wrong), with seamless mode in place and good documentation and the upcoming deployment training will suffice
- Leaving in place the name `devProxyToApiPath` so it's still clear the purpose of the feature will help
- It still can be disabled by setting the variable to ""
- It does not hurt to have it in there anyways