### PR TITLE
Storybook: Allow customising the action for the AlignWidget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### Documentation
 
+- Added controls for the `actions` property of the `AlignWidget` storybook @JeffersonBledsoe #3671
+
 ## 16.0.0-alpha.35 (2022-09-21)
 
 ### Breaking

--- a/src/components/manage/Widgets/AlignWidget.stories.jsx
+++ b/src/components/manage/Widgets/AlignWidget.stories.jsx
@@ -18,5 +18,10 @@ export default {
       </div>
     ),
   ],
-  argTypes: {},
+  argTypes: {
+    actions: {
+      control: 'check',
+      options: ['left', 'right', 'center', 'wide', 'full'],
+    },
+  },
 };


### PR DESCRIPTION
## Default behaviour

<img width="464" alt="Screenshot of the align widget storybook showing the default behaviour of displaying the left, right, centre and full options. None of the actions control checkboxes are selected." src="https://user-images.githubusercontent.com/30210785/191988058-2160777a-35db-4d0f-baba-886a904aa9d6.png">

## Customised actions

<img width="385" alt="Screenshot of the align widget storybook showing the align widget displaying the right, wide and centre options. The checkboxes for the action of those options have been selected." src="https://user-images.githubusercontent.com/30210785/191988376-743d0d0b-ace2-4515-a2cd-b2ec70f9e611.png">
