### PR TITLE
Usability fixes in addon control panel 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Feature
 
+- Show result of the addon install/uninstall/upgrade actions @erral
 - Working copy actions now render errors if they fail @pnicolli
 - lazyloading of rrule lib. @giuliaghisini
 

--- a/locales/ca/LC_MESSAGES/volto.po
+++ b/locales/ca/LC_MESSAGES/volto.po
@@ -199,6 +199,36 @@ msgstr "Configuració de complements"
 msgid "Additional date"
 msgstr "Data addicional"
 
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon could not be installed
+msgid "Addon could not be installed"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon could not be uninstalled
+msgid "Addon could not be uninstalled"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon could not be upgraded
+msgid "Addon could not be upgraded"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon installed succesfuly
+msgid "Addon installed succesfuly"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon uninstalled succesfuly
+msgid "Addon uninstalled succesfuly"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon upgraded succesfuly
+msgid "Addon upgraded succesfuly"
+msgstr ""
+
 #: config/Views
 # defaultMessage: Album view
 msgid "Album view"
@@ -1038,6 +1068,7 @@ msgid "Enter your username for verification."
 msgstr ""
 
 #: components/manage/Add/Add
+#: components/manage/Controlpanels/AddonsControlpanel
 #: components/manage/Controlpanels/ContentTypeSchema
 #: components/manage/Controlpanels/UndoControlpanel
 #: components/manage/Edit/Edit
@@ -2828,6 +2859,7 @@ msgstr "Assumpte"
 #: components/manage/Actions/Actions
 #: components/manage/Aliases/Aliases
 #: components/manage/Contents/Contents
+#: components/manage/Controlpanels/AddonsControlpanel
 #: components/manage/Controlpanels/Aliases
 #: components/manage/Controlpanels/ContentTypes
 #: components/manage/Controlpanels/ContentTypeSchema
@@ -3997,6 +4029,11 @@ msgstr "Títol"
 # defaultMessage: Table of Contents
 msgid "toc"
 msgstr "Taula de continguts"
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Update from version {origin} to {destination}
+msgid "upgradeVersions"
+msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
 # defaultMessage: Input must be valid url (www.something.com or http(s)://www.something.com)

--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -196,6 +196,36 @@ msgstr "Einstellungen Add-ons"
 msgid "Additional date"
 msgstr "Zusätzliches Datum"
 
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon could not be installed
+msgid "Addon could not be installed"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon could not be uninstalled
+msgid "Addon could not be uninstalled"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon could not be upgraded
+msgid "Addon could not be upgraded"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon installed succesfuly
+msgid "Addon installed succesfuly"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon uninstalled succesfuly
+msgid "Addon uninstalled succesfuly"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon upgraded succesfuly
+msgid "Addon upgraded succesfuly"
+msgstr ""
+
 #: config/Views
 # defaultMessage: Album view
 msgid "Album view"
@@ -1035,6 +1065,7 @@ msgid "Enter your username for verification."
 msgstr ""
 
 #: components/manage/Add/Add
+#: components/manage/Controlpanels/AddonsControlpanel
 #: components/manage/Controlpanels/ContentTypeSchema
 #: components/manage/Controlpanels/UndoControlpanel
 #: components/manage/Edit/Edit
@@ -2825,6 +2856,7 @@ msgstr "Betreff"
 #: components/manage/Actions/Actions
 #: components/manage/Aliases/Aliases
 #: components/manage/Contents/Contents
+#: components/manage/Controlpanels/AddonsControlpanel
 #: components/manage/Controlpanels/Aliases
 #: components/manage/Controlpanels/ContentTypes
 #: components/manage/Controlpanels/ContentTypeSchema
@@ -3994,6 +4026,11 @@ msgstr "Titel"
 # defaultMessage: Table of Contents
 msgid "toc"
 msgstr "Inhaltsverzeichnis"
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Update from version {origin} to {destination}
+msgid "upgradeVersions"
+msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
 # defaultMessage: Input must be valid url (www.something.com or http(s)://www.something.com)

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -190,6 +190,36 @@ msgstr ""
 msgid "Additional date"
 msgstr ""
 
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon could not be installed
+msgid "Addon could not be installed"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon could not be uninstalled
+msgid "Addon could not be uninstalled"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon could not be upgraded
+msgid "Addon could not be upgraded"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon installed succesfuly
+msgid "Addon installed succesfuly"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon uninstalled succesfuly
+msgid "Addon uninstalled succesfuly"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon upgraded succesfuly
+msgid "Addon upgraded succesfuly"
+msgstr ""
+
 #: config/Views
 # defaultMessage: Album view
 msgid "Album view"
@@ -1029,6 +1059,7 @@ msgid "Enter your username for verification."
 msgstr ""
 
 #: components/manage/Add/Add
+#: components/manage/Controlpanels/AddonsControlpanel
 #: components/manage/Controlpanels/ContentTypeSchema
 #: components/manage/Controlpanels/UndoControlpanel
 #: components/manage/Edit/Edit
@@ -2819,6 +2850,7 @@ msgstr ""
 #: components/manage/Actions/Actions
 #: components/manage/Aliases/Aliases
 #: components/manage/Contents/Contents
+#: components/manage/Controlpanels/AddonsControlpanel
 #: components/manage/Controlpanels/Aliases
 #: components/manage/Controlpanels/ContentTypes
 #: components/manage/Controlpanels/ContentTypeSchema
@@ -3987,6 +4019,11 @@ msgstr ""
 #: config/Blocks
 # defaultMessage: Table of Contents
 msgid "toc"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Update from version {origin} to {destination}
