### PR TITLE
Prevent ua-parser-js security breach.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Prevent ua-parser-js security breach. See: https://github.com/advisories/GHSA-pjwm-rvh2-c87w @thet
+
 ### Internal
 
 ## 14.0.0-alpha.23 (2021-10-21)

--- a/package.json
+++ b/package.json
@@ -407,12 +407,16 @@
     "tmp": "0.2.1",
     "use-trace-update": "1.3.2"
   },
+  "resolutions-comments": {
+    "ua-parser-js": "See https://github.com/faisalman/ua-parser-js/issues/536"
+  },
   "resolutions": {
     "http-proxy": "^1.18.1",
     "draft-js/immutable": "3.8.2",
     "draft-js-block-breakout-plugin/immutable": "3.8.2",
     "draft-js-inline-toolbar-plugin/immutable": "3.8.2",
-    "draft-js-plugins-editor/immutable": "3.8.2"
+    "draft-js-plugins-editor/immutable": "3.8.2",
+    "ua-parser-js": "0.7.28"
   },
   "volta": {
     "node": "14.17.0",


### PR DESCRIPTION
See: https://github.com/advisories/GHSA-pjwm-rvh2-c87w

Volto currently uses 0.7.28, which is good.
This PR should ensure to keep it that way.

ua-parser-js is used by:
fbjs/package.json
stream-http/package.json