### PR TITLE
Use subrequest in hero block to not lost locking token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugfix
 
-- Use subrequest in href block to not lost locking token. @cekk
+- Use subrequest in hero block to not lost locking token. @cekk
 ### Internal
 
 ## 14.0.0-alpha.37 (2021-11-26)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bugfix
 
+- Use subrequest in href block to not lost locking token. @cekk
 ### Internal
 
 ## 14.0.0-alpha.37 (2021-11-26)

--- a/src/components/manage/Blocks/HeroImageLeft/Edit.jsx
+++ b/src/components/manage/Blocks/HeroImageLeft/Edit.jsx
@@ -274,15 +274,19 @@ class Edit extends Component {
     });
     readAsDataURL(file).then((data) => {
       const fields = data.match(/^data:(.*);(.*),(.*)$/);
-      this.props.createContent(getBaseUrl(this.props.pathname), {
-        '@type': 'Image',
-        image: {
-          data: fields[3],
-          encoding: fields[2],
-          'content-type': fields[1],
-          filename: file.name,
+      this.props.createContent(
+        getBaseUrl(this.props.pathname),
+        {
+          '@type': 'Image',
+          image: {
+            data: fields[3],
+            encoding: fields[2],
+            'content-type': fields[1],
+            filename: file.name,
+          },
         },
-      });
+        this.props.block,
+      );
     });
   }
 
@@ -459,9 +463,9 @@ class Edit extends Component {
 export default compose(
   injectIntl,
   connect(
-    (state) => ({
-      request: state.content.create,
-      content: state.content.data,
+    (state, ownProps) => ({
+      request: state.content.subrequests[ownProps.block] || {},
+      content: state.content.subrequests[ownProps.block]?.data,
     }),
     { createContent },
   ),

--- a/src/components/manage/Blocks/HeroImageLeft/Edit.test.jsx
+++ b/src/components/manage/Blocks/HeroImageLeft/Edit.test.jsx
@@ -8,11 +8,16 @@ import Edit from './Edit';
 global.__SERVER__ = true; // eslint-disable-line no-underscore-dangle
 
 const mockStore = configureStore();
+const blockId = '1234';
+
 test('renders an edit hero block component', () => {
   const store = mockStore({
     content: {
       create: {},
       data: {},
+      subrequests: {
+        [blockId]: {},
+      },
     },
     intl: {
       locale: 'en',
@@ -24,7 +29,7 @@ test('renders an edit hero block component', () => {
       <Edit
         data={{ url: 'hero' }}
         selected={false}
-        block="1234"
+        block={blockId}
         content={{}}
         request={{
           loading: false,


### PR DESCRIPTION
Copied from image block where it already worked.

Without subrequest, we lost the lock token infos and we cannot save the changes.

