### PR TITLE
Display description in control panel if the field is available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Fixed the `description` field not appearing in control panel fieldsets @JeffersonBledsoe #3696
+
 ### Internal
 
 - Run yarn deduplicate on dependencies. @davisagli

--- a/src/components/manage/Form/Form.jsx
+++ b/src/components/manage/Form/Form.jsx
@@ -657,6 +657,11 @@ class Form extends Component {
                             {this.props.title}
                           </Segment>
                         ),
+                        item.description && (
+                          <Message attached="bottom">
+                            {item.description}
+                          </Message>
+                        ),
                         ...map(item.fields, (field, index) => (
                           <Field
                             {...schema.properties[field]}


### PR DESCRIPTION
This PR displays the description of any fieldsets in the control panel below the title, as shown below.

<img width="552" alt="Screenshot of a control panel titled Control Panel Title looking at a tab titled My other fieldset. In the tab pane is a new message box displaying the fieldset description of Description of fieldset one." src="https://user-images.githubusercontent.com/30210785/193011883-c72528ef-ea20-493d-b5fb-9020e19117f3.png">


Needs plone/plone.restapi#1499