### PR TITLE
`aria-*` attributes are now parsed correctly by jsx-lexer 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Documentation
 
+- `aria-*` attributes are now parsed correctly by jsx-lexer 2.0. @stevepiercy
+
 ## 16.0.0-alpha.12 (2022-07-13)
 
 ### Feature

--- a/docs/source/developer-guidelines/accessibility-guidelines.md
+++ b/docs/source/developer-guidelines/accessibility-guidelines.md
@@ -19,7 +19,7 @@ If available, use the translation machinery available to make the label appear i
 
 Example:
 
-```text
+```jsx
 <button className="cancel" aria-label="Cancel" onClick={() => this.onCancel()}>
   <Icon
     name={clearSVG}


### PR DESCRIPTION
## Before

![Screen Shot 2022-07-15 at 2 26 02 AM](https://user-images.githubusercontent.com/102112/179196756-82c84ec2-02cc-47b2-97c5-3f68d74f4e36.png)

## After

![Screen Shot 2022-07-15 at 2 26 10 AM](https://user-images.githubusercontent.com/102112/179196748-6e4ad958-ca61-47a9-948d-d6643e92a0e7.png)
