### PR TITLE
Fix alt image handling

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: Documentation
 on:
   push:
     branches:
-      - main
+      - master
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,6 @@
     
 ### Bugfix
 
-- Fix disable mode of `QuerystringWidget` when all criteria are deleted @kreafox
-
 ### Internal
 
 - Add RawMaterial website in Volto production sites @nzambello
@@ -37,6 +35,8 @@
 ### Bugfix
 
 - Fix loading of cookie on SSR for certain requests, revert slight change in how they are loaded introduced in alpha 16 @sneridagh
+- Fix disable mode of `QuerystringWidget` when all criteria are deleted @kreafox
+
 
 ## 14.0.0-alpha.22 (2021-10-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 ### Feature
 
+- FormFieldWrapper accepts now strings and elements for description @nzambello
+- Image block:
+    - When uploading an image or selecting that from the object browser, Image block will set an empty string as alternative text @nzambello
+    - Adds a description to the alt-tag with w3c explaination @nzambello
+
 ### Bugfix
 
 - Prevent ua-parser-js security breach. See: https://github.com/advisories/GHSA-pjwm-rvh2-c87w @thet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 
 ## 14.0.0-alpha.24 (2021-10-29)
 
+### Feature
+
 - Support Node 16 @timo
 
 ### Bugfix

--- a/cypress/tests/core/blocks-image.js
+++ b/cypress/tests/core/blocks-image.js
@@ -148,4 +148,22 @@ describe('Blocks Tests', () => {
         expect($img[0].naturalWidth).to.be.greaterThan(0);
       });
   });
+
+  it('Create an image block and initially alt attr is empty', () => {
+    // when I add an image block via upload
+    cy.get('.block.inner.text .public-DraftEditor-content').click();
+    cy.get('.ui.basic.icon.button.block-add-button').click();
+    cy.get('.ui.basic.icon.button.image').contains('Image').click();
+
+    cy.get('input[type="file"]').attachFile('image.png', {
+      subjectType: 'input',
+      encoding: 'utf8',
+    });
+    cy.waitForResourceToLoad('image.png/@@images/image');
+
+    // then in sidebar alt attr should be empty
+    cy.get('#sidebar-properties .field-wrapper-alt input#field-alt')
+      .should('have.attr', 'value')
+      .and('eq', '');
+  });
 });

--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -197,6 +197,16 @@ msgstr "alphabetisch"
 msgid "Alt text"
 msgstr "Alternative Text"
 
+#: components/manage/Blocks/Image/ImageSidebar
+# defaultMessage: Leave empty if the image is purely decorative.
+msgid "Alt text hint"
+msgstr ""
+
+#: components/manage/Blocks/Image/ImageSidebar
+# defaultMessage: Describe the purpose of the image.
+msgid "Alt text hint link text"
+msgstr ""
+
 #: components/manage/Toolbar/More
 # defaultMessage: Apply working copy
 msgid "Apply working copy"

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -182,6 +182,16 @@ msgstr ""
 msgid "Alt text"
 msgstr ""
 
+#: components/manage/Blocks/Image/ImageSidebar
+# defaultMessage: Leave empty if the image is purely decorative.
+msgid "Alt text hint"
+msgstr ""
+
+#: components/manage/Blocks/Image/ImageSidebar
+# defaultMessage: Describe the purpose of the image.
+msgid "Alt text hint link text"
+msgstr ""
+
 #: components/manage/Toolbar/More
 # defaultMessage: Apply working copy
 msgid "Apply working copy"

--- a/locales/es/LC_MESSAGES/volto.po
+++ b/locales/es/LC_MESSAGES/volto.po
@@ -192,6 +192,16 @@ msgstr "Alfabéticamente"
 msgid "Alt text"
 msgstr "Texto alternativo"
 
+#: components/manage/Blocks/Image/ImageSidebar
+# defaultMessage: Leave empty if the image is purely decorative.
+msgid "Alt text hint"
+msgstr ""
+
+#: components/manage/Blocks/Image/ImageSidebar
+# defaultMessage: Describe the purpose of the image.
+msgid "Alt text hint link text"
+msgstr ""
+
 #: components/manage/Toolbar/More
 # defaultMessage: Apply working copy
 msgid "Apply working copy"

