### PR TITLE
Fix changing Volto locale to match the content language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fix toolbar bottom opacity on edit page when toolbar is collapsed @ichim-david
 - Fixed secure cookie option. @giuliaghisini
 - Changed addon order in addon controlpanel to mimic Classic UI @erral
+- Fixed error when loading content in a language for which a Volto translation is not available. @davisagli
 
 ### Internal
 

--- a/src/middleware/api.js
+++ b/src/middleware/api.js
@@ -188,7 +188,12 @@ export default (api) => ({ dispatch, getState }) => (next) => (action) => {
         }
         if (type === GET_CONTENT) {
           const lang = result?.language?.token;
-          if (lang && getState().intl.language !== lang && !subrequest) {
+          if (
+            lang &&
+            getState().intl.language !== lang &&
+            !subrequest &&
+            config.settings.supportedLanguages.includes(lang)
+          ) {
             const langFileName = normalizeLanguageName(lang);
             import('~/../locales/' + langFileName + '.json').then((locale) => {
               dispatch(changeLanguage(lang, locale.default));

--- a/src/server.jsx
+++ b/src/server.jsx
@@ -236,7 +236,10 @@ server.get('/*', (req, res) => {
         req.headers['accept-language'];
 
       if (cookie_lang !== contentLang) {
-        store.dispatch(changeLanguage(contentLang, locales[contentLang], req));
+        const newLocale = new locale.Locales(contentLang)
+          .best(supported)
+          .toString();
+        store.dispatch(changeLanguage(newLocale, locales[newLocale], req));
       }
 
       const context = {};


### PR DESCRIPTION
If content is loaded in a language other than the current locale, Volto tries to switch to the new locale, but it breaks if it's a locale with no Volto translation available. This includes language-specific variants like en_US when only the en locale is available.

To avoid that error, this takes a bit more care to only change to the new language if it's supported.

Fixes #3297

(This is my first Volto PR, so please let me know if I'm missing anything.)