### PR TITLE
Update to use Plone 6 beta 2

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -235,6 +235,7 @@ jobs:
           # Recommended: pass the GitHub token lets this action correctly
           # determine the unique run id necessary to re-run the checks
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          KGS: plone.restapi==8.27.0 plone.volto==4.0.0a13 plone.rest==2.0.0a5
         with:
           record: true
           parallel: false # Since they run on different node versions, we can't parallel
@@ -243,7 +244,7 @@ jobs:
           group: Core Basic - Plone 6
           spec: cypress/tests/core/basic/**/*.js
           start: |
-            make start-test-acceptance-server DOCKER_IMAGE=plone/plone-backend:5.2.9 KGS="plone.restapi==8.27.0 plone.volto==4.0.0a13 plone.rest==2.0.0a5"
+            make start-test-acceptance-server DOCKER_IMAGE=plone/plone-backend:5.2.9 KGS=$KGS
             make start-test-acceptance-frontend
           wait-on: 'npx wait-on --httpTimeout 20000 http-get://localhost:55001/plone http://localhost:3000'
 

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -235,7 +235,6 @@ jobs:
           # Recommended: pass the GitHub token lets this action correctly
           # determine the unique run id necessary to re-run the checks
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          KGS: '"plone.restapi==8.27.0 plone.volto==4.0.0a13 plone.rest==2.0.0a5"'
         with:
           record: true
           parallel: false # Since they run on different node versions, we can't parallel
@@ -244,7 +243,7 @@ jobs:
           group: Core Basic - Plone 6
           spec: cypress/tests/core/basic/**/*.js
           start: |
-            make start-test-acceptance-server DOCKER_IMAGE=plone/plone-backend:5.2.9 KGS=${{ env.KGS }}
+            make start-test-acceptance-server-5
             make start-test-acceptance-frontend
           wait-on: 'npx wait-on --httpTimeout 20000 http-get://localhost:55001/plone http://localhost:3000'
 

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -235,7 +235,7 @@ jobs:
           # Recommended: pass the GitHub token lets this action correctly
           # determine the unique run id necessary to re-run the checks
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          KGS: plone.restapi==8.27.0 plone.volto==4.0.0a13 plone.rest==2.0.0a5
+          KGS: "plone.restapi==8.27.0 plone.volto==4.0.0a13 plone.rest==2.0.0a5"
         with:
           record: true
           parallel: false # Since they run on different node versions, we can't parallel
@@ -244,7 +244,7 @@ jobs:
           group: Core Basic - Plone 6
           spec: cypress/tests/core/basic/**/*.js
           start: |
-            make start-test-acceptance-server DOCKER_IMAGE=plone/plone-backend:5.2.9 KGS=$KGS
+            make start-test-acceptance-server DOCKER_IMAGE=plone/plone-backend:5.2.9 KGS=${{ env.KGS }}
             make start-test-acceptance-frontend
           wait-on: 'npx wait-on --httpTimeout 20000 http-get://localhost:55001/plone http://localhost:3000'
 

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -196,9 +196,9 @@ jobs:
           name: cypress-videos
           path: cypress/videos
 
-  core6:
+  core5:
     runs-on: ubuntu-latest
-    name: Core Basic - Plone 6
+    name: Core Basic - Plone 5
     strategy:
       matrix:
         node-version: [16.x]
@@ -243,7 +243,7 @@ jobs:
           group: Core Basic - Plone 6
           spec: cypress/tests/core/basic/**/*.js
           start: |
-            make start-test-acceptance-server DOCKER_IMAGE=plone/plone-backend:6.0.0b1 KGS=
+            make start-test-acceptance-server DOCKER_IMAGE=plone/plone-backend:5.2.9 KGS="plone.restapi==8.27.0 plone.volto==4.0.0a13 plone.rest==2.0.0a5"
             make start-test-acceptance-frontend
           wait-on: 'npx wait-on --httpTimeout 20000 http-get://localhost:55001/plone http://localhost:3000'
 

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -235,7 +235,7 @@ jobs:
           # Recommended: pass the GitHub token lets this action correctly
           # determine the unique run id necessary to re-run the checks
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          KGS: "plone.restapi==8.27.0 plone.volto==4.0.0a13 plone.rest==2.0.0a5"
+          KGS: '"plone.restapi==8.27.0 plone.volto==4.0.0a13 plone.rest==2.0.0a5"'
         with:
           record: true
           parallel: false # Since they run on different node versions, we can't parallel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 ### Internal
 
 - Run yarn deduplicate on dependencies. @davisagli
