### PR TITLE
Fix virtualization (windowing) when displaying options with long titles for select widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Fix virtualization (windowing) when displaying options with long titles for select widgets. (The virtualization happen when the number of options is greater than 25). Add dynamic height aware options using `react-virtualized`. @sneridagh
+
 ### Internal
 
 ### Documentation

--- a/package.json
+++ b/package.json
@@ -357,6 +357,7 @@
     "react-sortable-hoc": "2.0.0",
     "react-test-renderer": "17.0.2",
     "react-toastify": "5.4.1",
+    "react-virtualized": "9.22.3",
     "react-window": "1.8.6",
     "redraft": "0.10.2",
     "redux": "4.1.0",

--- a/src/components/manage/ReactVirtualized/DynamicRowHeightList.jsx
+++ b/src/components/manage/ReactVirtualized/DynamicRowHeightList.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { CellMeasurerCache, List, CellMeasurer } from 'react-virtualized';
+
+export default class DynamicHeightList extends React.PureComponent {
+  // As per `react-virtualized` docs, one should use a PureComponent
+  // to avoid performance issues
+  // We could have used a React.memo + functional component instead,
+  // but relied on the class-based implementation for simplicity
+  constructor(props) {
+    super(props);
+
+    this._cache = new CellMeasurerCache({
+      fixedWidth: true,
+      minHeight: 50,
+    });
+
+    this._rowRenderer = this._rowRenderer.bind(this);
+  }
+
+  _rowRenderer({ index, key, parent, style }) {
+    return (
+      <CellMeasurer
+        cache={this._cache}
+        columnIndex={0}
+        key={key}
+        rowIndex={index}
+        parent={parent}
+      >
+        {({ measure }) => (
+          <div style={style}>
+            <div className="item">{this.props.children[index]}</div>
+          </div>
+        )}
+      </CellMeasurer>
+    );
+  }
+
+  render() {
+    return (
+      <List
+        {...this.props}
+        ref={(element) => {
+          this._list = element;
+        }}
+        deferredMeasurementCache={this._cache}
+        overscanRowCount={0}
+        rowCount={this.props.children.length}
+        rowHeight={this._cache.rowHeight}
+        rowRenderer={this._rowRenderer}
+        width={200}
+        height={500}
+      />
+    );
+  }
+}

--- a/src/components/manage/ReactVirtualized/DynamicRowHeightList.jsx
+++ b/src/components/manage/ReactVirtualized/DynamicRowHeightList.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { CellMeasurerCache, List, CellMeasurer } from 'react-virtualized';
+import { injectLazyLibs } from '@plone/volto/helpers/Loadable/Loadable';
 
