### PR TITLE
Overwrite isValidNewOption of ArrayWidget. Ignore lower and upper case.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@
 - Pass placeholder and isDisabled properties to EmailWidget and UrlWidget @mihaislobozeanu
 - Pass placeholder property to PasswordWidget and NumberWidget @mihaislobozeanu
 - Fix getVocabName when vocabNameOrURL is false @avoinea #2955, #2919
+- Overwrite isValidNewOption of ArrayWidget to allow variants @ksuess
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@
 - Pass placeholder and isDisabled properties to EmailWidget and UrlWidget @mihaislobozeanu
 - Pass placeholder property to PasswordWidget and NumberWidget @mihaislobozeanu
 - Fix getVocabName when vocabNameOrURL is false @avoinea #2955, #2919
+- Overwrite isValidNewOption of ArrayWidget to allow variants @ksuess
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Overwrite isValidNewOption of ArrayWidget to allow variants @ksuess
+
 ### Internal
 
 ### Documentation
@@ -79,7 +81,6 @@
 - Pass placeholder and isDisabled properties to EmailWidget and UrlWidget @mihaislobozeanu
 - Pass placeholder property to PasswordWidget and NumberWidget @mihaislobozeanu
 - Fix getVocabName when vocabNameOrURL is false @avoinea #2955, #2919
-- Overwrite isValidNewOption of ArrayWidget to allow variants @ksuess
 
 ### Internal
 

--- a/src/components/manage/Widgets/ArrayWidget.jsx
+++ b/src/components/manage/Widgets/ArrayWidget.jsx
@@ -318,6 +318,7 @@ class ArrayWidget extends Component {
           value={selectedOption || []}
           placeholder={this.props.intl.formatMessage(messages.select)}
           onChange={this.handleChange}
+          isValidNewOption={() => true}
           isClearable
           isMulti
         />

--- a/src/components/manage/Widgets/ArrayWidget.jsx
+++ b/src/components/manage/Widgets/ArrayWidget.jsx
@@ -108,6 +108,22 @@ function normalizeChoices(choices) {
 }
 
 /**
+ * Compare values and return true if equal.
+ * Consider upper and lower case.
+ * @method compareOption
+ * @param {*} inputValue
+ * @param {*} option
+ * @param {*} accessors
+ * @returns {boolean}
+ */
+const compareOption = (inputValue = '', option, accessors) => {
+  const candidate = String(inputValue);
+  const optionValue = String(accessors.getOptionValue(option));
+  const optionLabel = String(accessors.getOptionLabel(option));
+  return optionValue === candidate || optionLabel === candidate;
+};
+
+/**
  * ArrayWidget component class.
  * @class ArrayWidget
  * @extends Component
@@ -318,7 +334,22 @@ class ArrayWidget extends Component {
           value={selectedOption || []}
           placeholder={this.props.intl.formatMessage(messages.select)}
           onChange={this.handleChange}
-          isValidNewOption={() => true}
+          isValidNewOption={(
+            inputValue,
+            selectValue,
+            selectOptions,
+            accessors,
+          ) =>
+            !(
+              !inputValue ||
+              selectValue.some((option) =>
+                compareOption(inputValue, option, accessors),
+              ) ||
+              selectOptions.some((option) =>
+                compareOption(inputValue, option, accessors),
+              )
+            )
+          }
           isClearable
           isMulti
         />


### PR DESCRIPTION


Fix https://github.com/plone/volto/issues/3214

https://github.com/JedWatson/react-select/blob/b0411ff46bc1ecf45d9bca4fb58fbce1e57f847c/packages/react-select/src/Creatable.js#L35-L37
https://react-select.com/props#creatable-props

Hi @giuliaghisini and @tiberiuichim would you please have a look on what is needed to restrict new keywords. You've seen way more use cases than me. My use case is variants of glossary terms, which obviously come along often as for example 'BEB' and 'BeB'.
It's for sure not OK to overwrite with a brutal `()=>true`.