### PR TITLE
Add PreviewImage component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Feature
 
+- Added a new component, PreviewImage. It renders a preview image for a catalog brain (based on the `image_field` prop). @tiberiuichim
+
 ### Bugfix
 
 ### Internal

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -26,6 +26,7 @@ export OutdatedBrowser from '@plone/volto/components/theme/OutdatedBrowser/Outda
 export LanguageSelector from '@plone/volto/components/theme/LanguageSelector/LanguageSelector';
 export RenderBlocks from '@plone/volto/components/theme/View/RenderBlocks';
 export SkipLinks from '@plone/volto/components/theme/SkipLinks/SkipLinks';
+export PreviewImage from '@plone/volto/components/theme/PreviewImage/PreviewImage';
 
 export Error from '@plone/volto/components/theme/Error/Error';
 export NotFound from '@plone/volto/components/theme/NotFound/NotFound';

--- a/src/components/manage/Blocks/Listing/SummaryTemplate.jsx
+++ b/src/components/manage/Blocks/Listing/SummaryTemplate.jsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { ConditionalLink } from '@plone/volto/components';
+import { ConditionalLink, PreviewImage } from '@plone/volto/components';
 import { flattenToAppURL } from '@plone/volto/helpers';
 
-import DefaultImageSVG from '@plone/volto/components/manage/Blocks/Listing/default-image.svg';
 import { isInternalURL } from '@plone/volto/helpers/Url/Url';
 
 const SummaryTemplate = ({ items, linkTitle, linkHref, isEditMode }) => {
@@ -26,15 +25,7 @@ const SummaryTemplate = ({ items, linkTitle, linkHref, isEditMode }) => {
         {items.map((item) => (
           <div className="listing-item" key={item['@id']}>
             <ConditionalLink item={item} condition={!isEditMode}>
-              {!item.image_field && <img src={DefaultImageSVG} alt="" />}
-              {item.image_field && (
-                <img
-                  src={flattenToAppURL(
-                    `${item['@id']}/@@images/${item.image_field}/preview`,
-                  )}
-                  alt={item.title}
-                />
-              )}
+              <PreviewImage item={item} />
               <div className="listing-body">
                 <h3>{item.title ? item.title : item.id}</h3>
                 <p>{item.description}</p>

--- a/src/components/theme/PreviewImage/PreviewImage.jsx
+++ b/src/components/theme/PreviewImage/PreviewImage.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import cx from 'classnames';
+
+import { flattenToAppURL } from '@plone/volto/helpers';
+
+import DefaultImageSVG from '@plone/volto/components/manage/Blocks/Listing/default-image.svg';
+
+/**
+ * Renders a preview image for a catalog brain result item.
+ *
+ */
+function PreviewImage(props) {
+  const { item, size = 'preview', cover, ...rest } = props;
+  const src = item.image_field
+    ? flattenToAppURL(`${item['@id']}/@@images/${item.image_field}/${size}`)
+    : DefaultImageSVG;
+
+  return cover ? (
+    <img
+      src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
+      style={{ backgroundImage: `url("${src}")` }}
+      alt={item.title}
+      className={cx('preview-image', size)}
+    />
+  ) : (
+    <img src={src} alt={item.title} {...rest} />
+  );
+}
+
+PreviewImage.propTypes = {
+  size: PropTypes.string,
+  item: PropTypes.shape({
+    '@id': PropTypes.string.isRequired,
+    image_field: PropTypes.string,
+    title: PropTypes.string.isRequired,
+  }),
+};
+
+export default PreviewImage;

--- a/src/components/theme/PreviewImage/PreviewImage.test.js
+++ b/src/components/theme/PreviewImage/PreviewImage.test.js
@@ -1,0 +1,78 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import PreviewImage from './PreviewImage';
+
+describe('PreviewImage', () => {
+  it('renders a preview image', () => {
+    const item = {
+      image_field: 'image',
+      title: 'Item title',
+      '@id': 'http://localhost:3000/something',
+    };
+    const component = renderer.create(<PreviewImage item={item} />);
+    const json = component.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('renders a preview image with extra props', () => {
+    const item = {
+      image_field: 'image',
+      title: 'Item title',
+      '@id': 'http://localhost:3000/something',
+    };
+    const component = renderer.create(
+      <PreviewImage item={item} className="extra" />,
+    );
+    const json = component.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('renders a preview image with custom size', () => {
+    const item = {
+      image_field: 'image',
+      title: 'Item title',
+      '@id': 'http://localhost:3000/something',
+    };
+    const component = renderer.create(
+      <PreviewImage item={item} size="large" />,
+    );
+    const json = component.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('renders a preview image as a background cover', () => {
+    const item = {
+      image_field: 'image',
+      title: 'Item title',
+      '@id': 'http://localhost:3000/something',
+    };
+    const component = renderer.create(
+      <PreviewImage item={item} size="large" cover />,
+    );
+    const json = component.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('renders a fallback image', () => {
+    const item = {
+      title: 'Item title',
+      '@id': 'http://localhost:3000/something',
+    };
+    const component = renderer.create(<PreviewImage item={item} />);
+    const json = component.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+
+  it('renders a fallback image with extra props', () => {
+    const item = {
+      title: 'Item title',
+      '@id': 'http://localhost:3000/something',
+    };
+    const component = renderer.create(
+      <PreviewImage item={item} className="extra" />,
+    );
+    const json = component.toJSON();
+    expect(json).toMatchSnapshot();
+  });
+});

--- a/src/components/theme/PreviewImage/__snapshots__/PreviewImage.test.js.snap
+++ b/src/components/theme/PreviewImage/__snapshots__/PreviewImage.test.js.snap
@@ -1,0 +1,51 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PreviewImage renders a fallback image 1`] = `
+<img
+  alt="Item title"
+  src="default-image.svg"
+/>
+`;
+
+exports[`PreviewImage renders a fallback image with extra props 1`] = `
+<img
+  alt="Item title"
+  className="extra"
+  src="default-image.svg"
+/>
+`;
+
+exports[`PreviewImage renders a preview image 1`] = `
+<img
+  alt="Item title"
+  src="http://localhost:3000/something/@@images/image/preview"
+/>
+`;
+
+exports[`PreviewImage renders a preview image as a background cover 1`] = `
+<img
+  alt="Item title"
+  className="preview-image large"
+  src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
+  style={
+    Object {
+      "backgroundImage": "url(\\"http://localhost:3000/something/@@images/image/large\\")",
+    }
+  }
+/>
+`;
+
+exports[`PreviewImage renders a preview image with custom size 1`] = `
+<img
+  alt="Item title"
+  src="http://localhost:3000/something/@@images/image/large"
+/>
+`;
+
+exports[`PreviewImage renders a preview image with extra props 1`] = `
+<img
+  alt="Item title"
+  className="extra"
+  src="http://localhost:3000/something/@@images/image/preview"
+/>
+`;

--- a/theme/themes/pastanaga/extras/main.less
+++ b/theme/themes/pastanaga/extras/main.less
@@ -505,6 +505,10 @@ body.has-toolbar-collapsed .mobile-menu {
   transition: transform 0.5s cubic-bezier(0.09, 0.11, 0.24, 0.91);
 }
 
+.preview-image {
+  background-size: cover;
+}
+
 // Deprecated as per https://github.com/plone/volto/issues/1265
 // @import 'utils';
 @import 'toolbar';


### PR DESCRIPTION
There's a bunch of this logic that gets repeated in listings. This component makes it easier to reuse that logic.

There's a 'cover' option, which sets the preview image as background image. I thought it would be interesting to have it, there's listing scenarios where it could be useful.