### PR TITLE
controlpanels: multi select users/groups and ability to delete, improve styling on `checkboxes` (*the Plone 6 way*)

### DIFF
--- a/src/components/manage/Controlpanels/Groups/RenderGroups.jsx
+++ b/src/components/manage/Controlpanels/Groups/RenderGroups.jsx
@@ -4,11 +4,12 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { FormattedMessage, injectIntl } from 'react-intl';
-import { Dropdown, Table, Checkbox } from 'semantic-ui-react';
-import trashSVG from '@plone/volto/icons/delete.svg';
-import ploneSVG from '@plone/volto/icons/plone.svg';
+import { injectIntl } from 'react-intl';
+import { Table } from 'semantic-ui-react';
 import { Icon } from '@plone/volto/components';
+import checkboxUncheckedSVG from '@plone/volto/icons/checkbox-unchecked.svg';
+import checkboxCheckedSVG from '@plone/volto/icons/checkbox-checked.svg';
+import groupSVG from '@plone/volto/icons/group.svg';
 
 /**
  * UsersControlpanelGroups class.
@@ -48,7 +49,7 @@ class RenderGroups extends Component {
    */
   constructor(props) {
     super(props);
-    this.onChange = this.onChange.bind(this);
+    this.onChangeRole = this.onChangeRole.bind(this);
   }
 
   /**
@@ -56,7 +57,7 @@ class RenderGroups extends Component {
    * @param {*} { value }
    * @memberof UsersControlpanelUser
    */
