### PR TITLE
fix: retrieve vocabulary name in action without regex look behind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Fix action vocabularies call avoiding regex look behind @nzambello
+
 ### Internal
 
 - Fix select family widgets stories in storybook @sneridagh

--- a/src/actions/vocabularies/vocabularies.js
+++ b/src/actions/vocabularies/vocabularies.js
@@ -45,9 +45,7 @@ export function getVocabulary(vocabNameOrURL, query = null, start = 0) {
  */
 export function getVocabularyTokenTitle(vocabNameOrURL, token = null) {
   // In case we have a URL, we have to get the vocabulary name
-  const vocabulary = /(?<=\/@vocabularies\/)(.*)/.test(vocabNameOrURL)
-    ? /(?<=\/@vocabularies\/)(.*)/.exec(vocabNameOrURL)[0]
-    : vocabNameOrURL;
+  const vocabulary = getVocabName(vocabNameOrURL);
 
   return {
     type: GET_VOCABULARY_TOKEN_TITLE,

--- a/src/actions/vocabularies/vocabularies.js
+++ b/src/actions/vocabularies/vocabularies.js
@@ -7,6 +7,7 @@ import {
   GET_VOCABULARY,
   GET_VOCABULARY_TOKEN_TITLE,
 } from '@plone/volto/constants/ActionTypes';
+import { getVocabName } from '@plone/volto/helpers/Vocabularies/Vocabularies';
 
 /**
  * Get vocabulary given a URL (coming from a Schema) or from a vocabulary name.
@@ -18,9 +19,7 @@ import {
  */
 export function getVocabulary(vocabNameOrURL, query = null, start = 0) {
   // In case we have a URL, we have to get the vocabulary name
-  const vocabulary = /(?<=\/@vocabularies\/)(.*)/.test(vocabNameOrURL)
-    ? /(?<=\/@vocabularies\/)(.*)/.exec(vocabNameOrURL)[0]
-    : vocabNameOrURL;
+  const vocabulary = getVocabName(vocabNameOrURL);
   let queryString = `b_start=${start}`;
   if (query) {
     queryString = `${queryString}&title=${query}`;

--- a/src/helpers/Vocabularies/Vocabularies.js
+++ b/src/helpers/Vocabularies/Vocabularies.js
@@ -54,6 +54,18 @@ export function getVocabFromItems(props) {
 }
 
 /**
+ * Get vocabulary given a URL (coming from a Schema) or from a vocabulary name.
+ * @function getVocabName
+ * @param {string} vocabNameOrURL
+ * @returns {string} Vocabulary name
+ */
+export function getVocabName(vocabNameOrURL) {
+  return vocabNameOrURL.indexOf('@vocabularies') > -1
+    ? vocabNameOrURL.split('@vocabularies/')[1]
+    : vocabNameOrURL;
+}
+
+/**
  * Get Fields vocabulary
  * @function getFieldsVocabulary
  * @returns {Object} Fields vocabulary


### PR DESCRIPTION
Fixes: #2865 

Changes #2862 with a different solution avoiding regex look behind since it's not supported by Safari