### PR TITLE
added meta html values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,10 +84,10 @@
 ### Documentation
 
 - Updated README.md @ktsrivastava29
-
 - Added language to code-blocks in md files @ktsrivastava29
 - Added html_meta values and labels for Intersphinx cross-references from Trainings. @stevepiercy
 - Replaced `docs.voltocms.com` with MyST references. @stevepiercy
+- Added meta-html values in most of the pages. @ktsrivastava29
 
 ## 15.0.0 (2022-03-14)
 

--- a/docs/source/addons/i18n.md
+++ b/docs/source/addons/i18n.md
@@ -1,8 +1,8 @@
 ---
 html_meta:
-  "description": ""
-  "property=og:description": ""
-  "property=og:title": ""
+  "description": "Internationalize your add-on and override translations"
+  "property=og:description": "Internationalize your add-on and override translations"
+  "property=og:title": "Add-on Internationalization"
   "keywords": "Internationalization, i18n, add-on"
 ---
 

--- a/docs/source/backend/index.md
+++ b/docs/source/backend/index.md
@@ -1,9 +1,9 @@
 ---
 html_meta:
-  "description": ""
-  "property=og:description": ""
-  "property=og:title": ""
-  "keywords": ""
+  "description": "Integrate Plone backend using the Plone API framework"
+  "property=og:description": "Integrate Plone backend using the Plone API framework"
+  "property=og:title": "Integration with the backend"
+  "keywords": "Volto, Plone, frontend, React, Backend integration"
 ---
 
 # Integration with the backend

--- a/docs/source/blocks/introduction.md
+++ b/docs/source/blocks/introduction.md
@@ -3,7 +3,7 @@ html_meta:
   "description": "How to manually enable Blocks on a content type"
   "property=og:description": "How to manually enable Blocks on a content type"
   "property=og:title": "Blocks"
-  "keywords": "Volto, Plone, frontend, React"
+  "keywords": "Volto, Plone, frontend, React, blocks"
 ---
 
 # Blocks

--- a/docs/source/blocks/introduction.md
+++ b/docs/source/blocks/introduction.md
@@ -1,9 +1,9 @@
 ---
 html_meta:
-  "description": ""
-  "property=og:description": ""
-  "property=og:title": ""
-  "keywords": ""
+  "description": "How to manually enable Blocks on a content type"
+  "property=og:description": "How to manually enable Blocks on a content type"
+  "property=og:title": "Blocks"
+  "keywords": "Volto, Plone, frontend, React"
 ---
 
 # Blocks

--- a/docs/source/blocks/settings.md
+++ b/docs/source/blocks/settings.md
@@ -1,7 +1,7 @@
 ---
 html_meta:
-  "description": "How to configure a new block"
-  "property=og:description": "How to configure a new block"
+  "description": "How to configure custom block"
+  "property=og:description": "How to configure custom block"
   "property=og:title": "Blocks settings"
   "keywords": "Volto, Plone, frontend, React, Block settings"
 ---

--- a/docs/source/blocks/settings.md
+++ b/docs/source/blocks/settings.md
@@ -1,9 +1,9 @@
 ---
 html_meta:
-  "description": ""
-  "property=og:description": ""
-  "property=og:title": ""
-  "keywords": ""
+  "description": "How to configure a new block"
+  "property=og:description": "How to configure a new block"
+  "property=og:title": "Blocks settings"
+  "keywords": "Volto, Plone, frontend, React, Block settings"
 ---
 
 # Blocks settings

--- a/docs/source/blocks/settings.md
+++ b/docs/source/blocks/settings.md
@@ -1,7 +1,7 @@
 ---
 html_meta:
-  "description": "How to configure custom block"
-  "property=og:description": "How to configure custom block"
+  "description": "How to configure custom blocks"
+  "property=og:description": "How to configure custom blocks"
   "property=og:title": "Blocks settings"
   "keywords": "Volto, Plone, frontend, React, Block settings"
 ---

--- a/docs/source/blocks/ssr.md
+++ b/docs/source/blocks/ssr.md
@@ -3,7 +3,7 @@ html_meta:
   "description": "Learn to render async-fetched data that doesn't get rendered fully in the server-side rendering phase"
   "property=og:description": "Learn to render async-fetched data that doesn't get rendered fully in the server-side rendering phase"
   "property=og:title": "Server-side rendering for async blocks"
-  "keywords": "Volto, Plone, frontend, React, Render, async-block"
+  "keywords": "Volto, Plone, frontend, React, Render, async, block"
 ---
 
 # Server-side rendering for async blocks

