### PR TITLE
Close glossary backticks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Documentation
 
+- Fix Sphinx warning `WARNING: glossary terms must not be separated by empty lines` by closing unclosed glossary directive's triple backticks. @stevepiercy
+
 ## 16.0.0-alpha.34 (2022-09-17)
 
 ### Breaking

--- a/docs/source/configuration/settings-reference.md
+++ b/docs/source/configuration/settings-reference.md
@@ -291,6 +291,7 @@ layoutViewsNamesMapping
       },
     })
     ```
+```
 
 ## Server-specific serverConfig
 


### PR DESCRIPTION
This PR fixes warnings when building the docs: `WARNING: glossary terms must not be separated by empty lines` by closing an unclosed glossary entry's triple-backticks.