### PR TITLE
fix: always add lang attr in html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Always add lang attr in html @nzambello
+
 ### Internal
 
 - Fix select family widgets stories in storybook @sneridagh

--- a/src/components/theme/App/App.jsx
+++ b/src/components/theme/App/App.jsx
@@ -8,7 +8,7 @@ import jwtDecode from 'jwt-decode';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
-import { asyncConnect } from '@plone/volto/helpers';
+import { asyncConnect, Helmet } from '@plone/volto/helpers';
 import { Segment } from 'semantic-ui-react';
 import { renderRoutes } from 'react-router-config';
 import { Slide, ToastContainer, toast } from 'react-toastify';
@@ -19,6 +19,7 @@ import cx from 'classnames';
 import config from '@plone/volto/registry';
 import { PluggablesProvider } from '@plone/volto/components/manage/Pluggable';
 import { visitBlocks } from '@plone/volto/helpers/Blocks/Blocks';
+import { injectIntl } from 'react-intl';
 
 import Error from '@plone/volto/error';
 
@@ -109,8 +110,16 @@ class App extends Component {
     const isCmsUI = isCmsUi(this.props.pathname);
     const ConnectionRefusedView = views.errorViews.ECONNREFUSED;
 
+    const language =
+      this.props.content?.language?.token ?? this.props.intl?.locale;
+
     return (
       <PluggablesProvider>
+        {language && (
+          <Helmet>
+            <html lang={language} />
+          </Helmet>
+        )}
         <BodyClass className={`view-${action}view`} />
 
         {/* Body class depending on content type */}
@@ -262,6 +271,7 @@ export default compose(
         __SERVER__ && dispatch(getWorkflow(getBaseUrl(location.pathname))),
     },
   ]),
+  injectIntl,
   connect(
     (state, props) => ({
       pathname: props.location.pathname,

--- a/src/components/theme/ContentMetadataTags/ContentMetadataTags.jsx
+++ b/src/components/theme/ContentMetadataTags/ContentMetadataTags.jsx
@@ -4,7 +4,6 @@ import config from '@plone/volto/registry';
 
 const ContentMetadataTags = (props) => {
   const {
-    language,
     opengraph_title,
     opengraph_description,
     seo_title,
@@ -48,7 +47,6 @@ const ContentMetadataTags = (props) => {
   return (
     <>
       <Helmet>
-        {language && <html lang={language.token} />}
         <title>{seo_title || title}</title>
         <meta name="description" content={seo_description || description} />
         <meta


### PR DESCRIPTION
Currently it's added on contents' views.
But in /add, /edit or other views, the browser doesn't have that attribute, which is important for screen readers, linters and some font variations (like hyphenation).
I'm adding it to App so it's always set.