### PR TITLE
Fix if `canary` selected, the tests should not include `--env=jest-en…

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Fix if `canary` selected, the tests should not include `--env=jest-environment-jsdom-sixteen` @sneridagh
+
 ### Internal
 
 ## 2.1.0 (2022-09-28)

--- a/packages/scripts/addon/generators.js
+++ b/packages/scripts/addon/generators.js
@@ -95,7 +95,7 @@ export async function runGitGenerator({
       `Preparing and amending testing project ${chalk.yellow('package.json')}`,
     ),
   );
-  amendPackageJSON(name, destination);
+  amendPackageJSON(name, destination, isCanary);
 }
 
 export async function runLocalGenerator({
@@ -189,5 +189,5 @@ export async function runLocalGenerator({
       `Preparing and amending testing project ${chalk.yellow('package.json')}`,
     ),
   );
-  amendPackageJSON(name, destination);
+  amendPackageJSON(name, destination, isCanary);
 }

--- a/packages/scripts/addon/utils.js
+++ b/packages/scripts/addon/utils.js
@@ -1,13 +1,15 @@
 import fs from 'fs';
 
-export function amendPackageJSON(name, destination) {
+export function amendPackageJSON(name, destination, isCanary) {
   const packageJSON = JSON.parse(
     fs.readFileSync(`${destination}/package.json`, 'utf8'),
   );
   packageJSON.scripts = {
     ...packageJSON.scripts,
     'cypress:open': `cd src/addons/${name} && NODE_ENV=test cypress open`,
-    test: `RAZZLE_JEST_CONFIG=src/addons/${name}/jest-addon.config.js razzle test --env=jest-environment-jsdom-sixteen --passWithNoTests`,
+    test: `RAZZLE_JEST_CONFIG=src/addons/${name}/jest-addon.config.js razzle test ${
+      isCanary ? '' : '--env=jest-environment-jsdom-sixteen'
+    } --passWithNoTests`,
     'cypress:run': `cd src/addons/${name} && NODE_ENV=test cypress run`,
   };
   fs.writeFileSync(


### PR DESCRIPTION
…vironment-jsdom-sixteen`