### PR TITLE
Syncronize the content language with the UI language in multilingual …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Enable `components` property in Volto's config registry. Does not expose any direct feature but this will open the door to be able to override registered components using the config registry and avoid using shadowing explicitly. @sneridagh
 - Add `resolve` and `register` helper methods for the Volto config. They retrieve and register new components in the registry. @tiberiuichim @sneridagh
 - Add `Component` component, given a `name` of a component registered in the registry, it renders it, passing down the props. @tiberiuichim
+- Syncronize the content language with the UI language in multilingual sites. So when you are accessing a content in a given language the rest of the interface literals follow along (it updates the language cookie). So the UI remains consistent. @sneridagh
 
 ### Bugfix
 

--- a/src/components/theme/App/App.jsx
+++ b/src/components/theme/App/App.jsx
@@ -146,7 +146,10 @@ class App extends Component {
         <SkipLinks />
         <Header pathname={path} />
         <Breadcrumbs pathname={path} />
-        <MultilingualRedirector pathname={this.props.pathname}>
+        <MultilingualRedirector
+          pathname={this.props.pathname}
+          contentLanguage={this.props.content?.language?.token}
+        >
           <Segment basic className="content-area">
             <main>
               <OutdatedBrowser />

--- a/src/components/theme/MultilingualRedirector/MultilingualRedirector.jsx
+++ b/src/components/theme/MultilingualRedirector/MultilingualRedirector.jsx
@@ -8,7 +8,7 @@ import { normalizeLanguageName } from '@plone/volto/helpers';
 
 const MultilingualRedirector = (props) => {
   const { settings } = config;
-  const { pathname, children } = props;
+  const { pathname, contentLanguage, children } = props;
   const currentLanguage =
     cookie.load('I18N_LANGUAGE') || settings.defaultLanguage;
   const redirectToLanguage = settings.supportedLanguages.includes(
@@ -17,6 +17,33 @@ const MultilingualRedirector = (props) => {
     ? currentLanguage
     : settings.defaultLanguage;
   const dispatch = useDispatch();
+
+  React.useEffect(() => {
+    // This ensures the current content language and the current active language in the
+    // UI are the same. Otherwise, there are inconsistencies between the UI main elements
+    // eg. Home link in breadcrumbs, other i18n dependant literals from the main UI and
+    // the current content language.
+    if (
+      contentLanguage &&
+      currentLanguage !== contentLanguage &&
+      pathname &&
+      // We don't want to trigger it in Babel View, since Babel view already takes care
+      // of it
+      !pathname.endsWith('/add') &&
+      settings.isMultilingual
+    ) {
+      const langFileName = normalizeLanguageName(contentLanguage);
+      import('~/../locales/' + langFileName + '.json').then((locale) => {
+        dispatch(changeLanguage(contentLanguage, locale.default));
+      });
+    }
+  }, [
+    pathname,
+    dispatch,
+    currentLanguage,
+    contentLanguage,
+    settings.isMultilingual,
+  ]);
 
   React.useEffect(() => {
     // ToDo: Add means to support language negotiation (with config)


### PR DESCRIPTION
…sites. So when you are accessing a content in a given language the rest of the interface literals follow along (it updates the language cookie). So the UI remains consistent.

I can imagine that this could be conflictive and one could say that's not the behavior that everybody wants for their sites, but this is something that I think it's sensible, as default. At some point, someone could add a parameter in the config to control it.