### PR TITLE
CSS fix on `QueryWidget` to prevent line jumping for clear button whe…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Prevent ua-parser-js security breach. See: https://github.com/advisories/GHSA-pjwm-rvh2-c87w @thet
 - Fix storybook errors in the connected components, api is undefined. Using now a mock of the store instead of the whole thing @sneridagh
+- CSS fix on `QueryWidget` to prevent line jumping for clear button when the multi selection widget has multiple items @kreafox
 
 ### Internal
 

--- a/src/components/manage/Widgets/QueryWidget.jsx
+++ b/src/components/manage/Widgets/QueryWidget.jsx
@@ -169,7 +169,7 @@ class QuerystringWidget extends Component {
         );
       case 'MultipleSelectionWidget':
         return (
-          <Form.Field style={{ flex: '1 0 auto', maxWidth: '93%' }}>
+          <Form.Field style={{ flex: '1 0 auto', maxWidth: '92%' }}>
             <Select
               {...props}
               className="react-select-container"


### PR DESCRIPTION
…n the multi selection widget has multiple items

Before: 
![before](https://user-images.githubusercontent.com/20109479/139238046-5b28d1d1-56b2-4767-9a08-4873727e0f1b.png)

After:
![after](https://user-images.githubusercontent.com/20109479/139238086-c5e099ae-4324-4fe0-b6ca-5763e466d562.png)


