### PR TITLE
Fix gap of image block in Paragraph styling that shows in chrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Fix gap of image block in Paragraph styling that shows in chrome @iRohitSingh
+
 ### Internal
 
 ## 14.0.0-alpha.26 (2021-11-01)

--- a/theme/themes/pastanaga/extras/blocks.less
+++ b/theme/themes/pastanaga/extras/blocks.less
@@ -112,6 +112,7 @@
 
 .block.align.left {
   z-index: 2;
+  margin-bottom: 0px;
 
   &.video .video-inner,
   &.maps iframe,
@@ -146,6 +147,7 @@
 
 .block.align.right {
   z-index: 2;
+  margin-bottom: 0px;
 
   &.maps iframe,
   &.video .video-inner,


### PR DESCRIPTION
Fixed #2768 