--- a/locales/eu/LC_MESSAGES/volto.po
+++ b/locales/eu/LC_MESSAGES/volto.po
@@ -189,6 +189,16 @@ msgstr "Alfabetikoki"
 msgid "Alt text"
 msgstr "Ordezko testua (alt)"
 
+#: components/manage/Blocks/Image/ImageSidebar
+# defaultMessage: Leave empty if the image is purely decorative.
+msgid "Alt text hint"
+msgstr ""
+
+#: components/manage/Blocks/Image/ImageSidebar
+# defaultMessage: Describe the purpose of the image.
+msgid "Alt text hint link text"
+msgstr ""
+
 #: components/manage/Toolbar/More
 # defaultMessage: Apply working copy
 msgid "Apply working copy"

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -199,6 +199,16 @@ msgstr ""
 msgid "Alt text"
 msgstr "Texte pour la balise alt"
 
+#: components/manage/Blocks/Image/ImageSidebar
+# defaultMessage: Leave empty if the image is purely decorative.
+msgid "Alt text hint"
+msgstr ""
+
+#: components/manage/Blocks/Image/ImageSidebar
+# defaultMessage: Describe the purpose of the image.
+msgid "Alt text hint link text"
+msgstr ""
+
 #: components/manage/Toolbar/More
 # defaultMessage: Apply working copy
 msgid "Apply working copy"

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -182,6 +182,16 @@ msgstr "Alfabetico"
 msgid "Alt text"
 msgstr "Testo alternativo"
 
+#: components/manage/Blocks/Image/ImageSidebar
+# defaultMessage: Leave empty if the image is purely decorative.
+msgid "Alt text hint"
+msgstr "Lascia vuoto se l'immagine è decorativa."
+
+#: components/manage/Blocks/Image/ImageSidebar
+# defaultMessage: Describe the purpose of the image.
+msgid "Alt text hint link text"
+msgstr "Descrivi lo scopo dell'immagine."
+
 #: components/manage/Toolbar/More
 # defaultMessage: Apply working copy
 msgid "Apply working copy"
@@ -241,7 +251,7 @@ msgstr "Base"
 #: components/manage/Blocks/Search/schema
 # defaultMessage: Base search query
 msgid "Base search query"
-msgstr ""
+msgstr "Query di ricerca di base"
 
 #: components/manage/Sidebar/Sidebar
 # defaultMessage: Block
@@ -391,7 +401,7 @@ msgstr "Annulla"
 #: components/manage/Blocks/Search/components/FilterList
 # defaultMessage: Clear filters
 msgid "Clear filters"
-msgstr ""
+msgstr "Pulisci filtri"
 
 #: components/theme/View/ImageView
 # defaultMessage: Click to download full sized image
@@ -490,7 +500,7 @@ msgstr "Contenuti"
 #: components/manage/Blocks/Search/schema
 # defaultMessage: Controls
 msgid "Controls"
-msgstr ""
+msgstr "Controlli"
 
 #: components/manage/Actions/Actions
 #: components/manage/Contents/Contents
@@ -548,7 +558,7 @@ msgstr "Criteri"
 #: components/manage/Blocks/Search/components/FilterList
 # defaultMessage: Current filters applied
 msgid "Current filters applied"
-msgstr ""
+msgstr "Filtri applicati"
 
 #: components/manage/Preferences/ChangePassword
 # defaultMessage: Current password
@@ -947,37 +957,37 @@ msgstr "URL esterno"
 #: components/manage/Blocks/Search/schema
 # defaultMessage: Facet
 msgid "Facet"
-msgstr ""
+msgstr "Faccetta"
 
 #: components/manage/Blocks/Search/schema
 # defaultMessage: Facet widget
 msgid "Facet widget"
-msgstr ""
+msgstr "Widget faccette"
 
 #: components/manage/Blocks/Search/schema
 # defaultMessage: Facets
 msgid "Facets"
-msgstr ""
+msgstr "Faccette"
 
 #: config/Blocks
 # defaultMessage: Facets on left side
 msgid "Facets on left side"
-msgstr ""
+msgstr "Faccette nel lato sinistro"
 
 #: config/Blocks
 # defaultMessage: Facets on right side
 msgid "Facets on right side"
