### PR TITLE
Properly generate URL for listing block when used with slots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ### Internal
 
+- Allow listing block to be used in non-content pages (when used in a slot it
+  shouldn't crash on add/edit pages) @tiberiuichim
+
 ## 14.0.0-alpha.37 (2021-11-26)
 
 ### Bugfix

--- a/src/components/manage/Blocks/Listing/withQuerystringResults.jsx
+++ b/src/components/manage/Blocks/Listing/withQuerystringResults.jsx
@@ -4,7 +4,7 @@ import hoistNonReactStatics from 'hoist-non-react-statics';
 import useDeepCompareEffect from 'use-deep-compare-effect';
 
 import { getContent, getQueryStringResults } from '@plone/volto/actions';
-import { usePagination } from '@plone/volto/helpers';
+import { usePagination, getBaseUrl } from '@plone/volto/helpers';
 
 import config from '@plone/volto/registry';
 
@@ -22,7 +22,7 @@ export default function withQuerystringResults(WrappedComponent) {
     const { b_size = settings.defaultPageSize } = querystring; // batchsize
 
     // save the path so it won't trigger dispatch on eager router location change
-    const [initialPath] = React.useState(path);
+    const [initialPath] = React.useState(getBaseUrl(path));
 
     const copyFields = ['limit', 'query', 'sort_on', 'sort_order', 'depth'];
 


### PR DESCRIPTION
Actually, based on the `relative_path` changes needed, it's always a good idea to filter paths through Volto's api for URL mangling.