-  onChange(event, { value }) {
+  onChangeRole(event, value) {
     const [group, role] = value.split('.');
     this.props.updateGroups(group, role);
   }
@@ -69,52 +70,70 @@ class RenderGroups extends Component {
   isAuthGroup = (roleId) => {
     return this.props.inheritedRole.includes(roleId);
   };
+
+  /**
+   *@param {string}
+   *@returns {Boolean}
+   *@memberof RenderGroups
+   */
+  renderIcon = (role) =>
+    this.props.group.id === 'AuthenticatedUsers'
+      ? this.isAuthGroup(role.id)
+      : this.props.group.roles.includes(role.id);
+
   /**
    * Render method.
    * @method render
    * @returns {string} Markup for the component.
    */
   render() {
+    const {
+      selected,
+      group,
+      onChangeSelect,
+      roles,
+      inheritedRole,
+    } = this.props;
+    const isSelected = selected.includes(group.id);
     return (
-      <Table.Row key={this.props.group.title}>
-        <Table.Cell>{this.props.group.groupname}</Table.Cell>
-        {this.props.roles.map((role) => (
+      <Table.Row key={group.title}>
+        <Table.Cell>
+          <Icon
+            name={isSelected ? checkboxCheckedSVG : checkboxUncheckedSVG}
+            color={isSelected ? '#007eb1' : '#826a6a'}
+            onClick={(e) => {
+              e.stopPropagation();
+              onChangeSelect(group.id);
+            }}
+            size="24px"
+          />
+        </Table.Cell>
+        <Table.Cell>{group.groupname}</Table.Cell>
+        {roles.map((role) => (
           <Table.Cell key={role.id}>
-            {this.props.inheritedRole &&
-            this.props.inheritedRole.includes(role.id) &&
-            this.props.group.roles.includes('Authenticated') ? (
+            {inheritedRole &&
+            inheritedRole.includes(role.id) &&
+            group.roles.includes('Authenticated') ? (
               <Icon
-                name={ploneSVG}
+                name={groupSVG}
                 size="20px"
                 color="#007EB1"
                 title={'plone-svg'}
               />
             ) : (
-              <Checkbox
-                checked={
-                  this.props.group.id === 'AuthenticatedUsers'
-                    ? this.isAuthGroup(role.id)
-                    : this.props.group.roles.includes(role.id)
+              <Icon
+                name={
+                  this.renderIcon(role)
+                    ? checkboxCheckedSVG
+                    : checkboxUncheckedSVG
                 }
-                onChange={this.onChange}
-                value={`${this.props.group.id}.${role.id}`}
+                onClick={(e) => this.onChangeRole(e, `${group.id}.${role.id}`)}
+                color={this.renderIcon(role) ? '#007eb1' : '#826a6a'}
+                size="24px"
               />
             )}
           </Table.Cell>
         ))}
-        <Table.Cell textAlign="right">
-          <Dropdown icon="ellipsis horizontal">
-            <Dropdown.Menu className="left">
-              <Dropdown.Item
-                onClick={this.props.onDelete}
-                value={this.props.group['@id']}
-              >
-                <Icon name={trashSVG} size="15px" />
-                <FormattedMessage id="Delete" defaultMessage="Delete" />
-              </Dropdown.Item>
-            </Dropdown.Menu>
-          </Dropdown>
-        </Table.Cell>
       </Table.Row>
     );
   }

--- a/src/components/manage/Controlpanels/Groups/RenderGroups.test.jsx
+++ b/src/components/manage/Controlpanels/Groups/RenderGroups.test.jsx
@@ -49,6 +49,7 @@ describe('UsersControlpanelGroups', () => {
           group={testGroups}
           roles={testRoles}
           onDelete={() => {}}
+          selected={[]}
         />
       </Provider>,
     );

--- a/src/components/manage/Controlpanels/Groups/__snapshots__/GroupsControlpanel.test.jsx.snap
+++ b/src/components/manage/Controlpanels/Groups/__snapshots__/GroupsControlpanel.test.jsx.snap
@@ -42,15 +42,15 @@ exports[`UsersControlpanel renders a user control component 1`] = `
     <div
       className="ui segment"
     >
-      <form
-        className="ui form"
-        onSubmit={[Function]}
+      <div
+        className="ui secondary attached menu"
       >
         <div
-          className="field"
+          className="left item"
+          onClick={[Function]}
         >
           <div
-            className="ui action input"
+            className="ui large transparent input"
           >
             <input
               id="group-search-input"
@@ -59,66 +59,113 @@ exports[`UsersControlpanel renders a user control component 1`] = `
               placeholder="Search group…"
               type="text"
             />
-            <button
-              className="ui icon button"
-              onClick={[Function]}
-            >
-              <i
-                aria-hidden="true"
-                className="search icon"
-                onClick={[Function]}
-              />
-            </button>
           </div>
+          <svg
+            className="icon zoom"
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": undefined,
+              }
+            }
+            onClick={[Function]}
+            style={
+              Object {
+                "fill": "#007eb1",
+                "height": "30px",
+                "width": "auto",
+              }
+            }
+            viewBox=""
+            xmlns=""
+          />
         </div>
-      </form>
-    </div>
-    <form
-      className="ui form"
-      onSubmit={[Function]}
-    >
-      <div
-        className="table"
-      >
-        <table
-          className="ui striped unstackable attached padded table"
+        <button
+          className="ui button disabled icon item"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
         >
-          <thead
+          <svg
+            className="icon delete"
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": undefined,
+              }
+            }
+            onClick={null}
+            style={
+              Object {
+                "fill": "grey",
+                "height": "24px",
+                "width": "auto",
+              }
+            }
+            viewBox=""
+            xmlns=""
+          />
+        </button>
+      </div>
+    </div>
+    <div
+      className="table"
+    >
+      <table
+        className="ui striped unstackable attached padded table"
+      >
+        <thead
+          className=""
+        >
+          <tr
             className=""
           >
-            <tr
+            <th
               className=""
             >
-              <th
-                className=""
-              >
-                Groupname
-              </th>
-              <th
-                className=""
-              >
-                Actions
-              </th>
-            </tr>
-          </thead>
-          <tbody
-            className=""
-            data-group="groups"
-          />
-        </table>
-      </div>
+              <svg
+                className="icon"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": undefined,
+                  }
+                }
+                onClick={[Function]}
+                style={
+                  Object {
+                    "fill": "#007eb1",
+                    "height": "24px",
+                    "width": "auto",
+                  }
+                }
+                viewBox=""
+                xmlns=""
+              />
+            </th>
+            <th
+              className=""
+            >
+              Groupname
+            </th>
+          </tr>
+        </thead>
+        <tbody
+          className=""
+          data-group="groups"
+        />
+      </table>
+    </div>
+    <div
+      className="contents-pagination"
+    >
       <div
-        className="contents-pagination"
+        className="ui secondary attached menu"
       >
         <div
-          className="ui secondary attached menu"
-        >
-          <div
-            className="menu"
-          />
-        </div>
+          className="menu"
+        />
       </div>
-    </form>
+    </div>
   </div>
   <div
     id="Portal"

--- a/src/components/manage/Controlpanels/Groups/__snapshots__/RenderGroups.test.jsx.snap
+++ b/src/components/manage/Controlpanels/Groups/__snapshots__/RenderGroups.test.jsx.snap
@@ -7,126 +7,95 @@ exports[`UsersControlpanelGroups renders a UsersControlpanelGroups component 1`]
   <td
     className=""
   >
+    <svg
+      className="icon"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": undefined,
+        }
+      }
+      onClick={[Function]}
+      style={
+        Object {
+          "fill": "#826a6a",
+          "height": "24px",
+          "width": "auto",
+        }
+      }
+      viewBox=""
+      xmlns=""
+    />
+  </td>
+  <td
+    className=""
+  >
     Administrators
   </td>
   <td
     className=""
   >
-    <div
-      className="ui fitted checkbox"
-      onChange={[Function]}
+    <svg
+      className="icon"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": undefined,
+        }
+      }
       onClick={[Function]}