+msgid "upgradeVersions"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels

--- a/locales/es/LC_MESSAGES/volto.po
+++ b/locales/es/LC_MESSAGES/volto.po
@@ -200,6 +200,36 @@ msgstr "Configuración de complementos"
 msgid "Additional date"
 msgstr "Fecha adicional"
 
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon could not be installed
+msgid "Addon could not be installed"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon could not be uninstalled
+msgid "Addon could not be uninstalled"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon could not be upgraded
+msgid "Addon could not be upgraded"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon installed succesfuly
+msgid "Addon installed succesfuly"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon uninstalled succesfuly
+msgid "Addon uninstalled succesfuly"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon upgraded succesfuly
+msgid "Addon upgraded succesfuly"
+msgstr ""
+
 #: config/Views
 # defaultMessage: Album view
 msgid "Album view"
@@ -1039,6 +1069,7 @@ msgid "Enter your username for verification."
 msgstr "Introduzca su nombre de usuario para verificar."
 
 #: components/manage/Add/Add
+#: components/manage/Controlpanels/AddonsControlpanel
 #: components/manage/Controlpanels/ContentTypeSchema
 #: components/manage/Controlpanels/UndoControlpanel
 #: components/manage/Edit/Edit
@@ -2829,6 +2860,7 @@ msgstr "Asunto"
 #: components/manage/Actions/Actions
 #: components/manage/Aliases/Aliases
 #: components/manage/Contents/Contents
+#: components/manage/Controlpanels/AddonsControlpanel
 #: components/manage/Controlpanels/Aliases
 #: components/manage/Controlpanels/ContentTypes
 #: components/manage/Controlpanels/ContentTypeSchema
@@ -3998,6 +4030,11 @@ msgstr "Título"
 # defaultMessage: Table of Contents
 msgid "toc"
 msgstr "Tabla de contenidos"
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Update from version {origin} to {destination}
+msgid "upgradeVersions"
+msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
 # defaultMessage: Input must be valid url (www.something.com or http(s)://www.something.com)

--- a/locales/eu/LC_MESSAGES/volto.po
+++ b/locales/eu/LC_MESSAGES/volto.po
@@ -197,6 +197,36 @@ msgstr "Gehigarrien ezarpenak"
 msgid "Additional date"
 msgstr "Data gehigarria"
 
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon could not be installed
+msgid "Addon could not be installed"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon could not be uninstalled
+msgid "Addon could not be uninstalled"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon could not be upgraded
+msgid "Addon could not be upgraded"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon installed succesfuly
+msgid "Addon installed succesfuly"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon uninstalled succesfuly
+msgid "Addon uninstalled succesfuly"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon upgraded succesfuly
+msgid "Addon upgraded succesfuly"
+msgstr ""
+
 #: config/Views
 # defaultMessage: Album view
 msgid "Album view"
@@ -1036,6 +1066,7 @@ msgid "Enter your username for verification."
 msgstr "Idatzi zure erabiltzaile-izena egiaztatu dezagun."
 
 #: components/manage/Add/Add
+#: components/manage/Controlpanels/AddonsControlpanel
 #: components/manage/Controlpanels/ContentTypeSchema
 #: components/manage/Controlpanels/UndoControlpanel
 #: components/manage/Edit/Edit
@@ -2826,6 +2857,7 @@ msgstr "Gaia"
 #: components/manage/Actions/Actions
 #: components/manage/Aliases/Aliases
 #: components/manage/Contents/Contents
+#: components/manage/Controlpanels/AddonsControlpanel
 #: components/manage/Controlpanels/Aliases
 #: components/manage/Controlpanels/ContentTypes
 #: components/manage/Controlpanels/ContentTypeSchema
@@ -3995,6 +4027,11 @@ msgstr "Izenburua"
 # defaultMessage: Table of Contents
 msgid "toc"
 msgstr "Edukien taula"
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Update from version {origin} to {destination}
+msgid "upgradeVersions"
+msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
 # defaultMessage: Input must be valid url (www.something.com or http(s)://www.something.com)

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -207,6 +207,36 @@ msgstr "Paramètres des modules"
 msgid "Additional date"
 msgstr ""
 
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon could not be installed
+msgid "Addon could not be installed"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon could not be uninstalled
+msgid "Addon could not be uninstalled"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon could not be upgraded
+msgid "Addon could not be upgraded"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon installed succesfuly
+msgid "Addon installed succesfuly"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon uninstalled succesfuly
+msgid "Addon uninstalled succesfuly"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon upgraded succesfuly
+msgid "Addon upgraded succesfuly"
+msgstr ""
+
 #: config/Views
 # defaultMessage: Album view
 msgid "Album view"
@@ -1046,6 +1076,7 @@ msgid "Enter your username for verification."
 msgstr ""
 
 #: components/manage/Add/Add
+#: components/manage/Controlpanels/AddonsControlpanel
 #: components/manage/Controlpanels/ContentTypeSchema
 #: components/manage/Controlpanels/UndoControlpanel
 #: components/manage/Edit/Edit
@@ -2836,6 +2867,7 @@ msgstr "Sujet"
 #: components/manage/Actions/Actions
 #: components/manage/Aliases/Aliases
 #: components/manage/Contents/Contents
+#: components/manage/Controlpanels/AddonsControlpanel
 #: components/manage/Controlpanels/Aliases
 #: components/manage/Controlpanels/ContentTypes
 #: components/manage/Controlpanels/ContentTypeSchema
