### PR TITLE
Press Enter in some blocks does not focus on the text block below

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ### Bugfix
 
+- Fix Press Enter in some blocks does not focus on the text block below #3647 @dobri1408
 - Add `matchAllRoutes` to AsyncConnect so that it matches all configured `asyncPropsExtenders` @tiberiuichim
 - Fix acceptence test groups controlpanel @ksuess
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Feature
 
 ### Bugfix
+
 - Fix the typo in change workflow status dialog in "de" @iRohitSingh
 
 - Fix selection error when pressing backspace @robgietema

--- a/cypress/tests/core/blocks/blocks-autofocus.js
+++ b/cypress/tests/core/blocks/blocks-autofocus.js
@@ -1,0 +1,172 @@
+describe('New Block Auto Focus Tests', () => {
+  beforeEach(() => {
+    // given a logged in editor and a page in edit mode
+    cy.visit('/');
+    cy.autologin();
+    cy.createContent({
+      contentType: 'Document',
+      contentId: 'my-page',
+      contentTitle: 'My Page',
+    });
+    cy.visit('/my-page');
+    cy.waitForResourceToLoad('@navigation');
+    cy.waitForResourceToLoad('@breadcrumbs');
+    cy.waitForResourceToLoad('@actions');
+    cy.waitForResourceToLoad('@types');
+    cy.waitForResourceToLoad('my-page');
+    cy.navigate('/my-page/edit');
+  });
+
+  it('Press Enter on a description block adds new autofocused default block', () => {
+    cy.intercept('GET', '/**/my-page').as('content');
+    cy.intercept('PATCH', '*').as('save');
+    // when I add a text block
+    //add listing block
+    cy.getSlate().click();
+    cy.get('button.block-add-button').click();
+    cy.get('.blocks-chooser .title').contains('Text').click();
+    cy.get('.blocks-chooser .text').contains('Description').click();
+    cy.get('.documentDescription').first().click().type('{enter}');
+    cy.get('*[class^="block-editor"]')
+      .eq(2)
+      .within(() => {
+        return cy.get('.selected');
+      });
+  });
+
+  it('Press Enter on a text block adds new autofocused default block', () => {
+    cy.intercept('GET', '/**/my-page').as('content');
+    cy.intercept('PATCH', '*').as('save');
+    // when I add a text block
+    //add listing block
+    cy.getSlate().click();
+    cy.get('button.block-add-button').click();
+    cy.get('.blocks-chooser .title').contains('Text').click();
+    cy.get('.blocks-chooser .text').contains('Text').click();
+    cy.get('.text-slate-editor-inner').first().click().type('{enter}');
+    cy.get('*[class^="block-editor"]')
+      .eq(2)
+      .within(() => {
+        return cy.get('.selected');
+      });
+  });
+
+  it('Press Enter on a image block adds new autofocused default block', () => {
+    cy.intercept('GET', '/**/my-page').as('content');
+    cy.intercept('PATCH', '*').as('save');
+    // when I add a text block
+    //add listing block
+    cy.getSlate().click();
+    cy.get('button.block-add-button').click();
+    cy.get('.blocks-chooser .title').contains('Media').click();
+    cy.get('.blocks-chooser .media').contains('Image').click();
+    cy.get('.block-editor-image').first().click().type('{enter}');
+    cy.get('*[class^="block-editor"]')
+      .eq(2)
+      .within(() => {
+        return cy.get('.selected');
+      });
+  });
+
+  it('Press Enter on a video block adds new autofocused default block', () => {
+    cy.intercept('GET', '/**/my-page').as('content');
+    cy.intercept('PATCH', '*').as('save');
+    // when I add a text block
+    //add listing block
+    cy.getSlate().click();
+    cy.get('button.block-add-button').click();
+    cy.get('.blocks-chooser .title').contains('Media').click();
+    cy.get('.blocks-chooser .media').contains('Video').click();
+    cy.get('.block-editor-video').first().click().type('{enter}');
+    cy.get('*[class^="block-editor"]')
+      .eq(2)
+      .within(() => {
+        return cy.get('.selected');
+      });
+  });
+
+  it('Press Enter on a listing block adds new autofocused default block', () => {
+    cy.intercept('GET', '/**/my-page').as('content');
+    cy.intercept('PATCH', '*').as('save');
+    // when I add a text block
+    //add listing block
+    cy.getSlate().click();
+    cy.get('button.block-add-button').click();
+    cy.get('.blocks-chooser .title').contains('Common').click();
+    cy.get('.blocks-chooser .common').contains('Listing').click();
+    cy.get('.block-editor-listing').first().click().type('{enter}');
+    cy.get('*[class^="block-editor"]')
+      .eq(2)
+      .within(() => {
+        return cy.get('.selected');
+      });
+  });
+
+  it('Press Enter on a table of contents block adds new autofocused default block', () => {
+    cy.intercept('GET', '/**/my-page').as('content');
+    cy.intercept('PATCH', '*').as('save');
+    // when I add a text block
+    //add listing block
+    cy.getSlate().click();
+    cy.get('button.block-add-button').click();
+    cy.get('.blocks-chooser .title').contains('Common').click();
+    cy.get('.blocks-chooser .common').contains('Table of Contents').click();
+    cy.get('.block-editor-toc').first().click().type('{enter}');
+    cy.get('*[class^="block-editor"]')
+      .eq(2)
+      .within(() => {
+        return cy.get('.selected');
+      });
+  });
+
+  it('Press Enter on a maps block adds new autofocused default block', () => {
+    cy.intercept('GET', '/**/my-page').as('content');
+    cy.intercept('PATCH', '*').as('save');
+    // when I add a text block
+    //add listing block
+    cy.getSlate().click();
+    cy.get('button.block-add-button').click();
+    cy.get('.blocks-chooser .title').contains('Common').click();
+    cy.get('.blocks-chooser .common').contains('Maps').click();
+    cy.get('.block-editor-maps').first().click().type('{enter}');
+    cy.get('*[class^="block-editor"]')
+      .eq(2)
+      .within(() => {
+        return cy.get('.selected');
+      });
+  });
+
+  it('Press Enter on a html block adds new autofocused default block', () => {
+    cy.intercept('GET', '/**/my-page').as('content');
+    cy.intercept('PATCH', '*').as('save');
+    // when I add a text block
+    //add listing block
+    cy.getSlate().click();
+    cy.get('button.block-add-button').click();
+    cy.get('.blocks-chooser .title').contains('Common').click();
+    cy.get('.blocks-chooser .common').contains('HTML').click();
+    cy.get('.block-editor-html').first().click().type('{enter}');
+    cy.get('*[class^="block-editor"]')
+      .eq(2)
+      .within(() => {
+        return cy.get('.selected');
+      });
+  });
+
+  it('Press Enter on a search block adds new autofocused default block', () => {
+    cy.intercept('GET', '/**/my-page').as('content');
+    cy.intercept('PATCH', '*').as('save');
+    // when I add a text block
+    //add listing block
+    cy.getSlate().click();
+    cy.get('button.block-add-button').click();
+    cy.get('.blocks-chooser .title').contains('Common').click();
+    cy.get('.blocks-chooser .common').contains('Search').click();
+    cy.get('.block-editor-search').first().click().type('{enter}');
+    cy.get('*[class^="block-editor"]')
+      .eq(2)
+      .within(() => {
+        return cy.get('.selected');
+      });
+  });
+});

