### PR TITLE
#2818 folder contents dropdown changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 
 ### Bugfix
 
+- Folder contents table header and breadcrumbs dropdown now appear only from the
+  bottom, fixing an issue where the breadcrumb dropdown content was clipped 
+  by the header area @ichim-david
+- Folder contents sort dropdown is now also simple as the other dropdowns 
+  ensuring we have the same behavior between adjecent dropdown @ichim-david
+
 ### Internal
 
 ## 14.0.0-alpha.31 (2021-11-07)

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -114,6 +114,7 @@ export BlocksToolbar from '@plone/volto/components/manage/Form/BlocksToolbar';
 export Field from '@plone/volto/components/manage/Form/Field';
 export SearchTags from '@plone/volto/components/theme/Search/SearchTags';
 export CommentEditModal from '@plone/volto/components/theme/Comments/CommentEditModal';
+export ContentsBreadcrumbs from '@plone/volto/components/manage/Contents/ContentsBreadcrumbs';
 export ContentsIndexHeader from '@plone/volto/components/manage/Contents/ContentsIndexHeader';
 export ContentsItem from '@plone/volto/components/manage/Contents/ContentsItem';
 export ContentsUploadModal from '@plone/volto/components/manage/Contents/ContentsUploadModal';

--- a/src/components/manage/Contents/Contents.jsx
+++ b/src/components/manage/Contents/Contents.jsx
@@ -52,6 +52,7 @@ import {
 } from '@plone/volto/actions';
 import Indexes, { defaultIndexes } from '@plone/volto/constants/Indexes';
 import {
+  ContentsBreadcrumbs,
   ContentsIndexHeader,
   ContentsItem,
   ContentsRenameModal,
@@ -66,7 +67,6 @@ import {
   Unauthorized,
 } from '@plone/volto/components';
 
-import ContentsBreadcrumbs from './ContentsBreadcrumbs';
 import { Helmet, getBaseUrl } from '@plone/volto/helpers';
 import { injectLazyLibs } from '@plone/volto/helpers/Loadable/Loadable';
 
@@ -1431,6 +1431,7 @@ class Contents extends Component {
                         <ContentsBreadcrumbs items={this.props.breadcrumbs} />
                         <Dropdown
                           item
+                          upward={false}
                           icon={
                             <Icon name={moreSVG} size="24px" color="#826a6a" />
                           }
@@ -1495,7 +1496,13 @@ class Contents extends Component {
                           <Table.Row>
                             <Table.HeaderCell>
                               <Dropdown
-                                trigger={
+                                item
+                                upward={false}
+                                className="sort-icon"
+                                aria-label={this.props.intl.formatMessage(
+                                  messages.sort,
+                                )}
+                                icon={
                                   <Icon
                                     name={configurationSVG}
                                     size="24px"
@@ -1503,12 +1510,6 @@ class Contents extends Component {
                                     className="configuration-svg"
                                   />
                                 }
-                                className="sort-icon"
-                                aria-label={this.props.intl.formatMessage(
-                                  messages.sort,
-                                )}
-                                icon={null}
-                                simple
                               >
                                 <Dropdown.Menu>
                                   <Dropdown.Header
@@ -1572,6 +1573,7 @@ class Contents extends Component {
                             </Table.HeaderCell>
                             <Table.HeaderCell>
                               <Dropdown
+                                upward={false}
                                 trigger={
                                   <Icon
                                     name={

--- a/src/components/manage/Contents/__snapshots__/Contents.test.jsx.snap
+++ b/src/components/manage/Contents/__snapshots__/Contents.test.jsx.snap
@@ -995,6 +995,12 @@ exports[`Contents renders a folder contents view component 1`] = `
                       role="listbox"
                       tabIndex={0}
                     >
+                      <div
+                        aria-atomic={true}
+                        aria-live="polite"
+                        className="text"
+                        role="alert"
+                      />
                       <svg
                         className="icon configuration-svg"
                         dangerouslySetInnerHTML={
@@ -1002,7 +1008,7 @@ exports[`Contents renders a folder contents view component 1`] = `
                             "__html": undefined,
                           }
                         }
-                        onClick={null}
+                        onClick={[Function]}
                         style={
                           Object {
                             "fill": "#826a6a",

--- a/src/components/manage/Contents/__snapshots__/Contents.test.jsx.snap
+++ b/src/components/manage/Contents/__snapshots__/Contents.test.jsx.snap
@@ -986,7 +986,7 @@ exports[`Contents renders a folder contents view component 1`] = `
                     <div
                       aria-expanded={false}
                       aria-label="sort"
-                      className="ui simple dropdown sort-icon"
+                      className="ui item dropdown sort-icon"
                       onBlur={[Function]}
                       onChange={[Function]}
                       onClick={[Function]}

--- a/theme/themes/pastanaga/extras/contents.less
+++ b/theme/themes/pastanaga/extras/contents.less
@@ -19,6 +19,7 @@
   .ui.dropdown > .menu > .item:active > .menu {
     top: 0 !important;
     left: 100% !important;
+    display: block;
     overflow: visible;
     width: auto;
     height: auto;

--- a/theme/themes/pastanaga/extras/contents.less
+++ b/theme/themes/pastanaga/extras/contents.less
@@ -13,6 +13,17 @@
       padding-top: 4px;
     }
   }
+  // #2818 allow any dropdown to reveal extra menu on hover
+  // not just the simple dropdown within /contents area
+  .ui.dropdown:hover > .menu > .item:hover > .menu,
+  .ui.dropdown > .menu > .item:active > .menu {
+    top: 0 !important;
+    left: 100% !important;
+    overflow: visible;
+    width: auto;
+    height: auto;
+    opacity: 1;
+  }
 
   .ui.dropdown .menu > .item {
     display: flex;


### PR DESCRIPTION
- The sort dropdown is now item dropdown as well, you need to click on it to show the menu items,
  the secondary hover items still show up on menu item hover
- The dropdown menus from the breadcrumbs and the table headers are now forced to render downwards
  in order to avoid clipping when the window is small such as when you have dev tools enabled