### PR TITLE
Fix docs configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 
 ### Documentation
 
+- Remove sphinx_sitemap configuration because Volto's docs are now imported into the main docs, making this setting unnecessary. @stevepiercy
+- Set the ogp_site_url to main docs, instead of training. @stevepiercy
+
 ## 16.0.0-alpha.11 (2022-06-21)
 
 ### Feature

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -164,7 +164,7 @@ graphviz_output_format = "svg"
 
 # -- OpenGraph configuration ----------------------------------
 
-ogp_site_url = "https://training.plone.org/5/"
+ogp_site_url = "https://6.dev-docs.plone.org/"
 ogp_description_length = 200
 ogp_image = "https://docs.plone.org/_static/Plone_logo_square.png"
 ogp_site_name = "Plone Documentation"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -59,7 +59,6 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.todo",
     "sphinx_copybutton",
-    "sphinx_sitemap",
     "sphinxcontrib.spelling",
     "sphinxext.opengraph",
 ]
@@ -226,9 +225,6 @@ html_title = "%(project)s v%(release)s" % {"project": project, "release": releas
 
 # If false, no index is generated.
 html_use_index = True
-
-# Used by sphinx_sitemap to generate a sitemap
-html_baseurl = "https://docs.voltocms.com/"
 
 # -- Options for HTML help output -------------------------------------------------
 


### PR DESCRIPTION
- Remove sphinx_sitemap configuration because Volto's docs are now imported into the main docs, making this setting unnecessary.
- Set the ogp_site_url to main docs, instead of training.
