### PR TITLE
Fix backspace selection error.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Fix selection error when pressing backspace @robgietema
+
 ### Internal
 
 ### Documentation

--- a/packages/volto-slate/src/blocks/Text/DefaultTextBlockEditor.jsx
+++ b/packages/volto-slate/src/blocks/Text/DefaultTextBlockEditor.jsx
@@ -152,13 +152,8 @@ export const DefaultTextBlockEditor = (props) => {
       if (defaultSelection) {
         const selection = parseDefaultSelection(editor, defaultSelection);
         if (selection) {
-          setTimeout(() => {
-            Transforms.select(editor, selection);
-            saveSlateBlockSelection(block, null);
-          }, 120);
-          // TODO: use React sync render API
-          // without setTimeout, the join is not correct. Slate uses internally
-          // a 100ms throttle, so setting to a bigger value seems to help
+          Transforms.select(editor, selection);
+          saveSlateBlockSelection(block, null);
         }
       }
     },


### PR DESCRIPTION
Since setting the selection has a timeout an error occurs when you press backspace multiple times. This is because the editor tries to set the selection of the first update when the content is already updated and so the selection is out of range. The issue which is raised in the comments is tested and also works without the timeout;

- moving between blocks with up/down arrows
- clicking inside the text of a block should not reset the cursor position to head/end of block text
- split the block with enter in the text