### PR TITLE
Update email widget validation regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Fix selection error when pressing backspace @robgietema
 - Fix sidebarTab in Toc Block @iRohitSingh
 - Fix virtualization (windowing) when displaying options with long titles for select widgets. (The virtualization happen when the number of options is greater than 25). Add dynamic height aware options using `react-virtualized`. @sneridagh
+- Fix email validation to ensure all addresses are correctly validated @instification
 
 ### Documentation
 

--- a/src/helpers/FormValidation/FormValidation.js
+++ b/src/helpers/FormValidation/FormValidation.js
@@ -40,7 +40,7 @@ const isMinPropertyValid = (value, valueToCompare, maxCriterion, intlFunc) => {
 const widgetValidation = {
   email: {
     isValidEmail: (emailValue, emailObj, intlFunc) => {
-      const emailRegex = /^(([^<>()[\].,;:\s@"]+(\.[^<>()[\].,;:\s@"]+)*)|(".+"))@(([^<>()[\].,;:\s@"]+\.)+[^<>()[\].,;:\s@"]{2,})$/i;
+      const emailRegex = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
       const isValid = emailRegex.test(emailValue);
       return !isValid ? intlFunc(messages.isValidEmail) : null;
     },

--- a/src/helpers/FormValidation/FormValidation.js
+++ b/src/helpers/FormValidation/FormValidation.js
@@ -40,7 +40,7 @@ const isMinPropertyValid = (value, valueToCompare, maxCriterion, intlFunc) => {
 const widgetValidation = {
   email: {
     isValidEmail: (emailValue, emailObj, intlFunc) => {
-      const emailRegex = /^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$/;
+      const emailRegex = /^(([^<>()[\]\.,;:\s@\"]+(\.[^<>()[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/i;
       const isValid = emailRegex.test(emailValue);
       return !isValid ? intlFunc(messages.isValidEmail) : null;
     },

--- a/src/helpers/FormValidation/FormValidation.js
+++ b/src/helpers/FormValidation/FormValidation.js
@@ -40,7 +40,7 @@ const isMinPropertyValid = (value, valueToCompare, maxCriterion, intlFunc) => {
 const widgetValidation = {
   email: {
     isValidEmail: (emailValue, emailObj, intlFunc) => {
-      const emailRegex = /^(([^<>()[\]\.,;:\s@\"]+(\.[^<>()[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/i;
+      const emailRegex = /^(([^<>()[\].,;:\s@"]+(\.[^<>()[\].,;:\s@"]+)*)|(".+"))@(([^<>()[\].,;:\s@"]+\.)+[^<>()[\].,;:\s@"]{2,})$/i;
       const isValid = emailRegex.test(emailValue);
       return !isValid ? intlFunc(messages.isValidEmail) : null;
     },

--- a/src/helpers/FormValidation/FormValidation.js
+++ b/src/helpers/FormValidation/FormValidation.js
@@ -40,6 +40,8 @@ const isMinPropertyValid = (value, valueToCompare, maxCriterion, intlFunc) => {
 const widgetValidation = {
   email: {
     isValidEmail: (emailValue, emailObj, intlFunc) => {
+      // Email Regex taken from from WHATWG living standard:
+      // https://html.spec.whatwg.org/multipage/input.html#e-mail-state-(type=email)
       const emailRegex = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
       const isValid = emailRegex.test(emailValue);
       return !isValid ? intlFunc(messages.isValidEmail) : null;

--- a/src/helpers/FormValidation/FormValidation.test.js
+++ b/src/helpers/FormValidation/FormValidation.test.js
@@ -76,5 +76,16 @@ describe('FormValidation', () => {
         email: [messages.isValidEmail.defaultMessage],
       });
     });
+
+    it('validates correct email', () => {
+      formData.email = 'test@domain.name'
+      expect(
+        FormValidation.validateFieldsPerFieldset({
+          schema,
+          formData,
+          formatMessage,
+        }),
+      ).toEqual({})
+    })
   });
 });

--- a/src/helpers/FormValidation/FormValidation.test.js
+++ b/src/helpers/FormValidation/FormValidation.test.js
@@ -78,14 +78,14 @@ describe('FormValidation', () => {
     });
 
     it('validates correct email', () => {
-      formData.email = 'test@domain.name'
+      formData.email = 'test@domain.name';
       expect(
         FormValidation.validateFieldsPerFieldset({
           schema,
           formData,
           formatMessage,
         }),
-      ).toEqual({})
-    })
+      ).toEqual({});
+    });
   });
 });


### PR DESCRIPTION
Fixes #3663 

Regex was taken from https://html.spec.whatwg.org/multipage/input.html#e-mail-state-(type=email)

Also included an additional test to show the longer domain TLD being correctly validated.