### PR TITLE
HTTP Range support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Feature
 
+- Forward `HTTP Range` headers to the backend. @mamico
+
 ### Bugfix
 
 ### Internal

--- a/src/express-middleware/files.js
+++ b/src/express-middleware/files.js
@@ -17,6 +17,7 @@ function fileMiddleware(req, res, next) {
           res.set(header, resource.headers[header]);
         }
       });
+      res.status(resource.statusCode);
       res.send(resource.body);
     })
     .catch(next);

--- a/src/express-middleware/files.js
+++ b/src/express-middleware/files.js
@@ -2,10 +2,11 @@ import express from 'express';
 import { getAPIResourceWithAuth } from '@plone/volto/helpers';
 
 const HEADERS = [
-  'cache-control',
-  'content-disposition',
-  'content-range',
-  'content-type',
+  'Accept-Ranges',
+  'Cache-Control',
+  'Content-Disposition',
+  'Content-Range',
+  'Content-Type',
 ];
 
 function fileMiddleware(req, res, next) {
@@ -13,8 +14,8 @@ function fileMiddleware(req, res, next) {
     .then((resource) => {
       // Just forward the headers that we need
       HEADERS.forEach((header) => {
-        if (resource.headers[header]) {
-          res.set(header, resource.headers[header]);
+        if (resource.get(header)) {
+          res.set(header, resource.get(header));
         }
       });
       res.status(resource.statusCode);

--- a/src/express-middleware/files.js
+++ b/src/express-middleware/files.js
@@ -1,7 +1,12 @@
 import express from 'express';
 import { getAPIResourceWithAuth } from '@plone/volto/helpers';
 
-const HEADERS = ['content-type', 'content-disposition', 'cache-control'];
+const HEADERS = [
+  'cache-control',
+  'content-disposition',
+  'content-range',
+  'content-type',
+];
 
 function fileMiddleware(req, res, next) {
   getAPIResourceWithAuth(req)

--- a/src/helpers/Proxy/Proxy.js
+++ b/src/helpers/Proxy/Proxy.js
@@ -4,6 +4,9 @@
  * @param {Object} req Original request object
  * @return {function} Superagent request function
  */
+
+const HEADERS = ["range", "if-range"];
+
 export const addHeadersFactory = (orig) => {
   return (request) => {
     const x_forwarded_host = orig.headers['x-forwarded-host'] || orig['host'];
@@ -17,5 +20,11 @@ export const addHeadersFactory = (orig) => {
       request.set('x-forwarded-for', x_forwarded_for);
     }
     x_forwarded_host && request.set('x-forwarded-host', x_forwarded_host);
+    // forward additional headers
+    HEADERS.forEach((header) => {
+      if (orig.headers[header]) {
+        request.set(header, orig.headers[header]);
+      }
+    });
   };
 };

--- a/src/helpers/Proxy/Proxy.js
+++ b/src/helpers/Proxy/Proxy.js
@@ -5,7 +5,7 @@
  * @return {function} Superagent request function
  */
 
-const HEADERS = ["range", "if-range"];
+const HEADERS = ['range', 'if-range'];
 
 export const addHeadersFactory = (orig) => {
   return (request) => {


### PR DESCRIPTION
HTTP Range [HTTP](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Range)
actually implemented by Zope/Plone doesn't works when Volto act as proxy.

Test to reproduce.

Add a large video file and simulate a Range request:

Plone:
```
curl 'http://localhost:8080/Plone/video.mp4/@@download/file/video.mp4' -H 'Range: bytes=0-100' --dump-header - --output /dev/null
HTTP/1.1 206 Partial Content
Accept-Ranges: bytes
Content-Disposition: attachment; filename*=UTF-8'video.mp4
Content-Length: 101
Content-Range: bytes 0-100/169504558
Content-Type: video/mp4
Date: Tue, 24 May 2022 06:32:18 GMT
Server: waitress
Via: waitress
X-Frame-Options: SAMEORIGIN
X-Powered-By: Zope (www.zope.org), Python (www.python.org)

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   100  100   100    0     0   5539      0 --:--:-- --:--:-- --:--:--  5882
```

Volto:
```
curl 'http://localhost:3000/video.mp4/@@download/file/video.mp4' -H 'Range: bytes=0-100' --dump-header - --output /dev/null
HTTP/1.1 200 OK
content-type: video/mp4
content-disposition: attachment; filename*=UTF-8'video.mp4
Content-Length: 169504558
ETag: W/"a1a6f2e-/V5nkRk0kQlFgmzA3D7iIaJNS8M"
Date: Tue, 24 May 2022 06:11:47 GMT
Connection: keep-alive
Keep-Alive: timeout=5

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  161M  100  161M    0     0  35.2M      0  0:00:04  0:00:04 --:--:-- 36.8M
```
