### PR TITLE
Pass the correct id to the blocks in RenderBlocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - complete pt_BR translation @ericof
 - Fix action `listUsers`. Provide default. @ksuess
+- Provide the correct id to the blocks wrapped by StyleWrapper. @razvanMiu
 
 ### Internal
 

--- a/src/components/theme/View/RenderBlocks.jsx
+++ b/src/components/theme/View/RenderBlocks.jsx
@@ -38,7 +38,7 @@ const RenderBlocks = (props) => {
         });
 
         return Block ? (
-          <StyleWrapper key={block} {...props} data={blockData}>
+          <StyleWrapper key={block} {...props} id={block} data={blockData}>
             <Block
               id={block}
               metadata={metadata}


### PR DESCRIPTION
StyleWrapper will rewrite its children props and will override the id with the one from `props` so we need to specify the correct id of the block.
We can also remove some of the props passed to the Block as StyleWrapper passes all its props to it.