-      onMouseDown={[Function]}
-      onMouseUp={[Function]}
-    >
-      <input
-        checked={false}
-        className="hidden"
-        readOnly={true}
-        tabIndex={0}
-        type="checkbox"
-        value="Administrators.Member"
-      />
-      <label />
-    </div>
+      style={
+        Object {
+          "fill": "#826a6a",
+          "height": "24px",
+          "width": "auto",
+        }
+      }
+      viewBox=""
+      xmlns=""
+    />
   </td>
   <td
     className=""
   >
-    <div
-      className="ui fitted checkbox"
-      onChange={[Function]}
+    <svg
+      className="icon"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": undefined,
+        }
+      }
       onClick={[Function]}
-      onMouseDown={[Function]}
-      onMouseUp={[Function]}
-    >
-      <input
-        checked={false}
-        className="hidden"
-        readOnly={true}
-        tabIndex={0}
-        type="checkbox"
-        value="Administrators.Reader"
-      />
-      <label />
-    </div>
+      style={
+        Object {
+          "fill": "#826a6a",
+          "height": "24px",
+          "width": "auto",
+        }
+      }
+      viewBox=""
+      xmlns=""
+    />
   </td>
   <td
     className=""
   >
-    <div
-      className="ui checked fitted checkbox"
-      onChange={[Function]}
+    <svg
+      className="icon"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": undefined,
+        }
+      }
       onClick={[Function]}
