### PR TITLE
typo paralel vs. parallel

### DIFF
--- a/src/middleware/api.js
+++ b/src/middleware/api.js
@@ -108,7 +108,7 @@ export default (api) => ({ dispatch, getState }) => (next) => (action) => {
     return action(dispatch, getState);
   }
 
-  const { request, type, mode = 'paralel', ...rest } = action;
+  const { request, type, mode = 'parallel', ...rest } = action;
   let actionPromise;
 
   if (!request) {


### PR DESCRIPTION
this is just a typo "paralel" vs "parallel" it seems to me that nothing changes, because it is the default behavior 