### PR TITLE
fix TokenWidget choices when editing a recently created content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Bugfix
 
+- fix TokenWidget choices when editing a recently created content. @giuliaghisini
+
 ### Internal
 
 ### Documentation

--- a/src/components/manage/Widgets/TokenWidget.jsx
+++ b/src/components/manage/Widgets/TokenWidget.jsx
@@ -61,6 +61,8 @@ class TokenWidget extends Component {
     error: PropTypes.arrayOf(PropTypes.string),
     getVocabulary: PropTypes.func.isRequired,
     choices: PropTypes.arrayOf(PropTypes.object),
+    vocabLoading: PropTypes.bool,
+    vocabLoaded: PropTypes.bool,
     items: PropTypes.shape({
       vocabulary: PropTypes.object,
     }),
@@ -113,6 +115,20 @@ class TokenWidget extends Component {
         vocabNameOrURL: this.props.vocabBaseUrl,
         size: -1,
         subrequest: this.props.intl.locale,
+      });
+    }
+  }
+
+  componentDidUpdate() {
+    if (
+      !this.props.choices?.length &&
+      this.props.vocabLoading === undefined &&
+      !this.props.vocabLoaded
+    ) {
+      this.props.getVocabulary({
+        vocabNameOrURL: this.props.vocabBaseUrl,
+        size: -1,
+        subrequest: this.props.lang,
       });
     }
   }
@@ -198,6 +214,8 @@ export default compose(
                 value: item.value,
               }))
             : [],
+          vocabLoading: vocabState.loading,
+          vocabLoaded: vocabState.loaded,
           vocabBaseUrl,
         };
       }


### PR DESCRIPTION
fixes https://github.com/plone/volto/issues/3393