-msgstr ""
+msgstr "Faccette nel lato destro"
 
 #: config/Blocks
 # defaultMessage: Facets on top
 msgid "Facets on top"
-msgstr ""
+msgstr "Faccette sopra"
 
 #: components/manage/Blocks/Search/schema
 # defaultMessage: Field
 msgid "Field"
-msgstr ""
+msgstr "Campo"
 
 #: components/manage/Toolbar/Toolbar
 # defaultMessage: File
@@ -1108,12 +1118,12 @@ msgstr "Cella d'intestazione"
 #: components/manage/Blocks/Search/schema
 # defaultMessage: Headline
 msgid "Headline"
-msgstr ""
+msgstr "Intestazione"
 
 #: components/manage/Blocks/Search/schema
 # defaultMessage: Hidden facets will still filter the results if proper parameters are passed in URLs
 msgid "Hidden facets will still filter the results if proper parameters are passed in URLs"
-msgstr ""
+msgstr "Le faccette nascoste filtreranno comunque i risultati se i relativi parametri vengono passati nell'URL"
 
 #: components/theme/Comments/Comments
 # defaultMessage: Hide Replies
@@ -1123,7 +1133,7 @@ msgstr "Nascondi risposte"
 #: components/manage/Blocks/Search/schema
 # defaultMessage: Hide facet?
 msgid "Hide facet?"
-msgstr ""
+msgstr "Nascondi faccetta"
 
 #: components/manage/History/History
 #: components/manage/Toolbar/More
@@ -1171,7 +1181,7 @@ msgstr "Se questa data è in futuro, il contenuto non verrà mostrato negli elen
 #: components/manage/LockingToastsFactory/LockingToastsFactory
 # defaultMessage: If you are certain this user has abandoned the object, you may unlock the object. You will then be able to edit it.
 msgid "If you are certain this user has abandoned the object, you may unlock the object. You will then be able to edit it."
-msgstr ""
+msgstr "Se sei certo che questo utente ha abbandonato il contenuto, puoi sbloccarlo per poterlo modificare."
 
 #: components/theme/NotFound/NotFound
 #: components/theme/Unauthorized/Unauthorized
@@ -1189,7 +1199,7 @@ msgstr "Immagine"
 #: config/Blocks
 # defaultMessage: Image gallery
 msgid "Image gallery"
-msgstr ""
+msgstr "Galleria di immagini"
 
 #: components/manage/Widgets/RecurrenceWidget/Occurences
 # defaultMessage: Include this occurence
@@ -1319,7 +1329,7 @@ msgstr "Gli elementi devono essere unici."
 #: components/manage/Blocks/Search/schema
 # defaultMessage: Label
 msgid "Label"
-msgstr ""
+msgstr "Etichetta"
 
 #: components/manage/Preferences/PersonalPreferences
 # defaultMessage: Language
@@ -1543,7 +1553,7 @@ msgstr "Sposta in cima alla cartella"
 #: components/manage/Blocks/Search/schema
 # defaultMessage: Multiple choices?
 msgid "Multiple choices?"
-msgstr ""
+msgstr "Scelta multipla"
 
 #: components/theme/PasswordReset/PasswordReset
 # defaultMessage: My email address is
@@ -2030,7 +2040,7 @@ msgstr "Anteprima dei risultati"
 #: components/manage/Blocks/Search/SearchBlockEdit
 # defaultMessage: Results template
 msgid "Results template"
-msgstr ""
+msgstr "Template dei risultati"
 
 #: components/manage/Widgets/QuerystringWidget
 # defaultMessage: Reversed order
@@ -2125,12 +2135,12 @@ msgstr "Cerca nel sito"
 #: components/manage/Blocks/Search/schema
 # defaultMessage: Search block
 msgid "Search block"
-msgstr ""
+msgstr "Blocco di ricerca"
 
 #: components/manage/Blocks/Search/schema
 # defaultMessage: Search button label
 msgid "Search button label"
-msgstr ""
+msgstr "Etichetta del bottone di ricerca"
 
 #: components/manage/Sidebar/ObjectBrowserBody
 # defaultMessage: Search content
