### PR TITLE
Feature: Added Error Handling in Addons, Database components of Controlpanel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Feature
 
+- Added Error Handling in Addons and Database components of control panel @avimishra18
+
 ### Bugfix
 
 ### Internal

--- a/src/components/manage/Controlpanels/AddonsControlpanel.jsx
+++ b/src/components/manage/Controlpanels/AddonsControlpanel.jsx
@@ -27,7 +27,7 @@ import {
   upgradeAddon,
 } from '@plone/volto/actions';
 import { Helmet } from '@plone/volto/helpers';
-import { Icon, Toolbar } from '@plone/volto/components';
+import { Icon, Toolbar, Error } from '@plone/volto/components';
 import circleBottomSVG from '@plone/volto/icons/circle-bottom.svg';
 import circleTopSVG from '@plone/volto/icons/circle-top.svg';
 import backSVG from '@plone/volto/icons/back.svg';
@@ -230,6 +230,9 @@ class AddonsControlpanel extends Component {
    * @returns {string} Markup for the component.
    */
   render() {
+    if (this.props.error) {
+      return <Error error={this.props.error} />;
+    }
     return (
       <Container id="page-addons" className="controlpanel-addons">
         <Helmet title="Addons" />
@@ -464,6 +467,7 @@ export default compose(
       installedAddons: state.addons.installedAddons,
       availableAddons: state.addons.availableAddons,
       upgradableAddons: state.addons.upgradableAddons,
+      error: state.addons.error,
       pathname: props.location.pathname,
     }),
     { installAddon, listAddons, uninstallAddon, upgradeAddon },

--- a/src/components/manage/Controlpanels/DatabaseInformation.jsx
+++ b/src/components/manage/Controlpanels/DatabaseInformation.jsx
@@ -13,7 +13,7 @@ import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
 
 import { getDatabaseInformation } from '@plone/volto/actions';
 import { Helmet } from '@plone/volto/helpers';
-import { Icon, Toolbar } from '@plone/volto/components';
+import { Icon, Toolbar, Error } from '@plone/volto/components';
 import backSVG from '@plone/volto/icons/back.svg';
 
 const messages = defineMessages({
@@ -65,6 +65,9 @@ class DatabaseInformation extends Component {
    * @returns {string} Markup for the component.
    */
   render() {
+    if (this.props.database?.error) {
+      return <Error error={this.props.database.error} />;
+    }
     return this.props.databaseInformation ? (
       <Container id="database-page" className="controlpanel-database">
         <Helmet title="DatabaseInformation" />
@@ -241,6 +244,7 @@ export default compose(
   connect(
     (state, props) => ({
       databaseInformation: state.controlpanels.databaseinformation,
+      database: state.controlpanels.database,
       pathname: props.location.pathname,
     }),
     { getDatabaseInformation },


### PR DESCRIPTION
See #1898 

# URL Updated
- [x] https://volto.kitconcept.com/controlpanel/addons
- [x] https://volto.kitconcept.com/controlpanel/database
- [ ] https://volto.kitconcept.com/controlpanel/moderate-comments => Back-end is not responding with 401 error message. (See, [comment](https://github.com/plone/volto/issues/1898#issuecomment-1067243026) in issue for details)