### PR TITLE
Fix visibility of toolbar workflow dropdown for more states as fitting in .toolbar-content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Fix visibility of toolbar workflow dropdown for more states as fitting in .toolbar-content. @ksuess
+
 ### Internal
 
 ### Documentation

--- a/theme/themes/pastanaga/extras/toolbar.less
+++ b/theme/themes/pastanaga/extras/toolbar.less
@@ -295,8 +295,8 @@ body:not(.has-sidebar):not(.has-sidebar-collapsed) {
 
   .toolbar-content {
     z-index: 3;
+    overflow: visible;
     box-shadow: 0 1px 2px 0 #c7d5d8;
-    overflow-y: auto;
   }
 
   .pusher-puller {


### PR DESCRIPTION
all states should be visible or at least to be scrolled into view.