### PR TITLE
Generic Setup -> `GenericSetup`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Documentation
 
 - Added controls for the `actions` property of the `AlignWidget` storybook @JeffersonBledsoe #3671
+- Generic Setup -> `GenericSetup`. @stevepiercy
 
 ## 16.0.0-alpha.35 (2022-09-21)
 

--- a/docs/source/configuration/locking.md
+++ b/docs/source/configuration/locking.md
@@ -12,7 +12,7 @@ myst:
 Content edit locking feature is to prevent simultaneous conflicting edits of the same content.
 If the editor forgot to press Save or Cancel explicit unlocking must be performed on locked objects if you want to modify them.
 
-Volto provides support for Plone's locking feature, but you need to enable the `plone.locking` behavior on your Dexterity content types first. You can do that in Plone's control panel or using the Generic Setup facilities.
+Volto provides support for Plone's locking feature, but you need to enable the `plone.locking` behavior on your Dexterity content types first. You can do that in Plone's control panel or using the `GenericSetup` facilities.
 
 1. Log-in as `Site Administrator` and click `Personal tools` in the left Toolbar
 2. Go to `Site Setup` -> `Dexterity Content Types`, select the content type.

--- a/docs/source/configuration/workingcopy.md
+++ b/docs/source/configuration/workingcopy.md
@@ -9,7 +9,7 @@ myst:
 
 # Working copy support
 
-Volto provide support for Plone's Working Copy feature. You need to install `plone.app.iterate` add-on in your Plone site that comes available by default. You can do that in Plone's control panel or using the Generic Setup facility.
+Volto provide support for Plone's Working Copy feature. You need to install `plone.app.iterate` add-on in your Plone site that comes available by default. You can do that in Plone's control panel or using the `GenericSetup` facility.
 
 ## Volto configuration
 


### PR DESCRIPTION
Its package name is [`products.GenericSetup`](https://github.com/plone/products.GenericSetup), but it is fine to just use `GenericSetup` to hint that it is a package.