### PR TITLE
Remove soft hyphens from the title tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Feature
 
 - Show the content type of the content object you are adding/editing in the sidebar @robgietema
+- Remove soft hyphens from the title tag @davisagli
 
 ### Bugfix
 

--- a/src/components/theme/ContentMetadataTags/ContentMetadataTags.jsx
+++ b/src/components/theme/ContentMetadataTags/ContentMetadataTags.jsx
@@ -48,7 +48,7 @@ const ContentMetadataTags = (props) => {
   return (
     <>
       <Helmet>
-        <title>{seo_title || title}</title>
+        <title>{(seo_title || title)?.replace(/\u00AD/g, '')}</title>
         <meta name="description" content={seo_description || description} />
         <meta
           property="og:title"


### PR DESCRIPTION
(so they don't appear in browser tabs)

I'm not sure what the best way is to write a test for the metadata rendered by react-helmet