### PR TITLE
fixed editing links and image url in blocks and ObjectBrowser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Feature
 
 ### Bugfix
-- Fixed edit internal link and image url in this blocks: image block, leadimage block, video block, objectBrowser. In objectBrowser, if pasted url was internal, it wasn't flatted and wass handled from Plone as an external.
+- Fixed edit internal link and image url in this blocks: image block, leadimage block, video block, objectBrowser. In objectBrowser, if pasted url was internal, it wasn't flatted and wass handled from Plone as an external. @giuliaghisini
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Feature
 
 ### Bugfix
+- Fixed edit internal link and image url in this blocks: image block, leadimage block, video block, objectBrowser. In objectBrowser, if pasted url was internal, it wasn't flatted and wass handled from Plone as an external.
 
 ### Internal
 

--- a/src/components/manage/Blocks/Image/Edit.jsx
+++ b/src/components/manage/Blocks/Image/Edit.jsx
@@ -176,7 +176,7 @@ class Edit extends Component {
   onSubmitUrl = () => {
     this.props.onChangeBlock(this.props.block, {
       ...this.props.data,
-      url: this.state.url,
+      url: flattenToAppURL(this.state.url),
     });
   };
 

--- a/src/components/manage/Blocks/Image/ImageSidebar.jsx
+++ b/src/components/manage/Blocks/Image/ImageSidebar.jsx
@@ -123,7 +123,7 @@ const ImageSidebar = ({
                 id="Origin"
                 title={intl.formatMessage(messages.Origin)}
                 required={false}
-                value={data.url.split('/').slice(-1)[0]}
+                value={data.url.replace(/\/$/, '').split('/').slice(-1)[0]}
                 icon={data.url ? clearSVG : navTreeSVG}
                 iconAction={
                   data.url
@@ -247,7 +247,7 @@ const ImageSidebar = ({
                 id="link"
                 title={intl.formatMessage(messages.LinkTo)}
                 required={false}
-                value={data.href}
+                value={flattenToAppURL(data.href)}
                 icon={data.href ? clearSVG : navTreeSVG}
                 iconAction={
                   data.href
@@ -262,7 +262,7 @@ const ImageSidebar = ({
                 onChange={(name, value) => {
                   onChangeBlock(block, {
                     ...data,
-                    href: value,
+                    href: flattenToAppURL(value),
                   });
                 }}
               />

--- a/src/components/manage/Blocks/LeadImage/LeadImageSidebar.jsx
+++ b/src/components/manage/Blocks/LeadImage/LeadImageSidebar.jsx
@@ -154,7 +154,7 @@ const LeadImageSidebar = ({
                 id="link"
                 title={intl.formatMessage(messages.LinkTo)}
                 required={false}
-                value={data.href}
+                value={flattenToAppURL(data.href)}
                 icon={data.href ? clearSVG : navTreeSVG}
                 iconAction={
                   data.href
@@ -169,7 +169,7 @@ const LeadImageSidebar = ({
                 onChange={(name, value) => {
                   onChangeBlock(block, {
                     ...data,
-                    href: value,
+                    href: flattenToAppURL(value),
                   });
                 }}
               />

--- a/src/components/manage/Blocks/Video/VideoSidebar.jsx
+++ b/src/components/manage/Blocks/Video/VideoSidebar.jsx
@@ -5,7 +5,7 @@ import { Accordion, Grid, Segment } from 'semantic-ui-react';
 import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
 import { CheckboxWidget, Icon, TextWidget } from '@plone/volto/components';
 import AlignBlock from '@plone/volto/components/manage/Sidebar/AlignBlock';
-
+import { flattenToAppURL, isInternalURL } from '@plone/volto/helpers';
 import videoSVG from '@plone/volto/icons/videocamera.svg';
 import clearSVG from '@plone/volto/icons/clear.svg';
 import upSVG from '@plone/volto/icons/up-key.svg';
@@ -92,7 +92,14 @@ const VideoSidebar = ({
                   id="video-preview-image"
                   title={intl.formatMessage(messages.Preview_image)}
                   required={false}
-                  value={data.preview_image?.split('/').slice(-1)[0]}
+                  value={
+                    isInternalURL(data.preview_image)
+                      ? data.preview_image
+                          ?.replace(/\/$/, '')
+                          .split('/')
+                          .slice(-1)[0]
+                      : data.preview_image
+                  }
                   icon={data.preview_image ? clearSVG : navTreeSVG}
                   iconAction={
                     data.preview_image
@@ -161,7 +168,7 @@ const VideoSidebar = ({
                   id="link"
                   title={intl.formatMessage(messages.LinkTo)}
                   required={false}
-                  value={data.href}
+                  value={flattenToAppURL(data.href)}
                   icon={data.href ? clearSVG : navTreeSVG}
                   iconAction={
                     data.href
@@ -176,7 +183,7 @@ const VideoSidebar = ({
                   onChange={(name, value) => {
                     onChangeBlock(block, {
                       ...data,
-                      href: value,
+                      href: flattenToAppURL(value),
                     });
                   }}
                 />

--- a/src/components/manage/Widgets/ObjectBrowserWidget.jsx
+++ b/src/components/manage/Widgets/ObjectBrowserWidget.jsx
@@ -239,7 +239,7 @@ export class ObjectBrowserWidgetComponent extends Component {
             } else {
               this.props.onChange(this.props.id, [
                 {
-                  '@id': normalizeUrl(link),
+                  '@id': flattenToAppURL(link),
                   title: removeProtocol(link),
                 },
               ]);


### PR DESCRIPTION
Fixed edit link and image url in this blocks:
- **image block** and **leadimage block**: if an internal url was manually pasted into the field, it wasn't flatten and Plone handled it as an external url. Also, if pasted url ended with '/' nothing was dispalyed in 'Origin' field in sidebar. 
- **video block**: if pasted url was internal and ended with '/' nothing was dispalyed in 'Preview image' field in sidebar. Also if an internal url was pasted in 'Link' field in sidebar, it wasn't flatted and handled from Plone as an external link.
- **objectBrowser**: also in objectBrowser, if pasted url was internal, it wasn't flatted and handled from Plone as an external.. 