### PR TITLE
Inject the style classNames in the main Block Editor wrapper.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,15 @@
 ### Breaking
 
 - Rename `src/components/manage/Widgets/ColorPicker.jsx` component to `src/components/manage/Widgets/ColorPickerWidget.jsx` @sneridagh
+- Remove the style wrapper around the `<Block />` component in Edit mode, moved to the main edit wrapper @sneridagh
 
 ### Feature
 
 - Updated Brazilian Portuguese translation @ericof
 - Forward `HTTP Range` headers to the backend. @mamico
 - Add default value to color picker, if `default` is present in the widget schema. @sneridagh
+- Inject the classnames of the StyleWrapper into the main edit wrapper (it was wrapping directly the Edit component before). This way, the flexibility is bigger and you can act upon the whole edit container and artifacts (handlers, etc) @sneridagh
+- Include the align, size block settings properties into the classname builder function @sneridagh
 
 ### Bugfix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Add default value to color picker, if `default` is present in the widget schema. @sneridagh
 - Inject the classnames of the StyleWrapper into the main edit wrapper (it was wrapping directly the Edit component before). This way, the flexibility is bigger and you can act upon the whole edit container and artifacts (handlers, etc) @sneridagh
 - Include the align, size block settings properties into the classname builder function @sneridagh
+- Enable default color in `backgroundColor` default StyleWrapper field @sneridagh
 
 ### Bugfix
 

--- a/src/components/manage/Blocks/Block/Edit.jsx
+++ b/src/components/manage/Blocks/Block/Edit.jsx
@@ -13,7 +13,6 @@ import { setSidebarTab } from '@plone/volto/actions';
 import config from '@plone/volto/registry';
 import withObjectBrowser from '@plone/volto/components/manage/Sidebar/ObjectBrowser';
 import { applyBlockDefaults } from '@plone/volto/helpers';
