### PR TITLE
Docs: Add selectableTypes example to ObjectBrowserWidget storybook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
 - Make the parseDateTime function to handle only date as well @iFlameing
 - Fix ContextNavigation component with Link type objects @UnaiEtxaburu #3232
 
+### Documentation
+
+- Added a `selectableTypes` example to the `ObjectBrowserWidget` storybook @JeffersonBledsoe #3255
+
 ### Internal
 
 - Upgrade react-image-gallery to latest to fix a11y problem @sneridagh

--- a/docs/source/blocks/editcomponent.md
+++ b/docs/source/blocks/editcomponent.md
@@ -290,7 +290,7 @@ export const widgets = {
 
 #### Selectable types
 
-If **selectableTypes** is set in `widgetOptions.pattern_options`, then only items whose content type has a name that is defined in `widgetOptions.pattern_options.selectableTypes` will be selectable.
+If `selectableTypes` is set in `widgetOptions.pattern_options`, then only items whose content type has a name that is defined in `widgetOptions.pattern_options.selectableTypes` will be selectable.
 
 ```jsx
 <ObjectBrowserWidget ... widgetOptions={{pattern_options:{selectableTypes:['News Item','Event']}}}>

--- a/docs/source/blocks/editcomponent.md
+++ b/docs/source/blocks/editcomponent.md
@@ -290,7 +290,7 @@ export const widgets = {
 
 #### Selectable types
 
-If **selectableTypes** is set in _widgetOptions.pattern_options_, widget allows to select only items that matches types defined in _widgetOptions.pattern_options.selectableTypes_.
+If **selectableTypes** is set in `widgetOptions.pattern_options`, then only items whose content type has a name that is defined in `widgetOptions.pattern_options.selectableTypes` will be selectable.
 
 ```jsx
 <ObjectBrowserWidget ... widgetOptions={{pattern_options:{selectableTypes:['News Item','Event']}}}>

--- a/src/components/manage/Widgets/ObjectBrowserWidget.stories.js
+++ b/src/components/manage/Widgets/ObjectBrowserWidget.stories.js
@@ -191,6 +191,21 @@ const ObjectBrowserWidget = (args) => {
 
 export default {
   title: 'Widgets/Object Browser',
+  argTypes: {
+    selectableTypes: {
+      name: 'widgetOptions.pattern_options.selectableTypes',
+      description: 'List of content type names that can be selected',
+      table: {
+        type: {
+          summary: 'Something short',
+          detail: 'Something really really long',
+        },
+      },
+      control: {
+        type: null,
+      },
+    },
+  },
   component: OBC,
   decorators: [
     (Story) => (
@@ -206,3 +221,10 @@ export default {
 export const Connected = () => <ObjectBrowserWidget />;
 export const SingleElement = () => <ObjectBrowserWidget mode="link" />;
 export const Image = () => <ObjectBrowserWidget mode="image" return="single" />;
+export const SelectableType = () => (
+  <ObjectBrowserWidget
+    widgetOptions={{
+      pattern_options: { selectableTypes: ['Folder', 'Image', 'Event'] },
+    }}
+  />
+);


### PR DESCRIPTION
Just a quick PR to add an example of the `selectableTypes` to the `ObjectBrowserWidget`'s storybook.

Closes #2993 