### PR TITLE
Fix Sphinx warnings when built in Plone 6 Documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Clean up toctree errors by removing obsolete files, adding `:orphan:` field list, and reorganizing some files. @sneridagh and @stevepiercy
 - Switch to using netlify.toml to configure Netlify Python environment. @stevepiercy
 - Convert admonition syntax from Markdown to MyST. @sneridagh
+- Make links build both in Volto and Plone documentation. See https://github.com/plone/volto/pull/3094 @stevepiercy
 
 ## 15.0.0-alpha.5 (2022-02-16)
 

--- a/docs/source/addons/index.md
+++ b/docs/source/addons/index.md
@@ -457,4 +457,4 @@ You can use `yarn test src/addons/addon-name` to run tests.
 If you have generated your Volto project recently (after the summer of 2020),
 you don't have to do anything to have automatic integration with ESLint,
 otherwise make sure to upgrade your project's `.eslintrc` to the `.eslintrc.js`
-version, according to the {doc}`/upgrade-guide/index`.
+version, according to the {doc}`../upgrade-guide/index`.

--- a/docs/source/configuration/how-to.md
+++ b/docs/source/configuration/how-to.md
@@ -34,7 +34,7 @@ Both use the same method, using a function as the default export. This function 
 add-ons, it must be provided in the main `index.js` module of the add-on. For project's
 it must be provided in the `src/config.js` module of the project.
 
-See the {doc}`/addons/index` section for extended information on how to work with add-ons.
+See the {doc}`../addons/index` section for extended information on how to work with add-ons.
 
 ## Extending configuration in a project
 
@@ -70,9 +70,8 @@ a Volto project.
 
 ## settings
 
-The `settings` object of the configruration registry is a big registry of miscellaneous
-settings. See the [Settings reference](/configuration/settings-reference) for
-a bit more details.
+The `settings` object of the configruration registry is a big registry of miscellaneous settings.
+See {doc}`settings-reference` for details.
 
 ## widgets
 
