### PR TITLE
fix: timewidget positioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Fix time widget position on 24h format @nzambello
+
 ### Internal
 
 ## 14.0.0-alpha.37 (2021-11-26)

--- a/theme/themes/pastanaga/extras/time-picker-overrides.less
+++ b/theme/themes/pastanaga/extras/time-picker-overrides.less
@@ -35,7 +35,7 @@
 
     .rc-time-picker-panel-inner {
       width: @timePickerWidthNarrow;
-      right: 74px !important;
+      right: 84px;
     }
   }
 

--- a/theme/themes/pastanaga/extras/time-picker-overrides.less
+++ b/theme/themes/pastanaga/extras/time-picker-overrides.less
@@ -35,6 +35,7 @@
 
     .rc-time-picker-panel-inner {
       width: @timePickerWidthNarrow;
+      right: 74px !important;
     }
   }
 


### PR DESCRIPTION
...don't ask why 84px.
To have the same behavior on 12 and 24 hrs, if in the current case it's positioned on 24px from right. If it's in "narrow" mode (so 24h) I need 60px more to have the picker dropdown to be aligned correctly.
