### PR TITLE
Documentation | Feature: make epub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Feature
 
+- Added `make epub` feature for Volto documentation @avimishra18
+
 ### Bugfix
 
 ### Internal

--- a/Makefile
+++ b/Makefile
@@ -246,3 +246,9 @@ clean-tmp-worktrees:  ## Cleanup temporary worktrees managed by this `./Makefile
 	    git worktree remove --force "$${REPLY}"
 	    git branch -D "$$(basename "$${REPLY}")"
 	done
+
+.PHONY: epub
+epub:
+	cd $(DOCS_DIR) && $(SPHINXBUILD) -b epub $(ALLSPHINXOPTS) $(BUILDDIR)/epub
+	@echo
+	@echo "Build finished. The epub file is in $(BUILDDIR)/epub."


### PR DESCRIPTION
Feature: `make epub` of the Volto documentation
Similar to one written in [plone/training](https://github.com/plone/training/blob/228c768a85f761ac5d197b1c02f724a0b313a645/Makefile#L109-L113)