### PR TITLE
mock all loadable libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Internal
 
+-  mock all loadable libraries. @mamico
+
 ### Documentation
 
 ## 16.0.0-alpha.11 (2022-06-21)

--- a/cypress/tests/core/blocks/blocks.js
+++ b/cypress/tests/core/blocks/blocks.js
@@ -204,7 +204,9 @@ describe('Blocks Tests', () => {
       'be.visible',
     );
 
-    cy.get('.celled.fixed.table tr:first-child() th:nth-child(2)').click();
+    cy.get('.celled.fixed.table tr:first-child() th:nth-child(2)').click({
+      waitForAnimations: false,
+    });
 
     // without the second click the test fails. so this makes the test green.
     cy.get('.celled.fixed.table tr:first-child() th:nth-child(2)').click();

--- a/src/helpers/Loadable/__mocks__/Loadable.js
+++ b/src/helpers/Loadable/__mocks__/Loadable.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { loadables } from '@plone/volto/config/Loadables';
+import config from '@plone/volto/registry';
+const loadables = config.settings.loadables;
 
 let mockAllLoadables = Object.create(null);
 


### PR DESCRIPTION
Adding more libraries for `lazyloading` is not evaluated in the mock of Loadable, my suggestion is to use `config.settings.loadables` in mock where the lazy loadable libraries are actually registered.

i.e.
https://github.com/RedTurtle/design-volto-theme/blob/master/src/config/italiaConfig.js#L112