### PR TITLE
Reenable `make docs-linkcheckbroken`.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,8 +38,8 @@ jobs:
       - name: pip install requirements
         run: pip install -r requirements-docs.txt
 
-      # - name: Check for broken links
-      #   run: make docs-linkcheckbroken
+      - name: Check for broken links
+        run: make docs-linkcheckbroken
 
       - name: Build HTML documentation
         run: make docs-html


### PR DESCRIPTION
If this becomes annoying or problematic, we can yeet it.