### PR TITLE
Make `internalApiPath` client aware, since there are some corner case…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Feature
 
+- Make `internalApiPath` client aware, since there are some corner cases when the client needs to know it to properly handle API server URLs @sneridagh
+
 ### Bugfix
 
 - Fix sitemap.xml.gz @robgietema

--- a/src/start-client.jsx
+++ b/src/start-client.jsx
@@ -49,6 +49,14 @@ export default () => {
   if (window.env.publicURL) {
     config.settings.publicURL = window.env.publicURL;
   }
+  // There are some cases that the client needs to know the internal server URL
+  // too, as some helpers (isInternalURL and flattenToAppURL) need to be aware of it.
+  // This is specially important when the hydration of the store coming from the first SSR
+  // request happens, since there all the server URLs might be the internalApiPath ones,
+  // and the client should be able to take care of them properly.
+  if (window.env.RAZZLE_INTERNAL_API_PATH) {
+    config.settings.internalApiPath = window.env.RAZZLE_INTERNAL_API_PATH;
+  }
   // TODO: To be removed when the use of the legacy traverse is deprecated.
   if (window.env.RAZZLE_LEGACY_TRAVERSE) {
     config.settings.legacyTraverse = true;


### PR DESCRIPTION
…s when the client needs to know it to properly handle API server URLs.

Fixes: #3584