### PR TITLE
fix: fixed object browser selected items number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Fixed object browser selected items number. @giuliaghisini
+
 ### Internal
 
 - Fix select family widgets stories in storybook @sneridagh

--- a/src/components/manage/Sidebar/ObjectBrowserBody.jsx
+++ b/src/components/manage/Sidebar/ObjectBrowserBody.jsx
@@ -448,7 +448,7 @@ class ObjectBrowserBody extends Component {
           <Segment className="infos">
             {this.props.intl.formatMessage(messages.SelectedItems)}:{' '}
             {this.props.data?.length}
-            {this.props.maximumSelectionSize && (
+            {this.props.maximumSelectionSize > 0 && (
               <>
                 {' '}
                 {this.props.intl.formatMessage(messages.of)}{' '}


### PR DESCRIPTION
There was a problem on selected items number in object browser widget if maximumSelectionSize was 0. 
This video shows problem

https://user-images.githubusercontent.com/51911425/143557450-5df874ab-3a63-43f8-a0e9-7dff444cc87a.mov

