### PR TITLE
Fix Sentry failing to load due to adblock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugfix
 
 - Fix UniversalLink storybook @tiberiuichim
+- Change sentry chunk name to avoid ad blockers. Only load sentry if env vars exist @tiberiuichim
 
 ### Internal
 

--- a/src/components/theme/App/App.jsx
+++ b/src/components/theme/App/App.jsx
@@ -47,7 +47,9 @@ import MultilingualRedirector from '@plone/volto/components/theme/MultilingualRe
 import WorkingCopyToastsFactory from '@plone/volto/components/manage/WorkingCopyToastsFactory/WorkingCopyToastsFactory';
 import LockingToastsFactory from '@plone/volto/components/manage/LockingToastsFactory/LockingToastsFactory';
 
-const Sentry = loadable.lib(() => import('@sentry/browser'));
+const Sentry = loadable.lib(
+  () => import(/* webpackChunkName: "s_entry-browser" */ '@sentry/browser'), // chunk name avoids ad blockers
+);
 
 /**
  * @export

--- a/src/middleware/crashReporter.js
+++ b/src/middleware/crashReporter.js
@@ -1,7 +1,11 @@
 import loadable from '@loadable/component';
 
-const SentryBrowser = loadable.lib(() => import('@sentry/browser'));
-const SentryNode = loadable.lib(() => import('@sentry/browser'));
+const SentryBrowser = loadable.lib(() =>
+  import(/* webpackChunkName: "s_entry-browser" */ '@sentry/browser'),
+);
+const SentryNode = loadable.lib(() =>
+  import(/* webpackChunkName: "s_entry-browser" */ '@sentry/browser'),
+);
 
 const crashReporter = (store) => (next) => (action) => {
   try {

--- a/src/start-client.jsx
+++ b/src/start-client.jsx
@@ -20,7 +20,9 @@ import initSentry from '@plone/volto/sentry';
 export const history = createBrowserHistory();
 
 const sentryLibraries = {
-  Sentry: loadable.lib(() => import('@sentry/browser')),
+  Sentry: loadable.lib(() =>
+    import(/* webpackChunkName: "s_entry-browser" */ '@sentry/browser'),
+  ),
   SentryIntegrations: loadable.lib(() => import('@sentry/integrations')),
 };
 
@@ -38,7 +40,8 @@ const loadSentry = () => {
   });
 };
 
-loadSentry();
+if ((__CLIENT__ && window?.env?.RAZZLE_SENTRY_DSN) || __SENTRY__?.SENTRY_DSN)
+  loadSentry();
 
 function reactIntlErrorHandler(error) {
   debug('i18n')(error);


### PR DESCRIPTION
This crashed development websites.

Also make sentry load only when configured.