### PR TITLE
Use absolute dates instead of "x hours/days ago" in History view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Added placeholder param to widget, to change default placeholder @giuliaghisini
 - Add a headline (`headline` field) to the listing block schema by default @sneridagh
 - Add scroll into view setting to slate @robgietema
+- Use absolute dates instead of "x hours ago" in History view @steffenri
 
 ### Bugfix
 

--- a/src/components/manage/History/History.jsx
+++ b/src/components/manage/History/History.jsx
@@ -15,7 +15,7 @@ import { Portal } from 'react-portal';
 import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
 
 import {
-  FormattedRelativeDate,
+  FormattedDate,
   Icon as IconNext,
   Toolbar,
 } from '@plone/volto/components';
@@ -209,7 +209,7 @@ class History extends Component {
                   </Table.Cell>
                   <Table.Cell>{entry.actor.fullname}</Table.Cell>
                   <Table.Cell>
-                    <FormattedRelativeDate date={entry.time} />
+                    <FormattedDate date={entry.time} includeTime />
                   </Table.Cell>
                   <Table.Cell>{entry.comments}</Table.Cell>
                   <Table.Cell>

--- a/src/components/manage/History/__snapshots__/History.test.jsx.snap
+++ b/src/components/manage/History/__snapshots__/History.test.jsx.snap
@@ -91,7 +91,7 @@ exports[`History renders a history component 1`] = `
               dateTime="2017-04-19T14:09:36+02:00"
               title="Wednesday, April 19, 2017 at 12:09 PM"
             >
-              4 days ago
+              4/19/17, 12:09 PM
             </time>
           </td>
           <td
@@ -130,7 +130,7 @@ exports[`History renders a history component 1`] = `
               dateTime="2017-04-19T14:09:35+02:00"
               title="Wednesday, April 19, 2017 at 12:09 PM"
             >
-              4 days ago
+              4/19/17, 12:09 PM
             </time>
           </td>
           <td
@@ -192,7 +192,7 @@ exports[`History renders a history component 1`] = `
               dateTime="2017-04-19T14:09:34+02:00"
               title="Wednesday, April 19, 2017 at 12:09 PM"
             >
-              4 days ago
+              4/19/17, 12:09 PM
             </time>
           </td>
           <td


### PR DESCRIPTION
# Issue link:
https://github.com/plone/volto/issues/3620

# Old Screenshot:
![History (3)](https://user-images.githubusercontent.com/54619639/189670241-fe8689b7-387e-415f-9e19-8e5d0fe0526d.png)


# New Screenshot:
![History (2)](https://user-images.githubusercontent.com/54619639/189670284-1c69078c-143c-47ad-ae99-22a3e46fe890.png)