--- a/docs/source/blocks/ssr.md
+++ b/docs/source/blocks/ssr.md
@@ -1,9 +1,9 @@
 ---
 html_meta:
-  "description": ""
-  "property=og:description": ""
-  "property=og:title": ""
-  "keywords": ""
+  "description": "Learn to render async-fetched data that doesn't get rendered fully in the server-side rendering phase"
+  "property=og:description": "Learn to render async-fetched data that doesn't get rendered fully in the server-side rendering phase"
+  "property=og:title": "Server-side rendering for async blocks"
+  "keywords": "Volto, Plone, frontend, React, Render, async-block"
 ---
 
 # Server-side rendering for async blocks

--- a/docs/source/configuration/backend.md
+++ b/docs/source/configuration/backend.md
@@ -1,7 +1,7 @@
 ---
 html_meta:
-  "description": "Prepare the Plone backend content API for volto in order to fully support all volto features"
-  "property=og:description": "Prepare the Plone backend content API for volto in order to fully support all volto features"
+  "description": "Prepare the Plone backend content API for Volto in order to fully support all volto features"
+  "property=og:description": "Prepare the Plone backend content API for Volto in order to fully support all volto features"
   "property=og:title": "Backend configuration"
   "keywords": "Volto, Plone, frontend, React, backend configuration"
 ---

--- a/docs/source/configuration/backend.md
+++ b/docs/source/configuration/backend.md
@@ -1,9 +1,9 @@
 ---
 html_meta:
-  "description": ""
-  "property=og:description": ""
-  "property=og:title": ""
-  "keywords": ""
+  "description": "Prepare the Plone backend content API for volto in order to fully support all volto features"
+  "property=og:description": "Prepare the Plone backend content API for volto in order to fully support all volto features"
+  "property=og:title": "Backend configuration"
+  "keywords": "Volto, Plone, frontend, React, backend configuration"
 ---
 
 # Backend configuration

--- a/docs/source/configuration/expanders.md
+++ b/docs/source/configuration/expanders.md
@@ -1,7 +1,7 @@
 ---
 html_meta:
-  "description": "Learn to configure the API expanders Volto uses using the `settings.apiExpanders` like this"
-  "property=og:description": "Learn to configure the API expanders Volto uses using the `settings.apiExpanders` like this"
+  "description": "Configure the API expanders in Volto using the `settings.apiExpanders`"
+  "property=og:description": "Configure the API expanders in Volto using the `settings.apiExpanders`"
   "property=og:title": "API expanders"
   "keywords": "Volto, Plone, frontend, React, api expanders"
 ---

--- a/docs/source/configuration/expanders.md
+++ b/docs/source/configuration/expanders.md
@@ -1,9 +1,9 @@
 ---
 html_meta:
-  "description": ""
-  "property=og:description": ""
-  "property=og:title": ""
-  "keywords": ""
+  "description": "Learn to configure the API expanders Volto uses using the `settings.apiExpanders` like this"
+  "property=og:description": "Learn to configure the API expanders Volto uses using the `settings.apiExpanders` like this"
+  "property=og:title": "API expanders"
+  "keywords": "Volto, Plone, frontend, React, api expanders"
 ---
 
 # API expanders

--- a/docs/source/configuration/index.md
+++ b/docs/source/configuration/index.md
@@ -1,9 +1,9 @@
 ---
 html_meta:
-  "description": ""
-  "property=og:description": ""
-  "property=og:title": ""
-  "keywords": ""
+  "description": "Main configuration file"
+  "property=og:description": "Main configuration file"
+  "property=og:title": "Configuration"
+  "keywords": "Volto, Plone, frontend, React, configuration"
 ---
 
 # Configuration

--- a/docs/source/configuration/locking.md
+++ b/docs/source/configuration/locking.md
@@ -1,7 +1,7 @@
 ---
 html_meta:
-  "description": "Content edit locking feature is to prevent simultaneous conflicting edits of the same content."
-  "property=og:description": "Content edit locking feature is to prevent simultaneous conflicting edits of the same content."
+  "description": "Content edit locking prevents simultaneous conflicting edits of the same content."
+  "property=og:description": "Content edit locking prevents simultaneous conflicting edits of the same content."
   "property=og:title": "Locking support"
   "keywords": "Volto, Plone, frontend, React, locking support"
 ---