@@ -4005,6 +4037,11 @@ msgstr "titre"
 # defaultMessage: Table of Contents
 msgid "toc"
 msgstr "toc"
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Update from version {origin} to {destination}
+msgid "upgradeVersions"
+msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
 # defaultMessage: Input must be valid url (www.something.com or http(s)://www.something.com)

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -190,6 +190,36 @@ msgstr "Impostazioni Add-ons"
 msgid "Additional date"
 msgstr "Data aggiuntiva"
 
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon could not be installed
+msgid "Addon could not be installed"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon could not be uninstalled
+msgid "Addon could not be uninstalled"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon could not be upgraded
+msgid "Addon could not be upgraded"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon installed succesfuly
+msgid "Addon installed succesfuly"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon uninstalled succesfuly
+msgid "Addon uninstalled succesfuly"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon upgraded succesfuly
+msgid "Addon upgraded succesfuly"
+msgstr ""
+
 #: config/Views
 # defaultMessage: Album view
 msgid "Album view"
@@ -1029,6 +1059,7 @@ msgid "Enter your username for verification."
 msgstr "Inserisci il tuo username per la verifica."
 
 #: components/manage/Add/Add
+#: components/manage/Controlpanels/AddonsControlpanel
 #: components/manage/Controlpanels/ContentTypeSchema
 #: components/manage/Controlpanels/UndoControlpanel
 #: components/manage/Edit/Edit
@@ -2819,6 +2850,7 @@ msgstr "Oggetto"
 #: components/manage/Actions/Actions
 #: components/manage/Aliases/Aliases
 #: components/manage/Contents/Contents
+#: components/manage/Controlpanels/AddonsControlpanel
 #: components/manage/Controlpanels/Aliases
 #: components/manage/Controlpanels/ContentTypes
 #: components/manage/Controlpanels/ContentTypeSchema
@@ -3988,6 +4020,11 @@ msgstr "Titolo"
 # defaultMessage: Table of Contents
 msgid "toc"
 msgstr "Indice dei contenuti"
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Update from version {origin} to {destination}
+msgid "upgradeVersions"
+msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
 # defaultMessage: Input must be valid url (www.something.com or http(s)://www.something.com)

--- a/locales/ja/LC_MESSAGES/volto.po
+++ b/locales/ja/LC_MESSAGES/volto.po
@@ -198,6 +198,36 @@ msgstr "アドオン設定"
 msgid "Additional date"
 msgstr "追加日"
 
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon could not be installed
+msgid "Addon could not be installed"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon could not be uninstalled
+msgid "Addon could not be uninstalled"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon could not be upgraded
+msgid "Addon could not be upgraded"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon installed succesfuly
+msgid "Addon installed succesfuly"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon uninstalled succesfuly
+msgid "Addon uninstalled succesfuly"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon upgraded succesfuly
+msgid "Addon upgraded succesfuly"
+msgstr ""
+
 #: config/Views
 # defaultMessage: Album view
 msgid "Album view"
@@ -1037,6 +1067,7 @@ msgid "Enter your username for verification."
 msgstr ""
 
 #: components/manage/Add/Add
+#: components/manage/Controlpanels/AddonsControlpanel
 #: components/manage/Controlpanels/ContentTypeSchema
 #: components/manage/Controlpanels/UndoControlpanel
 #: components/manage/Edit/Edit
@@ -2827,6 +2858,7 @@ msgstr "件名"
 #: components/manage/Actions/Actions
 #: components/manage/Aliases/Aliases
 #: components/manage/Contents/Contents
+#: components/manage/Controlpanels/AddonsControlpanel
 #: components/manage/Controlpanels/Aliases
 #: components/manage/Controlpanels/ContentTypes
 #: components/manage/Controlpanels/ContentTypeSchema
@@ -3996,6 +4028,11 @@ msgstr "タイトル"
 # defaultMessage: Table of Contents
 msgid "toc"
 msgstr "目次"
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Update from version {origin} to {destination}
+msgid "upgradeVersions"
+msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
 # defaultMessage: Input must be valid url (www.something.com or http(s)://www.something.com)

--- a/locales/nl/LC_MESSAGES/volto.po
+++ b/locales/nl/LC_MESSAGES/volto.po
@@ -209,6 +209,36 @@ msgstr ""
 msgid "Additional date"
 msgstr ""
 
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon could not be installed
+msgid "Addon could not be installed"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon could not be uninstalled
+msgid "Addon could not be uninstalled"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon could not be upgraded
+msgid "Addon could not be upgraded"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon installed succesfuly
+msgid "Addon installed succesfuly"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon uninstalled succesfuly
+msgid "Addon uninstalled succesfuly"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon upgraded succesfuly
+msgid "Addon upgraded succesfuly"
+msgstr ""
+
 #: config/Views
 # defaultMessage: Album view
 msgid "Album view"
@@ -1048,6 +1078,7 @@ msgid "Enter your username for verification."
 msgstr ""
 
 #: components/manage/Add/Add
+#: components/manage/Controlpanels/AddonsControlpanel
 #: components/manage/Controlpanels/ContentTypeSchema
 #: components/manage/Controlpanels/UndoControlpanel
 #: components/manage/Edit/Edit
@@ -2838,6 +2869,7 @@ msgstr ""
 #: components/manage/Actions/Actions
 #: components/manage/Aliases/Aliases
 #: components/manage/Contents/Contents
+#: components/manage/Controlpanels/AddonsControlpanel
 #: components/manage/Controlpanels/Aliases
 #: components/manage/Controlpanels/ContentTypes
 #: components/manage/Controlpanels/ContentTypeSchema