-      onMouseDown={[Function]}
-      onMouseUp={[Function]}
-    >
-      <input
-        checked={true}
-        className="hidden"
-        readOnly={true}
-        tabIndex={0}
-        type="checkbox"
-        value="Administrators.Manager"
-      />
-      <label />
-    </div>
-  </td>
-  <td
-    className="right aligned"
-  >
-    <div
-      aria-expanded={false}
-      className="ui dropdown"
-      onBlur={[Function]}
-      onChange={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onMouseDown={[Function]}
-      role="listbox"
-      tabIndex={0}
-    >
-      <div
-        aria-atomic={true}
-        aria-live="polite"
-        className="text"
-        role="alert"
-      />
-      <i
-        aria-hidden="true"
-        className="ellipsis horizontal icon"
-        onClick={[Function]}
-      />
-      <div
-        className="menu transition left"
-      >
-        <div
-          className="item"
-          onClick={[Function]}
-          role="option"
-        >
-          <svg
-            className="icon"
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": undefined,
-              }
-            }
-            onClick={null}
-            style={
-              Object {
-                "fill": "currentColor",
-                "height": "15px",
-                "width": "auto",
-              }
-            }
-            viewBox=""
-            xmlns=""
-          />
-          Delete
-        </div>
-      </div>
-    </div>
+      style={
+        Object {
+          "fill": "#007eb1",
+          "height": "24px",
+          "width": "auto",
+        }
+      }
+      viewBox=""
+      xmlns=""
+    />
   </td>
 </tr>
 `;

--- a/src/components/manage/Controlpanels/Users/RenderUsers.jsx
+++ b/src/components/manage/Controlpanels/Users/RenderUsers.jsx
@@ -4,11 +4,12 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { FormattedMessage, injectIntl } from 'react-intl';
-import { Dropdown, Table, Checkbox } from 'semantic-ui-react';
-import trashSVG from '@plone/volto/icons/delete.svg';
+import { injectIntl } from 'react-intl';
+import { Table } from 'semantic-ui-react';
 import { Icon } from '@plone/volto/components';
-import ploneSVG from '@plone/volto/icons/plone.svg';
+import checkboxUncheckedSVG from '@plone/volto/icons/checkbox-unchecked.svg';
+import checkboxCheckedSVG from '@plone/volto/icons/checkbox-checked.svg';
+import groupSVG from '@plone/volto/icons/group.svg';
 
 /**
  * UsersControlpanelUser class.
@@ -52,55 +53,65 @@ class RenderUsers extends Component {
    * @memberof UsersControlpanelUser
    */
 
-  onChange(event, { value }) {
+  onChange(event, value) {
     const [user, role] = value.split('.');
     this.props.updateUser(user, role);
   }
+
+  /**
+   *@param {string}
+   *@returns {Boolean}
+   *@memberof RenderUsers
+   */
+  renderIcon = (role) => this.props.user.roles.includes(role.id);
+
   /**
    * Render method.
    * @method render
    * @returns {string} Markup for the component.
    */
   render() {
+    const { selected, user, onChangeSelect, roles, inheritedRole } = this.props;
+    const isSelected = selected.includes(user.id);
     return (
       <Table.Row key={this.props.user.username}>
-        <Table.Cell className="fullname">
-          {this.props.user.fullname
-            ? this.props.user.fullname
-            : this.props.user.username}
+        <Table.Cell>
+          <Icon
+            name={isSelected ? checkboxCheckedSVG : checkboxUncheckedSVG}
+            color={isSelected ? '#007eb1' : '#826a6a'}
+            onClick={(e) => {
+              e.stopPropagation();
+              onChangeSelect(user.id);
+            }}
+            size="24px"
+          />
         </Table.Cell>
-        {this.props.roles.map((role) => (
+        <Table.Cell className="fullname">
+          {user.fullname || user.username}
+        </Table.Cell>
+        {roles.map((role) => (
           <Table.Cell key={role.id}>
-            {this.props.inheritedRole &&
-            this.props.inheritedRole.includes(role.id) ? (
+            {inheritedRole && inheritedRole.includes(role.id) ? (
               <Icon
-                name={ploneSVG}
+                name={groupSVG}
                 size="20px"
                 color="#007EB1"
                 title={'plone-svg'}
               />
             ) : (
-              <Checkbox
-                checked={this.props.user.roles.includes(role.id)}
-                onChange={this.onChange}
-                value={`${this.props.user.id}.${role.id}`}
+              <Icon
+                name={
+                  this.renderIcon(role)
+                    ? checkboxCheckedSVG
+                    : checkboxUncheckedSVG
+                }
+                onClick={(e) => this.onChange(e, `${user.id}.${role.id}`)}
+                color={this.renderIcon(role) ? '#007eb1' : '#826a6a'}
+                size="24px"
               />
             )}
           </Table.Cell>
         ))}
-        <Table.Cell textAlign="right">
-          <Dropdown icon="ellipsis horizontal">
-            <Dropdown.Menu className="left">
-              <Dropdown.Item
-                onClick={this.props.onDelete}
-                value={this.props.user['@id']}
-              >
-                <Icon name={trashSVG} size="15px" />
-                <FormattedMessage id="Delete" defaultMessage="Delete" />
-              </Dropdown.Item>
-            </Dropdown.Menu>
-          </Dropdown>
-        </Table.Cell>
       </Table.Row>
     );
   }

--- a/src/components/manage/Controlpanels/Users/RenderUsers.test.jsx
+++ b/src/components/manage/Controlpanels/Users/RenderUsers.test.jsx
@@ -47,7 +47,12 @@ describe('UsersControlpanelUser', () => {
     });
     const component = renderer.create(
       <Provider store={store}>
-        <RenderUsers user={testUser} roles={testRoles} onDelete={() => {}} />
+        <RenderUsers
+          user={testUser}
+          roles={testRoles}
+          onDelete={() => {}}
+          selected={[]}
+        />
       </Provider>,
     );
     const json = component.toJSON();

--- a/src/components/manage/Controlpanels/Users/__snapshots__/RenderUsers.test.jsx.snap
+++ b/src/components/manage/Controlpanels/Users/__snapshots__/RenderUsers.test.jsx.snap
@@ -5,6 +5,28 @@ exports[`UsersControlpanelUser renders a UsersControlpanelUser component 1`] = `
   className=""
 >
   <td