+- Upgrade to Plone 6 beta 2 @sneridagh
+- Flip testing matrix for acceptance tests, make Plone 6 principal subject, Plone 5 as secondary @sneridagh
 
 ### Documentation
 

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,10 @@ KGS=
 TESTING_ADDONS=plone.app.robotframework==2.0.0b2 plone.app.testing==7.0.0a3
 NODEBIN = ./node_modules/.bin
 
+# Plone 5 legacy
+DOCKER_IMAGE5=plone/plone-backend:5.2.9
+KGS5=plone.restapi==8.27.0 plone.volto==4.0.0a13 plone.rest==2.0.0a5
+
 # Sphinx variables
 # You can set these variables from the command line.
 SPHINXOPTS      ?=
@@ -334,3 +338,9 @@ test-acceptance-guillotina-headless: ## Start the Guillotina Cypress Acceptance 
 .PHONY: full-test-acceptance-guillotina
 full-test-acceptance-guillotina: ## Runs the Guillotina Full Acceptance Testing in headless mode
 	$(NODEBIN)/start-test "make start-test-acceptance-server-guillotina" http-get://localhost:8081 "make start-test-acceptance-frontend-guillotina" http://localhost:3000 "make test-acceptance-guillotina-headless"
+
+######### Plone 5 Acceptance tests
+
+.PHONY: start-test-acceptance-server-5
+start-test-acceptance-server-5: ## Start Test Acceptance Server Main Fixture Plone 5 (docker container)
+	docker run -i --rm -e ZSERVER_HOST=0.0.0.0 -e ZSERVER_PORT=55001 -p 55001:55001 -e ADDONS='$(KGS5) $(TESTING_ADDONS)' -e APPLY_PROFILES=plone.app.contenttypes:plone-content,plone.restapi:default,plone.volto:default-homepage -e CONFIGURE_PACKAGES=plone.app.contenttypes,plone.restapi,plone.volto,plone.volto.cors $(DOCKER_IMAGE5) ./bin/robot-server plone.app.robotframework.testing.VOLTO_ROBOT_TESTING

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ NODEBIN = ./node_modules/.bin
 
 # Plone 5 legacy
 DOCKER_IMAGE5=plone/plone-backend:5.2.9
-KGS5=plone.restapi==8.27.0 plone.volto==4.0.0a13 plone.rest==2.0.0a5
+KGS5=plone.restapi==8.29.0 plone.volto==4.0.0a13 plone.rest==2.0.0a5
 
 # Sphinx variables
 # You can set these variables from the command line.

--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,9 @@ MAKEFLAGS+=--no-builtin-rules
 # Project settings
 
 INSTANCE_PORT=8080
-DOCKER_IMAGE=plone/plone-backend:5.2.9
-KGS=plone.restapi==8.24.1 plone.volto==4.0.0a9 plone.rest==2.0.0a5
-TESTING_ADDONS=plone.app.robotframework==2.0.0b1 plone.app.testing==7.0.0a3
+DOCKER_IMAGE=plone/plone-backend:6.0.0b2
+KGS=
+TESTING_ADDONS=plone.app.robotframework==2.0.0b2 plone.app.testing==7.0.0a3
 NODEBIN = ./node_modules/.bin
 
 # Sphinx variables

--- a/api/buildout.cfg
+++ b/api/buildout.cfg
@@ -1,7 +1,7 @@
 [buildout]
 index = https://pypi.org/simple/
 extends =
-    http://dist.plone.org/release/5.2.9/versions.cfg
+    http://dist.plone.org/release/6.0.0b2/versions.cfg
     version-constraints.cfg
     versions.cfg
 parts = instance plonesite site-packages test robot-server

--- a/cypress/tests/core/blocks/blocks-listing.js
+++ b/cypress/tests/core/blocks/blocks-listing.js
@@ -9,7 +9,6 @@ describe('Listing Block Tests', () => {
       contentId: 'my-page',
       contentTitle: 'My Page',
     });
-    cy.removeContent({ path: 'front-page' });
     cy.removeContent({ path: 'news' });
     cy.removeContent({ path: 'events' });
     cy.removeContent({ path: 'Members' });


### PR DESCRIPTION
Let's see how this goes.

- Upgrade to Plone 6 beta 2
- Flip testing matrix for acceptance tests, make Plone 6 principal subject, Plone 5 as secondary 

I tried to upgrade the convenience `api` folder and it broke. Maybe it's time to go to full mxdiv with it?