@@ -2150,7 +2160,7 @@ msgstr "Cerca gruppo…"
 #: components/manage/Blocks/Search/schema
 # defaultMessage: Search input label
 msgid "Search input label"
-msgstr ""
+msgstr "Etichetta dell'input di ricerca"
 
 #: components/manage/Blocks/Search/components/SearchDetails
 #: components/theme/Search/Search
@@ -2171,7 +2181,7 @@ msgstr "Cerca utenti…"
 #: components/manage/Blocks/Search/components/SearchDetails
 # defaultMessage: Searched for
 msgid "Searched for"
-msgstr ""
+msgstr "Cerco per"
 
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
 # defaultMessage: Second
@@ -2181,7 +2191,7 @@ msgstr "Secondo"
 #: components/manage/Blocks/Search/schema
 # defaultMessage: Section title
 msgid "Section title"
-msgstr ""
+msgstr "Titolo della sezione"
 
 #: components/manage/Sidebar/ObjectBrowserNav
 # defaultMessage: Select
@@ -2297,17 +2307,17 @@ msgstr "Mostra elemento"
 #: components/manage/Blocks/Search/schema
 # defaultMessage: Show search button?
 msgid "Show search button?"
-msgstr ""
+msgstr "Mostra bottone di ricerca"
 
 #: components/manage/Blocks/Search/schema
 # defaultMessage: Show search input?
 msgid "Show search input?"
-msgstr ""
+msgstr "Mostra campo di ricerca"
 
 #: components/manage/Blocks/Search/schema
 # defaultMessage: Show sorting?
 msgid "Show sorting?"
-msgstr ""
+msgstr "Mostra ordinamento"
 
 #: components/manage/Sidebar/Sidebar
 # defaultMessage: Shrink sidebar
@@ -2381,12 +2391,12 @@ msgstr "Ordina per"
 #: components/manage/Blocks/Search/schema
 # defaultMessage: Sort on label
 msgid "Sort on label"
-msgstr ""
+msgstr "Etichetta campo di ordinamento"
 
 #: components/manage/Blocks/Search/schema
 # defaultMessage: Sort on options
 msgid "Sort on options"
-msgstr ""
+msgstr "Opzioni ordinamento"
 
 #: components/manage/Blocks/HTML/Edit
 # defaultMessage: Source
@@ -2462,7 +2472,7 @@ msgstr "Successo"
 #: config/Blocks
 # defaultMessage: Summary
 msgid "Summary"
-msgstr ""
+msgstr "Sommario"
 
 #: components/theme/LanguageSelector/LanguageSelector
 # defaultMessage: Switch to
@@ -2546,7 +2556,7 @@ msgstr "Il server di backend del tuo sito web non risponde, ci scusiamo per l'in
 #: components/manage/Blocks/Search/schema
 # defaultMessage: The button presence disables the live search, the query is issued when you press ENTER
 msgid "The button presence disables the live search, the query is issued when you press ENTER"
-msgstr ""
+msgstr "La presenza del bottone disabilita la ricerca live, quindi la ricerca viene effettuata quando viene premuto INVIO"
 
 #: components/manage/Contents/Contents
 # defaultMessage: The item could not be deleted.
@@ -2607,7 +2617,7 @@ msgstr "Questa è una copia di lavoro di {title}"
 #: components/manage/LockingToastsFactory/LockingToastsFactory
 # defaultMessage: This item was locked by {creator} on {date}
 msgid "This item was locked by {creator} on {date}"
-msgstr ""
+msgstr "Questo contenuto è stato bloccato da {creator} il {date}"
 
 #: components/manage/Contents/ContentsRenameModal
 # defaultMessage: This name will be displayed in the URL.
@@ -2740,7 +2750,7 @@ msgstr "Scollega traduzione per"
 #: components/manage/Toolbar/Toolbar
 # defaultMessage: Unlock
 msgid "Unlock"
-msgstr ""
+msgstr "Sblocca"
 
 #: components/manage/Controlpanels/AddonsControlpanel
 # defaultMessage: Update

--- a/locales/ja/LC_MESSAGES/volto.po
+++ b/locales/ja/LC_MESSAGES/volto.po
@@ -190,6 +190,16 @@ msgstr "アルファベット順"
 msgid "Alt text"
 msgstr "代替テキスト"
 
