### PR TITLE
Draft: #3344 Created a local glossary for volto

### DIFF
--- a/docs/source/configuration/settings-reference.md
+++ b/docs/source/configuration/settings-reference.md
@@ -19,17 +19,14 @@ This list is still incomplete, contributions are welcomed!
 
 They are exposed in `config.settings`:
 
-```{glossary}
-:sorted:
-
 navDepth
-    Navigation levels depth used in the navigation endpoint calls. Increasing this is useful for implementing fat navigation menus. Defaults to `1`.
+:   Navigation levels depth used in the navigation endpoint calls. Increasing this is useful for implementing fat navigation menus. Defaults to `1`.
 
 defaultBlockType
-    The default block type in Volto is "text", which uses the current DraftJS-based implementation for the rich text editor. Future alternative rich text editors will need to use this setting and replace it with their block type. The block definition should also include the `blockHasValue` function, which is needed to activate the Block Chooser functionality. See this function signature in [Blocks > Settings](../blocks/settings.md).
+:   The default block type in Volto is "text", which uses the current DraftJS-based implementation for the rich text editor. Future alternative rich text editors will need to use this setting and replace it with their block type. The block definition should also include the `blockHasValue` function, which is needed to activate the Block Chooser functionality. See this function signature in [Blocks > Settings](../blocks/settings.md).
 
 sentryOptions
-    Sentry configuration:
+:   Sentry configuration:
 
     ```js
     import {
@@ -64,29 +61,10 @@ sentryOptions
     ```
 
 contentIcons
-    With this property you can configure Content Types icons.
-    Those are visible in Contents view (ex "Folder contents").  The default
-    ones are in
-    [config/ContentIcons.jsx](https://github.com/plone/volto/blob/master/src/config/ContentIcons.jsx)
-    and you can extend them in your project's config for custom content types
-    using `settings.contentIcons`.
-
-    In Volto projects, you can configure this for custom content types like:
-
-    ```js
-    import * as config from '@plone/volto/config';
-    import courseSVG from './icons/course.svg';
-
-    export const settings = {
-      ...config.settings,
-      contentIcons: {
-        ...config.settings.contentIcons,
-        Course: courseSVG,
-    };
-    ```
+:   See {term}`contentIcons`.
 
 bbb_getContentFetchesFullobjects
-    Before Volto 10, the main content-grabbing request, triggered as a result of
+:   Before Volto 10, the main content-grabbing request, triggered as a result of
     `getContent` action, always used the `fullobjects` flag, which fully serialized
     the immediate children of the context request. If your code depends on this
     behavior, set this flag to `true` in the `settings` object.
@@ -99,11 +77,11 @@ bbb_getContentFetchesFullobjects
     ```
 
 persistentReducers
-    A list of reducer names that should use the browser's localstorage to
+:   A list of reducer names that should use the browser's localstorage to
     persist their data.
 
 maxResponseSize
-    The library that we use to get files and images from the backend (superagent)
+:   The library that we use to get files and images from the backend (superagent)
     has a response size limit of 200 mb, so if you want to get a file bigger than 200 mb
     from Plone, the SSR will throw an error.
 
@@ -111,7 +89,7 @@ maxResponseSize
     (for example, to set 500 mb you need to write 5000000000).
 
 initialReducersBlacklist
-    The initial state passed from server to browser needs to be minimal in order to optimize the resultant html generated. This state gets stored in `window.__data` and received in client.
+:   The initial state passed from server to browser needs to be minimal in order to optimize the resultant html generated. This state gets stored in `window.__data` and received in client.
 
     You can blacklist a few reducers that you don't want to be part of `window.__data`,thus decreasing the initial html size for performance gains.
 
@@ -128,23 +106,23 @@ initialReducersBlacklist
     ```
 
 loadables
-    A mapping of loadable libraries that can be injected into components using
+:   A mapping of loadable libraries that can be injected into components using
     the `injectLazyLibs` HOC wrapper. See the [Lazy
     loading](../recipes/lazyload) page for more details.
 
 lazyBundles
-    A mapping of bundles to list of lazy library names. Create new bundles (or
+:   A mapping of bundles to list of lazy library names. Create new bundles (or
     change the already provided `cms` bundle to be able to preload multiple
     lazy libraries (with `preloadLazyLibs`) or quickly load them with
     `injectLazyLibs`.
 
 storeExtenders
-    A list of callables with signature `(middlewaresList) => middlewaresList`.
+:   A list of callables with signature `(middlewaresList) => middlewaresList`.
     These callables receive the whole stack of middlewares used in Volto and
     they can add new middleware or tweak this list.
 
 asyncPropsExtenders
-    Per-route customizable `asyncConnect` action dispatcher. These enable
+:   Per-route customizable `asyncConnect` action dispatcher. These enable
     proper server-side rendering of content that depends on additional async
     props coming from backend calls. It is a list of route-like configuration
     objects (they are matched using
@@ -167,7 +145,7 @@ asyncPropsExtenders
     ```
 
 externalRoutes
-    If another application is published under the same top domain as Volto, you could have a route like `/abc` which should be not rendered by Volto.
+:   If another application is published under the same top domain as Volto, you could have a route like `/abc` which should be not rendered by Volto.
     This can be achieved by a rule in the reverse proxy (Apache or nginx for example) but, when navigating client side, you may have references to that route so Volto is
     handling that as an internal URL and fetching the content will break.
     You can disable that path in `config.settings.externalRoutes` so it will be handled as an external link.
@@ -196,13 +174,13 @@ externalRoutes
     ```
 
 contentMetadataTagsImageField
-    The OpenGraph image that will represent this content item, will be used in the metadata HEAD tag as og:image for SEO purposes. Defaults to image. See the OpenGraph Protocol for more details.
+:   The OpenGraph image that will represent this content item, will be used in the metadata HEAD tag as og:image for SEO purposes. Defaults to image. See the OpenGraph Protocol for more details.
 
 hasWorkingCopySupport
-    This setting will enable working copy support in your site. You need to install the `plone.app.iterate` add-on in your Plone site in order to make it working.
+:   This setting will enable working copy support in your site. You need to install the `plone.app.iterate` add-on in your Plone site in order to make it working.
 
 controlpanels
-    Register a component as control panel.
+:   Register a component as control panel.
 
     Example configuration in `config.js` of your project or add-on:
 
@@ -228,7 +206,7 @@ controlpanels
     The group can be one of the default groups 'General', 'Content', 'Security', 'Add-on Configuration', 'Users and Groups' or a custom group.
 
 workflowMapping
-    It's an object that defines the mapping between workflow states/transitions and the color that should show in the change Workflow dropdown. This is the default:
+:   It's an object that defines the mapping between workflow states/transitions and the color that should show in the change Workflow dropdown. This is the default:
 
     ```js
     export const workflowMapping = {
@@ -245,17 +223,13 @@ workflowMapping
 
     It's meant to be extended with your own workflows/transitions.
     It is recommended to assign the same color to the transition as the destination state, so the user can have the visual hint to which state are they transitioning to.
-```
 
 ## Views settings
 
 They are exposed in `config.views`:
 
-```{glossary}
-:sorted:
-
 layoutViewsNamesMapping
-    Plone's layout views are identified by a simple string. This object maps this string with a nice literal (in English as default).
+:   Plone's layout views are identified by a simple string. This object maps this string with a nice literal (in English as default).
     These view names are exposed in the `Display` component in the toolbar's {guilabel}`more` menu.
     The keys are the name of the Plone layout, and the values are the i18n string `id`:
 
@@ -291,31 +265,26 @@ layoutViewsNamesMapping
       },
     })
     ```
-```
 
 ## Server-specific serverConfig
 
 Settings that are relevant to the Express-powered Volto SSR server are stored
 in the `config.settings.serverConfig` object.
 
