### PR TITLE
Add links to trainings and PloneConf 2020, 2021 YouTube playlists

### DIFF
--- a/docs/source/getting-started/others.md
+++ b/docs/source/getting-started/others.md
@@ -1,8 +1,25 @@
 # Other learning resources
 
+## Plone Trainings
+
 On the [Plone Trainings Website](https://training.plone.org) you'll find
 Volto-dedicated open training materials plus React and other
 Javascript-centered trainings.
+
+- [Volto](https://training.plone.org/5/volto/index.html)
+- [Volto Hands-On](https://training.plone.org/5/voltohandson/index.html)
+- [Volto Add-ons Development](https://training.plone.org/5/voltoaddons/index.html)
+- [Plone Deployment](https://training.plone.org/5/plone-deployment/index.html)
+- [React](https://training.plone.org/5/react/index.html)
+- [JavaScript For Plone Developers](https://training.plone.org/5/javascript/index.html)
+
+## PloneConf 2021
+
+[Playlist on YouTube](https://www.youtube.com/playlist?list=PLGN9BI-OAQkQDLQinBwdEXpebDTQCwdGi)
+
+## PloneConf 2020
+
+[Playlist on YouTube](https://www.youtube.com/playlist?list=PLGN9BI-OAQkTJPayNdKIZ8lLDm5RVOLV3)
 
 ## PloneConf 2019
 


### PR DESCRIPTION
It appears that there are no talks posted yet for 2021.

I am too lazy to dig into 2020. This at least improves it.