### PR TITLE
Fix the wrong link alteration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Bugfix
 
+- Fix wrong link alteration in UrlWidget @dobri1408
 - Fix "cannot have two html5 backends at the same time" error @davisagli
 - Reset filter in folder contents when navigating @robgietema
 - Fix bug showing incorrect history after a revert action @robgietema

--- a/src/components/manage/Widgets/UrlWidget.jsx
+++ b/src/components/manage/Widgets/UrlWidget.jsx
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
 import { Input, Button } from 'semantic-ui-react';
 import { FormFieldWrapper, Icon } from '@plone/volto/components';
 import {
-  addAppURL,
+  toPublicURL,
   isInternalURL,
   flattenToAppURL,
   URLUtils,
@@ -70,7 +70,7 @@ export const UrlWidget = (props) => {
 
     setValue(newValue);
 
-    newValue = isInternalURL(newValue) ? addAppURL(newValue) : newValue;
+    newValue = isInternalURL(newValue) ? toPublicURL(newValue) : newValue;
 
     if (!isInternalURL(newValue) && newValue.length > 0) {
       const checkedURL = URLUtils.checkAndNormalizeUrl(newValue);


### PR DESCRIPTION
In this pr, I propose to modify the way the link is altered when it is an internal link. I saw that if a link is an internal one like "/front-page", the UrlWidget component is transforming it in "settings.apiPath/frontpage" through the function addAppURL. But I think that this is not right in every case. For example what if the settings.apiPath is different from the link that is running volto on. So, if you started volto with the following command "RAZZLE_API_PATH=http://localhost:8080/circularity yarn start" the volto will be running on localhost:3000 and the settings.apiPath will be http://localhost:8080/circularity. So, this means that we will be altering the link like this "http://localhost:8080/circularity/frontpage" instead of "http://localhost:3000/frontpage". This is why I think that instead of altering the internal link with the function addAppURL is better to alter it with toPublicURL, which will chose always the right way, the one that matched where the volto is running.
This case that I am talking about, actually happened in production on one of our EEA websites, the Circular Economy Website.