--- a/docs/source/configuration/locking.md
+++ b/docs/source/configuration/locking.md
@@ -1,9 +1,9 @@
 ---
 html_meta:
-  "description": ""
-  "property=og:description": ""
-  "property=og:title": ""
-  "keywords": ""
+  "description": "Content edit locking feature is to prevent simultaneous conflicting edits of the same content."
+  "property=og:description": "Content edit locking feature is to prevent simultaneous conflicting edits of the same content."
+  "property=og:title": "Locking support"
+  "keywords": "Volto, Plone, frontend, React, locking support"
 ---
 
 # Locking support

--- a/docs/source/configuration/multilingual.md
+++ b/docs/source/configuration/multilingual.md
@@ -1,9 +1,9 @@
 ---
 html_meta:
-  "description": ""
-  "property=og:description": ""
-  "property=og:title": ""
-  "keywords": ""
+  "description": "Install multilingual support to use Plone's multilingual feature"
+  "property=og:description": "Install multilingual support to use Plone's multilingual feature"
+  "property=og:title": "Multilingual"
+  "keywords": "Volto, Plone, frontend, React, multilingual"
 ---
 
 # Multilingual

--- a/docs/source/configuration/richeditor-settings.md
+++ b/docs/source/configuration/richeditor-settings.md
@@ -1,7 +1,7 @@
 ---
 html_meta:
-  "description": "In this chapter we will learn how to change settings for the Rich Text Editor."
-  "property=og:description": "In this chapter we will learn how to change settings for the Rich Text Editor."
+  "description": "How to change settings for the rich text editor."
+  "property=og:description": "How to change settings for the rich text editor."
   "property=og:title": "RichEditor Settings"
   "keywords": "Volto, Plone, frontend, React, rich text editor"
 ---

--- a/docs/source/configuration/richeditor-settings.md
+++ b/docs/source/configuration/richeditor-settings.md
@@ -1,9 +1,9 @@
 ---
 html_meta:
-  "description": ""
-  "property=og:description": ""
-  "property=og:title": ""
-  "keywords": ""
+  "description": "In this chapter we will learn how to change settings for the Rich Text Editor."
+  "property=og:description": "In this chapter we will learn how to change settings for the Rich Text Editor."
+  "property=og:title": "RichEditor Settings"
+  "keywords": "Volto, Plone, frontend, React, rich text editor"
 ---
 
 # RichEditor Settings

--- a/docs/source/configuration/workingcopy.md
+++ b/docs/source/configuration/workingcopy.md
@@ -1,9 +1,9 @@
 ---
 html_meta:
-  "description": ""
-  "property=og:description": ""
-  "property=og:title": ""
-  "keywords": ""
+  "description": "Enable working copy support in Volto's configuration object"
+  "property=og:description": "Enable working copy support in Volto's configuration object"
+  "property=og:title": "Working copy support"
+  "keywords": "Volto, Plone, frontend, React, working copy, app iterate"
 ---
 
 # Working copy support

--- a/docs/source/contributing/guidelines.md
+++ b/docs/source/contributing/guidelines.md
@@ -1,9 +1,9 @@
 ---
 html_meta:
-  "description": ""
-  "property=og:description": ""
-  "property=og:title": ""
-  "keywords": ""
+  "description": "A guide on how to contribute to the Plone's community"
+  "property=og:description": "A guide on how to contribute to the Plone's community"
+  "property=og:title": "Guidelines"
+  "keywords": "Volto, Plone, frontend, React, guidelines"
 ---
 
 # Guidelines

--- a/docs/source/contributing/index.md
+++ b/docs/source/contributing/index.md
@@ -1,7 +1,7 @@
 ---
 html_meta:
-  "description": "Since the very beginning, Volto has been developed with a set of principles in mind, brought from the years of experience developing Plone"
-  "property=og:description": "Since the very beginning, Volto has been developed with a set of principles in mind, brought from the years of experience developing Plone"
+  "description": "Volto design principles"
+  "property=og:description": "Volto design principles"
   "property=og:title": "Design principles"
   "keywords": "Volto, Plone, frontend, React, contributing, design principles"
 ---

--- a/docs/source/contributing/index.md
+++ b/docs/source/contributing/index.md
@@ -1,9 +1,9 @@
 ---
 html_meta:
