### PR TITLE
Personal information from controlpanel

### DIFF
--- a/src/components/manage/Controlpanels/Users/RenderUsers.jsx
+++ b/src/components/manage/Controlpanels/Users/RenderUsers.jsx
@@ -5,10 +5,13 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { FormattedMessage, injectIntl } from 'react-intl';
+import { withRouter } from 'react-router-dom';
+import { compose } from 'redux';
 import { Dropdown, Table, Checkbox } from 'semantic-ui-react';
 import trashSVG from '@plone/volto/icons/delete.svg';
 import { Icon } from '@plone/volto/components';
 import ploneSVG from '@plone/volto/icons/plone.svg';
+import showSVG from '@plone/volto/icons/show.svg';
 
 /**
  * UsersControlpanelUser class.
@@ -92,6 +95,20 @@ class RenderUsers extends Component {
           <Dropdown icon="ellipsis horizontal">
             <Dropdown.Menu className="left">
               <Dropdown.Item
+                onClick={() => {
+                  this.props.history.push(
+                    `/personal-information/${this.props.user.username}`,
+                  );
+                }}
+                value={this.props.user['@id']}
+              >
+                <Icon name={showSVG} size="15px" />
+                <FormattedMessage
+                  id="View user info"
+                  defaultMessage="View user info"
+                />
+              </Dropdown.Item>
+              <Dropdown.Item
                 onClick={this.props.onDelete}
                 value={this.props.user['@id']}
               >
@@ -106,4 +123,4 @@ class RenderUsers extends Component {
   }
 }
 
-export default injectIntl(RenderUsers);
+export default compose(injectIntl, withRouter)(RenderUsers);

--- a/src/components/manage/Preferences/PersonalInformation.jsx
+++ b/src/components/manage/Preferences/PersonalInformation.jsx
@@ -106,6 +106,11 @@ class PersonalInformation extends Component {
     return (
       this.props?.userschema?.loaded && (
         <Form
+          title={`Personal Information for ${
+            this.props.user.fullname
+              ? this.props.user.fullname
+              : this.props.user.email
+          }`}
           formData={this.props.user}
           schema={this.props?.userschema.userschema}
           onSubmit={this.onSubmit}

--- a/src/components/manage/Preferences/PersonalInformation.jsx
+++ b/src/components/manage/Preferences/PersonalInformation.jsx
@@ -12,8 +12,8 @@ import { withRouter } from 'react-router-dom';
 import jwtDecode from 'jwt-decode';
 import { toast } from 'react-toastify';
 import { messages } from '@plone/volto/helpers';
-import { Form, Toast } from '@plone/volto/components';
 import { getUser, updateUser, getUserSchema } from '@plone/volto/actions';
+import { Form, Toast, Unauthorized } from '@plone/volto/components';
 
 /**
  * PersonalInformation class.
@@ -99,6 +99,10 @@ class PersonalInformation extends Component {
    * @returns {string} Markup for the component.
    */
   render() {
+    if (this.props.error && this.props.error.status === 401) {
+      return <Unauthorized />;
+    }
+
     return (
       this.props?.userschema?.loaded && (
         <Form
@@ -119,7 +123,10 @@ export default compose(
   connect(
     (state, props) => ({
       user: state.users.user,
-      userId: state.userSession.token
+      error: state.users.get.error,
+      userId: props.match.params.username
+        ? props.match.params.username
+        : state.userSession.token
         ? jwtDecode(state.userSession.token).sub
         : '',
       loaded: state.users.get.loaded,

--- a/src/components/manage/Preferences/PersonalInformation.jsx
+++ b/src/components/manage/Preferences/PersonalInformation.jsx
@@ -110,7 +110,7 @@ class PersonalInformation extends Component {
             this.props.user.fullname
               ? this.props.user.fullname
               : this.props.user.email
-          }`}
+          } (${this.props.user.username})`}
           formData={this.props.user}
           schema={this.props?.userschema.userschema}
           onSubmit={this.onSubmit}

--- a/src/routes.js
+++ b/src/routes.js
@@ -240,6 +240,11 @@ export const defaultRoutes = [
     exact: true,
   },
   {
+    path: '/personal-information/:username',
+    component: PersonalInformation,
+    exact: true,
+  },
+  {
     path: '/**',
     component: View,
   },


### PR DESCRIPTION
This PR makes it possible to view the personal information of other users, similar to what is already available in Plone with the `@@user-information?userid?` view. Additionally, I've added a link in the _Actions_ menu in the _Users_ control panel to view the information for a particular user.

## Todo

- Check that permissions apply correctly
  - [x] User's who shouldn't be able to get other user's info should be taken to unauthorized.
  - [ ] Should users be able to edit other user's personal information? Site Administrators/ Administrators can (as is it with existing Plone), but I'm not sure if custom roles which would let you view but not edit will display the form as editable

Below is a short video showing the 'View user info' option that was added to the User's control panel and looking at user's profile pages.
https://user-images.githubusercontent.com/30210785/194428307-fc0aa9fd-5b62-4fc5-ae89-c21594e2b97c.mov

