### PR TITLE
fix: querystring widget query param access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- QuerystringWidget more resilient on old schemas @nzambello
+
 ### Internal
 
 ## 14.0.0-alpha.38 (2021-11-30)

--- a/src/components/manage/Widgets/QuerystringWidget.jsx
+++ b/src/components/manage/Widgets/QuerystringWidget.jsx
@@ -85,7 +85,7 @@ export const objectSchema = ({ intl, isDisabled, value }) => ({
 
 const QuerystringWidget = (props) => {
   const { block, onChange, schemaEnhancer } = props;
-  const isDisabled = props.value?.query.length ? false : true;
+  const isDisabled = props.value?.query?.length ? false : true;
 
   const intl = useIntl();
   let schema = objectSchema({ ...props, intl, isDisabled });


### PR DESCRIPTION
Gives QuerystringWidget more resilience on old schema