--- a/cypress/tests/core/blocks/blocks-autofocus.js
+++ b/cypress/tests/core/blocks/blocks-autofocus.js
@@ -15,15 +15,15 @@ describe('New Block Auto Focus Tests', () => {
     cy.waitForResourceToLoad('@types');
     cy.waitForResourceToLoad('my-page');
     cy.navigate('/my-page/edit');
-  });
-
-  it('Press Enter on a description block adds new autofocused default block', () => {
     cy.intercept('GET', '/**/my-page').as('content');
     cy.intercept('PATCH', '*').as('save');
     // when I add a text block
     //add listing block
     cy.getSlate().click();
     cy.get('button.block-add-button').click();
+  });
+
+  it('Press Enter on a description block adds new autofocused default block', () => {
     cy.get('.blocks-chooser .title').contains('Text').click();
     cy.get('.blocks-chooser .text').contains('Description').click();
     cy.get('.documentDescription').first().click().type('{enter}');
@@ -35,12 +35,6 @@ describe('New Block Auto Focus Tests', () => {
   });
 
   it('Press Enter on a text block adds new autofocused default block', () => {
-    cy.intercept('GET', '/**/my-page').as('content');
-    cy.intercept('PATCH', '*').as('save');
-    // when I add a text block
-    //add listing block
-    cy.getSlate().click();
-    cy.get('button.block-add-button').click();
     cy.get('.blocks-chooser .title').contains('Text').click();
     cy.get('.blocks-chooser .text').contains('Text').click();
     cy.get('.text-slate-editor-inner').first().click().type('{enter}');
@@ -52,12 +46,6 @@ describe('New Block Auto Focus Tests', () => {
   });
 
   it('Press Enter on a image block adds new autofocused default block', () => {
-    cy.intercept('GET', '/**/my-page').as('content');
-    cy.intercept('PATCH', '*').as('save');
-    // when I add a text block
-    //add listing block
-    cy.getSlate().click();
-    cy.get('button.block-add-button').click();
     cy.get('.blocks-chooser .title').contains('Media').click();
     cy.get('.blocks-chooser .media').contains('Image').click();
     cy.get('.block-editor-image').first().click().type('{enter}');
@@ -69,12 +57,6 @@ describe('New Block Auto Focus Tests', () => {
   });
 
   it('Press Enter on a video block adds new autofocused default block', () => {
-    cy.intercept('GET', '/**/my-page').as('content');
-    cy.intercept('PATCH', '*').as('save');
-    // when I add a text block
-    //add listing block
-    cy.getSlate().click();
-    cy.get('button.block-add-button').click();
     cy.get('.blocks-chooser .title').contains('Media').click();
     cy.get('.blocks-chooser .media').contains('Video').click();
     cy.get('.block-editor-video').first().click().type('{enter}');
@@ -86,12 +68,6 @@ describe('New Block Auto Focus Tests', () => {
   });
 
   it('Press Enter on a listing block adds new autofocused default block', () => {
-    cy.intercept('GET', '/**/my-page').as('content');
-    cy.intercept('PATCH', '*').as('save');
-    // when I add a text block
-    //add listing block
-    cy.getSlate().click();
-    cy.get('button.block-add-button').click();
     cy.get('.blocks-chooser .title').contains('Common').click();
     cy.get('.blocks-chooser .common').contains('Listing').click();
     cy.get('.block-editor-listing').first().click().type('{enter}');
@@ -103,12 +79,6 @@ describe('New Block Auto Focus Tests', () => {
   });
 
   it('Press Enter on a table of contents block adds new autofocused default block', () => {
-    cy.intercept('GET', '/**/my-page').as('content');
-    cy.intercept('PATCH', '*').as('save');
-    // when I add a text block
-    //add listing block
-    cy.getSlate().click();
-    cy.get('button.block-add-button').click();
     cy.get('.blocks-chooser .title').contains('Common').click();
     cy.get('.blocks-chooser .common').contains('Table of Contents').click();
     cy.get('.block-editor-toc').first().click().type('{enter}');
@@ -120,12 +90,6 @@ describe('New Block Auto Focus Tests', () => {
   });
 
   it('Press Enter on a maps block adds new autofocused default block', () => {
-    cy.intercept('GET', '/**/my-page').as('content');
-    cy.intercept('PATCH', '*').as('save');
-    // when I add a text block
-    //add listing block
-    cy.getSlate().click();
-    cy.get('button.block-add-button').click();
     cy.get('.blocks-chooser .title').contains('Common').click();
     cy.get('.blocks-chooser .common').contains('Maps').click();
     cy.get('.block-editor-maps').first().click().type('{enter}');
@@ -137,11 +101,6 @@ describe('New Block Auto Focus Tests', () => {
   });
 
   it('Press Enter on a html block adds new autofocused default block', () => {
-    cy.intercept('GET', '/**/my-page').as('content');
-    cy.intercept('PATCH', '*').as('save');
-    // when I add a text block
-    //add listing block
-    cy.getSlate().click();
     cy.get('button.block-add-button').click();
     cy.get('.blocks-chooser .title').contains('Common').click();
     cy.get('.blocks-chooser .common').contains('HTML').click();
@@ -154,11 +113,6 @@ describe('New Block Auto Focus Tests', () => {
   });
 
   it('Press Enter on a search block adds new autofocused default block', () => {
-    cy.intercept('GET', '/**/my-page').as('content');
-    cy.intercept('PATCH', '*').as('save');
-    // when I add a text block
-    //add listing block
-    cy.getSlate().click();
     cy.get('button.block-add-button').click();
     cy.get('.blocks-chooser .title').contains('Common').click();
     cy.get('.blocks-chooser .common').contains('Search').click();

--- a/src/components/manage/Blocks/Block/BlocksForm.jsx
+++ b/src/components/manage/Blocks/Block/BlocksForm.jsx
@@ -77,7 +77,7 @@ const BlocksForm = (props) => {
       e.preventDefault();
     }
     if (e.key === 'Enter' && !disableEnter) {
-      onAddBlock(config.settings.defaultBlockType, index + 1);
+      onSelectBlock(onAddBlock(config.settings.defaultBlockType, index + 1));
       e.preventDefault();
     }
   };


### PR DESCRIPTION
Fixes https://github.com/plone/volto/issues/3647.
I saw that all the time when  onAddBlock was executed, also the onSelectBlock was because we wanted to select the added block, but with an exception, that I fixed it now.