-```{glossary}
-:sorted:
-
 expressMiddleware
-    A list of ExpressJs middleware that can extend the built-in functionality of
+:   A list of ExpressJs middleware that can extend the built-in functionality of
     Volto's server. See the [Express](../recipes/express) section for more details.
 
 criticalCssPath
-    A path relative to the project root that points to an optional CSS file. If
+:   A path relative to the project root that points to an optional CSS file. If
     this file exists it is loaded and its content is embedded inline into the
     generated HTML. By default this path is `public/critical.css`. See the
     {doc}`../deploying/performance` section for more details.
 
 extractScripts
-    An object that allows you to configure the insertion of scripts on the page
+:   An object that allows you to configure the insertion of scripts on the page
     in some particular cases.
     For the moment it admits only one property: `errorPages` whose value is a Boolean.
 
     If `extractScripts.errorPages` is `true`, the JS will be inserted into the error page.
 
-```

--- a/docs/source/glossary.md
+++ b/docs/source/glossary.md
@@ -1,0 +1,38 @@
+---
+myst:
+  html_meta:
+    "description": "Terms and definitions used in the Volto Documentation."
+    "property=og:description": "Terms and definitions used in the Volto Documentation."
+    "property=og:title": "Glossary"
+    "keywords": "Volto, Plone, documentation, glossary, term, definition"
+---
+
+(glossary-label)=
+
+# Glossary
+
+```{glossary}
+:sorted: true
+
+contentIcons
+    With this property you can configure Content Types icons.
+    Those are visible in Contents view (ex "Folder contents").  The default
+    ones are in
+    [config/ContentIcons.jsx](https://github.com/plone/volto/blob/master/src/config/ContentIcons.jsx)
+    and you can extend them in your project's config for custom content types
+    using `settings.contentIcons`.
+
+    In Volto projects, you can configure this for custom content types like:
+
+    ```js
+    import * as config from '@plone/volto/config';
+    import courseSVG from './icons/course.svg';
+
+    export const settings = {
+      ...config.settings,
+      contentIcons: {
+        ...config.settings.contentIcons,
+        Course: courseSVG,
+    };
+    ```
+```

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -49,3 +49,10 @@ deploying/index
 upgrade-guide/index
 developer-guidelines/index
 ```
+
+## Glossary
+
+```{toctree}
+
+/glossary
+```


### PR DESCRIPTION
See #3344

### Status

- [x]  Create a local Glossary for Volto
- [x]  Convert the 3 local glossaries in [configuration/settings-reference.md](https://github.com/plone/volto/blob/master/docs/source/configuration/settings-reference.md) to [definition lists](https://myst-parser.readthedocs.io/en/latest/syntax/optional.html#definition-lists).

- The glossary was sorted alphabetically?  How to do the same for the definition list?

### Not sure how to implement
- [ ] When terms are added to the local Glossary, they should also be added to the global one in [plone/documentation](https://github.com/plone/documentation).
- [ ] Configure plone/documentation's [conf.py](https://github.com/plone/documentation/blob/6-dev/docs/conf.py) to igore Volto's local glossary.

