### PR TITLE
Fix content loading in `DefaultView` infinite loop if a listing block…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Fix content loading in `DefaultView` infinite loop if a listing block with no query is present. @sneridagh
+
 ### Internal
 
 ### Documentation


### PR DESCRIPTION
… with no query is present.

@avoinea don't know if we could improve the locking behaviour at some point. I tried and seemed not trivial :( For now, I added a comment in the View.

Anyways, if we move to a non AsyncConnect infrastructure and namespaced paths cached queries the situation would improve.

Refinement of: https://github.com/plone/volto/pull/3480