### PR TITLE
Drag-and-drop list placeholder fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Fixed drag-and-drop list placeholder issues @reebalazs
+
 ### Internal
 
 ## 14.0.0-alpha.37 (2021-11-26)

--- a/src/components/manage/DragDropList/DragDropList.jsx
+++ b/src/components/manage/DragDropList/DragDropList.jsx
@@ -1,7 +1,51 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { isEmpty } from 'lodash';
 import { DragDropContext, Draggable, Droppable } from 'react-beautiful-dnd';
 import { v4 as uuid } from 'uuid';
+
+const getPlaceholder = (draggedDOM, sourceIndex, destinationIndex) => {
+  // Because of the margin rendering rules, there is no easy
+  // way to calculate the offset of the placeholder.
+  //
+  // (Note that this is the reason we cannot use the solutions
+  // published on the net, because they assume that we are in control
+  // of the content and there are no additional margins involved.)
+  //
+  // To get a placeholder that looks good in all cases, we
+  // fill up the space between the previous and the next element.
+  const childrenArray = [...draggedDOM.parentNode.children];
+  // Remove the source element
+  childrenArray.splice(sourceIndex, 1);
+  // Also remove the placeholder that the library always inserts at the end
+  childrenArray.splice(-1, 1);
+  const parentRect = draggedDOM.parentNode.getBoundingClientRect();
+  const prevNode = childrenArray[destinationIndex - 1];
+  const nextNode = childrenArray[destinationIndex];
+  let top, bottom;
+  if (prevNode) {
+    const prevRect = prevNode.getBoundingClientRect();
+    top = prevRect.top + prevRect.height - parentRect.top;
+  } else {
+    top = 0;
+  }
+  if (nextNode) {
+    const nextRect = nextNode.getBoundingClientRect();
+    bottom = nextRect.top - parentRect.top;
+  } else {
+    bottom =
+      parentRect.bottom +
+      draggedDOM.getBoundingClientRect().height -
+      parentRect.top;
+  }
+  return {
+    clientY: top,
+    clientHeight: bottom - top,
+    clientX: parseFloat(
+      window.getComputedStyle(draggedDOM.parentNode).paddingLeft,
+    ),
+    clientWidth: draggedDOM.clientWidth,
+  };
+};
 
 const DragDropList = (props) => {
   const {
@@ -14,99 +58,68 @@ const DragDropList = (props) => {
   } = props; //renderChild
   const [placeholderProps, setPlaceholderProps] = React.useState({});
   const [uid] = React.useState(uuid());
+  // queueing timed action
+  const timer = useRef(null);
 
-  const handleDragStart = React.useCallback((event) => {
+  const onDragStart = React.useCallback((event) => {
+    clearTimeout(timer.current);
     const queryAttr = 'data-rbd-draggable-id';
     const domQuery = `[${queryAttr}='${event.draggableId}']`;
     const draggedDOM = document.querySelector(domQuery);
-
     if (!draggedDOM) {
       return;
     }
-
-    const { clientHeight, clientWidth } = draggedDOM;
     const sourceIndex = event.source.index;
-    var clientY =
-      parseFloat(window.getComputedStyle(draggedDOM.parentNode).paddingTop) +
-      [...draggedDOM.parentNode.children]
-        .slice(0, sourceIndex)
-        .reduce((total, curr) => {
-          const style = curr.currentStyle || window.getComputedStyle(curr);
-          const marginBottom = parseFloat(style.marginBottom);
-          return total + curr.clientHeight + marginBottom;
-        }, 0);
-
-    setPlaceholderProps({
-      clientHeight,
-      clientWidth,
-      clientY,
-      clientX: parseFloat(
-        window.getComputedStyle(draggedDOM.parentNode).paddingLeft,
-      ),
-    });
+    setPlaceholderProps(getPlaceholder(draggedDOM, sourceIndex, sourceIndex));
   }, []);
 
+  const onDragEnd = React.useCallback(
+    (result) => {
+      clearTimeout(timer.current);
+      onMoveItem(result);
+      setPlaceholderProps({});
+    },
+    [onMoveItem],
+  );
+
   const onDragUpdate = React.useCallback((update) => {
+    clearTimeout(timer.current);
+    setPlaceholderProps({});
     if (!update.destination) {
       return;
     }
     const draggableId = update.draggableId;
-    const destinationIndex = update.destination.index;
-
     const queryAttr = 'data-rbd-draggable-id';
     const domQuery = `[${queryAttr}='${draggableId}']`;
     const draggedDOM = document.querySelector(domQuery);
-
     if (!draggedDOM) {
       return;
     }
-    const { clientHeight, clientWidth } = draggedDOM;
     const sourceIndex = update.source.index;
-    const childrenArray = [...draggedDOM.parentNode.children];
-    const movedItem = childrenArray[sourceIndex];
-    childrenArray.splice(sourceIndex, 1);
-
-    const updatedArray = [
-      ...childrenArray.slice(0, destinationIndex),
-      movedItem,
-      ...childrenArray.slice(destinationIndex + 1),
-    ];
-
-    var clientY =
-      parseFloat(window.getComputedStyle(draggedDOM.parentNode).paddingTop) +
-      updatedArray.slice(0, destinationIndex).reduce((total, curr) => {
-        if (!curr) return total;
-        const style = curr.currentStyle || window.getComputedStyle(curr);
-        const marginBottom = parseFloat(style.marginBottom);
-        return total + curr.clientHeight + marginBottom;
-      }, 0);
-
-    setPlaceholderProps({
-      clientHeight,
-      clientWidth,
-      clientY,
-      clientX: parseFloat(
-        window.getComputedStyle(draggedDOM.parentNode).paddingLeft,
-      ),
-    });
+    const destinationIndex = update.destination.index;
+    // Wait until the animations have finished, to make it look good.
+    timer.current = setTimeout(
+      () =>
+        setPlaceholderProps(
+          getPlaceholder(draggedDOM, sourceIndex, destinationIndex),
+        ),
+      250,
+    );
   }, []);
 
   const AsDomComponent = as;
   return (
     <DragDropContext
-      onDragEnd={(result) => {
-        const isMoved = onMoveItem(result);
-        if (isMoved) setPlaceholderProps({});
-      }}
-      onDragStart={handleDragStart}
+      onDragStart={onDragStart}
       onDragUpdate={onDragUpdate}
+      onDragEnd={onDragEnd}
     >
       <Droppable droppableId={uid}>
         {(provided, snapshot) => (
           <AsDomComponent
             ref={provided.innerRef}
             {...provided.droppableProps}
-            style={{ position: 'relative', ...style }}
+            style={{ ...style, position: 'relative' }}
             aria-labelledby={forwardedAriaLabelledBy}
           >
             {childList
@@ -116,19 +129,23 @@ const DragDropList = (props) => {
                   draggableId={childId.toString()}
                   index={index}
                   key={childId}
+                  style={{
+                    userSelect: 'none',
+                  }}
                 >
                   {(draginfo) => children({ child, childId, index, draginfo })}
                 </Draggable>
               ))}
             {provided.placeholder}
-            {!isEmpty(placeholderProps) && (
+            {!isEmpty(placeholderProps) && snapshot.isDraggingOver && (
               <div
                 style={{
                   position: 'absolute',
-                  top: `${placeholderProps.clientY}px`,
-                  height: `${placeholderProps.clientHeight + 18}px`,
+                  top: placeholderProps.clientY,
+                  left: placeholderProps.clientX,
+                  height: placeholderProps.clientHeight,
                   background: '#eee',
-                  width: `${placeholderProps.clientWidth}px`,
+                  width: placeholderProps.clientWidth,
                   borderRadius: '3px',
                 }}
               />


### PR DESCRIPTION
- Fix placeholder position to work with subtree margins.
  The original calculation assumes that there are no margins. The update
  works for all cases included when the subtree contains margins that
  extend to the node's parent.
- Remove placeholder when dropping in all cases.
- Make placeholder disappear when the element is moved outside the
  parent (thus, causes the place to be removed).