### PR TITLE
Turn `lazyLibraries` action into a thunk. Added a conditional if the …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Turn `lazyLibraries` action into a thunk. Added a conditional if the library is loaded or in process to be loaded, do not try to load it again. This fixes the lag on load `draftjs` when having a lot of draftjs blocks. @sneridagh
+
 ### Internal
 
 ## 15.0.0-alpha.9 (2022-02-28)

--- a/src/actions/lazyLibraries/lazyLibraries.js
+++ b/src/actions/lazyLibraries/lazyLibraries.js
@@ -1,9 +1,13 @@
 import { LOAD_LAZY_LIBRARY } from '@plone/volto/constants/ActionTypes';
 
 export function loadLazyLibrary(libName, libModule) {
-  return {
-    type: LOAD_LAZY_LIBRARY,
-    libName,
-    libModule,
+  return (dispatch, getState) => {
+    if (!getState().lazyLibraries?.[libName]) {
+      dispatch({
+        type: LOAD_LAZY_LIBRARY,
+        libName,
+        libModule,
+      });
+    }
   };
 }

--- a/src/components/manage/Contents/ContentsIndexHeader.test.jsx
+++ b/src/components/manage/Contents/ContentsIndexHeader.test.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
 import { Provider } from 'react-intl-redux';
 
 import { ContentsIndexHeader } from '@plone/volto/components';
 
-const mockStore = configureStore();
+const mockStore = configureStore([thunk]);
 
 describe('ContentsIndexHeader', () => {
   it('renders a contents titles component', () => {

--- a/src/components/theme/EventDetails/EventDetails.test.jsx
+++ b/src/components/theme/EventDetails/EventDetails.test.jsx
@@ -2,10 +2,11 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 import { Provider } from 'react-intl-redux';
 import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
 import config from '@plone/volto/registry';
 import EventDetails from './EventDetails';
 
-const mockStore = configureStore();
+const mockStore = configureStore([thunk]);
 
 const store = mockStore({
   intl: {


### PR DESCRIPTION
…library is loaded or in process to be loaded, do not try to load it again. This fixes the lag on load `draftjs` when having a lot of draftjs blocks.