-  "description": ""
-  "property=og:description": ""
-  "property=og:title": ""
-  "keywords": ""
+  "description": "Since the very beginning, Volto has been developed with a set of principles in mind, brought from the years of experience developing Plone"
+  "property=og:description": "Since the very beginning, Volto has been developed with a set of principles in mind, brought from the years of experience developing Plone"
+  "property=og:title": "Design principles"
+  "keywords": "Volto, Plone, frontend, React, contributing, design principles"
 ---
 
 # Design principles

--- a/docs/source/deploying/apache.md
+++ b/docs/source/deploying/apache.md
@@ -1,9 +1,9 @@
 ---
 html_meta:
-  "description": ""
-  "property=og:description": ""
-  "property=og:title": ""
-  "keywords": ""
+  "description": "Apache configuration for a Plone backend deployed under /api and a Volto frontend deployed under the root."
+  "property=og:description": "Apache configuration for a Plone backend deployed under /api and a Volto frontend deployed under the root."
+  "property=og:title": "Apache"
+  "keywords": "Volto, Plone, frontend, React, backend, apache"
 ---
 
 # Apache

--- a/docs/source/deploying/index.md
+++ b/docs/source/deploying/index.md
@@ -1,7 +1,7 @@
 ---
 html_meta:
-  "description": "A guide to deployment"
-  "property=og:description": "A guide to deployment"
+  "description": "A guide to Volto frontend deployment"
+  "property=og:description": "A guide to Volto frontend deployment"
   "property=og:title": "Deploying"
   "keywords": "Volto, Plone, frontend, React, deploying"
 ---

--- a/docs/source/deploying/index.md
+++ b/docs/source/deploying/index.md
@@ -1,9 +1,9 @@
 ---
 html_meta:
-  "description": ""
-  "property=og:description": ""
-  "property=og:title": ""
-  "keywords": ""
+  "description": "A guide to deployment"
+  "property=og:description": "A guide to deployment"
+  "property=og:title": "Deploying"
+  "keywords": "Volto, Plone, frontend, React, deploying"
 ---
 
 # Deploying

--- a/docs/source/deploying/simple.md
+++ b/docs/source/deploying/simple.md
@@ -1,9 +1,9 @@
 ---
 html_meta:
-  "description": ""
-  "property=og:description": ""
-  "property=og:title": ""
-  "keywords": ""
+  "description": "Volto is a Node application that runs on your machine/server and listens to a port. Once you are ready to deploy it, you should build it running:"
+  "property=og:description": "Volto is a Node application that runs on your machine/server and listens to a port. Once you are ready to deploy it, you should build it running:"
+  "property=og:title": "Simple deployment"
+  "keywords": "Volto, Plone, frontend, React, deployment"
 ---
 
 # Simple deployment

--- a/docs/source/deploying/simple.md
+++ b/docs/source/deploying/simple.md
@@ -1,7 +1,7 @@
 ---
 html_meta:
-  "description": "Volto is a Node application that runs on your machine/server and listens to a port. Once you are ready to deploy it, you should build it running:"
-  "property=og:description": "Volto is a Node application that runs on your machine/server and listens to a port. Once you are ready to deploy it, you should build it running:"
+  "description": "Simple deployment of a Volto application"
+  "property=og:description": "Simple deployment of a Volto application"
   "property=og:title": "Simple deployment"
   "keywords": "Volto, Plone, frontend, React, deployment"
 ---

--- a/docs/source/developer-guidelines/acceptance-tests.md
+++ b/docs/source/developer-guidelines/acceptance-tests.md
@@ -3,7 +3,7 @@ html_meta:
   "description": "Developer guidelines for acceptance tests."
   "property=og:description": "Developer guidelines for acceptance tests."
   "property=og:title": "Acceptance tests"
-  "keywords": "Volto, Plone, frontend, React, helper command, redux"
+  "keywords": "Volto, Plone, frontend, React, helper command, redux, acceptance, tests, Cypress"
 ---
 
 # Acceptance tests

--- a/docs/source/developer-guidelines/acceptance-tests.md
+++ b/docs/source/developer-guidelines/acceptance-tests.md
@@ -1,9 +1,9 @@
 ---
 html_meta:
-  "description": ""
-  "property=og:description": ""
-  "property=og:title": ""
-  "keywords": ""
+  "description": "Developer guidelines for acceptance tests."
+  "property=og:description": "Developer guidelines for acceptance tests."
+  "property=og:title": "Acceptance tests"
+  "keywords": "Volto, Plone, frontend, React, helper command, redux"
 ---
 
 # Acceptance tests

--- a/docs/source/developer-guidelines/design-principles.md
+++ b/docs/source/developer-guidelines/design-principles.md
@@ -1,9 +1,13 @@
 ---
 html_meta:
