### PR TITLE
Fix Image gallery listing block variation only gets 25 if no query is…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Bugfix
 
+- Fix Image gallery listing block variation only gets 25 if no query is set @sneridagh
+
 ### Internal
 
 ### Documentation

--- a/src/components/manage/Blocks/Listing/withQuerystringResults.jsx
+++ b/src/components/manage/Blocks/Listing/withQuerystringResults.jsx
@@ -89,6 +89,7 @@ export default function withQuerystringResults(WrappedComponent) {
             initialPath,
             {
               ...adaptedQuery,
+              b_size: 10000000000,
               query: [
                 {
                   i: 'path',


### PR DESCRIPTION
… set.

Having the custom variation query hardcoded in the `withQuerystringResults` HOC is a bit goofy, but this one fixes it. We need to find out a way that we could modify the query from the variation, and the HOC gets it, if necessary. But this is another story.