### PR TITLE
Multiple async props extenders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Add `matchAllRoutes` to AsyncConnect so that it matches all configured `asyncPropsExtenders` @tiberiuichim
+
 ### Internal
 
 ### Documentation

--- a/src/helpers/AsyncConnect/AsyncConnect.test.js
+++ b/src/helpers/AsyncConnect/AsyncConnect.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Provider, connect } from 'react-redux';
 import { withRouter, StaticRouter, MemoryRouter } from 'react-router';
-import { renderRoutes } from 'react-router-config';
+import { matchRoutes, renderRoutes } from 'react-router-config';
 import { createStore, combineReducers } from 'redux';
 import { render } from '@testing-library/react';
 
@@ -498,5 +498,21 @@ describe('<ReduxAsyncConnect />', () => {
       );
       expect(serial).toBe(1);
     });
+  });
+
+  it('Matches multiple asyncPropExtenders', function () {
+    //
+    const routes = [
+      {
+        key: 'nav',
+        path: '/',
+      },
+      {
+        key: 'footer',
+        path: '/',
+      },
+    ];
+    const match = matchRoutes(routes, '/en');
+    expect(match.length).toBe(2);
   });
 });

--- a/src/helpers/AsyncConnect/AsyncConnect.test.js
+++ b/src/helpers/AsyncConnect/AsyncConnect.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Provider, connect } from 'react-redux';
 import { withRouter, StaticRouter, MemoryRouter } from 'react-router';
-import { matchRoutes, renderRoutes } from 'react-router-config';
+import { renderRoutes } from 'react-router-config';
 import { createStore, combineReducers } from 'redux';
 import { render } from '@testing-library/react';
 
@@ -10,6 +10,7 @@ import reduxAsyncConnect from '@plone/volto/reducers/asyncConnect/asyncConnect';
 
 import { AsyncConnectWithContext, AsyncConnect } from './AsyncConnect'; // , AsyncConnect
 import { asyncConnect, loadOnServer } from './';
+import { matchAllRoutes } from './utils';
 
 import '@testing-library/jest-dom/extend-expect';
 
@@ -501,7 +502,6 @@ describe('<ReduxAsyncConnect />', () => {
   });
 
   it('Matches multiple asyncPropExtenders', function () {
-    //
     const routes = [
       {
         key: 'nav',
@@ -511,8 +511,16 @@ describe('<ReduxAsyncConnect />', () => {
         key: 'footer',
         path: '/',
       },
+      {
+        key: 'breads',
+        path: '/something',
+      },
     ];
-    const match = matchRoutes(routes, '/en');
+    const match = matchAllRoutes(routes, '/en');
     expect(match.length).toBe(2);
+    expect(match.map(({ route }) => route.key)).toStrictEqual([
+      'nav',
+      'footer',
+    ]);
   });
 });

--- a/src/helpers/AsyncConnect/index.js
+++ b/src/helpers/AsyncConnect/index.js
@@ -1,7 +1,7 @@
 import { withRouter } from 'react-router';
 import { connect } from 'react-redux';
 import config from '@plone/volto/registry';
-import { matchRoutes } from 'react-router-config';
+import { matchAllRoutes } from './utils';
 
 import {
   load,
@@ -57,7 +57,7 @@ const wrapWithDispatch = (Component, asyncItems = []) => {
 
 const applyExtenders = (asyncItems, pathname) => {
   const { asyncPropsExtenders = [] } = config.settings;
-  const extenders = matchRoutes(asyncPropsExtenders, pathname);
+  const extenders = matchAllRoutes(asyncPropsExtenders, pathname);
 
   const foundAsyncItems = extenders.reduce(
     (acc, extender) => extender.route.extend(acc),

--- a/src/helpers/AsyncConnect/utils.js
+++ b/src/helpers/AsyncConnect/utils.js
@@ -1,3 +1,4 @@
+import { matchRoutes } from 'react-router-config';
 export function isPromise(obj) {
   return typeof obj === 'object' && obj && obj.then instanceof Function;
 }
@@ -29,3 +30,11 @@ let immutableStateFunc = identity;
 let mutableStateFunc = identity;
 export const getImmutableState = (state) => immutableStateFunc(state);
 export const getMutableState = (state) => mutableStateFunc(state);
+
+export const matchAllRoutes = (routes, pathname) => {
+  const matching = routes.reduce(
+    (acc, route) => [...acc, ...matchRoutes([route], pathname)],
+    [],
+  );
+  return matching;
+};


### PR DESCRIPTION
Stupidly, the matchRoutes, although returns an Array, it does not match all possible routes. This made it impossible to use multiple asyncPropsExtenders for the same route.