### PR TITLE
Fix disable mode of `QuerystringWidget` when all criteria are deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Feature
 
 - Support Node 16 @timo
+
 ### Bugfix
 
 - Prevent ua-parser-js security breach. See: https://github.com/advisories/GHSA-pjwm-rvh2-c87w @thet
@@ -23,6 +24,7 @@
 ### Bugfix
 
 - Fix loading of cookie on SSR for certain requests, revert slight change in how they are loaded introduced in alpha 16 @sneridagh
+- Fix disable mode of `QuerystringWidget` when all criteria are deleted @kreafox
 
 ## 14.0.0-alpha.22 (2021-10-20)
 

--- a/src/components/manage/Widgets/QuerystringWidget.jsx
+++ b/src/components/manage/Widgets/QuerystringWidget.jsx
@@ -85,7 +85,7 @@ export const objectSchema = ({ intl, isDisabled, value }) => ({
 
 const QuerystringWidget = (props) => {
   const { block, onChange, schemaEnhancer } = props;
-  const isDisabled = props.value ? false : true;
+  const isDisabled = props.value?.query.length ? false : true;
 
   const intl = useIntl();
   let schema = objectSchema({ ...props, intl, isDisabled });


### PR DESCRIPTION
Fix issue: #2738