### PR TITLE
Fixed missing typescript docs link in navigation

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -87,6 +87,7 @@ nav:
       - Testing: 'developer-guidelines/testing.md'
       - Acceptance tests: 'developer-guidelines/acceptance-tests.md'
       - Accessibility: 'developer-guidelines/accessibility-guidelines.md'
+      - TypeScript: 'developer-guidelines/typescript.md'
   - Contributing:
       - Guidelines: 'contributing/guidelines.md'
 


### PR DESCRIPTION
I forgot it when I added compatibility in #2795 