### PR TITLE
Fix flaky cypress tests (block-listing)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 ### Bugfix
 
 - Fix edge cases in Cypress flaky tests when the Edit component was loaded without loading the type schema. @sneridagh & @davisagli
+- Fix edge cases in Cypress flaky tests when the Edit component was loaded for the wrong content path. @davisagli
 
 ### Internal
 

--- a/src/storeProtectLoadUtils.js
+++ b/src/storeProtectLoadUtils.js
@@ -32,6 +32,7 @@ export const protectLoadStart = ({ dispatch, getState }) => (next) => (
       const { location } = action.payload;
       const { pathname: path } = location;
       const currentPath = getState().router.location.pathname;
+      const result = next(action);
       if (isCmsUi(path)) {
         // Next path: isCmsUI, Non Content. There is no
         // loading here, so skip counting altogether.
@@ -51,7 +52,7 @@ export const protectLoadStart = ({ dispatch, getState }) => (next) => (
           resetBeforeFetch: isCmsUi(currentPath),
         });
       }
-      return next(action);
+      return result;
     default:
       return next(action);
   }


### PR DESCRIPTION
If redux middleware dispatches a new action while processing a LOCATION_CHANGED action, then connected-react-router will process the new action while the history still has the old path and will end up updating the history location extra times (see https://github.com/supasate/connected-react-router/issues/309), for example if trying to navigate from /my-page to /my-page/edit then the location will change from /my-page -> /my-page/edit -> /my-page -> /my-page/edit. This in turn was contributing to some flaky tests if the Edit component's asyncConnect handlers get started while the location is set to the old path, and loads the wrong content.

The workaround is to make sure that the middleware in storeProtectLoadUtils.js gives the LOCATION_CHANGED action a chance to be fully processed before dispatching additional actions.