-  "description": ""
-  "property=og:description": ""
-  "property=og:title": ""
-  "keywords": ""
+  "description": "Volto has been developed with a set of principles in mind,
+brought from the years of experience developing Plone core and implementing projects on
+it."
+  "property=og:description": "Volto has been developed with a set of principles in mind,
+brought from the years of experience developing Plone core and implementing projects on
+it."
+  "property=og:title": "Design principles"
+  "keywords": "Volto, Plone, frontend, React, design principles"
 ---
 
 # Design principles

--- a/docs/source/developer-guidelines/design-principles.md
+++ b/docs/source/developer-guidelines/design-principles.md
@@ -1,11 +1,7 @@
 ---
 html_meta:
-  "description": "Volto has been developed with a set of principles in mind,
-brought from the years of experience developing Plone core and implementing projects on
-it."
-  "property=og:description": "Volto has been developed with a set of principles in mind,
-brought from the years of experience developing Plone core and implementing projects on
-it."
+  "description": "Volto design principles"
+  "property=og:description": "Volto design principles"
   "property=og:title": "Design principles"
   "keywords": "Volto, Plone, frontend, React, design principles"
 ---

--- a/docs/source/developer-guidelines/linting.md
+++ b/docs/source/developer-guidelines/linting.md
@@ -1,9 +1,11 @@
 ---
 html_meta:
-  "description": ""
-  "property=og:description": ""
-  "property=og:title": ""
-  "keywords": ""
+  "description": "Volto developers can enjoy a lot of freedom in their choice of text editors and
+IDEs"
+  "property=og:description": "Volto developers can enjoy a lot of freedom in their choice of text editors and
+IDEs"
+  "property=og:title": "Linting"
+  "keywords": "Volto, Plone, frontend, React, lint"
 ---
 
 # Linting

--- a/docs/source/developer-guidelines/linting.md
+++ b/docs/source/developer-guidelines/linting.md
@@ -1,9 +1,7 @@
 ---
 html_meta:
-  "description": "Volto developers can enjoy a lot of freedom in their choice of text editors and
-IDEs"
-  "property=og:description": "Volto developers can enjoy a lot of freedom in their choice of text editors and
-IDEs"
+  "description": "Code linting in Volto"
+  "property=og:description": "Code linting in Volto"
   "property=og:title": "Linting"
   "keywords": "Volto, Plone, frontend, React, lint"
 ---

--- a/docs/source/developer-guidelines/typescript.md
+++ b/docs/source/developer-guidelines/typescript.md
@@ -1,9 +1,9 @@
 ---
 html_meta:
-  "description": ""
-  "property=og:description": ""
-  "property=og:title": ""
-  "keywords": ""
+  "description": "Learn how to enable TypeScript support when developing you project with Volto."
+  "property=og:description": "Learn how to enable TypeScript support when developing you project with Volto."
+  "property=og:title": "TypeScript"
+  "keywords": "Volto, Plone, frontend, React, typescript, css"
 ---
 
 # TypeScript

--- a/docs/source/getting-started/others.md
+++ b/docs/source/getting-started/others.md
@@ -1,9 +1,9 @@
 ---
 html_meta:
-  "description": ""
-  "property=og:description": ""
-  "property=og:title": ""
-  "keywords": ""
+  "description": "Links to other learning resources."
+  "property=og:description": "Links to other learning resources."
+  "property=og:title": "learning resources"
+  "keywords": "Volto, Plone, frontend, React, learning resources"
 ---
 
 # Other learning resources

--- a/docs/source/getting-started/roadmap.md
+++ b/docs/source/getting-started/roadmap.md
@@ -1,9 +1,9 @@
 ---
 html_meta:
-  "description": ""
-  "property=og:description": ""
-  "property=og:title": ""
-  "keywords": ""
+  "description": "A roadmap to learn Volto."
+  "property=og:description": "A roadmap to learn Volto."
+  "property=og:title": "Developer roadmap"
+  "keywords": "Volto, Plone, frontend, React, developer roadmap, development basic"
 ---
 
 # Developer roadmap

--- a/docs/source/getting-started/roadmap.md
+++ b/docs/source/getting-started/roadmap.md
@@ -1,7 +1,7 @@
 ---
 html_meta:
