### PR TITLE
show "no results" message when there are no results in ListingBlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Bugfix
 
+- Fix ListingBlock to add "No results" message when there are no messages @erral
 - Fix overflow table in Content view @giuliaghisini
 - Fixed url validation in FormValidation to admit ip addresses. @giuliaghisini
 

--- a/src/components/manage/Blocks/Listing/ListingBody.jsx
+++ b/src/components/manage/Blocks/Listing/ListingBody.jsx
@@ -97,6 +97,12 @@ const ListingBody = withQuerystringResults((props) => {
     </div>
   ) : (
     <div>
+      {hasLoaded && (
+        <FormattedMessage
+          id="No results found."
+          defaultMessage="No results found."
+        />
+      )}
       <Dimmer active={!hasLoaded} inverted>
         <Loader indeterminate size="small">
           <FormattedMessage id="loading" defaultMessage="Loading" />

--- a/src/components/manage/Blocks/Listing/__snapshots__/ListingBody.test.jsx.snap
+++ b/src/components/manage/Blocks/Listing/__snapshots__/ListingBody.test.jsx.snap
@@ -2,6 +2,7 @@
 
 exports[`renders a ListingBody component 1`] = `
 <div>
+  No results found.
   <div
     className="ui inverted dimmer"
     onClick={[Function]}


### PR DESCRIPTION
As a first step to #2979, at least we can show a generic "No results" message when there are no results in the listing block