### PR TITLE
Form defaults: onChangeFormData in InlineForm

### DIFF
--- a/docs/source/upgrade-guide/index.md
+++ b/docs/source/upgrade-guide/index.md
@@ -148,6 +148,42 @@ The mobile navigation menu has been improved using a customizable `CSSTransition
 
 In order to match the Plone logo and in lieu to use a better generic icon starting point, the `Logo.jsx` component and `.logo-nav-wrapper` styling have been adjusted. The logo is not constrained by default to `64px` and the wrapper now centers vertically. Please check that your project logo placeholder is still in good shape after upgrade.
 
+### Defaults in `BlockDataForm` and `InlineForm` helper components
+
+ Not strictly breaking, since the feature won't work if no action is taken, but for this new feature to work properly, you have to pass down this props `onChangeFormData` down in every instantiation of `BlockDataForm` or `InlineForm` like is shown here:
+
+ ```diff
+ --- a/src/components/manage/Blocks/Listing/ListingData.jsx
+ +++ b/src/components/manage/Blocks/Listing/ListingData.jsx
+
+ @@ -19,7 +19,7 @@ const ListingData = (props) => {
+            [id]: value,
+          });
+        }}
+ +      onChangeFormData={(data) => onChangeBlock(block, data)}
+        formData={data}
+        block={block}
+      />
+ ```
+
+Also, in your custom blocks settings you have to add a new property in `src/config.js`:
+
+```js hl_lines="8"
+  import searchBlockSchema from '@plone/volto/components/manage/Blocks/Search/schema';
+  ...
+  search: {
+    id: 'search',
+    title: 'Search',
+    icon: searchSVG,
+    group: 'common',
+    view: SearchBlockView,
+    edit: SearchBlockEdit,
+    schema: searchBlockSchema,
+    restricted: false,
+    mostUsed: false,
+    ...
+```
+
 ## Upgrading to Volto 13.x.x
 
 ## Deprecating NodeJS 10

--- a/src/components/manage/Blocks/Search/SearchBlockEdit.jsx
+++ b/src/components/manage/Blocks/Search/SearchBlockEdit.jsx
@@ -69,6 +69,7 @@ const SearchBlockEdit = (props) => {
             });
           }}
           formData={data}
+          onChangeFormData={(data) => onChangeBlock(block, data)}
         />
       </SidebarPortal>
     </>

--- a/src/components/manage/Form/InlineForm.jsx
+++ b/src/components/manage/Form/InlineForm.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Accordion, Segment, Message } from 'semantic-ui-react';
 import { defineMessages, injectIntl } from 'react-intl';
 import AnimateHeight from 'react-animate-height';
-import { keys, map, isEqual } from 'lodash';
+import { keys, map } from 'lodash';
 
 import { Field, Icon } from '@plone/volto/components';
 
@@ -40,12 +40,14 @@ const InlineForm = (props) => {
     footer,
     focusIndex,
     intl,
+    onChangeFormData,
   } = props;
   const _ = intl.formatMessage;
   const defaultFieldset = schema.fieldsets.find((o) => o.id === 'default');
   const other = schema.fieldsets.filter((o) => o.id !== 'default');
 
   React.useEffect(() => {
+    if (!onChangeFormData) return;
     // Will set field values from schema, by matching the default values
 
     const objectSchema = typeof schema === 'function' ? schema(props) : schema;
@@ -64,11 +66,8 @@ const InlineForm = (props) => {
       ...formData,
     };
 
-    Object.keys(initialData).forEach((k) => {
-      if (!isEqual(initialData[k], formData?.[k])) {
-        onChangeField(k, initialData[k]);
-      }
-    });
+    onChangeFormData(initialData);
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/src/components/manage/Form/InlineForm.test.jsx
+++ b/src/components/manage/Form/InlineForm.test.jsx
@@ -20,13 +20,21 @@ function NewBaseWidget(name) {
 }
 
 const withStateManagement = (Component) => ({ ...props }) => {
+  // onChangeField, formData, onChangeFormData
+  // are required props, connected to the main Volto's formdata state.
+  // Mocked here with local state.
   const [formData, setFormData] = React.useState(props.formData || {});
   const onChangeField = (id, value) => {
     setFormData({ ...formData, [id]: value });
   };
-
+  const onChangeFormData = (data) => setFormData({ ...formData, ...data });
   return (
-    <Component {...props} onChangeField={onChangeField} formData={formData} />
+    <Component
+      {...props}
+      onChangeField={onChangeField}
+      formData={formData}
+      onChangeFormData={onChangeFormData}
+    />
   );
 };
 


### PR DESCRIPTION
@sneridagh This is the other variant, with onChangeFormData in InlineForm. The problem with this approach is that there needs to be code updates everywhere (pass onChangeFormData). We can move that call into the BlockDataForm, but then we'd have to pass `{...props}` in all BlockDataForms.