### PR TITLE
fixes in sitemap.xml.gz

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
 
 - Fix addon registry regression @sneridagh
 - Fix `Bosnian` language @avoinea
+- Fix headers in sitemap middleware when errors occur in the sitemap generation @mamico
+- Fix use `settings.internalApiPath` in sitemap genaration @mamico
 
 ### Documentation
 

--- a/src/express-middleware/sitemap.js
+++ b/src/express-middleware/sitemap.js
@@ -3,10 +3,17 @@ import { generateSitemap } from '@plone/volto/helpers';
 
 export const sitemap = function (req, res, next) {
   generateSitemap(req).then((sitemap) => {
-    res.set('Content-Type', 'application/x-gzip');
-    res.set('Content-Encoding', 'gzip');
-    res.set('Content-Disposition', 'attachment; filename="sitemap.xml.gz"');
-    res.send(sitemap);
+    if (Buffer.isBuffer(sitemap)) {
+      res.set('Content-Type', 'application/x-gzip');
+      res.set('Content-Encoding', 'gzip');
+      res.set('Content-Disposition', 'attachment; filename="sitemap.xml.gz"');
+      res.send(sitemap);
+    } else {
+      // {"errno":-111, "code":"ECONNREFUSED", "host": ...}
+      res.status(500);
+      // Some data, such as the internal API address, may be sensitive to be published
+      res.send(`Sitemap generation error: ${sitemap.code ?? '-'}`);
+    }
   });
 };
 

--- a/src/helpers/Sitemap/Sitemap.js
+++ b/src/helpers/Sitemap/Sitemap.js
@@ -19,8 +19,9 @@ import config from '@plone/volto/registry';
 export const generateSitemap = (_req) =>
   new Promise((resolve) => {
     const { settings } = config;
+    const apiPath = settings.internalApiPath ?? settings.apiPath;
     const request = superagent.get(
-      `${settings.apiPath}/@search?metadata_fields=modified&b_size=100000000&use_site_search_settings=1`,
+      `${apiPath}/@search?metadata_fields=modified&b_size=100000000&use_site_search_settings=1`,
     );
     request.set('Accept', 'application/json');
     const authToken = _req.universalCookies.get('auth_token');


### PR DESCRIPTION
* generateSitemap use apiPath instead of preferring internalApiPath when it exists
* sitemap middleware returns wrong headers when errors occur in the sitemap generation 