### PR TITLE
Fix autocomplete widget with an empty search result (Invalid offset NaN specified)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugfix
 
 - Fix UniversalLink storybook @tiberiuichim
+- Fix autocomplete widget with an empty search result @reebalazs
 
 ### Internal
 

--- a/src/components/manage/ReactVirtualized/DynamicRowHeightList.jsx
+++ b/src/components/manage/ReactVirtualized/DynamicRowHeightList.jsx
@@ -43,7 +43,7 @@ class DynamicHeightList extends React.PureComponent {
         }}
         deferredMeasurementCache={this._cache}
         overscanRowCount={0}
-        rowCount={this.props.children.length}
+        rowCount={this.props.children?.length || 0}
         rowHeight={this._cache.rowHeight}
         rowRenderer={this._rowRenderer}
         width={200}


### PR DESCRIPTION
If the user types a string into an autocomplete widget that has no results, an exception is thrown. This fixes this problem.

`Invalid offset NaN specified`