+    className=""
+  >
+    <svg
+      className="icon"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": undefined,
+        }
+      }
+      onClick={[Function]}
+      style={
+        Object {
+          "fill": "#826a6a",
+          "height": "24px",
+          "width": "auto",
+        }
+      }
+      viewBox=""
+      xmlns=""
+    />
+  </td>
+  <td
     className="fullname"
   >
     Test User
@@ -12,121 +34,68 @@ exports[`UsersControlpanelUser renders a UsersControlpanelUser component 1`] = `
   <td
     className=""
   >
-    <div
-      className="ui checked fitted checkbox"
-      onChange={[Function]}
+    <svg
+      className="icon"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": undefined,
+        }
+      }
       onClick={[Function]}
-      onMouseDown={[Function]}
-      onMouseUp={[Function]}
-    >
-      <input
-        checked={true}
-        className="hidden"
-        readOnly={true}
-        tabIndex={0}
-        type="checkbox"
-        value="testuser.Member"
-      />
-      <label />
-    </div>
+      style={
+        Object {
+          "fill": "#007eb1",
+          "height": "24px",
+          "width": "auto",
+        }
+      }
+      viewBox=""
+      xmlns=""
+    />
   </td>
   <td
     className=""
   >
-    <div
-      className="ui fitted checkbox"
-      onChange={[Function]}
+    <svg
+      className="icon"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": undefined,
+        }
+      }
       onClick={[Function]}
-      onMouseDown={[Function]}
-      onMouseUp={[Function]}
-    >
-      <input
-        checked={false}
-        className="hidden"
-        readOnly={true}
-        tabIndex={0}
-        type="checkbox"
-        value="testuser.Reader"
-      />
-      <label />
-    </div>
+      style={
+        Object {
+          "fill": "#826a6a",
+          "height": "24px",
+          "width": "auto",
+        }
+      }
+      viewBox=""
+      xmlns=""
+    />
   </td>
   <td
     className=""
   >
-    <div
-      className="ui fitted checkbox"
-      onChange={[Function]}
+    <svg
+      className="icon"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": undefined,
+        }
+      }
       onClick={[Function]}
-      onMouseDown={[Function]}
-      onMouseUp={[Function]}
-    >
-      <input
-        checked={false}
-        className="hidden"
-        readOnly={true}
-        tabIndex={0}
-        type="checkbox"
-        value="testuser.Manager"
-      />
-      <label />
-    </div>
-  </td>
-  <td
-    className="right aligned"
-  >
-    <div
-      aria-expanded={false}
-      className="ui dropdown"
-      onBlur={[Function]}
-      onChange={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onMouseDown={[Function]}
-      role="listbox"
-      tabIndex={0}
-    >
-      <div
-        aria-atomic={true}
-        aria-live="polite"
-        className="text"
-        role="alert"
-      />
-      <i
-        aria-hidden="true"
-        className="ellipsis horizontal icon"
-        onClick={[Function]}
-      />
-      <div
-        className="menu transition left"
-      >
-        <div
-          className="item"
-          onClick={[Function]}
-          role="option"
-        >
-          <svg
-            className="icon"
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": undefined,
-              }
-            }
-            onClick={null}
-            style={
-              Object {
-                "fill": "currentColor",
-                "height": "15px",
-                "width": "auto",
-              }
-            }
-            viewBox=""
-            xmlns=""
-          />
-          Delete
-        </div>
-      </div>
-    </div>
+      style={
+        Object {
+          "fill": "#826a6a",
+          "height": "24px",
+          "width": "auto",
+        }
+      }
+      viewBox=""
+      xmlns=""
+    />
   </td>
 </tr>
 `;

--- a/src/components/manage/Controlpanels/Users/__snapshots__/UsersControlpanel.test.jsx.snap
+++ b/src/components/manage/Controlpanels/Users/__snapshots__/UsersControlpanel.test.jsx.snap
@@ -42,15 +42,15 @@ exports[`UsersControlpanel renders a user control component 1`] = `
     <div
       className="ui segment"
     >
-      <form
-        className="ui form"
-        onSubmit={[Function]}
+      <div
+        className="ui secondary attached menu"
       >
         <div
-          className="field"
+          className="left item"
+          onClick={[Function]}
         >
           <div
-            className="ui action input"
+            className="ui large transparent input"
           >
             <input
               id="user-search-input"
@@ -59,66 +59,113 @@ exports[`UsersControlpanel renders a user control component 1`] = `
               placeholder="Search users…"
               type="text"
             />
