### PR TITLE
Simplify over the existing Component Registry API, The `component` ke…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - change password-reset url to be consistent with Plone configuration @erral
 - Simplify over the existing Component Registry API. The `component` key has been flattened for simplification and now it's mapped directly to the `component` argument of `registerComponent`. @sneridagh
 
-See https://docs.voltocms.com/upgrade-guide/ for more information.
+See https://6.dev-docs.plone.org/volto/upgrade-guide/index.html for more information.
 
 ### Feature
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Breaking
 
 - change password-reset url to be consistent with Plone configuration @erral
+- Simplify over the existing Component Registry API. The `component` key has been flattened for simplification and now it's mapped directly to the `component` argument of `registerComponent`. @sneridagh
+
+See https://docs.voltocms.com/upgrade-guide/ for more information.
 
 ### Feature
 

--- a/docs/source/configuration/component-registry.md
+++ b/docs/source/configuration/component-registry.md
@@ -17,9 +17,7 @@ import MyToolbarComponent from './MyToolbarComponent'
 
 config.registerComponent({
   name: 'Toolbar',
-  component: {
-    component: MyToolbarComponent,
-  },
+  component: MyToolbarComponent,
 });
 ```
 
@@ -48,9 +46,7 @@ import MyTeaserNewsItemComponent from './MyTeaserNewsItemComponent'
 
 config.registerComponent({
     name: 'Teaser',
-    component: {
-      component: MyTeaserNewsItemComponent,
-    },
+    component: MyTeaserNewsItemComponent,
     dependencies: 'News Item',
   });
 ```
@@ -72,16 +68,12 @@ import MyTeaserNewsItemComponent from './MyTeaserNewsItemComponent'
 
 config.registerComponent({
     name: 'Teaser',
-    component: {
-      component: MyTeaserDefaultComponent,
-    },
+    component: MyTeaserDefaultComponent,
   });
 
 config.registerComponent({
     name: 'Teaser',
-    component: {
-      component: MyTeaserNewsItemComponent,
-    },
+    component: MyTeaserNewsItemComponent,
     dependencies: 'News Item',
   });
 ```

--- a/docs/source/upgrade-guide/index.md
+++ b/docs/source/upgrade-guide/index.md
@@ -216,6 +216,17 @@ It maintains signature compatibility with `registry.resolve` but introduces new 
 
 See documentation for more information.
 
+````{note}
+The `component` argument changed in alpha 23. The `component` key has been flattened for simplification and now it's mapped directly to the `component` argument of `registerComponent`:
+
+```js
+config.registerComponent({
+    name: 'Teaser',
+    component: MyTeaserDefaultComponent,
+  });
+```
+````
+
 (volto-upgrade-guide-15.x.x)=
 
 ## Upgrading to Volto 15.x.x

--- a/docs/source/upgrade-guide/index.md
+++ b/docs/source/upgrade-guide/index.md
@@ -216,8 +216,9 @@ It maintains signature compatibility with `registry.resolve` but introduces new 
 
 See documentation for more information.
 
-````{note}
-The `component` argument changed in alpha 23. The `component` key has been flattened for simplification and now it's mapped directly to the `component` argument of `registerComponent`:
+````{versionchanged} 16.0.0-alpha.23
+The `component` argument changed in 16.0.0-alpha.23.
+The `component` key has been flattened for simplification and now it's mapped directly to the `component` argument of `registerComponent`:
 
 ```js
 config.registerComponent({

--- a/src/components/theme/Component/Component.test.jsx
+++ b/src/components/theme/Component/Component.test.jsx
@@ -21,9 +21,7 @@ describe('Component component :P', () => {
   it('Render a Component in the registry using dependencies array', () => {
     config.registerComponent({
       name: 'Teaser',
-      component: {
-        component: (props) => <div>this is the Teaser component</div>,
-      },
+      component: (props) => <div>this is the Teaser component</div>,
       dependencies: 'News Item',
     });
     const { container } = render(

--- a/src/registry.js
+++ b/src/registry.js
@@ -119,7 +119,7 @@ class Config {
       }
       const componentName = `${name}${depsString ? `|${depsString}` : ''}`;
 
-      this._data.components[componentName] = component;
+      this._data.components[componentName] = { component };
     }
   }
 }

--- a/src/registry.test.js
+++ b/src/registry.test.js
@@ -35,9 +35,7 @@ describe('registry', () => {
   it('registers and gets a component by name (as string)', () => {
     config.registerComponent({
       name: 'Toolbar.Bar',
-      component: {
-        component: 'this is a Bar component',
-      },
+      component: 'this is a Bar component',
     });
     expect(config.getComponent('Toolbar.Bar').component).toEqual(
       'this is a Bar component',
@@ -46,9 +44,7 @@ describe('registry', () => {
   it('registers and gets a component by name (as an object)', () => {
     config.registerComponent({
       name: 'Toolbar.Bar',
-      component: {
-        component: 'this is a Bar component',
-      },
+      component: 'this is a Bar component',
     });
     expect(config.getComponent({ name: 'Toolbar.Bar' }).component).toEqual(
       'this is a Bar component',
@@ -57,9 +53,7 @@ describe('registry', () => {
   it('registers a component by name with dependencies', () => {
     config.registerComponent({
       name: 'Toolbar.Bar',
-      component: {
-        component: 'this is a Bar component',
-      },
+      component: 'this is a Bar component',
       dependencies: 'News Item',
     });
     expect(
@@ -70,9 +64,7 @@ describe('registry', () => {
   it('registers a component by name with dependencies array', () => {
     config.registerComponent({
       name: 'Toolbar.Bar',
-      component: {
-        component: 'this is a Bar component',
-      },
+      component: 'this is a Bar component',
       dependencies: ['News Item', 'StringFieldWidget'],
     });
     expect(


### PR DESCRIPTION
…y has been flattened for simplification and now it's mapped directly to the `component` argument of `registerComponent`.