### PR TITLE
Add default to `null` for `token` prop in `Navigation` component. Thi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugfix
 
 - Fix unlock after changing the id and saving a page @reebalazs
+- Add default to `null` for `token` prop in `Navigation` component. This prevents the component to shoot an extra call when the logout happens @sneridagh
 
 ### Internal
 

--- a/src/components/theme/Navigation/Navigation.jsx
+++ b/src/components/theme/Navigation/Navigation.jsx
@@ -50,6 +50,10 @@ class Navigation extends Component {
     lang: PropTypes.string.isRequired,
   };
 
+  static defaultProps = {
+    token: null,
+  };
+
   /**
    * Constructor
    * @method constructor


### PR DESCRIPTION
…s prevents the component to shoot an extra call when the logout happens