### PR TITLE
updated code block in readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### Internal
 
+### Documentation
+
+- Updated README.md @ktsrivastava29
+
 ## 15.0.0 (2022-03-14)
 
 ### Breaking

--- a/README.md
+++ b/README.md
@@ -63,12 +63,15 @@ Create a new Volto project by using the `@plone/generator-volto` utility.
 It will bootstrap a Volto project in a folder of your choice with all the required
 boilerplate to start customizing your Volto site.
 
-    $ npm install -g yo @plone/generator-volto
-    $ yo @plone/volto
-
+```
+npm install -g yo @plone/generator-volto
+yo @plone/volto
+```
 follow the prompts questions, provide `myvoltoproject` as project name then, when it finishes:
 
-    $ cd myvoltoproject
+```
+cd myvoltoproject
+```
 
 ### Bootstrap the Plone API backend
 


### PR DESCRIPTION
I've changed the code block in README.md
Also see https://github.com/plone/volto/pull/3142

I've erased the $ symbol before the commands because it's an outdated format and the $ symbol also gets copied when we try to copy directly

Previously 
```
$ npm install -g yo @plone/generator-volto
$ yo @plone/volto
```
now,

```
npm install -g yo @plone/generator-volto
yo @plone/volto
```

Apart from this I also wish to move the other parts to the docs namely training, talks, videos, development directions, etc. from the `README` to `docs` folder.

