### PR TITLE
docs(contrib): Changelog entry CI check exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 - Update to plone.restapi 8.16.2 (revert missing_value PR) @sneridagh
 - Update Plone version in api backend to 5.2.5. Update README and cleanup @fredvd
+- Document CI changelog verifier failure details that mislead contributors
 
 ## 14.0.0-alpha.40 (2021-12-01)
 

--- a/docs/source/contributing/guidelines.md
+++ b/docs/source/contributing/guidelines.md
@@ -35,7 +35,14 @@ upgrade in the [upgrade guide](../upgrade-guide/index.md).
 All text that can be shown in a browser must be translatable. Please mark all such
 strings as translatable as defined in the [i18n guide](../recipes/i18n.md)
 
-Code formatting and linting are already enforced in Volto.
+Code formatting and linting are already enforced in Volto.  Note that this project uses
+a GitHub PR check that enforces all changes must include an entry in `./CHANGELOG.md`.
+If a PR is missing such an entry [the details
+link](https://jenkins.plone.org/roboto/missing-changelog) indicates that entries should
+be added as files in `./news/`.  This is true for the Plone projects that use
+[towncrier](https://pypi.org/project/towncrier/) but not for this project.  Simply add
+an entry directly to `./CHANGELOG.md` as a part of the commit the makes the described
+change.
 
 See if you can use git to squash multiple commits into one where this makes sense.
 If you are not comfortable with git, never mind.


### PR DESCRIPTION
The GitHub CI check for changelog entries misleads new, would be contributors [indicating that entries should be added in `./news/*` files](https://jenkins.plone.org/roboto/missing-changelog).

[Apparently](https://github.com/plone/volto/pull/2901#issuecomment-989581010) that check comes from [mr.roboto](https://docs.plone.org/develop/coredev/docs/roboto.html).  If that check successfully handles `./CHANGELOG.md` handles in addition to `towncrier` `./news/*` entries, then it's failure message should reflect which is the case for the repo it's checking.  As such, this does seem like a bug in `mr.roboto` or whatever code and/or configuration is responsible for that check and its output.

[This project instead uses simple entries added to `./CHANGELOG.md`](https://github.com/plone/volto/pull/2901#issuecomment-990856372) but perhaps it should change to `./news/*` entries if only to be consistent with the rest of the ecosystem to make contributing across the ecosystem a smoother experience.  In the meantime, we should at least document this exception.