@@ -4006,6 +4038,11 @@ msgstr ""
 #: config/Blocks
 # defaultMessage: Table of Contents
 msgid "toc"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Update from version {origin} to {destination}
+msgid "upgradeVersions"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels

--- a/locales/pt/LC_MESSAGES/volto.po
+++ b/locales/pt/LC_MESSAGES/volto.po
@@ -198,6 +198,36 @@ msgstr ""
 msgid "Additional date"
 msgstr ""
 
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon could not be installed
+msgid "Addon could not be installed"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon could not be uninstalled
+msgid "Addon could not be uninstalled"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon could not be upgraded
+msgid "Addon could not be upgraded"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon installed succesfuly
+msgid "Addon installed succesfuly"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon uninstalled succesfuly
+msgid "Addon uninstalled succesfuly"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon upgraded succesfuly
+msgid "Addon upgraded succesfuly"
+msgstr ""
+
 #: config/Views
 # defaultMessage: Album view
 msgid "Album view"
@@ -1037,6 +1067,7 @@ msgid "Enter your username for verification."
 msgstr ""
 
 #: components/manage/Add/Add
+#: components/manage/Controlpanels/AddonsControlpanel
 #: components/manage/Controlpanels/ContentTypeSchema
 #: components/manage/Controlpanels/UndoControlpanel
 #: components/manage/Edit/Edit
@@ -2827,6 +2858,7 @@ msgstr "Assunto"
 #: components/manage/Actions/Actions
 #: components/manage/Aliases/Aliases
 #: components/manage/Contents/Contents
+#: components/manage/Controlpanels/AddonsControlpanel
 #: components/manage/Controlpanels/Aliases
 #: components/manage/Controlpanels/ContentTypes
 #: components/manage/Controlpanels/ContentTypeSchema
@@ -3995,6 +4027,11 @@ msgstr "título"
 #: config/Blocks
 # defaultMessage: Table of Contents
 msgid "toc"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Update from version {origin} to {destination}
+msgid "upgradeVersions"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels

--- a/locales/pt_BR/LC_MESSAGES/volto.po
+++ b/locales/pt_BR/LC_MESSAGES/volto.po
@@ -200,6 +200,36 @@ msgstr "Configurações dos complementos"
 msgid "Additional date"
 msgstr "Outra data"
 
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon could not be installed
+msgid "Addon could not be installed"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon could not be uninstalled
+msgid "Addon could not be uninstalled"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon could not be upgraded
+msgid "Addon could not be upgraded"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon installed succesfuly
+msgid "Addon installed succesfuly"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon uninstalled succesfuly
+msgid "Addon uninstalled succesfuly"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon upgraded succesfuly
+msgid "Addon upgraded succesfuly"
+msgstr ""
+
 #: config/Views
 # defaultMessage: Album view
 msgid "Album view"
@@ -1039,6 +1069,7 @@ msgid "Enter your username for verification."
 msgstr "Informe seu nome de usuário para verificação."
 
 #: components/manage/Add/Add
+#: components/manage/Controlpanels/AddonsControlpanel
 #: components/manage/Controlpanels/ContentTypeSchema
 #: components/manage/Controlpanels/UndoControlpanel
 #: components/manage/Edit/Edit
@@ -2829,6 +2860,7 @@ msgstr "Assunto"
 #: components/manage/Actions/Actions
 #: components/manage/Aliases/Aliases
 #: components/manage/Contents/Contents
+#: components/manage/Controlpanels/AddonsControlpanel
 #: components/manage/Controlpanels/Aliases
 #: components/manage/Controlpanels/ContentTypes
 #: components/manage/Controlpanels/ContentTypeSchema
@@ -3998,6 +4030,11 @@ msgstr "título"
 # defaultMessage: Table of Contents
 msgid "toc"
 msgstr "tabela de conteúdos"
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Update from version {origin} to {destination}
+msgid "upgradeVersions"
+msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
 # defaultMessage: Input must be valid url (www.something.com or http(s)://www.something.com)

--- a/locales/ro/LC_MESSAGES/volto.po
+++ b/locales/ro/LC_MESSAGES/volto.po
@@ -190,6 +190,36 @@ msgstr "Setări add-on-uri"
 msgid "Additional date"
 msgstr "Dată suplimentară"
 
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon could not be installed
+msgid "Addon could not be installed"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon could not be uninstalled
+msgid "Addon could not be uninstalled"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon could not be upgraded
+msgid "Addon could not be upgraded"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon installed succesfuly
+msgid "Addon installed succesfuly"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon uninstalled succesfuly
+msgid "Addon uninstalled succesfuly"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon upgraded succesfuly
+msgid "Addon upgraded succesfuly"
+msgstr ""
+
 #: config/Views
 # defaultMessage: Album view
 msgid "Album view"
@@ -1029,6 +1059,7 @@ msgid "Enter your username for verification."
 msgstr ""
 
 #: components/manage/Add/Add
+#: components/manage/Controlpanels/AddonsControlpanel
 #: components/manage/Controlpanels/ContentTypeSchema
 #: components/manage/Controlpanels/UndoControlpanel
 #: components/manage/Edit/Edit
@@ -2819,6 +2850,7 @@ msgstr "Subiect"
 #: components/manage/Actions/Actions
 #: components/manage/Aliases/Aliases
 #: components/manage/Contents/Contents
