### PR TITLE
Move the stylewrapper to the top parent container in edit mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,14 @@
 ### Breaking
 
 - Rename `src/components/manage/Widgets/ColorPicker.jsx` component to `src/components/manage/Widgets/ColorPickerWidget.jsx` @sneridagh
+- Remove the style wrapper around the `<Block />` component in Edit mode, moved to the main edit wrapper @sneridagh
 
 ### Feature
 
 - Updated Brazilian Portuguese translation @ericof
 - Forward `HTTP Range` headers to the backend. @mamico
 - Add default value to color picker, if `default` is present in the widget schema. @sneridagh
+- Inject the classnames of the StyleWrapper into the main edit wrapper (it was wrapping directly the Edit component before). This way, the flexibility is bigger and you can act upon the whole edit container and artifacts (handlers, etc) @sneridagh
 
 ### Bugfix
 

--- a/src/components/manage/Blocks/Block/Edit.jsx
+++ b/src/components/manage/Blocks/Block/Edit.jsx
@@ -13,7 +13,6 @@ import { setSidebarTab } from '@plone/volto/actions';
 import config from '@plone/volto/registry';
 import withObjectBrowser from '@plone/volto/components/manage/Sidebar/ObjectBrowser';
 import { applyBlockDefaults } from '@plone/volto/helpers';
-import StyleWrapper from './StyleWrapper';
 
 import {
   SidebarPortal,
@@ -167,13 +166,11 @@ export class Edit extends Component {
             /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
             tabIndex={!blockHasOwnFocusManagement ? -1 : null}
           >
-            <StyleWrapper {...this.props}>
-              <Block
-                {...this.props}
-                blockNode={this.blockNode}
-                data={applyBlockDefaults(this.props)}
-              />
-            </StyleWrapper>
+            <Block
+              {...this.props}
+              blockNode={this.blockNode}
+              data={applyBlockDefaults(this.props)}
+            />
             {this.props.manage && (
               <SidebarPortal
                 selected={this.props.selected}


### PR DESCRIPTION
Striped this from the other PR, we need not have this duplication