### PR TITLE
Replace docs.voltocms.com with MyST references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 - Updated README.md @ktsrivastava29
 - Added language to codeblocks in md files @ktsrivastava29
+- Replaced `docs.voltocms.com` with MyST references. @stevepiercy
 
 ## 15.0.0 (2022-03-14)
 

--- a/docs/source/releases.md
+++ b/docs/source/releases.md
@@ -36,7 +36,7 @@ A `breaking` release indicates a `breaking change` that might break an applicati
 4.2.0 -> 5.0.0
 ````
 
-For every `breaking` release, a detailed documentation of what in a breaking change release can be found in our [upgrade guide](https://docs.voltocms.com/upgrade-guide/).
+For every `breaking` release, a detailed documentation of what in a breaking change release can be found in our {doc}`./upgrade-guide/index`.
 
 We sometimes might want to indicate a major
 

--- a/docs/source/upgrade-guide/index.md
+++ b/docs/source/upgrade-guide/index.md
@@ -6,6 +6,8 @@ html_meta:
   "keywords": "Volto, Plone, frontend, React, Upgrade, Guide"
 ---
 
+(volto-upgrade-guide)=
+
 # Upgrade Guide
 
 This upgrade guide lists all breaking changes in Volto and explains the
@@ -22,6 +24,8 @@ current Volto release. Please notice that the generator is able to tell you when
 runs if it's outdated. The generator is also able to "update" your project with
 the latest changes, and propose to you to merge the changes, so you can run it on top of your project by answering the prompt.
 ```
+
+(volto-upgrade-guide-15.x.x)=
 
 ## Upgrading to Volto 15.x.x
 
@@ -126,7 +130,7 @@ If you were already using Seamless mode in your deployments, you should update t
 The proxy in development mode will only work using the new traversal `++api++`. You need to upgrade your development environment to include the requirements explained above.
 ```
 
-Read the full documentation about Seamless mode: https://docs.voltocms.com/deploying/seamless-mode/
+Read the full documentation about Seamless mode: {doc}`../deploying/seamless-mode`.
 
 ### Update i18n configuration for projects and add-ons
 


### PR DESCRIPTION
There are also many entries in `ROADMAP.md` and `CHANGELOG.md` at the root of the project, but those are not part of the main documentation. I did not bother with those.