### PR TITLE
Added preconnect link tag to speed up google font retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Feature
 
+- Added preconnect link tag to speed up google font retrieval. @pnicolli
+
 ### Bugfix
 
 ### Internal
@@ -21,7 +23,7 @@
 
 ### Feature
 
-- Added viewableInBrowserObjects setting to use in alternative to downloadableObjects, if you want to view file in browser intstead downloading. @giuliaghisini
+- Added viewableInBrowserObjects setting to use in alternative to downloadableObjects, if you want to view file in browser instead downloading. @giuliaghisini
 - Disable already chosen criteria in querystring widget @kreafox
 - Added X-Forwarded-* headers to superagent requests. @mamico
 

--- a/src/helpers/Html/Html.jsx
+++ b/src/helpers/Html/Html.jsx
@@ -131,6 +131,7 @@ class Html extends Component {
             href="/apple-touch-icon.png"
           />
           <link rel="manifest" href="/site.webmanifest" />
+          <link rel="preconnect" href="https://fonts.gstatic.com" />
           <meta name="generator" content="Plone 6 - https://plone.org" />
           <meta name="viewport" content="width=device-width, initial-scale=1" />
           <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/src/helpers/Html/__snapshots__/Html.test.jsx.snap
+++ b/src/helpers/Html/__snapshots__/Html.test.jsx.snap
@@ -39,6 +39,10 @@ exports[`Html renders a html component 1`] = `
       href="/site.webmanifest"
       rel="manifest"
     />
+    <link
+      href="https://fonts.gstatic.com"
+      rel="preconnect"
+    />
     <meta
       content="Plone 6 - https://plone.org"
       name="generator"
@@ -133,6 +137,10 @@ exports[`Html renders a html component with apiPath present 1`] = `
     <link
       href="/site.webmanifest"
       rel="manifest"
+    />
+    <link
+      href="https://fonts.gstatic.com"
+      rel="preconnect"
     />
     <meta
       content="Plone 6 - https://plone.org"


### PR DESCRIPTION
Fixes #3328 

Add preconnect link tag as suggested by lighthouse. The current SemanticUI configuration requests 4 different font files from this origin, this preconnect should help optimize the connection.