### PR TITLE
Remove wrapping ul or ol when deselecting list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Remove wrapping ul or ol when deselecting list style @robgietema
+
 ### Internal
 
 ### Documentation

--- a/packages/volto-slate/src/utils/blocks.js
+++ b/packages/volto-slate/src/utils/blocks.js
@@ -212,7 +212,6 @@ export const toggleBlock = (editor, format, allowedChildren) => {
   const isListItem = isBlockActive(editor, slate.listItemType);
   const isActive = isBlockActive(editor, format);
   const wantsList = listTypes.includes(format);
-  // console.log({ isListItem, isActive, wantsList, format });
 
   if (isListItem && !wantsList) {
     toggleFormatAsListItem(editor, format);
@@ -223,7 +222,7 @@ export const toggleBlock = (editor, format, allowedChildren) => {
   } else if (!isListItem && !wantsList) {
     toggleFormat(editor, format, allowedChildren);
   } else if (isListItem && wantsList && isActive) {
-    toggleFormatAsListItem(editor, slate.defaultBlockType);
+    clearFormatting(editor);
   } else {
     console.warn('toggleBlock case not covered, please examine:', {
       wantsList,


### PR DESCRIPTION
When deselecting the list style from the toolbar the markup did replace the li-tags with p-tags but the wrapping ol or ul stayed which made the markup invalid and caused a bug when selecting the list style again (it became a list in a list).