### PR TITLE
Object browser: image search should only show images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Feature
 
+- Object browser: image search should only show images @reebalazs
+
 ### Bugfix
 
 - Fix unlock after changing the id and saving a page @reebalazs

--- a/cypress/tests/core/basic/objectBrowser.js
+++ b/cypress/tests/core/basic/objectBrowser.js
@@ -20,6 +20,16 @@ describe('Object Browser Tests', () => {
       contentTitle: 'My Image',
       path: '/my-page-1',
     });
+    cy.createContent({
+      contentType: 'Image',
+      contentId: 'my-searchable-image',
+      contentTitle: 'My Searchable Image',
+    });
+    cy.createContent({
+      contentType: 'Document',
+      contentId: 'my-searchable-page',
+      contentTitle: 'My Searchable Page',
+    });
     cy.visit('/my-page');
     cy.waitForResourceToLoad('@navigation');
     cy.waitForResourceToLoad('@breadcrumbs');
@@ -70,5 +80,30 @@ describe('Object Browser Tests', () => {
     cy.get('.toolbar-inner button.ui.basic.icon.button').click();
     cy.findByLabelText('Search SVG').click();
     cy.get('.ui.input.search input').should('be.focused');
+  });
+
+  it('As editor I can search and only get a list of images but not other content types', () => {
+    cy.getSlate().click();
+    cy.get('.ui.basic.icon.button.block-add-button').click();
+    cy.get('.ui.basic.icon.button.image').contains('Image').click();
+    cy.get('.toolbar-inner button.ui.basic.icon.button').click();
+    cy.findByLabelText('Search SVG').click();
+    cy.get('.ui.input.search').type('Searchable');
+
+    // The document is not in the list
+    cy.findByLabelText('Browse My Searchable Page').should('not.exist');
+    // And the list has only 1 item
+    cy.get('.ui.segment.object-listing li').should('have.length', 1);
+
+    // The image can be selected as usual
+    cy.findByLabelText('Select My Searchable Image').dblclick();
+    cy.get('#toolbar-save').click();
+    cy.wait(1000);
+    cy.url().should('eq', Cypress.config().baseUrl + '/my-page');
+
+    // then we should see a image
+    cy.get('.block img')
+      .should('have.attr', 'src')
+      .and('eq', '/my-searchable-image/@@images/image');
   });
 });

--- a/src/components/manage/Sidebar/ObjectBrowser.jsx
+++ b/src/components/manage/Sidebar/ObjectBrowser.jsx
@@ -54,6 +54,7 @@ const withObjectBrowser = (WrappedComponent) =>
       dataName = null,
       overlay = null,
       propDataName = null,
+      searchableTypes,
       selectableTypes,
       maximumSelectionSize,
       currentPath,
@@ -65,6 +66,7 @@ const withObjectBrowser = (WrappedComponent) =>
         dataName,
         overlay,
         propDataName,
+        searchableTypes,
         selectableTypes,
         maximumSelectionSize,
         currentPath,
@@ -105,6 +107,7 @@ const withObjectBrowser = (WrappedComponent) =>
                 mode={this.state.mode}
                 onSelectItem={this.state.onSelectItem}
                 dataName={this.state.dataName}
+                searchableTypes={this.state.searchableTypes}
                 selectableTypes={this.state.selectableTypes}
                 maximumSelectionSize={this.state.maximumSelectionSize}
               />

--- a/src/components/manage/Sidebar/ObjectBrowserBody.jsx
+++ b/src/components/manage/Sidebar/ObjectBrowserBody.jsx
@@ -71,6 +71,7 @@ class ObjectBrowserBody extends Component {
     dataName: PropTypes.string,
     maximumSelectionSize: PropTypes.number,
     contextURL: PropTypes.string,
+    searchableTypes: PropTypes.arrayOf(PropTypes.string),
   };
 
   /**
@@ -84,6 +85,7 @@ class ObjectBrowserBody extends Component {
     onSelectItem: null,
     dataName: null,
     selectableTypes: [],
+    searchableTypes: null,
     maximumSelectionSize: null,
   };
 
@@ -124,6 +126,12 @@ class ObjectBrowserBody extends Component {
           ? flattenToAppURL(this.props.data.href)
           : '',
       showSearchInput: false,
+      // In image mode, the searchable types default to the image types which
+      // can be overridden with the property if specified.
+      searchableTypes:
+        this.props.mode === 'image'
+          ? this.props.searchableTypes || config.settings.imageObjects
+          : this.props.searchableTypes,
     };
     this.searchInputRef = React.createRef();
   }
@@ -207,6 +215,7 @@ class ObjectBrowserBody extends Component {
           'path.depth': 1,
           sort_on: 'getObjPositionInParent',
           metadata_fields: '_all',
+          portal_type: this.state.searchableTypes,
         },
         `${this.props.block}-${this.props.mode}`,
       );
@@ -217,6 +226,7 @@ class ObjectBrowserBody extends Component {
             {
               SearchableText: `${text}*`,
               metadata_fields: '_all',
+              portal_type: this.state.searchableTypes,
             },
             `${this.props.block}-${this.props.mode}`,
           )
@@ -226,6 +236,7 @@ class ObjectBrowserBody extends Component {
               'path.depth': 1,
               sort_on: 'getObjPositionInParent',
               metadata_fields: '_all',
+              portal_type: this.state.searchableTypes,
             },
             `${this.props.block}-${this.props.mode}`,
           );


### PR DESCRIPTION
- When searching by string, the result list limits to images only, in image mode
- Additional searchableTypes property added to openObjectBrowser, to override above default behaviour and restrict search to a list of desired content types