### PR TITLE
change item order in addon controlpanel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fix sidebar full size bottom opacity on edit page when sidebar is collapsed @ichim-david
 - Fix toolbar bottom opacity on edit page when toolbar is collapsed @ichim-david
 - Fixed secure cookie option. @giuliaghisini
+- Changed addon order in addon controlpanel to mimic Classic UI @erral
 
 ### Internal
 

--- a/src/components/manage/Controlpanels/AddonsControlpanel.jsx
+++ b/src/components/manage/Controlpanels/AddonsControlpanel.jsx
@@ -277,6 +277,76 @@ class AddonsControlpanel extends Component {
             .
           </Segment>
 
+          <Segment key="header-available" secondary>
+            <FormattedMessage id="Available" defaultMessage="Available" />:
+            <Label circular>{this.props.availableAddons.length}</Label>
+          </Segment>
+
+          <Segment key="body-available" attached>
+            <Accordion>
+              <Divider />
+              {this.props.availableAddons.map((item) => (
+                <div key={item.id}>
+                  <Accordion.Title
+                    active={this.state.activeIndex === item.id}
+                    index={item.id}
+                    onClick={this.onAccordionClick}
+                  >
+                    {item.title}
+                    <Icon
+                      name={
+                        this.state.activeIndex === item.id
+                          ? circleTopSVG
+                          : circleBottomSVG
+                      }
+                      size="23px"
+                      className={`accordionToggle ${item.title}`}
+                    />
+                  </Accordion.Title>
+                  <Accordion.Content
+                    active={this.state.activeIndex === item.id}
+                  >
+                    <div className="description">{item.description}</div>
+                    {item.uninstall_profile_id === '' && (
+                      <div>
+                        <Message icon="warning" warning>
+                          <FormattedMessage
+                            id="No uninstall profile"
+                            defaultMessage="This addon does not provide an uninstall profile."
+                          />
+                        </Message>
+                      </div>
+                    )}
+                    <Button.Group floated="right">
+                      <Button
+                        primary
+                        basic
+                        onClick={this.onInstall}
+                        value={item.id}
+                        className="installAction"
+                      >
+                        <FormattedMessage
+                          id="Install"
+                          defaultMessage="Install"
+                          className="button-label"
+                        />
+                      </Button>
+                    </Button.Group>
+                    <div className="version">
+                      <FormattedMessage
+                        id="Latest version"
+                        defaultMessage="Latest version"
+                      />
+                      : &nbsp;
+                      {item.version}
+                    </div>
+                  </Accordion.Content>
+                  <Divider />
+                </div>
+              ))}
+            </Accordion>
+          </Segment>
+
           <Segment key="header-installed" secondary>
             <FormattedMessage id="Installed" defaultMessage="Installed" />:
             <Label circular>{this.props.installedAddons.length}</Label>
@@ -352,76 +422,6 @@ class AddonsControlpanel extends Component {
                         defaultMessage="Installed version"
                       />
                       : &nbsp; {item.version}
-                    </div>
-                  </Accordion.Content>
-                  <Divider />
-                </div>
-              ))}
-            </Accordion>
-          </Segment>
-
-          <Segment key="header-available" secondary>
-            <FormattedMessage id="Available" defaultMessage="Available" />:
-            <Label circular>{this.props.availableAddons.length}</Label>
-          </Segment>
-
-          <Segment key="body-available" attached>
-            <Accordion>
-              <Divider />
-              {this.props.availableAddons.map((item) => (
-                <div key={item.id}>
-                  <Accordion.Title
-                    active={this.state.activeIndex === item.id}
-                    index={item.id}
-                    onClick={this.onAccordionClick}
-                  >
-                    {item.title}
-                    <Icon
-                      name={
-                        this.state.activeIndex === item.id
-                          ? circleTopSVG
-                          : circleBottomSVG
-                      }
-                      size="23px"
-                      className={`accordionToggle ${item.title}`}
-                    />
-                  </Accordion.Title>
-                  <Accordion.Content
-                    active={this.state.activeIndex === item.id}
-                  >
-                    <div className="description">{item.description}</div>
-                    {item.uninstall_profile_id === '' && (
-                      <div>
-                        <Message icon="warning" warning>
-                          <FormattedMessage
-                            id="No uninstall profile"
-                            defaultMessage="This addon does not provide an uninstall profile."
-                          />
-                        </Message>
-                      </div>
-                    )}
-                    <Button.Group floated="right">
-                      <Button
-                        primary
-                        basic
-                        onClick={this.onInstall}
-                        value={item.id}
-                        className="installAction"
-                      >
-                        <FormattedMessage
-                          id="Install"
-                          defaultMessage="Install"
-                          className="button-label"
-                        />
-                      </Button>
-                    </Button.Group>
-                    <div className="version">
-                      <FormattedMessage
-                        id="Latest version"
-                        defaultMessage="Latest version"
-                      />
-                      : &nbsp;
-                      {item.version}
                     </div>
                   </Accordion.Content>
                   <Divider />

--- a/src/components/manage/Controlpanels/__snapshots__/AddonsControlpanel.test.jsx.snap
+++ b/src/components/manage/Controlpanels/__snapshots__/AddonsControlpanel.test.jsx.snap
@@ -45,6 +45,85 @@ exports[`AddonsControlpanel renders an addon control component 1`] = `
     <div
       className="ui secondary segment"
     >
+      Available
+      :
+      <div
+        className="ui circular label"
+        onClick={[Function]}
+      >
+        1
+      </div>
+    </div>
+    <div
+      className="ui attached segment"
+    >
+      <div
+        className="accordion ui"
+      >
+        <div
+          className="ui divider"
+        />
+        <div>
+          <div
+            className="title"
+            onClick={[Function]}
+          >
+            Something Else
+            <svg
+              className="icon accordionToggle Something Else"
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": undefined,
+                }
+              }
+              onClick={null}
+              style={
+                Object {
+                  "fill": "currentColor",
+                  "height": "23px",
+                  "width": "auto",
+                }
+              }
+              viewBox=""
+              xmlns=""
+            />
+          </div>
+          <div
+            className="content"
+          >
+            <div
+              className="description"
+            >
+              Does other things…
+            </div>
+            <div
+              className="ui right floated buttons"
+            >
+              <button
+                className="ui basic primary button installAction"
+                onClick={[Function]}
+                value="plone.app.somethingelse"
+              >
+                Install
+              </button>
+            </div>
+            <div
+              className="version"
+            >
+              Latest version
+              :  
+              1.0.0
+            </div>
+          </div>
+          <div
+            className="ui divider"
+          />
+        </div>
+      </div>
+    </div>
+    <div
+      className="ui secondary segment"
+    >
       Installed
       :
       <div
@@ -124,85 +203,6 @@ exports[`AddonsControlpanel renders an addon control component 1`] = `
             >
               Installed version
               :   
-              1.0.0
-            </div>
-          </div>
-          <div
-            className="ui divider"
-          />
-        </div>
-      </div>
-    </div>
-    <div
-      className="ui secondary segment"
-    >
-      Available
-      :
-      <div
-        className="ui circular label"
-        onClick={[Function]}
-      >
-        1
-      </div>
-    </div>
-    <div
-      className="ui attached segment"
-    >
-      <div
-        className="accordion ui"
-      >
-        <div
-          className="ui divider"
-        />
-        <div>
-          <div
-            className="title"
-            onClick={[Function]}
-          >
-            Something Else
-            <svg
-              className="icon accordionToggle Something Else"
-              dangerouslySetInnerHTML={
-                Object {
-                  "__html": undefined,
-                }
-              }
-              onClick={null}
-              style={
-                Object {
-                  "fill": "currentColor",
-                  "height": "23px",
-                  "width": "auto",
-                }
-              }
-              viewBox=""
-              xmlns=""
-            />
-          </div>
-          <div
-            className="content"
-          >
-            <div
-              className="description"
-            >
-              Does other things…
-            </div>
-            <div
-              className="ui right floated buttons"
-            >
-              <button
-                className="ui basic primary button installAction"
-                onClick={[Function]}
-                value="plone.app.somethingelse"
-              >
-                Install
-              </button>
-            </div>
-            <div
-              className="version"
-            >
-              Latest version
-              :  
               1.0.0
             </div>
           </div>


### PR DESCRIPTION
Fixes #3320 

Now addon controlpanel items are in the same order both in Classic and Volto:

- Available Upgrades
- Available Addons
- Installed Addons