-import StyleWrapper from './StyleWrapper';
 
 import {
   SidebarPortal,
@@ -167,13 +166,11 @@ export class Edit extends Component {
             /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
             tabIndex={!blockHasOwnFocusManagement ? -1 : null}
           >
-            <StyleWrapper {...this.props}>
-              <Block
-                {...this.props}
-                blockNode={this.blockNode}
-                data={applyBlockDefaults(this.props)}
-              />
-            </StyleWrapper>
+            <Block
+              {...this.props}
+              blockNode={this.blockNode}
+              data={applyBlockDefaults(this.props)}
+            />
             {this.props.manage && (
               <SidebarPortal
                 selected={this.props.selected}

--- a/src/components/manage/Blocks/Block/EditBlockWrapper.jsx
+++ b/src/components/manage/Blocks/Block/EditBlockWrapper.jsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import { Icon } from '@plone/volto/components';
-import { blockHasValue } from '@plone/volto/helpers';
+import {
+  blockHasValue,
+  buildStyleClassNamesFromData,
+} from '@plone/volto/helpers';
 import dragSVG from '@plone/volto/icons/drag.svg';
 import { Button } from 'semantic-ui-react';
 import includes from 'lodash/includes';
@@ -31,6 +34,8 @@ const EditBlockWrapper = (props) => {
     ? data.required
     : includes(config.blocks.requiredBlocks, type);
 
+  const styles = buildStyleClassNamesFromData(data.styles);
+
   return (
     <div
       ref={draginfo.innerRef}
@@ -38,10 +43,7 @@ const EditBlockWrapper = (props) => {
       // Right now, we can have the alignment information in the styles property or in the
       // block data root, we inject the classname here for having control over the whole
       // Block Edit wrapper
-      className={cx(`block-editor-${data['@type']}`, {
-        [data.align]: data.align,
-        [data.styles?.align]: data.styles?.align,
-      })}
+      className={cx(`block-editor-${data['@type']}`, styles)}
     >
       <div style={{ position: 'relative' }}>
         <div

--- a/src/components/manage/Blocks/Block/EditBlockWrapper.jsx
+++ b/src/components/manage/Blocks/Block/EditBlockWrapper.jsx
@@ -34,7 +34,7 @@ const EditBlockWrapper = (props) => {
     ? data.required
     : includes(config.blocks.requiredBlocks, type);
 
-  const styles = buildStyleClassNamesFromData(data.styles);
+  const styles = buildStyleClassNamesFromData(data);
 
   return (
     <div
@@ -43,9 +43,7 @@ const EditBlockWrapper = (props) => {
       // Right now, we can have the alignment information in the styles property or in the
       // block data root, we inject the classname here for having control over the whole
       // Block Edit wrapper
-      className={cx(`block-editor-${data['@type']}`, styles, {
-        [data.align]: data.align,
-      })}
+      className={cx(`block-editor-${data['@type']}`, styles)}
     >
       <div style={{ position: 'relative' }}>
         <div

--- a/src/components/manage/Blocks/Block/EditBlockWrapper.jsx
+++ b/src/components/manage/Blocks/Block/EditBlockWrapper.jsx
@@ -43,7 +43,9 @@ const EditBlockWrapper = (props) => {
       // Right now, we can have the alignment information in the styles property or in the
       // block data root, we inject the classname here for having control over the whole
       // Block Edit wrapper
-      className={cx(`block-editor-${data['@type']}`, styles)}
+      className={cx(`block-editor-${data['@type']}`, styles, {
+        [data.align]: data.align,
+      })}
     >
       <div style={{ position: 'relative' }}>
         <div

--- a/src/components/manage/Blocks/Block/StyleWrapper.jsx
+++ b/src/components/manage/Blocks/Block/StyleWrapper.jsx
@@ -4,7 +4,7 @@ import { buildStyleClassNamesFromData } from '@plone/volto/helpers';
 
 const StyleWrapper = (props) => {
   const { children, data = {} } = props;
-  const styles = buildStyleClassNamesFromData(data.styles);
+  const styles = buildStyleClassNamesFromData(data);
   const rewrittenChildren = React.Children.map(children, (child) => {
     if (React.isValidElement(child)) {
       const childProps = {

--- a/src/components/manage/Blocks/Block/StylesSchema.jsx
+++ b/src/components/manage/Blocks/Block/StylesSchema.jsx
@@ -24,8 +24,8 @@ const DEFAULT_COLORS = [
 export const defaultStyleSchema = ({ formData, intl }) => {
   const colors =
     config.blocks?.blocksConfig?.[formData['@type']]?.colors || DEFAULT_COLORS;
-  const defaultColor =
-    config.blocks?.blocksConfig?.[formData['@type']]?.defaultColor;
+  const defaultBGColor =
+    config.blocks?.blocksConfig?.[formData['@type']]?.defaultBGColor;
 
   return {
     fieldsets: [
@@ -46,7 +46,7 @@ export const defaultStyleSchema = ({ formData, intl }) => {
         widget: 'color_picker',
         title: intl.formatMessage(messages.backgroundColor),
         colors,
-        defaultColor,
+        default: defaultBGColor,
       },
     },
     required: [],

--- a/src/helpers/Blocks/Blocks.js
+++ b/src/helpers/Blocks/Blocks.js
@@ -406,15 +406,23 @@ export function applyBlockDefaults({ data, intl, ...rest }, blocksConfig) {
   return applySchemaDefaults({ data, schema });
 }
 
-export const buildStyleClassNamesFromData = (styles) => {
+export const buildStyleClassNamesFromData = (data) => {
+  const { styles, align, size } = data;
   // styles has the form
   // const styles = {
   // color: 'red',
   // backgroundColor: '#AABBCC',
   // }
   // Returns: ['has--color--red', 'has--backgroundColor--AABBCC']
+
   let styleArray = [];
-  const pairedStyles = toPairs(styles);
+  // We assume that no align, nor size will be present in the style object
+  // Otherwise, wins the styles defined ones
+  const pairedStyles = toPairs({
+    ...(align && { align }),
+    ...(size && { size }),
+    ...styles,
+  });
   pairedStyles.forEach((item) => {
     if (isObject(item[1])) {
       const flattenedNestedStyles = toPairs(item[1]).map((nested) => [

--- a/src/helpers/Blocks/Blocks.test.js
+++ b/src/helpers/Blocks/Blocks.test.js
@@ -576,25 +576,29 @@ describe('Blocks', () => {
   });
   describe('buildStyleClassNamesFromData', () => {
     it('Sets styles classname array according to style values', () => {
-      const styles = {
-        color: 'red',
-        backgroundColor: '#AABBCC',
+      const data = {
+        styles: {
+          color: 'red',
+          backgroundColor: '#AABBCC',
+        },
       };
-      expect(buildStyleClassNamesFromData(styles)).toEqual([
+      expect(buildStyleClassNamesFromData(data)).toEqual([
         'has--color--red',
         'has--backgroundColor--AABBCC',
       ]);
     });
     it('Sets styles classname array according to style values with nested', () => {
-      const styles = {
-        color: 'red',
-        backgroundColor: '#AABBCC',
-        nested: {
-          foo: 'white',
-          bar: 'black',
+      const data = {
+        styles: {
+          color: 'red',
+          backgroundColor: '#AABBCC',
+          nested: {
+            foo: 'white',
+            bar: 'black',
+          },
         },
       };
-      expect(buildStyleClassNamesFromData(styles)).toEqual([
+      expect(buildStyleClassNamesFromData(data)).toEqual([
         'has--color--red',
         'has--backgroundColor--AABBCC',
         'has--nested--foo--white',
@@ -602,15 +606,17 @@ describe('Blocks', () => {
       ]);
     });
     it('Sets styles classname array according to style values with nested and colors', () => {
-      const styles = {
-        color: 'red',
-        backgroundColor: '#AABBCC',
-        nested: {
-          foo: '#fff',
-          bar: '#000',
+      const data = {
+        styles: {
+          color: 'red',
+          backgroundColor: '#AABBCC',
+          nested: {
+            foo: '#fff',
+            bar: '#000',
+          },
         },
       };
-      expect(buildStyleClassNamesFromData(styles)).toEqual([
+      expect(buildStyleClassNamesFromData(data)).toEqual([
         'has--color--red',
         'has--backgroundColor--AABBCC',
         'has--nested--foo--fff',
@@ -619,13 +625,38 @@ describe('Blocks', () => {
     });
 
     it('Sets styles classname array according to style values with int values', () => {
-      const styles = {
-        color: 'red',
-        borderRadius: 8,
+      const data = {
+        styles: {
+          color: 'red',
+          borderRadius: 8,
+        },
       };
-      expect(buildStyleClassNamesFromData(styles)).toEqual([
+      expect(buildStyleClassNamesFromData(data)).toEqual([
         'has--color--red',
         'has--borderRadius--8',
+      ]);
+    });
+
+    it('Sets styles classname array according to style with nested values and align present', () => {
+      const data = {
+        align: 'wide',
+        size: 'l',
+        styles: {
+          color: 'red',
+          backgroundColor: '#AABBCC',
+          nested: {
+            foo: '#fff',
+            bar: '#000',
+          },
+        },
+      };
+      expect(buildStyleClassNamesFromData(data)).toEqual([
+        'has--align--wide',
+        'has--size--l',
+        'has--color--red',
+        'has--backgroundColor--AABBCC',
+        'has--nested--foo--fff',
+        'has--nested--bar--000',
       ]);
     });
   });


### PR DESCRIPTION
@ichim-david @tiberiuichim @pnicolli @giuliaghisini  

I've been developing a project with the new style wrapper and I really think that I missed the shot when deciding where to inject the classNames. 

I think that we should inject it at the very top of the Editor wrapper to be able to have enough flexibility and control over the CSS definitions in the Editor. I even think that we might save some definitions that work both for the editor and for the view mode. 

I also took a closer look at EEA's style wrapper, and I think that we need to replicate the inline styling in the current style wrapper. That's why I left it untouched, the idea is that we remove the class injection, but we leave a way to inject inline definitions (if any), what do you think?

From the merged PR thinkings:

@ichim-david Several "to-dos" from the other day talk:

I think we should include the current `size` and `align` data properties in the styling classname generator.

So now we have `has--align--` `has--size--` classnames. See questions below.

I'm convincing myself that when we talk about width containers, the wording is not "align"... although it's a widely used concept, but it Hink that "block/container width" would be more appropriate. What happens when, we have (fairly common) use case, that given a specific container width, you still want to "justify" the elements inside the block in a way (left, center, right). eg. A button block, or a heading block. 

Other use case that breaks the "align" wording is the block that has a background color, but the inner container is variable, let's say, a grid block that has a background color but the inner contents have a specific "inner width", that should be possible for a user to be able to configure.

So far, we have:
- "align/inline width" (images, videos, maps) blocks alignment (I think it's the only legit use case for that wording)
- "block/container width" (the outer container of a block)
- "inner width" (the inner container of a block, where the content lies)

Also, as legacy, we have these properties in the root of the `data` structure:
- size
- align 

all referring to image/video/maps but might be also present in custom blocks.

I think the style wrapper would have to deal with all these, and include the legacy size/align on it, generating a different set of CSS rules, so different classnames.

I do like a lot this approach, we need it for the next layout:

```
.addReducedTextElements() when (@reduceTextElementsSize = true) {
  @{textElementsParentSelector} {
    @{textElementsSelectors} {
      max-width: @textElementsMaxWidth;
      margin-right: @textElementsRightMargin;
      margin-left: @textElementsLeftMargin;
    }
  }
}
```

```
@textElementsSelectors: h2, h3, h4, h5, h6, p, ol, ul, blockquote;
```

However, as we discuss the other day, we would like more descriptive classnames, like

`container-lg`, etc...

and have the sizes be configurable. I agree with it, so they remain "neutral" and not tied to a name. In our last project we have:

```
:root {
  --layout-container-width: 1440px; // this is the header/footer container
  --default-container-width: 940px; // this is the "block inner width"
  --narrow-container-width: 620px; // this is the narrow (text elements) inner width
}
```

and the full-size (full viewport) in addition.

Questions:
- Does the prefix `has--` make any sense to you?
- Should we introduce these three types of container widths in the style wrapper?