+#: components/manage/Blocks/Image/ImageSidebar
+# defaultMessage: Leave empty if the image is purely decorative.
+msgid "Alt text hint"
+msgstr ""
+
+#: components/manage/Blocks/Image/ImageSidebar
+# defaultMessage: Describe the purpose of the image.
+msgid "Alt text hint link text"
+msgstr ""
+
 #: components/manage/Toolbar/More
 # defaultMessage: Apply working copy
 msgid "Apply working copy"

--- a/locales/nl/LC_MESSAGES/volto.po
+++ b/locales/nl/LC_MESSAGES/volto.po
@@ -201,6 +201,16 @@ msgstr ""
 msgid "Alt text"
 msgstr ""
 
+#: components/manage/Blocks/Image/ImageSidebar
+# defaultMessage: Leave empty if the image is purely decorative.
+msgid "Alt text hint"
+msgstr ""
+
+#: components/manage/Blocks/Image/ImageSidebar
+# defaultMessage: Describe the purpose of the image.
+msgid "Alt text hint link text"
+msgstr ""
+
 #: components/manage/Toolbar/More
 # defaultMessage: Apply working copy
 msgid "Apply working copy"

--- a/locales/pt/LC_MESSAGES/volto.po
+++ b/locales/pt/LC_MESSAGES/volto.po
@@ -190,6 +190,16 @@ msgstr ""
 msgid "Alt text"
 msgstr "Texto alternativo"
 
+#: components/manage/Blocks/Image/ImageSidebar
+# defaultMessage: Leave empty if the image is purely decorative.
+msgid "Alt text hint"
+msgstr ""
+
+#: components/manage/Blocks/Image/ImageSidebar
+# defaultMessage: Describe the purpose of the image.
+msgid "Alt text hint link text"
+msgstr ""
+
 #: components/manage/Toolbar/More
 # defaultMessage: Apply working copy
 msgid "Apply working copy"

--- a/locales/pt_BR/LC_MESSAGES/volto.po
+++ b/locales/pt_BR/LC_MESSAGES/volto.po
@@ -192,6 +192,16 @@ msgstr "Alfabeticamente"
 msgid "Alt text"
 msgstr "Descrição Alt"
 
+#: components/manage/Blocks/Image/ImageSidebar
+# defaultMessage: Leave empty if the image is purely decorative.
+msgid "Alt text hint"
+msgstr ""
+
+#: components/manage/Blocks/Image/ImageSidebar
+# defaultMessage: Describe the purpose of the image.
+msgid "Alt text hint link text"
+msgstr ""
+
 #: components/manage/Toolbar/More
 # defaultMessage: Apply working copy
 msgid "Apply working copy"

--- a/locales/ro/LC_MESSAGES/volto.po
+++ b/locales/ro/LC_MESSAGES/volto.po
@@ -182,6 +182,16 @@ msgstr ""
 msgid "Alt text"
 msgstr "Text alternativ"
 
+#: components/manage/Blocks/Image/ImageSidebar
+# defaultMessage: Leave empty if the image is purely decorative.
+msgid "Alt text hint"
+msgstr ""
+
+#: components/manage/Blocks/Image/ImageSidebar
+# defaultMessage: Describe the purpose of the image.
+msgid "Alt text hint link text"
+msgstr ""
+
 #: components/manage/Toolbar/More
 # defaultMessage: Apply working copy
 msgid "Apply working copy"

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2021-10-19T10:19:38.333Z\n"
+"POT-Creation-Date: 2021-10-28T09:55:11.185Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -182,6 +182,16 @@ msgstr ""
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
 # defaultMessage: Alt text
 msgid "Alt text"
+msgstr ""
+
+#: components/manage/Blocks/Image/ImageSidebar
+# defaultMessage: Leave empty if the image is purely decorative.
+msgid "Alt text hint"
+msgstr ""
+
+#: components/manage/Blocks/Image/ImageSidebar
+# defaultMessage: Describe the purpose of the image.
+msgid "Alt text hint link text"
 msgstr ""
 
 #: components/manage/Toolbar/More

