### PR TITLE
Add Widget additional information link

### DIFF
--- a/docs/source/configuration/how-to.md
+++ b/docs/source/configuration/how-to.md
@@ -74,6 +74,8 @@ but also the [lookup
 mechanism](https://github.com/plone/volto/blob/6fd62cb2860bc7cf3cb7c36ea86bfd8bd03247d9/src/components/manage/Form/Field.jsx#L112)
 to understand how things work.
 
+See [Widgets](/recipes/widget) for more information.
+
 ## views
 
 The `views` registry allows configuration of the components that will be used


### PR DESCRIPTION
Add a link to widget developer recipe at the end of Widget section. 

I think it is import to point developer where to find information about customizing and overriding widgets. 

Thanks @tiberiuichim  for the tip 
https://community.plone.org/t/using-react-currency-selector/14737