@@ -83,7 +82,7 @@ but also the [lookup
 mechanism](https://github.com/plone/volto/blob/6fd62cb2860bc7cf3cb7c36ea86bfd8bd03247d9/src/components/manage/Form/Field.jsx#L112)
 to understand how things work.
 
-See [Widgets](/recipes/widget) for more information.
+See {doc}`../recipes/widget` for more information.
 
 ## views
 
@@ -106,7 +105,7 @@ The `blocks` registry holds the information of all the registered blocks in Volt
 - groupBlocksOrder
 - initialBlocks
 
-See [Blocks](/blocks/settings) for more information.
+See {doc}`../blocks/settings` for more information.
 
 ## addonReducers
 

--- a/docs/source/configuration/internalproxy.md
+++ b/docs/source/configuration/internalproxy.md
@@ -1,9 +1,9 @@
 ---
 html_meta:
-  "description": ""
-  "property=og:description": ""
-  "property=og:title": ""
-  "keywords": ""
+  "description": "The server side Volto SSR process (based on Razzle) has an internal proxy to the backend API enabled by default, avoiding issues from CORS and allowing the developer to focus on using Volto."
+  "property=og:description": "The server side Volto SSR process (based on Razzle) has an internal proxy to the backend API enabled by default, avoiding issues from CORS and allowing the developer to focus on using Volto."
+  "property=og:title": "Internal proxy to content backend API"
+  "keywords": "Volto, Plone, frontend, React, internal proxy, backend, API, Razzle, SSR"
 ---
 
 # Internal proxy to content backend API
@@ -41,7 +41,7 @@ testing/demoing using the stock build, it is also enabled in production mode sin
 Volto 14. But it is bad for performance because the server side running Node process
 is also responsable for generating the SSR HTML. With Nginx, Apache or another
 'reverse proxy' you can also create an internal API mount which is more suited for
-that. For more deployment information see ['Seemless mode'](/deploying/seamless-mode)
+that. For more deployment information see {doc}`../deploying/seamless-mode`.
 ```
 
 ### Examples redefining the proxy target

--- a/docs/source/configuration/settings-reference.md
+++ b/docs/source/configuration/settings-reference.md
@@ -216,7 +216,7 @@ criticalCssPath
     A path relative to the project root that points to an optional CSS file. If
     this file exists it is loaded and its content is embedded inline into the
     generated HTML. By default this path is `public/critical.css`. See the
-    [Performance](/deploying/performance) section for more details.
+    {doc}`../deploying/performance` section for more details.
 
 extractScripts
     An object that allows you to configure the insertion of scripts on the page

--- a/docs/source/developer-guidelines/language-features.md
+++ b/docs/source/developer-guidelines/language-features.md
@@ -71,4 +71,4 @@ have to support.
 However, Volto (or its dependencies) might not be compatible with old browsers anyways,
 and you might need to provide some other workarounds to make the build work (and the
 deprecated browser not crash). You can refer to {doc}`this (outdated)
-document </recipes/ie11compat>` in order to get some hints on how to do it.
+document <../recipes/ie11compat>` in order to get some hints on how to do it.

--- a/docs/source/developer-guidelines/testing.md
+++ b/docs/source/developer-guidelines/testing.md
@@ -1,9 +1,9 @@
 ---
 html_meta:
-  "description": ""
-  "property=og:description": ""
-  "property=og:title": ""
-  "keywords": ""
+  "description": "We use Jest for unit testing in Volto. The popular @testing-library/react is also available for writing your tests. For every feature or component, a unit test is mandatory in Volto core."
+  "property=og:description": "We use Jest for unit testing in Volto. The popular @testing-library/react is also available for writing your tests. For every feature or component, a unit test is mandatory in Volto core."
+  "property=og:title": "Testing Volto"
+  "keywords": "Volto, Plone, frontend, React, testing, Jest"
 ---
 
 # Testing
@@ -23,7 +23,9 @@ or slightly modify it. Volto provide a way to do it using a `jest.config.js` fil
 pointing the test runner to a file of your choice, using `RAZZLE_JEST_CONFIG`
 environment variable.
 
-    RAZZLE_JEST_CONFIG=my-custom-jest-config.js yarn test
+```shell
+RAZZLE_JEST_CONFIG=my-custom-jest-config.js yarn test
+```
 
 ```{note}
 Both configurations are merged in a way that the keys of the config provided override  the initial (`package.json`) default config, either in Volto or in your projects.
@@ -40,7 +42,7 @@ You can use the `ADDONS` environment variable to define them.
 ADDONS=test-addon,test-addon2 yarn start
 ```
 
- See {doc}`/configuration/environmentvariables` for more information.
+ See {doc}`../configuration/environmentvariables` for more information.
 
 ## Developing Cypress tests
 

--- a/docs/source/getting-started/install.md
+++ b/docs/source/getting-started/install.md
@@ -3,7 +3,7 @@ html_meta:
   "description": "Installing Volto"
   "property=og:description": "Installing Volto"
   "property=og:title": "Getting Started"
-  "keywords": "Volto, Plone, frontend, React, install, nvm, nodejs"
+  "keywords": "Volto, Plone, frontend, React, install, nvm, NodeJS, JavaScript"
 ---
 
 # Getting Started
@@ -25,23 +25,23 @@ are assuming a MacOS/Linux machine:
 
 There are three processes continuously running when you have a working Volto website:
 
-1. A frontend web application running in your browser (Javascript)
-2. A Node.js server process that delivers the javascript to the client and does
-   Server Side Rendering (SSR) of your pages on first request (Javascript, the
+1. A frontend web application running in your browser (JavaScript)
+2. A Node.js server process that delivers the JavaScript to the client and does
+   Server Side Rendering (SSR) of your pages on first request (JavaScript, the
    Razzle package is used for SSR)
 3. A Plone server process that stores and delivers all content through a REST API (Python)
 
-When you start with Volto most of the first customisations you will want to make (or mabye
-ever need to make) are in the javascript code used in the browser and Razzle process. Therefore
-this getting started chapter will focus on installing a nodejs/javascript environment locally
+When you start with Volto most of the first customisations you will want to make (or maybe
+ever need to make) are in the JavaScript code used in the browser and Razzle process. Therefore
+this getting started chapter will focus on installing a NodeJS/JavaScript environment locally
 and suggest you start the API backend using a container.
 
 
 ## Install nvm (NodeJS version manager)
 
-If you have a working Node javascript development already set up on your machine or you prefer
+If you have a working Node JavaScript development already set up on your machine or you prefer
 another management tool to install/maintain node this step is not needed. If you have less
-experience with setting up javascript, it's a good idea to integrate nvm for development, as
+experience with setting up JavaScript, it's a good idea to integrate nvm for development, as
 it provides easy access to any NodeJS released version.
 
 1.  Open a terminal console and type:

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -33,7 +33,7 @@ developer frustration and improves end-user experience.
 
 To start developing a new Volto project you should have minimal React and
 modern Javascript knowledge. Follow the
-{doc}`/getting-started/install` guide to bootstrap a new Volto
+{doc}`getting-started/install` guide to bootstrap a new Volto
 project and start hacking!
 
 ```{toctree}

--- a/docs/source/recipes/i18n.md
+++ b/docs/source/recipes/i18n.md
@@ -12,7 +12,7 @@ Internationalization (i18n) is the process of creating user interfaces which are
 Volto uses the library [react-intl](https://www.npmjs.com/package/react-intl) to provide translations for any potential language.
 Anything you can read in the [official documentation of react-intl](https://formatjs.io/docs/react-intl/) also applies for Volto.
 
-However this section teaches you about the most common use cases relating to i18n you probably will have when developing your {doc}`/addons/index` or contributing to the Volto core itself.
+However this section teaches you about the most common use cases relating to i18n you probably will have when developing your {doc}`../addons/index` or contributing to the Volto core itself.
 
 ## Broad overview
 

--- a/docs/source/upgrade-guide/index.md
+++ b/docs/source/upgrade-guide/index.md
@@ -272,7 +272,7 @@ More information: https://docs.voltocms.com/upgrade-guide/#volto-configuration-r
 ### Content locking
 
 Not really a breaking change, but it's worth noting it. By default, Volto 14 comes with
-[content-locking](/configuration/locking) enabled, if the backend supports it. Thus:
+{doc}`../configuration/locking` enabled, if the backend supports it. Thus:
 
 - Upgrade Plone RestAPI
   - **plone.restapi**>=`8.9.0` (Plone 5+)
@@ -348,8 +348,8 @@ we are deprecating it in Volto 13. Please update your projects to a NodeJS LTS v
 
 Not really a breaking change, but it's worth noting it. By default, Volto 13 in
 development mode uses the internal proxy in seamless mode otherwise configured
-differently. To learn more about the seamless mode read: [Seamless mode](/deploying/seamless-mode)
-and [zero configuration builds](/configuration/zero-config-builds)
+differently. To learn more about the seamless mode read: {doc}`../deploying/seamless-mode`
+and {doc}`../configuration/zero-config-builds`.
 
 ## Refactored Listing block using schemas and ObjectWidget
 


### PR DESCRIPTION
# Important

This PR must be merged at the same time as:
https://github.com/plone/documentation/pull/1191

- Make links be compatible between both Volto and Plone documentation
- Add missing html_meta values of files I touched
- Use an explicit lexer `shell` for environment variables
- Use proper casing of JavaScript and NodeJS