-  "description": "A roadmap to learn Volto."
-  "property=og:description": "A roadmap to learn Volto."
+  "description": "Volto developer roadmap"
+  "property=og:description": "Volto developer roadmap"
   "property=og:title": "Developer roadmap"
   "keywords": "Volto, Plone, frontend, React, developer roadmap, development basic"
 ---

--- a/docs/source/recipes/appextras.md
+++ b/docs/source/recipes/appextras.md
@@ -1,9 +1,10 @@
 ---
 html_meta:
-  "description": ""
-  "property=og:description": ""
-  "property=og:title": ""
-  "keywords": ""
+  "description": "The `AppExtras` component is a general use insertion point for things like
+analytics, general purpose code spanning the whole application or third party services code."
+  "property=og:description": "The `AppExtras` component is a general use insertion point for things like analytics, general purpose code spanning the whole application or third party services code."
+  "property=og:title": "AppExtras component"
+  "keywords": "Volto, Plone, frontend, React, app extra component"
 ---
 
 # AppExtras component

--- a/docs/source/recipes/appextras.md
+++ b/docs/source/recipes/appextras.md
@@ -1,8 +1,7 @@
 ---
 html_meta:
-  "description": "The `AppExtras` component is a general use insertion point for things like
-analytics, general purpose code spanning the whole application or third party services code."
-  "property=og:description": "The `AppExtras` component is a general use insertion point for things like analytics, general purpose code spanning the whole application or third party services code."
+  "description": "The `AppExtras` component is a general use insertion point for general purpose code spanning the whole application or for third party services code."
+  "property=og:description": "The `AppExtras` component is a general use insertion point for general purpose code spanning the whole application or for third party services code."
   "property=og:title": "AppExtras component"
   "keywords": "Volto, Plone, frontend, React, app extra component"
 ---

--- a/docs/source/recipes/creating-project.md
+++ b/docs/source/recipes/creating-project.md
@@ -1,9 +1,9 @@
 ---
 html_meta:
-  "description": ""
-  "property=og:description": ""
-  "property=og:title": ""
-  "keywords": ""
+  "description": "Gain an understanding of how to create a new Volto project."
+  "property=og:description": "Gain an understanding of how to create a new Volto project."
+  "property=og:title": "Creating a new Volto project"
+  "keywords": "Volto, Plone, frontend, React, new, volto project, basic"
 ---
 
 # Creating a new Volto project

--- a/docs/source/recipes/creating-project.md
+++ b/docs/source/recipes/creating-project.md
@@ -1,7 +1,7 @@
 ---
 html_meta:
-  "description": "Gain an understanding of how to create a new Volto project."
-  "property=og:description": "Gain an understanding of how to create a new Volto project."
+  "description": "Creating a new Volto project"
+  "property=og:description": "Creating a new Volto project"
   "property=og:title": "Creating a new Volto project"
   "keywords": "Volto, Plone, frontend, React, new, volto project, basic"
 ---

--- a/docs/source/recipes/creating-views.md
+++ b/docs/source/recipes/creating-views.md
@@ -1,8 +1,7 @@
 ---
 html_meta:
-  "description": "In this chapter we are going to create a new type of view for displaying
-contents in a folder. We will call this view `full view`."
-  "property=og:description": "In this chapter we are going to create a new type of view for displaying contents in a folder. We will call this view `full view`."
+  "description": "Creating Volto views"
+  "property=og:description": "Creating Volto views"
   "property=og:title": "Creating Volto Views"
   "keywords": "Volto, Plone, frontend, React, views"
 ---

--- a/docs/source/recipes/creating-views.md
+++ b/docs/source/recipes/creating-views.md
@@ -1,9 +1,10 @@
 ---
 html_meta:
-  "description": ""
-  "property=og:description": ""
-  "property=og:title": ""
-  "keywords": ""
+  "description": "In this chapter we are going to create a new type of view for displaying
+contents in a folder. We will call this view `full view`."
+  "property=og:description": "In this chapter we are going to create a new type of view for displaying contents in a folder. We will call this view `full view`."
+  "property=og:title": "Creating Volto Views"
+  "keywords": "Volto, Plone, frontend, React, views"
 ---
 
 # Creating Volto Views

--- a/docs/source/recipes/customizing-components.md
+++ b/docs/source/recipes/customizing-components.md
@@ -1,9 +1,9 @@
 ---
 html_meta:
-  "description": ""
-  "property=og:description": ""
-  "property=og:title": ""
-  "keywords": ""
+  "description": "Use a pattern called component shadowing to customize volto components."
+  "property=og:description": "Use a pattern called component shadowing to customize volto components."
+  "property=og:title": "Customizing Components"
+  "keywords": "Volto, Plone, frontend, React, customizing component"
 ---
 
 # Customizing Components