-export default class DynamicHeightList extends React.PureComponent {
+class DynamicHeightList extends React.PureComponent {
   // As per `react-virtualized` docs, one should use a PureComponent
   // to avoid performance issues
   // We could have used a React.memo + functional component instead,
@@ -9,7 +9,7 @@ export default class DynamicHeightList extends React.PureComponent {
   constructor(props) {
     super(props);
 
-    this._cache = new CellMeasurerCache({
+    this._cache = new props.reactVirtualized.CellMeasurerCache({
       fixedWidth: true,
       minHeight: 50,
     });
@@ -18,6 +18,7 @@ export default class DynamicHeightList extends React.PureComponent {
   }
 
   _rowRenderer({ index, key, parent, style }) {
+    const CellMeasurer = this.props.reactVirtualized.CellMeasurer;
     return (
       <CellMeasurer
         cache={this._cache}
@@ -36,6 +37,8 @@ export default class DynamicHeightList extends React.PureComponent {
   }
 
   render() {
+    const List = this.props.reactVirtualized.List;
+
     return (
       <List
         {...this.props}
@@ -53,3 +56,5 @@ export default class DynamicHeightList extends React.PureComponent {
     );
   }
 }
+
+export default injectLazyLibs('reactVirtualized')(DynamicHeightList);

--- a/src/components/manage/ReactVirtualized/DynamicRowHeightList.jsx
+++ b/src/components/manage/ReactVirtualized/DynamicRowHeightList.jsx
@@ -27,11 +27,7 @@ class DynamicHeightList extends React.PureComponent {
         rowIndex={index}
         parent={parent}
       >
-        {({ measure }) => (
-          <div style={style}>
-            <div className="item">{this.props.children[index]}</div>
-          </div>
-        )}
+        {({ measure }) => <div style={style}>{this.props.children[index]}</div>}
       </CellMeasurer>
     );
   }

--- a/src/components/manage/Widgets/SelectStyling.jsx
+++ b/src/components/manage/Widgets/SelectStyling.jsx
@@ -6,8 +6,38 @@ import downSVG from '@plone/volto/icons/down-key.svg';
 import upSVG from '@plone/volto/icons/up-key.svg';
 import checkSVG from '@plone/volto/icons/check.svg';
 import clearSVG from '@plone/volto/icons/clear.svg';
+import useDimensions from './useDimensions';
 
 const height = 50; // The height of each option
+
+// // List data as an array of strings
+// const list = [
+//   'Brian Vaughn',
+//   // And so on...
+// ];
+
+// function rowRenderer({ key, index, style }) {
+//   debugger;
+//   return (
+//     <div key={key} style={style}>
+//       {list[index]}
+//     </div>
+//   );
+// }
+
+// export const MenuList = (props) => (
+//   <AutoSizer>
+//     {({ height, width }) => (
+//       <List
+//         height={height}
+//         rowCount={props.children.length}
+//         rowHeight={20}
+//         rowRenderer={rowRenderer}
+//         width={width}
+//       />
+//     )}
+//   </AutoSizer>
+// );
 
 export const MenuList = injectLazyLibs('reactWindow')((props) => {
   const { FixedSizeList: List } = props.reactWindow;
@@ -22,7 +52,20 @@ export const MenuList = injectLazyLibs('reactWindow')((props) => {
       itemSize={height}
       initialScrollOffset={initialOffset}
     >
-      {({ index, style }) => <div style={style}>{children[index]}</div>}
+      {({ index, style }) => {
+        const [ref, { x, y, height, width }] = useDimensions();
+        console.log(height);
+        const { height: oldHeight, ...newStyle } = style;
+        return (
+          <div
+            ref={ref}
+            className="hey"
+            style={{ ...newStyle, height: height + oldHeight }}
+          >
+            {children[index]}
+          </div>
+        );
+      }}
     </List>
   );
 });

--- a/src/components/manage/Widgets/SelectStyling.jsx
+++ b/src/components/manage/Widgets/SelectStyling.jsx
@@ -9,12 +9,9 @@ import checkSVG from '@plone/volto/icons/check.svg';
 import checkBlankSVG from '@plone/volto/icons/check-blank.svg';
 import clearSVG from '@plone/volto/icons/clear.svg';
 
-export const MenuList = injectLazyLibs('reactWindow')((props) => {
-  const { FixedSizeList: List } = props.reactWindow;
-  const { children } = props;
-
+export const MenuList = ({ children }) => {
   return <DynamicHeightList>{children}</DynamicHeightList>;
-});
+};
 
 export const SortableMultiValue = injectLazyLibs([
   'reactSelect',

--- a/src/components/manage/Widgets/SelectStyling.jsx
+++ b/src/components/manage/Widgets/SelectStyling.jsx
@@ -1,73 +1,19 @@
 import React from 'react';
 import { injectLazyLibs } from '@plone/volto/helpers/Loadable/Loadable';
 import { Icon } from '@plone/volto/components';
+import DynamicHeightList from '@plone/volto/components/manage/ReactVirtualized/DynamicRowHeightList';
 
 import downSVG from '@plone/volto/icons/down-key.svg';
 import upSVG from '@plone/volto/icons/up-key.svg';
 import checkSVG from '@plone/volto/icons/check.svg';
+import checkBlankSVG from '@plone/volto/icons/check-blank.svg';
 import clearSVG from '@plone/volto/icons/clear.svg';
-import useDimensions from './useDimensions';
-
-const height = 50; // The height of each option
-
-// // List data as an array of strings
-// const list = [
-//   'Brian Vaughn',
-//   // And so on...
-// ];
-
-// function rowRenderer({ key, index, style }) {
-//   debugger;
-//   return (
-//     <div key={key} style={style}>
-//       {list[index]}
-//     </div>
-//   );
-// }
-
-// export const MenuList = (props) => (
-//   <AutoSizer>
-//     {({ height, width }) => (
-//       <List
-//         height={height}
-//         rowCount={props.children.length}
-//         rowHeight={20}
-//         rowRenderer={rowRenderer}
-//         width={width}
-//       />
-//     )}
-//   </AutoSizer>
-// );
 
 export const MenuList = injectLazyLibs('reactWindow')((props) => {
   const { FixedSizeList: List } = props.reactWindow;
-  const { options, children, maxHeight, getValue } = props;
-  const [value] = getValue();
-  const initialOffset = options.indexOf(value) * height;
+  const { children } = props;
 
-  return (
-    <List
-      height={maxHeight}
-      itemCount={children.length}
-      itemSize={height}
-      initialScrollOffset={initialOffset}
-    >
-      {({ index, style }) => {
-        const [ref, { x, y, height, width }] = useDimensions();
-        console.log(height);
-        const { height: oldHeight, ...newStyle } = style;
-        return (
-          <div
-            ref={ref}
-            className="hey"
-            style={{ ...newStyle, height: height + oldHeight }}
-          >
-            {children[index]}
-          </div>
-        );
-      }}
-    </List>
-  );
+  return <DynamicHeightList>{children}</DynamicHeightList>;
 });
 
 export const SortableMultiValue = injectLazyLibs([
@@ -101,13 +47,14 @@ export const SortableMultiValueLabel = injectLazyLibs([
 
 export const Option = injectLazyLibs('reactSelect')((props) => {
   const { Option } = props.reactSelect.components;
+  const color = props.isFocused && !props.isSelected ? '#b8c6c8' : '#007bc1';
+  const svgIcon =
+    props.isFocused || props.isSelected ? checkSVG : checkBlankSVG;
+
   return (
     <Option {...props}>
       <div>{props.label}</div>
-      {props.isFocused && !props.isSelected && (
-        <Icon name={checkSVG} size="24px" color="#b8c6c8" />
-      )}
-      {props.isSelected && <Icon name={checkSVG} size="24px" color="#007bc1" />}
+      <Icon name={svgIcon} size="20px" color={color} />
     </Option>
   );
 });

--- a/src/components/manage/Widgets/useDimensions.js
+++ b/src/components/manage/Widgets/useDimensions.js
@@ -1,0 +1,51 @@
+import { useState, useCallback, useEffect } from 'react';
+
+function getDimensionObject(node) {
+  const rect = node.getBoundingClientRect();
+
+  if (rect.toJSON) {
+    return rect.toJSON();
+  } else {
+    return {
+      width: rect.width,
+      height: rect.height,
+      top: rect.top || rect.y,
+      left: rect.left || rect.x,
+      x: rect.x || rect.left,
+      y: rect.y || rect.top,
+      right: rect.right,
+      bottom: rect.bottom,
+    };
+  }
+}
+
+function useDimensions() {
+  const [dimensions, setDimensions] = useState({});
+  const [node, setNode] = useState(null);
+
+  const ref = useCallback((node) => {
+    setNode(node);
+  }, []);
+
+  useEffect(() => {
+    if (node) {
+      const measure = () =>
+        window.requestAnimationFrame(() =>
+          setDimensions(getDimensionObject(node)),
+        );
+      measure();
+
+      window.addEventListener('resize', measure);
+      window.addEventListener('scroll', measure);
+
+      return () => {
+        window.removeEventListener('resize', measure);
+        window.removeEventListener('scroll', measure);
+      };
+    }
+  }, [node]);
+
+  return [ref, dimensions, node];
+}
+
+export default useDimensions;

--- a/src/config/Loadables.jsx
+++ b/src/config/Loadables.jsx
@@ -7,6 +7,9 @@ export const loadables = {
   toastify: loadable.lib(() => import('react-toastify')),
   reactSelect: loadable.lib(() => import('react-select'), { ssr: false }),
   reactWindow: loadable.lib(() => import('react-window'), { ssr: false }),
+  reactVirtualized: loadable.lib(() => import('react-virtualized'), {
+    ssr: false,
+  }),
   reactSortableHOC: loadable.lib(() => import('react-sortable-hoc'), {
     ssr: false,
   }),

--- a/src/icons/check-blank.svg
+++ b/src/icons/check-blank.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="36" height="36" viewBox="0 0 36 36">
+  <g fill-rule="evenodd" fill-opacity="0">
+    <polygon points="29 8 13.561 23.439 7.121 17 5 19.12 13.561 27.681 31.12 10.12"/>
+    <polygon points="29 8 13.561 23.439 7.121 17 5 19.12 13.561 27.681 31.12 10.12"/>
+  </g>
+</svg>

--- a/theme/themes/pastanaga/extras/widgets.less
+++ b/theme/themes/pastanaga/extras/widgets.less
@@ -148,3 +148,8 @@ body.babel-view .field.language-independent-field {
     opacity: 0.3 !important;
   }
 }
+
+// makes sure that long words (eg. German) get properly broken in selects.
+.react-select__option {
+  .word-break();
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1195,6 +1195,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.8.7":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.19.0.tgz#22b11c037b094d27a8a2504ea4dcff00f50e2259"
+  integrity sha512-eR8Lo9hnDS7tqkO7NsV+mKvCmv5boaXFSZ70DnfhcgiEne8hv9oCEd36Klw74EtizEqLsy4YnW8UWwpBVolHZA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.10.4", "@babel/template@^7.12.7", "@babel/template@^7.14.5", "@babel/template@^7.16.7", "@babel/template@^7.3.3", "@babel/template@^7.4.0":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.16.7.tgz#8d126c8701fde4d66b264b3eba3d96f07666d155"
@@ -7278,6 +7285,14 @@ dom-helpers@^5.0.1:
   dependencies:
     "@babel/runtime" "^7.6.3"
     csstype "^2.6.7"
+
+dom-helpers@^5.1.3:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.1.tgz#d9400536b2bf8225ad98fe052e029451ac40e902"
+  integrity sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==
+  dependencies:
+    "@babel/runtime" "^7.8.7"
+    csstype "^3.0.2"
 
 dom-serializer@0:
   version "0.2.2"
@@ -16366,6 +16381,18 @@ react-transition-group@^4, react-transition-group@^4.3.0:
     dom-helpers "^5.0.1"
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
+
+react-virtualized@9.22.3:
+  version "9.22.3"
+  resolved "https://registry.yarnpkg.com/react-virtualized/-/react-virtualized-9.22.3.tgz#f430f16beb0a42db420dbd4d340403c0de334421"
+  integrity sha512-MKovKMxWTcwPSxE1kK1HcheQTWfuCxAuBoSTf2gwyMM21NdX/PXUhnoP8Uc5dRKd+nKm8v41R36OellhdCpkrw==
+  dependencies:
+    "@babel/runtime" "^7.7.2"
+    clsx "^1.0.4"
+    dom-helpers "^5.1.3"
+    loose-envify "^1.4.0"
+    prop-types "^15.7.2"
+    react-lifecycles-compat "^3.0.4"
 
 react-window@1.8.6:
   version "1.8.6"


### PR DESCRIPTION
Turns out that the library I introduced for making the windowing in case that we have lots of options in selects/arrays can't handle variable height options. So I had to change it with one that does have support for this: `react-virtualized`. I gave some love to the select widgets too, adding breaking words in the options.

I left `react-window` library, in case that someone is using it. Both are lazy loaded, so they won't have impact on the build.

Before:
<img width="345" alt="image" src="https://user-images.githubusercontent.com/486927/191273488-1867d3da-5315-42e2-843f-aa3aedac8742.png">

After:
<img width="219" alt="image" src="https://user-images.githubusercontent.com/486927/191273562-fa60fbf7-c0f4-4789-873f-12f92eecfa4b.png">