--- a/src/components/manage/Blocks/Image/Edit.jsx
+++ b/src/components/manage/Blocks/Image/Edit.jsx
@@ -93,7 +93,7 @@ class Edit extends Component {
       this.props.onChangeBlock(this.props.block, {
         ...this.props.data,
         url: nextProps.content['@id'],
-        alt: nextProps.properties.title,
+        alt: '',
       });
     }
   }

--- a/src/components/manage/Blocks/Image/ImageSidebar.jsx
+++ b/src/components/manage/Blocks/Image/ImageSidebar.jsx
@@ -32,6 +32,14 @@ const messages = defineMessages({
     id: 'Alt text',
     defaultMessage: 'Alt text',
   },
+  AltTextHint: {
+    id: 'Alt text hint',
+    defaultMessage: 'Leave empty if the image is purely decorative.',
+  },
+  AltTextHintLinkText: {
+    id: 'Alt text hint link text',
+    defaultMessage: 'Describe the purpose of the image.',
+  },
   Align: {
     id: 'Alignment',
     defaultMessage: 'Alignment',
@@ -120,15 +128,15 @@ const ImageSidebar = ({
                 iconAction={
                   data.url
                     ? () => {
-                        resetSubmitUrl();
-                        onChangeBlock(block, {
-                          ...data,
-                          url: '',
-                        });
-                      }
+                      resetSubmitUrl();
+                      onChangeBlock(block, {
+                        ...data,
+                        url: '',
+                      });
+                    }
                     : () => openObjectBrowser()
                 }
-                onChange={() => {}}
+                onChange={() => { }}
               />
             )}
             {!isInternalURL(data.url) && (
@@ -146,14 +154,27 @@ const ImageSidebar = ({
                     url: '',
                   });
                 }}
-                onChange={() => {}}
+                onChange={() => { }}
               />
             )}
             <TextWidget
               id="alt"
               title={intl.formatMessage(messages.AltText)}
+              description={
+                <>
+                  <a
+                    href="https://www.w3.org/WAI/tutorials/images/decision-tree/"
+                    title={intl.formatMessage(messages.openLinkInNewTab)}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {intl.formatMessage(messages.AltTextHintLinkText)}
+                  </a>{' '}
+                  {intl.formatMessage(messages.AltTextHint)}
+                </>
+              }
               required={false}
