### PR TITLE
Trigger build of Plone 6 docs when documentation is updated

### DIFF
--- a/.github/workflows/update_remote_docs.yml
+++ b/.github/workflows/update_remote_docs.yml
@@ -14,4 +14,4 @@ jobs:
           -H "Authorization: Bearer ${{secrets.DOCUMENTATION_BUILD_APPLICATION_KEY}}" \
           -H "Accept: application/vnd.github.v3+json" \
           https://api.github.com/repos/plone/documentation/actions/workflows/update_submodule.yml/dispatches \
-          -d '{"ref": "master"}'
+          -d '{"ref": "6-dev"}'

--- a/.github/workflows/update_remote_docs.yml
+++ b/.github/workflows/update_remote_docs.yml
@@ -3,7 +3,9 @@ name: Trigger build and deploy of Plone 6 documentation
 on:
   push:
     branches:
-      - "esteele-build-docs"
+      - "master"
+    paths:
+      - "docs/*"
 
 jobs:
   deploy:

--- a/.github/workflows/update_remote_docs.yml
+++ b/.github/workflows/update_remote_docs.yml
@@ -1,0 +1,17 @@
+name: Trigger build and deploy of Plone 6 documentation
+
+on:
+  push:
+    branches:
+      - "esteele-build-docs"
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          curl -X POST \
+          -H "Authorization: Bearer ${{secrets.DOCUMENTATION_BUILD_APPLICATION_KEY}}" \
+          -H "Accept: application/vnd.github.v3+json" \
+          https://api.github.com/repos/plone/documentatioj/actions/workflows/update_submodule.yml/dispatches \
+          -d '{"ref": "master"}'

--- a/.github/workflows/update_remote_docs.yml
+++ b/.github/workflows/update_remote_docs.yml
@@ -13,5 +13,5 @@ jobs:
           curl -X POST \
           -H "Authorization: Bearer ${{secrets.DOCUMENTATION_BUILD_APPLICATION_KEY}}" \
           -H "Accept: application/vnd.github.v3+json" \
-          https://api.github.com/repos/plone/documentatioj/actions/workflows/update_submodule.yml/dispatches \
+          https://api.github.com/repos/plone/documentation/actions/workflows/update_submodule.yml/dispatches \
           -d '{"ref": "master"}'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ### Documentation
 
+- Trigger a new deploy core Plone documentation when Volto documentation is updated @esteele
+
 ## 16.0.0-alpha.42 (2022-10-06)
 
 ### Breaking


### PR DESCRIPTION
Calls an Action on the Plone 6 documentation repo that updates the documentation registry's submodules and triggers a new build and deploy of the Plone 6 docs.

Refs plone/documentation#1214