### PR TITLE
Fix reading initial SearchableText param in search block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Bugfix
 
+- In search block, read SearchableText search param, to use it as search text input
+  @tiberiuichim
+
 ### Internal
 
 ## 14.0.0-alpha.37 (2021-11-26)

--- a/src/components/manage/Blocks/Search/hocs/withSearch.jsx
+++ b/src/components/manage/Blocks/Search/hocs/withSearch.jsx
@@ -119,9 +119,12 @@ const useHashState = () => {
   const location = useLocation();
   const history = useHistory();
 
-  const oldState = React.useMemo(() => qs.parse(location.hash), [
-    location.hash,
-  ]);
+  const oldState = React.useMemo(() => {
+    return {
+      ...qs.parse(location.search),
+      ...qs.parse(location.hash),
+    };
+  }, [location.hash, location.search]);
 
   // This creates a shallow copy. Why is this needed?
   const current = Object.assign(
@@ -149,8 +152,6 @@ const useHashState = () => {
       if (changed) {
         history.push({
           hash: qs.stringify(newParams),
-          // TODO: handle ?Subject= and ?SearchableText=
-          // search: location.search,
         });
       }
     },


### PR DESCRIPTION
This makes the search block properly read a URL with `?SearchableText=something`.