### PR TITLE
fix warnings related to missing key and missing  proptype (WIP)

### DIFF
--- a/src/components/manage/Contents/Contents.test.jsx
+++ b/src/components/manage/Contents/Contents.test.jsx
@@ -88,7 +88,16 @@ describe('Contents', () => {
       },
       intl: {
         locale: 'en',
-        messages: {},
+        messages: {
+          ID: {
+            id: 'ID',
+            defaultMessage: 'ID',
+          },
+          Type: {
+            id: 'Type',
+            defaultMessage: 'Type',
+          },
+        },
       },
     });
     const component = renderer.create(

--- a/src/components/manage/Pluggable/Pluggable.test.js
+++ b/src/components/manage/Pluggable/Pluggable.test.js
@@ -57,8 +57,10 @@ describe('<Pluggable />', () => {
                     </header>
                     <div className="pastanaga-menu-list">
                       <ul>
-                        {pluggables.map((p) => (
-                          <>{p()}</>
+                        {pluggables.map((p, index) => (
+                          <React.Fragment key={index.toString()}>
+                            {p()}
+                          </React.Fragment>
                         ))}
                       </ul>
                     </div>
@@ -91,8 +93,10 @@ describe('<Pluggable />', () => {
                     </header>
                     <div className="pastanaga-menu-list">
                       <ul>
-                        {pluggables.map((p) => (
-                          <>{p()}</>
+                        {pluggables.map((p, index) => (
+                          <React.Fragment key={index.toString()}>
+                            {p()}
+                          </React.Fragment>
                         ))}
                       </ul>
                     </div>

--- a/src/components/manage/Sidebar/AlignBlock.jsx
+++ b/src/components/manage/Sidebar/AlignBlock.jsx
@@ -56,8 +56,8 @@ const AlignBlock = ({
 
   return (
     <div className="align-buttons">
-      {actions.map((action) => (
-        <Button.Group>
+      {actions.map((action, index) => (
+        <Button.Group key={index.toString()}>
           <Button
             icon
             basic

--- a/src/components/manage/Toolbar/More.jsx
+++ b/src/components/manage/Toolbar/More.jsx
@@ -323,8 +323,10 @@ class More extends Component {
                   </header>
                   <div className="pastanaga-menu-list">
                     <ul>
-                      {pluggables.map((p) => (
-                        <>{p()}</>
+                      {pluggables.map((p, index) => (
+                        <React.Fragment key={index.toString()}>
+                          {p()}
+                        </React.Fragment>
                       ))}
                     </ul>
                   </div>

--- a/src/components/theme/View/ListingView.test.jsx
+++ b/src/components/theme/View/ListingView.test.jsx
@@ -25,12 +25,14 @@ describe('ListingView', () => {
               description: 'Hi',
               items: [
                 {
+                  '@id': 'my-item',
                   title: 'My item',
                   description: 'My item description',
                   url: '/item',
                   '@type': 'Document',
                 },
                 {
+                  '@id': 'my-second-item',
                   title: 'Second item',
                   description: 'My second item description',
                   url: '/item2',

--- a/src/components/theme/View/SummaryView.test.jsx
+++ b/src/components/theme/View/SummaryView.test.jsx
@@ -25,6 +25,7 @@ describe('TabularView', () => {
               description: 'Hi',
               items: [
                 {
+                  '@id': 'my-item',
                   title: 'My item',
                   description: 'My item description',
                   url: '/item',

--- a/src/components/theme/View/TabularView.test.jsx
+++ b/src/components/theme/View/TabularView.test.jsx
@@ -25,6 +25,7 @@ describe('TabularView', () => {
               description: 'Hi',
               items: [
                 {
+                  '@id': 'my-item',
                   title: 'My item',
                   description: 'My item description',
                   url: '/item',

--- a/src/components/theme/View/__snapshots__/ListingView.test.jsx.snap
+++ b/src/components/theme/View/__snapshots__/ListingView.test.jsx.snap
@@ -17,9 +17,9 @@ exports[`ListingView renders a listing_view component 1`] = `
         <h2>
           <a
             className={null}
-            href="/"
-            onClick={[Function]}
-            target={null}
+            href="http://my-item"
+            rel="noopener noreferrer"
+            target="_blank"
             title="Document"
           >
             My item
@@ -39,9 +39,9 @@ exports[`ListingView renders a listing_view component 1`] = `
         <h2>
           <a
             className={null}
-            href="/"
-            onClick={[Function]}
-            target={null}
+            href="http://my-second-item"
+            rel="noopener noreferrer"
+            target="_blank"
             title="Document"
           >
             Second item

--- a/src/components/theme/View/__snapshots__/SummaryView.test.jsx.snap
+++ b/src/components/theme/View/__snapshots__/SummaryView.test.jsx.snap
@@ -26,9 +26,9 @@ exports[`TabularView renders a summary view component 1`] = `
         <h2>
           <a
             className={null}
-            href="/"
-            onClick={[Function]}
-            target={null}
+            href="http://my-item"
+            rel="noopener noreferrer"
+            target="_blank"
             title="News Item"
           >
             My item
@@ -40,9 +40,9 @@ exports[`TabularView renders a summary view component 1`] = `
         <p>
           <a
             className={null}
-            href="/"
-            onClick={[Function]}
-            target={null}
+            href="http://my-item"
+            rel="noopener noreferrer"
+            target="_blank"
             title={null}
           >
             Read More…

--- a/src/components/theme/View/__snapshots__/TabularView.test.jsx.snap
+++ b/src/components/theme/View/__snapshots__/TabularView.test.jsx.snap
@@ -64,9 +64,9 @@ exports[`TabularView renders a tabular view component 1`] = `
             >
               <a
                 className="summary url"
-                href="/"
-                onClick={[Function]}
-                target={null}
+                href="http://my-item"
+                rel="noopener noreferrer"
+                target="_blank"
                 title={null}
               >
                 My item

--- a/src/components/theme/Widgets/ArrayWidget.jsx
+++ b/src/components/theme/Widgets/ArrayWidget.jsx
@@ -5,14 +5,14 @@ const ArrayWidget = ({ value, children, className }) =>
   value ? (
     <span className={cx(className, 'array', 'widget')}>
       {value.map((item, key) => (
-        <>
+        <React.Fragment key={item.token || item.title || item}>
           {key ? ', ' : ''}
-          <span key={item.token || item.title || item}>
+          <span>
             {children
               ? children(item.title || item.token || item)
               : item.title || item.token || item}
           </span>
-        </>
+        </React.Fragment>
       ))}
     </span>
   ) : (


### PR DESCRIPTION
Fix:
Missing Key for list item
- ArrayWidget.test.js
- AlignWidget.test.jsx
- LeadImageSidebar.test.jsx
- More.test.jsx
- Pluggable.test.js

Failed PropType: 

- ListingView.test.jsx
- TabularView.test.jsx 
- SummaryView.test.jsx 


Still to fix: 


warn: default extension
withBlockSchemaEnhancer.test.js (i dont know how to set default extension)

Failed propType:

- Edit.test.jsx 
- NumberWidget.test.jsx 
- ContentsItem.test.jsx 
- PasswordReset.test.jsx 
- Contents.test.js 

Function components cannot be given refs: 

- Controlpanel.test.jsx
- Edit.test.jsx
- ContentType.test.jsx


intl Errors:

- Contents.test.jsx

componentWillReceiveProps has been renamed:

- DateRangeFacet.test.jsx
- DatetimeWidget.test.jsx