-              value={data.alt}
+              value={data.alt || ''}
               icon={data.alt ? clearSVG : null}
               iconAction={() =>
                 onChangeBlock(block, {
@@ -161,7 +182,7 @@ const ImageSidebar = ({
                   alt: '',
                 })
               }
-              onChange={(name, value) => {
+              onChange={(_name, value) => {
                 onChangeBlock(block, {
                   ...data,
                   alt: value,
@@ -218,8 +239,8 @@ const ImageSidebar = ({
               {activeAccIndex === 0 ? (
                 <Icon name={upSVG} size="20px" />
               ) : (
-                <Icon name={downSVG} size="20px" />
-              )}
+                  <Icon name={downSVG} size="20px" />
+                )}
             </Accordion.Title>
             <Accordion.Content active={activeAccIndex === 0}>
               <TextWidget
@@ -231,11 +252,11 @@ const ImageSidebar = ({
                 iconAction={
                   data.href
                     ? () => {
-                        onChangeBlock(block, {
-                          ...data,
-                          href: '',
-                        });
-                      }
+                      onChangeBlock(block, {
+                        ...data,
+                        href: '',
+                      });
+                    }
                     : () => openObjectBrowser({ mode: 'link' })
                 }
                 onChange={(name, value) => {

--- a/src/components/manage/Blocks/Image/ImageSidebar.jsx
+++ b/src/components/manage/Blocks/Image/ImageSidebar.jsx
@@ -128,15 +128,15 @@ const ImageSidebar = ({
                 iconAction={
                   data.url
                     ? () => {
-                      resetSubmitUrl();
-                      onChangeBlock(block, {
-                        ...data,
-                        url: '',
-                      });
-                    }
+                        resetSubmitUrl();
+                        onChangeBlock(block, {
+                          ...data,
+                          url: '',
+                        });
+                      }
                     : () => openObjectBrowser()
                 }
-                onChange={() => { }}
+                onChange={() => {}}
               />
             )}
             {!isInternalURL(data.url) && (
@@ -154,7 +154,7 @@ const ImageSidebar = ({
                     url: '',
                   });
                 }}
-                onChange={() => { }}
+                onChange={() => {}}
               />
             )}
             <TextWidget
@@ -239,8 +239,8 @@ const ImageSidebar = ({
               {activeAccIndex === 0 ? (
                 <Icon name={upSVG} size="20px" />
               ) : (
-                  <Icon name={downSVG} size="20px" />
-                )}
+                <Icon name={downSVG} size="20px" />
+              )}
             </Accordion.Title>
             <Accordion.Content active={activeAccIndex === 0}>
               <TextWidget
@@ -252,11 +252,11 @@ const ImageSidebar = ({
                 iconAction={
                   data.href
                     ? () => {
-                      onChangeBlock(block, {
-                        ...data,
-                        href: '',
-                      });
-                    }
+                        onChangeBlock(block, {
+                          ...data,
+                          href: '',
+                        });
+                      }
                     : () => openObjectBrowser({ mode: 'link' })
                 }
                 onChange={(name, value) => {

--- a/src/components/manage/Blocks/Image/__snapshots__/ImageSidebar.test.jsx.snap
+++ b/src/components/manage/Blocks/Image/__snapshots__/ImageSidebar.test.jsx.snap
@@ -108,7 +108,7 @@ exports[`renders an Image Block Sidebar component 1`] = `
       </div>
     </div>
     <div
-      className="inline field text field-wrapper-alt"
+      className="inline field help text field-wrapper-alt"
     >
       <div
         className="ui grid"
@@ -182,6 +182,28 @@ exports[`renders an Image Block Sidebar component 1`] = `
                 xmlns=""
               />
             </button>
+          </div>
+        </div>
+        <div
+          className="stretched row"
+        >
+          <div
+            className="stretched twelve wide column"
+          >
+            <p
+              className="help"
+            >
+              <a
+                href="https://www.w3.org/WAI/tutorials/images/decision-tree/"
+                rel="noopener noreferrer"
+                target="_blank"
+                title="Open in a new tab"
+              >
+                Describe the purpose of the image.
+              </a>
+               
+              Leave empty if the image is purely decorative.
+            </p>
           </div>
         </div>
       </div>

--- a/src/components/manage/Sidebar/ObjectBrowserBody.jsx
+++ b/src/components/manage/Sidebar/ObjectBrowserBody.jsx
@@ -234,7 +234,6 @@ class ObjectBrowserBody extends Component {
 
   onSelectItem = (item) => {
     const url = item['@id'];
-    const title = item.title;
     const { block, data, mode, dataName, onChangeBlock } = this.props;
 
     const updateState = (mode) => {
@@ -267,7 +266,7 @@ class ObjectBrowserBody extends Component {
       onChangeBlock(block, {
         ...data,
         url: flattenToAppURL(item.getURL),
-        alt: title,
+        alt: '',
       });
     } else if (mode === 'link') {
       onChangeBlock(block, {

--- a/src/components/manage/Widgets/FormFieldWrapper.jsx
+++ b/src/components/manage/Widgets/FormFieldWrapper.jsx
@@ -33,7 +33,7 @@ class FormFieldWrapper extends Component {
   static propTypes = {
     id: PropTypes.string.isRequired,
     title: PropTypes.string.isRequired,
-    description: PropTypes.string,
+    description: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
     required: PropTypes.bool,
     error: PropTypes.arrayOf(PropTypes.string),
     wrapped: PropTypes.bool,


### PR DESCRIPTION
Fixes: #1503

1. `FormFieldWrapper` accepts now strings and elements for description

2. When uploading an image or selecting that from the object browser, Image block will set an empty string as alternative text

3. Adds a description to the alt-tag:
<img width="371" alt="Schermata 2021-10-28 alle 12 54 47" src="https://user-images.githubusercontent.com/21101435/139242231-0eabfebf-9dd4-48c3-99c4-062ef4bb7f0f.png">

We know have the description as:

>  [Describe the purpose of the image](https://www.w3.org/WAI/tutorials/images/decision-tree). Leave empty if the image is purely decorative.