--- a/docs/source/recipes/customizing-views.md
+++ b/docs/source/recipes/customizing-views.md
@@ -1,7 +1,7 @@
 ---
 html_meta:
-  "description": "Learn how to customize volto views."
-  "property=og:description": "Learn how to customize volto views."
+  "description": "Customize Volto views."
+  "property=og:description": "Customize Volto views."
   "property=og:title": "Customizing Volto Views"
   "keywords": "Volto, Plone, frontend, React, views"
 ---

--- a/docs/source/recipes/customizing-views.md
+++ b/docs/source/recipes/customizing-views.md
@@ -1,9 +1,9 @@
 ---
 html_meta:
-  "description": ""
-  "property=og:description": ""
-  "property=og:title": ""
-  "keywords": ""
+  "description": "Learn how to customize volto views."
+  "property=og:description": "Learn how to customize volto views."
+  "property=og:title": "Customizing Volto Views"
+  "keywords": "Volto, Plone, frontend, React, views"
 ---
 
 # Customizing Volto Views

--- a/docs/source/recipes/express.md
+++ b/docs/source/recipes/express.md
@@ -1,9 +1,9 @@
 ---
 html_meta:
-  "description": "Volto uses the popular Express server for its Server-Side Rendering implementation and static resource serving."
-  "property=og:description": "Volto uses the popular Express server for its Server-Side Rendering implementation and static resource serving."
+  "description": "Volto uses the popular Express server for its server-side rendering implementation and static resource serving."
+  "property=og:description": "Volto uses the popular Express server for its server-side rendering implementation and static resource serving."
   "property=og:title": "Custom Express middleware"
-  "keywords": "Volto, Plone, frontend, React, middleware"
+  "keywords": "Volto, Plone, frontend, React, custom, express, middleware"
 ---
 
 # Custom Express middleware

--- a/docs/source/recipes/express.md
+++ b/docs/source/recipes/express.md
@@ -1,9 +1,9 @@
 ---
 html_meta:
-  "description": ""
-  "property=og:description": ""
-  "property=og:title": ""
-  "keywords": ""
+  "description": "Volto uses the popular Express server for its Server-Side Rendering implementation and static resource serving."
+  "property=og:description": "Volto uses the popular Express server for its Server-Side Rendering implementation and static resource serving."
+  "property=og:title": "Custom Express middleware"
+  "keywords": "Volto, Plone, frontend, React, middleware"
 ---
 
 # Custom Express middleware

--- a/docs/source/recipes/folder-structure.md
+++ b/docs/source/recipes/folder-structure.md
@@ -1,7 +1,7 @@
 ---
 html_meta:
-  "description": ""Volto is based on React, Redux, and React-Router and follows its convention of resource location."
-  "property=og:description": ""Volto is based on React, Redux, and React-Router and follows its convention of resource location."
+  "description": "Volto is based on React, Redux, and React-Router and follows its convention of resource location."
+  "property=og:description": "Volto is based on React, Redux, and React-Router and follows its convention of resource location."
   "property=og:title": "Folder structure"
   "keywords": "Volto, Plone, frontend, React, folder structure"
 ---

--- a/docs/source/recipes/folder-structure.md
+++ b/docs/source/recipes/folder-structure.md
@@ -1,9 +1,11 @@
 ---
 html_meta:
-  "description": ""
-  "property=og:description": ""
-  "property=og:title": ""
-  "keywords": ""
+  "description": "Volto is based on React, Redux, and React-Router. All of the
+code is located in the `src` folder."
+  "property=og:description": "Volto is based on React, Redux, and React-Router. All of the
+code is located in the `src` folder."
+  "property=og:title": "Folder structure"
+  "keywords": "Volto, Plone, frontend, React, folder structure"
 ---
 
 # Folder structure

--- a/docs/source/recipes/folder-structure.md
+++ b/docs/source/recipes/folder-structure.md
@@ -1,9 +1,7 @@
 ---
 html_meta:
-  "description": "Volto is based on React, Redux, and React-Router. All of the
-code is located in the `src` folder."
-  "property=og:description": "Volto is based on React, Redux, and React-Router. All of the
-code is located in the `src` folder."
+  "description": ""Volto is based on React, Redux, and React-Router and follows its convention of resource location."
+  "property=og:description": ""Volto is based on React, Redux, and React-Router and follows its convention of resource location."
   "property=og:title": "Folder structure"
   "keywords": "Volto, Plone, frontend, React, folder structure"
 ---