-            <button
-              className="ui icon button"
-              onClick={[Function]}
-            >
-              <i
-                aria-hidden="true"
-                className="search icon"
-                onClick={[Function]}
-              />
-            </button>
           </div>
+          <svg
+            className="icon zoom"
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": undefined,
+              }
+            }
+            onClick={[Function]}
+            style={
+              Object {
+                "fill": "#007eb1",
+                "height": "30px",
+                "width": "auto",
+              }
+            }
+            viewBox=""
+            xmlns=""
+          />
         </div>
-      </form>
-    </div>
-    <form
-      className="ui form"
-      onSubmit={[Function]}
-    >
-      <div
-        className="table"
-      >
-        <table
-          className="ui striped unstackable attached padded table"
+        <button
+          className="ui button disabled icon item"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
         >
-          <thead
+          <svg
+            className="icon delete"
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": undefined,
+              }
+            }
+            onClick={null}
+            style={
+              Object {
+                "fill": "grey",
+                "height": "24px",
+                "width": "auto",
+              }
+            }
+            viewBox=""
+            xmlns=""
+          />
+        </button>
+      </div>
+    </div>
+    <div
+      className="table"
+    >
+      <table
+        className="ui striped unstackable attached padded table"
+      >
+        <thead
+          className=""
+        >
+          <tr
             className=""
           >
-            <tr
+            <th
               className=""
             >
-              <th
-                className=""
-              >
-                User name
-              </th>
-              <th
-                className=""
-              >
-                Actions
-              </th>
-            </tr>
-          </thead>
-          <tbody
-            className=""
-            data-user="users"
-          />
-        </table>
-      </div>
+              <svg
+                className="icon"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": undefined,
+                  }
+                }
+                onClick={[Function]}
+                style={
+                  Object {
+                    "fill": "#007eb1",
+                    "height": "24px",
+                    "width": "auto",
+                  }
+                }
+                viewBox=""
+                xmlns=""
+              />
+            </th>
+            <th
+              className=""
+            >
+              User name
+            </th>
+          </tr>
+        </thead>
+        <tbody
+          className=""
+          data-user="users"
+        />
+      </table>
+    </div>
+    <div
+      className="contents-pagination"
+    >
       <div
-        className="contents-pagination"
+        className="ui secondary attached menu"
       >
         <div
-          className="ui secondary attached menu"
-        >
-          <div
-            className="menu"
-          />
-        </div>
+          className="menu"
+        />
       </div>
-    </form>
+    </div>
   </div>
   <div
     id="Portal"

--- a/src/helpers/MessageLabels/MessageLabels.js
+++ b/src/helpers/MessageLabels/MessageLabels.js
@@ -158,6 +158,10 @@ export const messages = defineMessages({
     id: 'Success',
     defaultMessage: 'Success',
   },
+  delete: {
+    id: 'Delete',
+    defaultMessage: 'Delete',
+  },
   userCreated: {
     id: 'User created',
     defaultMessage: 'User created',

--- a/theme/themes/pastanaga/collections/menu.overrides
+++ b/theme/themes/pastanaga/collections/menu.overrides
@@ -171,6 +171,10 @@
   }
 }
 
+.users-control-panel .ui.attached.menu:not(.tabular) {
+border: none !important;
+}
+
 /* Pagination */
 .pagination-wrapper {
   text-align: center;


### PR DESCRIPTION
A bit more improvement to the designs in controlpanels, Ability to select multiple users/groups and apply actions such as `"delete"`.  I think we should also unify the use of checkboxes and other widgets to all over sites. 

For instance,  checkbox is using different designs when used as widget and as standalone( according to prototypes/designs). Maybe we should refactor them....?


<img width="1206" alt="Screenshot 2021-10-31 at 12 36 03 AM" src="https://user-images.githubusercontent.com/22280901/139555577-75ee953b-75d8-471b-b400-a9e15d6a30de.png">

