### PR TITLE
fix: fixed the position of the dropdown menu and white-space of tbody

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 - Pass placeholder and isDisabled properties to EmailWidget and UrlWidget @mihaislobozeanu
 - Pass placeholder property to PasswordWidget and NumberWidget @mihaislobozeanu
 - Fix getVocabName when vocabNameOrURL is false @avoinea #2955, #2919
+- Fix folder content layout @SaraBianchi
 
 ### Internal
 

--- a/theme/themes/pastanaga/extras/contents.less
+++ b/theme/themes/pastanaga/extras/contents.less
@@ -85,7 +85,7 @@
 
   .contents-table-wrapper {
     width: 100%;
-    min-height: 13.8888rem;
+    min-height: 14rem;
     overflow-x: auto;
 
     .ui.attached.table {

--- a/theme/themes/pastanaga/extras/contents.less
+++ b/theme/themes/pastanaga/extras/contents.less
@@ -78,8 +78,14 @@
     top: 3px;
   }
 
+  .ui.upward.dropdown > .menu {
+    top: 100%;
+    bottom: inherit;
+  }
+
   .contents-table-wrapper {
     width: 100%;
+    min-height: 13.8888rem;
     overflow-x: auto;
 
     .ui.attached.table {
@@ -132,6 +138,13 @@
     margin-right: 1em;
     background-color: rgb(228, 1, 102);
     color: white;
+  }
+
+  @media only screen and (min-width: @largeMonitorBreakpoint) {
+    .ui.table.single.line tbody {
+      white-space: normal;
+      word-break: break-word;
+    }
   }
 }
 


### PR DESCRIPTION
folder contents bugfix
- fixed the position of the dropdown menu of each table row
- added min-height for the table to better show the dropdown menu even when there is only one item
- added style to wrap titles on desktop monitor