### PR TITLE
Fix grouping of the "users and groups" control panels (plone-users ca…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Fix grouping of the "users and groups" control panels (plone-users category) @sneridagh
+
 ### Internal
 
 ### Documentation

--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -3031,12 +3031,12 @@ msgstr "Benutzername"
 #: helpers/MessageLabels/MessageLabels
 # defaultMessage: Users
 msgid "Users"
-msgstr "Nutzer"
+msgstr "Benutzer"
 
 #: components/manage/Controlpanels/Controlpanels
 # defaultMessage: Users and Groups
 msgid "Users and Groups"
-msgstr "Nutzer und Gruppen"
+msgstr "Benutzer und Gruppen"
 
 #: helpers/Extensions/withBlockSchemaEnhancer
 # defaultMessage: Variation

--- a/src/components/manage/Controlpanels/Controlpanels.jsx
+++ b/src/components/manage/Controlpanels/Controlpanels.jsx
@@ -54,6 +54,10 @@ const messages = defineMessages({
     id: 'Users and Groups',
     defaultMessage: 'Users and Groups',
   },
+  usersControlPanelCategory: {
+    id: 'Users',
+    defaultMessage: 'Users',
+  },
   users: {
     id: 'Users',
     defaultMessage: 'Users',
@@ -176,17 +180,23 @@ class Controlpanels extends Component {
         },
         {
           '@id': '/users',
-          group: this.props.intl.formatMessage(messages.usersandgroups),
+          group: this.props.intl.formatMessage(
+            messages.usersControlPanelCategory,
+          ),
           title: this.props.intl.formatMessage(messages.users),
         },
         {
           '@id': '/usergroupmembership',
-          group: this.props.intl.formatMessage(messages.usersandgroups),
+          group: this.props.intl.formatMessage(
+            messages.usersControlPanelCategory,
+          ),
           title: this.props.intl.formatMessage(messages.usergroupmemberbership),
         },
         {
           '@id': '/groups',
-          group: this.props.intl.formatMessage(messages.usersandgroups),
+          group: this.props.intl.formatMessage(
+            messages.usersControlPanelCategory,
+          ),
           title: this.props.intl.formatMessage(messages.groups),
         },
       ]),

--- a/src/components/manage/Controlpanels/__snapshots__/Controlpanels.test.jsx.snap
+++ b/src/components/manage/Controlpanels/__snapshots__/Controlpanels.test.jsx.snap
@@ -321,7 +321,7 @@ exports[`Controlpanels renders a controlpanels component 1`] = `
       <div
         className="ui secondary segment"
       >
-        Users and Groups
+        Users
       </div>
       <div
         className="ui attached segment"
@@ -676,7 +676,7 @@ exports[`Controlpanels renders an additional control panel 1`] = `
       <div
         className="ui secondary segment"
       >
-        Users and Groups
+        Users
       </div>
       <div
         className="ui attached segment"


### PR DESCRIPTION
…tegory)

Complementary fixes for: https://github.com/plone/plone.restapi/issues/1482

Fixed:
<img width="1146" alt="image" src="https://user-images.githubusercontent.com/486927/187908529-f9215657-7f78-4b37-90b1-4cbdb8e330b7.png">


Before:
<img width="548" alt="image" src="https://user-images.githubusercontent.com/486927/187908578-a7b19e60-2b35-4bbe-99f7-9e1776f9a327.png">
