### PR TITLE
Hamburger z-index bug on mobile resolutions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Bugfix
 
+- Fix z-index value of hamburger-wrapper on 767px or less overlapping the sidebar @ichim-david
 - Add missing layout view for document_view @MarcoCouto
 - Fix UniversalLink handling of remote URLs from Link @nzambello
 - Add missing `App.jsx` full paths @jimbiscuit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### Bugfix
 
-- Fix z-index value of hamburger-wrapper on 767px or less overlapping the sidebar @ichim-david
+- Fix z-index value of hamburger-wrapper on mobile resolutions overlapping the sidebar @ichim-david
 - Add missing layout view for document_view @MarcoCouto
 - Fix UniversalLink handling of remote URLs from Link @nzambello
 - Add missing `App.jsx` full paths @jimbiscuit

--- a/theme/themes/pastanaga/extras/main.less
+++ b/theme/themes/pastanaga/extras/main.less
@@ -482,7 +482,7 @@ fieldset.invisible {
 
 .hamburger-wrapper {
   position: relative;
-  z-index: 10001;
+  z-index: 5;
 }
 
 .mobile-menu {


### PR DESCRIPTION
In https://github.com/plone/volto/pull/2723 @sneridagh  you did some great changes to the mobile menu.
There is however a small bug when the high z-index value of the wrapper made it appear above the sidebar
content.

This pull request fixes this issue
Here is how it looked before
![before-the-change](https://user-images.githubusercontent.com/152852/146791942-af7a49f4-a99a-4f2b-b58f-d6489fd5e35d.png)

And how it looks after my change
![after-the-change](https://user-images.githubusercontent.com/152852/146791993-9a1d9928-036a-40e5-9ea9-9ba3b14ca735.png)

The hamburger icon is still visible within the nav menu to show or hide
![hamburger-still-visible](https://user-images.githubusercontent.com/152852/146792025-0f11fdaf-52f9-43c8-a694-98cf279a6f8f.png)