+#: components/manage/Controlpanels/AddonsControlpanel
 #: components/manage/Controlpanels/Aliases
 #: components/manage/Controlpanels/ContentTypes
 #: components/manage/Controlpanels/ContentTypeSchema
@@ -3988,6 +4020,11 @@ msgstr "Titlu"
 # defaultMessage: Table of Contents
 msgid "toc"
 msgstr "Cuprins"
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Update from version {origin} to {destination}
+msgid "upgradeVersions"
+msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
 # defaultMessage: Input must be valid url (www.something.com or http(s)://www.something.com)

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2022-09-23T09:41:15.663Z\n"
+"POT-Creation-Date: 2022-10-02T15:00:24.366Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -190,6 +190,36 @@ msgstr ""
 #: components/manage/Widgets/RecurrenceWidget/Occurences
 # defaultMessage: Additional date
 msgid "Additional date"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon could not be installed
+msgid "Addon could not be installed"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon could not be uninstalled
+msgid "Addon could not be uninstalled"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon could not be upgraded
+msgid "Addon could not be upgraded"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon installed succesfuly
+msgid "Addon installed succesfuly"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon uninstalled succesfuly
+msgid "Addon uninstalled succesfuly"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Addon upgraded succesfuly
+msgid "Addon upgraded succesfuly"
 msgstr ""
 
 #: config/Views
@@ -1031,6 +1061,7 @@ msgid "Enter your username for verification."
 msgstr ""
 
 #: components/manage/Add/Add
+#: components/manage/Controlpanels/AddonsControlpanel
 #: components/manage/Controlpanels/ContentTypeSchema
 #: components/manage/Controlpanels/UndoControlpanel
 #: components/manage/Edit/Edit
@@ -2821,6 +2852,7 @@ msgstr ""
 #: components/manage/Actions/Actions
 #: components/manage/Aliases/Aliases
 #: components/manage/Contents/Contents
+#: components/manage/Controlpanels/AddonsControlpanel
 #: components/manage/Controlpanels/Aliases
 #: components/manage/Controlpanels/ContentTypes
 #: components/manage/Controlpanels/ContentTypeSchema
@@ -3989,6 +4021,11 @@ msgstr ""
 #: config/Blocks
 # defaultMessage: Table of Contents
 msgid "toc"
+msgstr ""
+
+#: components/manage/Controlpanels/AddonsControlpanel
+# defaultMessage: Update from version {origin} to {destination}
+msgid "upgradeVersions"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels

--- a/src/components/manage/Controlpanels/AddonsControlpanel.jsx
+++ b/src/components/manage/Controlpanels/AddonsControlpanel.jsx
@@ -373,10 +373,11 @@ class AddonsControlpanel extends Component {
                     }
                   >
                     {item.title}
