### PR TITLE
Fix the `null` error in SelectAutoComplete Widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Fix the `null` error in SelectAutoComplete Widget @iFlameing
+
 ### Internal
 
 ## 15.0.0-alpha.0 (2022-02-09)

--- a/src/components/manage/Widgets/SelectAutoComplete.jsx
+++ b/src/components/manage/Widgets/SelectAutoComplete.jsx
@@ -135,7 +135,7 @@ class SelectAutoComplete extends Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    const { value, choices = [] } = this.props;
+    const { value, choices } = this.props;
     if (
       this.state.termsPairsCache.length === 0 &&
       value?.length > 0 &&

--- a/src/components/manage/Widgets/SelectAutoComplete.jsx
+++ b/src/components/manage/Widgets/SelectAutoComplete.jsx
@@ -139,7 +139,7 @@ class SelectAutoComplete extends Component {
     if (
       this.state.termsPairsCache.length === 0 &&
       value?.length > 0 &&
-      choices.length > 0
+      choices?.length > 0
     ) {
       this.setState((state) => ({
         termsPairsCache: [...state.termsPairsCache, ...choices],


### PR DESCRIPTION
@reebalazs I added this optional chaining because what happens props has the choices but its value is null. Then we don't get the array initialization.  