--- a/docs/source/recipes/ie11compat.md
+++ b/docs/source/recipes/ie11compat.md
@@ -1,9 +1,9 @@
 ---
 html_meta:
-  "description": ""
-  "property=og:description": ""
-  "property=og:title": ""
-  "keywords": ""
+  "description": "Legacy Browser Support (IE11 compatibility): Polyfills, babel-env, Pre-transpiling"
+  "property=og:description": "Legacy Browser Support (IE11 compatibility): Polyfills, babel-env, Pre-transpiling"
+  "property=og:title": "Legacy Browser Support"
+  "keywords": "Volto, Plone, frontend, React, legacy browser support"
 ---
 
 # Legacy Browser Support (IE11 compatibility)

--- a/docs/source/recipes/ie11compat.md
+++ b/docs/source/recipes/ie11compat.md
@@ -1,9 +1,9 @@
 ---
 html_meta:
-  "description": "Legacy Browser Support (IE11 compatibility): Polyfills, babel-env, Pre-transpiling"
-  "property=og:description": "Legacy Browser Support (IE11 compatibility): Polyfills, babel-env, Pre-transpiling"
-  "property=og:title": "Legacy Browser Support"
-  "keywords": "Volto, Plone, frontend, React, legacy browser support"
+  "description": "Legacy browser support with polyfills, babel-env, and pre- and post-transpiling"
+  "property=og:description": "Legacy browser support with polyfills, babel-env, and pre- and post-transpiling"
+  "property=og:title": "Legacy Browser Support (IE11 compatibility)"
+  "keywords": "Volto, Plone, frontend, React, IE11 compatability, polyfills, legacy browser support"
 ---
 
 # Legacy Browser Support (IE11 compatibility)

--- a/docs/source/recipes/index.md
+++ b/docs/source/recipes/index.md
@@ -1,7 +1,7 @@
 ---
 html_meta:
-  "description": "Recipes: Development"
-  "property=og:description": "Recipes: Development"
+  "description": "Volto development recipes"
+  "property=og:description": "Volto development recipes"
   "property=og:title": "Development recipes"
   "keywords": "Volto, Plone, frontend, React, development"
 ---

--- a/docs/source/recipes/index.md
+++ b/docs/source/recipes/index.md
@@ -1,9 +1,9 @@
 ---
 html_meta:
-  "description": ""
-  "property=og:description": ""
-  "property=og:title": ""
-  "keywords": ""
+  "description": "Recipes: Development"
+  "property=og:description": "Recipes: Development"
+  "property=og:title": "Development recipes"
+  "keywords": "Volto, Plone, frontend, React, development"
 ---
 
 # Development recipes

--- a/docs/source/recipes/lazyload.md
+++ b/docs/source/recipes/lazyload.md
@@ -1,9 +1,9 @@
 ---
 html_meta:
-  "description": ""
-  "property=og:description": ""
-  "property=og:title": ""
-  "keywords": ""
+  "description": "A guide to lazy-loading libraries as these libraries are not as straight-forward as with the React components."
+  "property=og:description": "A guide to lazy-loading libraries as these libraries are not as straight-forward as with the React components."
+  "property=og:title": "Lazy loading"
+  "keywords": "Volto, Plone, frontend, React, lazy loading, useLazyLibs hook"
 ---
 
 # Lazy loading

--- a/docs/source/recipes/lazyload.md
+++ b/docs/source/recipes/lazyload.md
@@ -1,7 +1,7 @@
 ---
 html_meta:
-  "description": "A guide to lazy-loading libraries as these libraries are not as straight-forward as with the React components."
-  "property=og:description": "A guide to lazy-loading libraries as these libraries are not as straight-forward as with the React components."
+  "description": "A guide to lazy-loading libraries in Volto."
+  "property=og:description": "A guide to lazy-loading libraries in Volto."
   "property=og:title": "Lazy loading"
   "keywords": "Volto, Plone, frontend, React, lazy loading, useLazyLibs hook"
 ---


### PR DESCRIPTION
fix: #3033 

**Problem**
The html_meta values were missing from most of the pages. These values are used to improve SEO. Omitting them results in errors when building the docs with Sphinx.

**Solution offered**
 I've added the meta html values in every page with the exception of three pages, as their documentation is currently being built.  