+
                     {item.upgrade_info.available && (
-                      <span className="updateText">
+                      <Label>
                         <FormattedMessage id="Update" defaultMessage="Update" />
-                      </span>
+                      </Label>
                     )}
                     <Icon
                       name={

--- a/src/components/manage/Controlpanels/AddonsControlpanel.jsx
+++ b/src/components/manage/Controlpanels/AddonsControlpanel.jsx
@@ -17,6 +17,8 @@ import {
   Label,
   Message,
   Segment,
+  Dimmer,
+  Loader,
 } from 'semantic-ui-react';
 import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
 
@@ -27,10 +29,11 @@ import {
   upgradeAddon,
 } from '@plone/volto/actions';
 import { Helmet } from '@plone/volto/helpers';
-import { Icon, Toolbar } from '@plone/volto/components';
+import { Icon, Toolbar, Toast } from '@plone/volto/components';
 import circleBottomSVG from '@plone/volto/icons/circle-bottom.svg';
 import circleTopSVG from '@plone/volto/icons/circle-top.svg';
 import backSVG from '@plone/volto/icons/back.svg';
+import { toast } from 'react-toastify';
 
 const messages = defineMessages({
   activateAndDeactivate: {
@@ -93,6 +96,38 @@ const messages = defineMessages({
   installingAnAddon: {
     id: 'Installing a third party add-on',
     defaultMessage: 'Installing a third party add-on',
+  },
+  success: {
+    id: 'Success',
+    defaultMessage: 'Success',
+  },
+  error: {
+    id: 'Error',
+    defaultMessage: 'Error',
+  },
+  addonUpgraded: {
+    id: 'Addon upgraded succesfuly',
+    defaultMessage: 'Addon upgraded succesfuly',
+  },
+  addonNotUpgraded: {
+    id: 'Addon could not be upgraded',
+    defaultMessage: 'Addon could not be upgraded',
+  },
+  addonInstalled: {
+    id: 'Addon installed succesfuly',
+    defaultMessage: 'Addon installed succesfuly',
+  },
+  addonNotInstalled: {
+    id: 'Addon could not be installed',
+    defaultMessage: 'Addon could not be installed',
+  },
+  addonUninstalled: {
+    id: 'Addon uninstalled succesfuly',
+    defaultMessage: 'Addon uninstalled succesfuly',
+  },
+  addonNotUninstalled: {
+    id: 'Addon could not be uninstalled',
+    defaultMessage: 'Addon could not be uninstalled',
   },
 });
 
@@ -192,7 +227,29 @@ class AddonsControlpanel extends Component {
    */
   onInstall(event, { value }) {
     event.preventDefault();
-    this.props.installAddon(value).then(() => this.props.listAddons());
+    this.props
+      .installAddon(value)
+      .then(() => {
+        toast.success(
+          <Toast
+            success
+            title={this.props.intl.formatMessage(messages.success)}
+            content={this.props.intl.formatMessage(messages.addonInstalled, {
+              title: this.props.title,
+            })}
+          />,
+        );
+      })
+      .catch(() => {
+        toast.error(
+          <Toast
+            error
+            title={this.props.intl.formatMessage(messages.error)}
+            content={this.props.intl.formatMessage(messages.addonNotInstalled)}
+          />,
+        );
+      })
+      .finally(() => this.props.listAddons());
   }
 
   /**
@@ -204,7 +261,32 @@ class AddonsControlpanel extends Component {
    */
   onUninstall(event, { value }) {
     event.preventDefault();
-    this.props.uninstallAddon(value).then(() => this.props.listAddons());
+    this.props
+      .uninstallAddon(value)
+      .then(() => {
+        toast.success(
+          <Toast
+            success
+            title={this.props.intl.formatMessage(messages.success)}
+            content={this.props.intl.formatMessage(messages.addonUninstalled)}
+          />,
+        );
+      })
+      .catch(() => {
+        toast.error(
+          <Toast
+            error
+            title={this.props.intl.formatMessage(messages.error)}
+            content={this.props.intl.formatMessage(
+              messages.addonNotUninstalled,
+              {
+                title: this.props.title,
+              },
+            )}
+          />,
+        );
+      })
+      .finally(() => this.props.listAddons());
   }
 
   /**
@@ -216,7 +298,27 @@ class AddonsControlpanel extends Component {
    */
   onUpgrade(event, { value }) {
     event.preventDefault();
-    this.props.upgradeAddon(value).then(() => this.props.listAddons());
+    this.props
+      .upgradeAddon(value)
+      .then(() => {
+        toast.success(
+          <Toast
+            success
+            title={this.props.intl.formatMessage(messages.success)}
+            content={this.props.intl.formatMessage(messages.addonUpgraded)}
+          />,
+        );
+      })
+      .catch(() => {
+        toast.error(
+          <Toast
+            error
+            title={this.props.intl.formatMessage(messages.error)}
+            content={this.props.intl.formatMessage(messages.addonNotUpgraded)}
+          />,
+        );
+      })
+      .finally(() => this.props.listAddons());
   }
 
   /**
@@ -248,193 +350,204 @@ class AddonsControlpanel extends Component {
               defaultMessage="Add-ons Settings"
             />
           </Segment>
-          {this.props.upgradableAddons.length > 0 && (
-            <Message attached>
-              <Message.Header>
+
+          {this.props.loadingAddons ? (
+            <Dimmer active>
+              <Loader />
+            </Dimmer>
+          ) : (
+            <>
+              {this.props.upgradableAddons.length > 0 && (
+                <Message attached>
+                  <Message.Header>
+                    <FormattedMessage
+                      id="Updates available"
+                      defaultMessage="Updates available"
+                    />
+                  </Message.Header>
+                  <FormattedMessage
+                    id="Update installed addons"
+                    defaultMessage="Update installed addons"
+                  />
+                </Message>
+              )}
+              <Segment>
+                <Header as="h3">
+                  <FormattedMessage
+                    id="Activate and deactivate"
+                    defaultMessage="Activate and deactivate add-ons in the lists below."
+                  />
+                </Header>
                 <FormattedMessage
-                  id="Updates available"
-                  defaultMessage="Updates available"
+                  id="Add Addons"
+                  defaultMessage="To make new add-ons show up here, add them to your buildout configuration, run buildout, and restart the server process. For detailed instructions see"
                 />
-              </Message.Header>
-              <FormattedMessage
-                id="Update installed addons"
-                defaultMessage="Update installed addons"
-              />
-            </Message>
-          )}
-
-          <Segment>
-            <Header as="h3">
-              <FormattedMessage
-                id="Activate and deactivate"
-                defaultMessage="Activate and deactivate add-ons in the lists below."
-              />
-            </Header>
-            <FormattedMessage
-              id="Add Addons"
-              defaultMessage="To make new add-ons show up here, add them to your buildout configuration, run buildout, and restart the server process. For detailed instructions see"
-            />
-            &nbsp;
-            <a
-              href="http://docs.plone.org/manage/installing/installing_addons.html"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              {this.props.intl.formatMessage(messages.installingAnAddon)}
-            </a>
-            .
-          </Segment>
-
-          <Segment key="header-available" secondary>
-            <FormattedMessage id="Available" defaultMessage="Available" />:
-            <Label circular>{this.props.availableAddons.length}</Label>
-          </Segment>
-
-          <Segment key="body-available" attached>
-            <Accordion>
-              <Divider />
-              {this.props.availableAddons.map((item) => (
-                <div key={item.id}>
-                  <Accordion.Title
-                    active={this.state.activeIndex === item.id}
-                    index={item.id}
-                    onClick={this.onAccordionClick}
-                  >
-                    {item.title}
-                    <Icon
-                      name={
-                        this.state.activeIndex === item.id
-                          ? circleTopSVG
-                          : circleBottomSVG
-                      }
-                      size="23px"
-                      className={`accordionToggle ${item.title}`}
-                    />
-                  </Accordion.Title>
-                  <Accordion.Content
-                    active={this.state.activeIndex === item.id}
-                  >
-                    <div className="description">{item.description}</div>
-                    {item.uninstall_profile_id === '' && (
-                      <div>
-                        <Message icon="warning" warning>
-                          <FormattedMessage
-                            id="No uninstall profile"
-                            defaultMessage="This addon does not provide an uninstall profile."
-                          />
-                        </Message>
-                      </div>
-                    )}
-                    <Button.Group floated="right">
-                      <Button
-                        primary
-                        onClick={this.onInstall}
-                        value={item.id}
-                        className="installAction"
+                &nbsp;
+                <a
+                  href="http://docs.plone.org/manage/installing/installing_addons.html"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {this.props.intl.formatMessage(messages.installingAnAddon)}
+                </a>
+                .
+              </Segment>
+              <Segment key="header-available" secondary>
+                <FormattedMessage id="Available" defaultMessage="Available" />:
+                <Label circular>{this.props.availableAddons.length}</Label>
+              </Segment>
+              <Segment key="body-available" attached>
+                <Accordion>
+                  <Divider />
+                  {this.props.availableAddons.map((item) => (
+                    <div key={item.id}>
+                      <Accordion.Title
+                        active={this.state.activeIndex === item.id}
+                        index={item.id}
+                        onClick={this.onAccordionClick}
                       >
-                        <FormattedMessage
-                          id="Install"
-                          defaultMessage="Install"
-                          className="button-label"
+                        {item.title}
+                        <Icon
+                          name={
+                            this.state.activeIndex === item.id
+                              ? circleTopSVG
+                              : circleBottomSVG
+                          }
+                          size="23px"
+                          className={`accordionToggle ${item.title}`}
                         />
-                      </Button>
-                    </Button.Group>
-                    <div className="version">
-                      <FormattedMessage
-                        id="Latest version"
-                        defaultMessage="Latest version"
-                      />
-                      : &nbsp;
-                      {item.version}
-                    </div>
-                  </Accordion.Content>
-                  <Divider />
-                </div>
-              ))}
-            </Accordion>
-          </Segment>
-
-          <Segment key="header-installed" secondary>
-            <FormattedMessage id="Installed" defaultMessage="Installed" />:
-            <Label circular>{this.props.installedAddons.length}</Label>
-          </Segment>
-
-          <Segment key="body-installed" attached>
-            <Accordion>
-              <Divider />
-              {this.props.installedAddons.map((item) => (
-                <div key={item.id}>
-                  <Accordion.Title
-                    active={this.state.activeIndex === item.id}
-                    index={item.id}
-                    onClick={this.onAccordionClick}
-                    className={
-                      item.upgrade_info.available ? 'updateAvailable' : ''
-                    }
-                  >
-                    {item.title}
-
-                    {item.upgrade_info.available && (
-                      <Label>
-                        <FormattedMessage id="Update" defaultMessage="Update" />
-                      </Label>
-                    )}
-                    <Icon
-                      name={
-                        this.state.activeIndex === item.id
-                          ? circleTopSVG
-                          : circleBottomSVG
-                      }
-                      size="24px"
-                      className={`accordionToggle ${item.title}`}
-                      color="#878f93"
-                    />
-                  </Accordion.Title>
-                  <Accordion.Content
-                    active={this.state.activeIndex === item.id}
-                  >
-                    <div className="description">{item.description}</div>
-                    <Button.Group floated="right">
-                      {item.upgrade_info.available && (
-                        <Button
-                          primary
-                          onClick={this.onUpgrade}
-                          value={item.id}
-                        >
+                      </Accordion.Title>
+                      <Accordion.Content
+                        active={this.state.activeIndex === item.id}
+                      >
+                        <div className="description">{item.description}</div>
+                        {item.uninstall_profile_id === '' && (
+                          <div>
+                            <Message icon="warning" warning>
+                              <FormattedMessage
+                                id="No uninstall profile"
+                                defaultMessage="This addon does not provide an uninstall profile."
+                              />
+                            </Message>
+                          </div>
+                        )}
+                        <Button.Group floated="right">
+                          <Button
+                            primary
+                            onClick={this.onInstall}
+                            value={item.id}
+                            className="installAction"
+                          >
+                            <FormattedMessage
+                              id="Install"
+                              defaultMessage="Install"
+                              className="button-label"
+                            />
+                          </Button>
+                        </Button.Group>
+                        <div className="version">
                           <FormattedMessage
-                            id="Update"
-                            defaultMessage="Update"
+                            id="Latest version"
+                            defaultMessage="Latest version"
                           />
-                        </Button>
-                      )}
-                      {item.uninstall_profile_id && (
-                        <Button
-                          negative
-                          onClick={this.onUninstall}
-                          value={item.id}
-                          className="uninstallAction"
-                        >
-                          <FormattedMessage
-                            id="Uninstall"
-                            defaultMessage="Uninstall"
-                            className="button-label"
-                          />
-                        </Button>
-                      )}
-                    </Button.Group>
-                    <div className="version">
-                      <FormattedMessage
-                        id="Installed version"
-                        defaultMessage="Installed version"
-                      />
-                      : &nbsp; {item.version}
+                          : &nbsp;
+                          {item.version}
+                        </div>
+                      </Accordion.Content>
+                      <Divider />
                     </div>
-                  </Accordion.Content>
+                  ))}
+                </Accordion>
+              </Segment>
+              <Segment key="header-installed" secondary>
+                <FormattedMessage id="Installed" defaultMessage="Installed" />:
+                <Label circular>{this.props.installedAddons.length}</Label>
+              </Segment>
+              <Segment key="body-installed" attached>
+                <Accordion>
                   <Divider />
-                </div>
-              ))}
-            </Accordion>
-          </Segment>
+                  {this.props.installedAddons.map((item) => (
+                    <div key={item.id}>
+                      <Accordion.Title
+                        active={this.state.activeIndex === item.id}
+                        index={item.id}
+                        onClick={this.onAccordionClick}
+                        className={
+                          item.upgrade_info.available ? 'updateAvailable' : ''
+                        }
+                      >
+                        {item.title}
+
+                        {item.upgrade_info.available && (
+                          <Label>
+                            <FormattedMessage
+                              id="Update"
+                              defaultMessage="Update"
+                            />
+                          </Label>
+                        )}
+                        <Icon
+                          name={
+                            this.state.activeIndex === item.id
+                              ? circleTopSVG
+                              : circleBottomSVG
+                          }
+                          size="24px"
+                          className={`accordionToggle ${item.title}`}
+                          color="#878f93"
+                        />
+                      </Accordion.Title>
+                      <Accordion.Content
+                        active={this.state.activeIndex === item.id}
+                      >
+                        <div className="description">{item.description}</div>
+                        <Button.Group floated="right">
+                          {item.upgrade_info.available && (
+                            <Button
+                              primary
+                              onClick={this.onUpgrade}
+                              value={item.id}
+                            >
+                              <FormattedMessage
+                                id="upgradeVersions"
+                                defaultMessage="Update from version {origin} to {destination}"
+                                values={{
+                                  origin: item.upgrade_info.installedVersion,
+                                  destination: item.upgrade_info.newVersion,
+                                }}
+                              />
+                            </Button>
+                          )}
+                          {item.uninstall_profile_id && (
+                            <Button
+                              negative
+                              onClick={this.onUninstall}
+                              value={item.id}
+                              className="uninstallAction"
+                            >
+                              <FormattedMessage
+                                id="Uninstall"
+                                defaultMessage="Uninstall"
+                                className="button-label"
+                              />
+                            </Button>
+                          )}
+                        </Button.Group>
+                        <div className="version">
+                          <FormattedMessage
+                            id="Installed version"
+                            defaultMessage="Installed version"
+                          />
+                          : &nbsp; {item.version}
+                        </div>
+                      </Accordion.Content>
+                      <Divider />
+                    </div>
+                  ))}
+                </Accordion>
+              </Segment>
+            </>
+          )}
         </Segment.Group>
 
         {this.state.isClient && (
@@ -470,6 +583,7 @@ export default compose(
       installedAddons: state.addons.installedAddons,
       availableAddons: state.addons.availableAddons,
       upgradableAddons: state.addons.upgradableAddons,
+      loadingAddons: state.addons.loading,
       pathname: props.location.pathname,
     }),
     { installAddon, listAddons, uninstallAddon, upgradeAddon },

--- a/src/components/manage/Controlpanels/AddonsControlpanel.jsx
+++ b/src/components/manage/Controlpanels/AddonsControlpanel.jsx
@@ -328,7 +328,6 @@ class AddonsControlpanel extends Component {
                     <Button.Group floated="right">
                       <Button
                         primary
-                        basic
                         onClick={this.onInstall}
                         value={item.id}
                         className="installAction"
@@ -398,7 +397,6 @@ class AddonsControlpanel extends Component {
                       {item.upgrade_info.available && (
                         <Button
                           primary
-                          basic
                           onClick={this.onUpgrade}
                           value={item.id}
                         >
@@ -411,7 +409,6 @@ class AddonsControlpanel extends Component {
                       {item.uninstall_profile_id && (
                         <Button
                           negative
-                          basic
                           onClick={this.onUninstall}
                           value={item.id}
                           className="uninstallAction"

--- a/src/components/manage/Controlpanels/__snapshots__/AddonsControlpanel.test.jsx.snap
+++ b/src/components/manage/Controlpanels/__snapshots__/AddonsControlpanel.test.jsx.snap
@@ -100,7 +100,7 @@ exports[`AddonsControlpanel renders an addon control component 1`] = `
               className="ui right floated buttons"
             >
               <button
-                className="ui basic primary button installAction"
+                className="ui primary button installAction"
                 onClick={[Function]}
                 value="plone.app.somethingelse"
               >
@@ -148,11 +148,12 @@ exports[`AddonsControlpanel renders an addon control component 1`] = `
             onClick={[Function]}
           >
             Whatever
-            <span
-              className="updateText"
+            <div
+              className="ui label"
+              onClick={[Function]}
             >
               Update
-            </span>
+            </div>
             <svg
               className="icon accordionToggle Whatever"
               dangerouslySetInnerHTML={
@@ -184,14 +185,14 @@ exports[`AddonsControlpanel renders an addon control component 1`] = `
               className="ui right floated buttons"
             >
               <button
-                className="ui basic primary button"
+                className="ui primary button"
                 onClick={[Function]}
                 value="plone.app.whatever"
               >
-                Update
+                Update from version  to 
               </button>
               <button
-                className="ui basic negative button uninstallAction"
+                className="ui negative button uninstallAction"
                 onClick={[Function]}
                 value="plone.app.whatever"
               >


### PR DESCRIPTION
- Mark Update indications as labels

![Pantaila-argazkia 2022-10-01 20-35-24](https://user-images.githubusercontent.com/817365/193423446-4dc1e277-46f2-42ca-8d20-66f3695ba31e.png)

- Show Update - Install - Uninstall actions as buttons

![Pantaila-argazkia 2022-10-01 20-35-56](https://user-images.githubusercontent.com/817365/193423479-8f0da098-eef7-4228-bbbb-d8044e03a21e.png)

- Show a "Loading..." dimmer while the load / install / update / uninstall action is being done
- Show toasts with the Update / Install / Uninstall action results.

Fixes #3681 