### PR TITLE
Fix isInternalUrl when settings.internalApiPath is empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,11 @@
 
 ### Bugfix
 
+- Fix `isInternalURL` when `settings.internalApiPath` is empty @tiberiuichim
 - Folder contents table header and breadcrumbs dropdown now appear only from the
-  bottom, fixing an issue where the breadcrumb dropdown content was clipped 
+  bottom, fixing an issue where the breadcrumb dropdown content was clipped
   by the header area @ichim-david
-- Folder contents sort dropdown is now also simple as the other dropdowns 
+- Folder contents sort dropdown is now also simple as the other dropdowns
   ensuring we have the same behavior between adjecent dropdown @ichim-david
 
 ### Internal

--- a/src/helpers/Url/Url.js
+++ b/src/helpers/Url/Url.js
@@ -176,7 +176,8 @@ export function isInternalURL(url) {
   return (
     url &&
     (url.indexOf(settings.publicURL) !== -1 ||
-      url.indexOf(settings.internalApiPath) !== -1 ||
+      (settings.internalApiPath &&
+        url.indexOf(settings.internalApiPath) !== -1) ||
       url.indexOf(settings.apiPath) !== -1 ||
       url.charAt(0) === '/' ||
       url.charAt(0) === '.' ||

--- a/src/helpers/Url/Url.test.js
+++ b/src/helpers/Url/Url.test.js
@@ -171,6 +171,13 @@ describe('Url', () => {
       expect(isInternalURL(href)).toBe(true);
       settings.internalApiPath = saved;
     });
+    it('tells if an URL is external if settings.internalApiPath is empty', () => {
+      const href = `http://google.com`;
+      const saved = settings.internalApiPath;
+      settings.internalApiPath = '';
+      expect(isInternalURL(href)).toBe(false);
+      settings.internalApiPath = saved;
+    });
     it('tells if an URL is internal if it is an anchor', () => {
       const href = '#anchor';
       expect(isInternalURL(href)).toBe(true);


### PR DESCRIPTION
For some reason my internalApiPath appears as empty string and it trips this edge case.