### PR TITLE
Fix select widget infinite loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@
 - Udate demo address @ksuess
 - Update list of trainings documentation @ksuess
 - Scroll to window top only when the location pathname changes, no longer take the window location search parameters into account. The search page and the listing block already use custom logic for their "scroll into view" behaviors. @tiberiuichim
+- In search block, read SearchableText search param, to use it as search text input
+  @tiberiuichim
+- Fix select widget infinite loop @reebalazs
 
 ### Internal
 

--- a/src/components/manage/Widgets/SelectWidget.jsx
+++ b/src/components/manage/Widgets/SelectWidget.jsx
@@ -169,9 +169,17 @@ class SelectWidget extends Component {
       this.props.value &&
       this.props.choices?.length > 0
     ) {
-      this.setState({
-        selectedOption: normalizeValue(this.props.choices, this.props.value),
-      });
+      const selectedOption = normalizeValue(
+        this.props.choices,
+        this.props.value,
+      );
+      if (selectedOption) {
+        // Note: only set the state when an option has been found,
+        // as setting this to null would cause an infinite loop.
+        this.setState({
+          selectedOption,
+        });
+      }
     }
   }
 


### PR DESCRIPTION
If an attempt is made to update a selection item that is not in the
choices, an infinite loop occurs. This can be caused by rare conditions
of a stale browser state.

This infinite loop has to be guarded by a condition in setState to
avoid triggering another component render and thus breaking the infinite
loop.