### PR TITLE
fix schema when content contains lock informations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- fix schema when content contains lock informations. @giuliaghisini
+
 ### Internal
 
 ### Documentation
@@ -23,7 +25,7 @@
 
 - Added viewableInBrowserObjects setting to use in alternative to downloadableObjects, if you want to view file in browser intstead downloading. @giuliaghisini
 - Disable already chosen criteria in querystring widget @kreafox
-- Added X-Forwarded-* headers to superagent requests. @mamico
+- Added X-Forwarded-\* headers to superagent requests. @mamico
 
 ### Bugfix
 

--- a/src/components/theme/View/DefaultView.jsx
+++ b/src/components/theme/View/DefaultView.jsx
@@ -39,7 +39,8 @@ const DefaultView = (props) => {
   );
 
   React.useEffect(() => {
-    !hasBlocksData(content) &&
+    content?.['@type'] &&
+      !hasBlocksData(content) &&
       dispatch(getSchema(content['@type'], location.pathname));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -52,7 +53,7 @@ const DefaultView = (props) => {
     <Container id="page-document">
       {fieldsets?.map((fs) => {
         return (
-          <>
+          <div className="fieldset" key={fs.id}>
             {fs.id !== 'default' && <h2>{fs.title}</h2>}
             {fs.fields?.map((f, key) => {
               let field = {
@@ -76,7 +77,7 @@ const DefaultView = (props) => {
                 <Widget key={key} value={content[f]} />
               );
             })}
-          </>
+          </div>
         );
       })}
     </Container>


### PR DESCRIPTION
When state.content contains the lock informations, 
DefaultView was calling getSchema without type because content wasn't in state.content and this caused a failing request

Fixed 