### PR TITLE
Fix `schemaEnhancer` not being applied if nested `blocksConfig` is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Fix `schemaEnhancer` not being applied if nested `blocksConfig` is present @sneridagh
+
 ### Internal
 
 ### Documentation

--- a/src/helpers/Extensions/withBlockSchemaEnhancer.js
+++ b/src/helpers/Extensions/withBlockSchemaEnhancer.js
@@ -257,7 +257,12 @@ export const withVariationSchemaEnhancer = (FormComponent) => (props) => {
   const blockType = formData['@type'];
   const variations = blocksConfig[blockType]?.variations || [];
 
-  let schema = applySchemaEnhancer({ schema: originalSchema, formData, intl });
+  let schema = applySchemaEnhancer({
+    schema: originalSchema,
+    formData,
+    intl,
+    blocksConfig,
+  });
 
   if (variations.length > 1) {
     addExtensionFieldToSchema({


### PR DESCRIPTION
Quite an slight one... 