### PR TITLE
Bugfix: avoid rendering a '0' in the search block when no facets were added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Don't render junk when no facets are added to the search block @tiberiuichim
+
 ### Internal
 
 ### Documentation

--- a/src/components/manage/Blocks/Search/layout/LeftColumnFacets.jsx
+++ b/src/components/manage/Blocks/Search/layout/LeftColumnFacets.jsx
@@ -57,7 +57,7 @@ const LeftColumnFacets = (props) => {
       </Grid.Row>
 
       <Grid.Row>
-        {data.facets?.length && (
+        {data.facets?.length ? (
           <Grid.Column mobile={12} tablet={4} computer={3}>
             <div className="facets">
               {data.facetsTitle && <h3>{data.facetsTitle}</h3>}
@@ -75,6 +75,8 @@ const LeftColumnFacets = (props) => {
               />
             </div>
           </Grid.Column>
+        ) : (
+          ''
         )}
 
         <Grid.Column

--- a/src/components/manage/Blocks/Search/layout/LeftColumnFacets.jsx
+++ b/src/components/manage/Blocks/Search/layout/LeftColumnFacets.jsx
@@ -57,7 +57,7 @@ const LeftColumnFacets = (props) => {
       </Grid.Row>
 
       <Grid.Row>
-        {data.facets?.length ? (
+        {data.facets?.length > 0 && (
           <Grid.Column mobile={12} tablet={4} computer={3}>
             <div className="facets">
               {data.facetsTitle && <h3>{data.facetsTitle}</h3>}
@@ -75,8 +75,6 @@ const LeftColumnFacets = (props) => {
               />
             </div>
           </Grid.Column>
-        ) : (
-          ''
         )}
 
         <Grid.Column

--- a/src/components/manage/Blocks/Search/layout/RightColumnFacets.jsx
+++ b/src/components/manage/Blocks/Search/layout/RightColumnFacets.jsx
@@ -121,7 +121,7 @@ const RightColumnFacets = (props) => {
           {children}
         </Grid.Column>
 
-        {data.facets?.length ? (
+        {data.facets?.length > 0 && (
           <Grid.Column mobile={12} tablet={4} computer={3}>
             <div className="facets">
               {data.facetsTitle && <h3>{data.facetsTitle}</h3>}
@@ -140,8 +140,6 @@ const RightColumnFacets = (props) => {
               />
             </div>
           </Grid.Column>
-        ) : (
-          ''
         )}
       </Grid.Row>
     </Grid>

--- a/src/components/manage/Blocks/Search/layout/RightColumnFacets.jsx
+++ b/src/components/manage/Blocks/Search/layout/RightColumnFacets.jsx
@@ -121,7 +121,7 @@ const RightColumnFacets = (props) => {
           {children}
         </Grid.Column>
 
-        {data.facets?.length && (
+        {data.facets?.length ? (
           <Grid.Column mobile={12} tablet={4} computer={3}>
             <div className="facets">
               {data.facetsTitle && <h3>{data.facetsTitle}</h3>}
@@ -140,6 +140,8 @@ const RightColumnFacets = (props) => {
               />
             </div>
           </Grid.Column>
+        ) : (
+          ''
         )}
       </Grid.Row>
     </Grid>

--- a/src/components/manage/Blocks/Search/layout/TopSideFacets.jsx
+++ b/src/components/manage/Blocks/Search/layout/TopSideFacets.jsx
@@ -111,7 +111,7 @@ const TopSideFacets = (props) => {
               />
             )}
           </div>
-          {data.facets?.length > 0 ? (
+          {data.facets?.length > 0 && (
             <div className="facets">
               {data.facetsTitle && <h3>{data.facetsTitle}</h3>}
               <Grid verticalAlign="bottom" columns={12}>
@@ -129,8 +129,6 @@ const TopSideFacets = (props) => {
                 />
               </Grid>
             </div>
-          ) : (
-            ''
           )}
           <SearchDetails text={searchedText} total={totalItems} as="h5" />
         </Grid.Column>

--- a/src/components/manage/Blocks/Search/layout/TopSideFacets.jsx
+++ b/src/components/manage/Blocks/Search/layout/TopSideFacets.jsx
@@ -111,7 +111,7 @@ const TopSideFacets = (props) => {
               />
             )}
           </div>
-          {data.facets?.length > 0 && (
+          {data.facets?.length > 0 ? (
             <div className="facets">
               {data.facetsTitle && <h3>{data.facetsTitle}</h3>}
               <Grid verticalAlign="bottom" columns={12}>
@@ -129,6 +129,8 @@ const TopSideFacets = (props) => {
                 />
               </Grid>
             </div>
+          ) : (
+            ''
           )}
           <SearchDetails text={searchedText} total={totalItems} as="h5" />
         </Grid.Column>


### PR DESCRIPTION
Fixes this little bugger. I can't really understand why something like this happens sometimes with the `&&` based conditional rendering

![image](https://user-images.githubusercontent.com/141568/171984915-ecdaced2-71c4-4592-860a-5c1dd63e6f8b.png)
