### PR TITLE
build(api): Fix redundant buildout install run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Internal
 
+- Cleanup redundant buildout install run.
+
 ## 14.8.0 (2022-02-03)
 
 ### Feature

--- a/api/Makefile
+++ b/api/Makefile
@@ -41,7 +41,6 @@ build:  ## Build Plone 5.2
 	bin/pip install --upgrade pip
 	bin/pip install --upgrade wheel
 	bin/pip install -r requirements.txt
-	bin/buildout
 	bin/buildout instance:http-address=$(INSTANCE_PORT)
 
 .PHONY: test


### PR DESCRIPTION
What an odd mistake to make!  I could have sworn I copied and pasted that from the
top-level `./Makefile` when I made this change but [no I
didn't](https://github.com/plone/volto/commit/c0f4e31c61ce0346937390706fe956f16abf1f27#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L57).

Fixes #2932