### PR TITLE
Be more robust towards invalid block configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Be more robust towards invalid block configuration @reebalazs
+
 ### Internal
 
 ### Documentation

--- a/locales/ca/LC_MESSAGES/volto.po
+++ b/locales/ca/LC_MESSAGES/volto.po
@@ -1707,6 +1707,11 @@ msgstr "Setmana(es)"
 msgid "Interval Yearly"
 msgstr "Any(s)"
 
+#: components/theme/View/RenderBlocks
+# defaultMessage: Invalid block - Will be removed on saving
+msgid "Invalid Block"
+msgstr ""
+
 #: components/manage/Widgets/QuerystringWidget
 # defaultMessage: Item batch size
 msgid "Item batch size"

--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -1704,6 +1704,11 @@ msgstr "Wöchentlich"
 msgid "Interval Yearly"
 msgstr "Jährliches Intervall"
 
+#: components/theme/View/RenderBlocks
+# defaultMessage: Invalid block - Will be removed on saving
+msgid "Invalid Block"
+msgstr "Ungültiger Block - Wird beim Speichern entfernt"
+
 #: components/manage/Widgets/QuerystringWidget
 # defaultMessage: Item batch size
 msgid "Item batch size"

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -1698,6 +1698,11 @@ msgstr ""
 msgid "Interval Yearly"
 msgstr ""
 
+#: components/theme/View/RenderBlocks
+# defaultMessage: Invalid block - Will be removed on saving
+msgid "Invalid Block"
+msgstr ""
+
 #: components/manage/Widgets/QuerystringWidget
 # defaultMessage: Item batch size
 msgid "Item batch size"

--- a/locales/es/LC_MESSAGES/volto.po
+++ b/locales/es/LC_MESSAGES/volto.po
@@ -1709,6 +1709,11 @@ msgstr "Intervalo semanal"
 msgid "Interval Yearly"
 msgstr "Intervalo anual"
 
+#: components/theme/View/RenderBlocks
+# defaultMessage: Invalid block - Will be removed on saving
+msgid "Invalid Block"
+msgstr ""
+
 #: components/manage/Widgets/QuerystringWidget
 # defaultMessage: Item batch size
 msgid "Item batch size"

--- a/locales/eu/LC_MESSAGES/volto.po
+++ b/locales/eu/LC_MESSAGES/volto.po
@@ -1705,6 +1705,11 @@ msgstr "astean behin"
 msgid "Interval Yearly"
 msgstr "urtean behin"
 
+#: components/theme/View/RenderBlocks
+# defaultMessage: Invalid block - Will be removed on saving
+msgid "Invalid Block"
+msgstr ""
+
 #: components/manage/Widgets/QuerystringWidget
 # defaultMessage: Item batch size
 msgid "Item batch size"

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -1715,6 +1715,11 @@ msgstr ""
 msgid "Interval Yearly"
 msgstr ""
 
+#: components/theme/View/RenderBlocks
+# defaultMessage: Invalid block - Will be removed on saving
+msgid "Invalid Block"
+msgstr ""
+
 #: components/manage/Widgets/QuerystringWidget
 # defaultMessage: Item batch size
 msgid "Item batch size"

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -1698,6 +1698,11 @@ msgstr "settimane"
 msgid "Interval Yearly"
 msgstr "anni"
 
+#: components/theme/View/RenderBlocks
+# defaultMessage: Invalid block - Will be removed on saving
+msgid "Invalid Block"
+msgstr ""
+
 #: components/manage/Widgets/QuerystringWidget
 # defaultMessage: Item batch size
 msgid "Item batch size"

--- a/locales/ja/LC_MESSAGES/volto.po
+++ b/locales/ja/LC_MESSAGES/volto.po
@@ -1706,6 +1706,11 @@ msgstr "週"
 msgid "Interval Yearly"
 msgstr "年"
 
+#: components/theme/View/RenderBlocks
+# defaultMessage: Invalid block - Will be removed on saving
+msgid "Invalid Block"
+msgstr ""
+
 #: components/manage/Widgets/QuerystringWidget
 # defaultMessage: Item batch size
 msgid "Item batch size"

--- a/locales/nl/LC_MESSAGES/volto.po
+++ b/locales/nl/LC_MESSAGES/volto.po
@@ -1705,6 +1705,11 @@ msgstr "Wekelijks interval"
 msgid "Interval Yearly"
 msgstr "Jaarlijsk interval"
 
+#: components/theme/View/RenderBlocks
+# defaultMessage: Invalid block - Will be removed on saving
+msgid "Invalid Block"
+msgstr ""
+
 #: components/manage/Widgets/QuerystringWidget
 # defaultMessage: Item batch size
 msgid "Item batch size"

--- a/locales/pt/LC_MESSAGES/volto.po
+++ b/locales/pt/LC_MESSAGES/volto.po
@@ -1706,6 +1706,11 @@ msgstr ""
 msgid "Interval Yearly"
 msgstr ""
 
+#: components/theme/View/RenderBlocks
+# defaultMessage: Invalid block - Will be removed on saving
+msgid "Invalid Block"
+msgstr ""
+
 #: components/manage/Widgets/QuerystringWidget
 # defaultMessage: Item batch size
 msgid "Item batch size"

--- a/locales/pt_BR/LC_MESSAGES/volto.po
+++ b/locales/pt_BR/LC_MESSAGES/volto.po
@@ -1708,6 +1708,11 @@ msgstr "Intervalo Semanal"
 msgid "Interval Yearly"
 msgstr "Intervalo Anual"
 
+#: components/theme/View/RenderBlocks
+# defaultMessage: Invalid block - Will be removed on saving
+msgid "Invalid Block"
+msgstr ""
+
 #: components/manage/Widgets/QuerystringWidget
 # defaultMessage: Item batch size
 msgid "Item batch size"

--- a/locales/ro/LC_MESSAGES/volto.po
+++ b/locales/ro/LC_MESSAGES/volto.po
@@ -1698,6 +1698,11 @@ msgstr "Interval Lunar"
 msgid "Interval Yearly"
 msgstr "Interval Anual"
 
+#: components/theme/View/RenderBlocks
+# defaultMessage: Invalid block - Will be removed on saving
+msgid "Invalid Block"
+msgstr ""
+
 #: components/manage/Widgets/QuerystringWidget
 # defaultMessage: Item batch size
 msgid "Item batch size"

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2022-10-31T12:15:48.236Z\n"
+"POT-Creation-Date: 2022-11-03T15:58:59.686Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -1698,6 +1698,11 @@ msgstr ""
 #: components/manage/Widgets/RecurrenceWidget/RecurrenceWidget
 # defaultMessage: year(s)
 msgid "Interval Yearly"
+msgstr ""
+
+#: components/theme/View/RenderBlocks
+# defaultMessage: Invalid block - Will be removed on saving
+msgid "Invalid Block"
 msgstr ""
 
 #: components/manage/Widgets/QuerystringWidget

--- a/src/components/manage/Blocks/Block/BlocksForm.jsx
+++ b/src/components/manage/Blocks/Block/BlocksForm.jsx
@@ -150,6 +150,17 @@ const BlocksForm = (props) => {
 
   const editBlockWrapper = children || defaultBlockWrapper;
 
+  // Remove invalid blocks on saving
+  // Note they are alreaady filtered by DragDropList, but we also want them
+  // to be removed when the user saves the page next. Otherwise the invalid
+  // blocks would linger for ever.
+  for (const [n, v] of blockList) {
+    if (!v) {
+      const newFormData = deleteBlock(properties, n);
+      onChangeFormData(newFormData);
+    }
+  }
+
   return (
     <div className="blocks-form" ref={ref}>
       <fieldset className="invisible" disabled={!editable}>

--- a/src/components/manage/Blocks/Block/BlocksForm.test.jsx
+++ b/src/components/manage/Blocks/Block/BlocksForm.test.jsx
@@ -70,3 +70,68 @@ test('Allow override of blocksConfig', () => {
   );
   expect(container).toMatchSnapshot();
 });
+
+test('Removes invalid blocks on saving', () => {
+  const store = mockStore({
+    intl: {
+      locale: 'en',
+      messages: {},
+    },
+  });
+
+  const onChangeFormData = jest.fn(() => {});
+
+  const data = {
+    pathname: '/test',
+    properties: {
+      blocks_layout: {
+        items: ['a', 'b', 'MISSING-YOU-1', 'MISSING-YOU-2'],
+      },
+      blocks: {
+        a: {
+          '@type': 'custom',
+          text: 'a',
+        },
+        b: {
+          '@type': 'custom',
+          text: 'b',
+        },
+      },
+    },
+    selectedBlock: 'a',
+    title: 'Edit blocks',
+    metadata: {},
+    blocksConfig: {
+      ...config.blocks.blocksConfig,
+      custom: {
+        id: 'custom',
+        edit: ({ id, data }) => (
+          <div>
+            {id} - {data.text}
+          </div>
+        ),
+      },
+    },
+    onChangeFormData,
+  };
+
+  render(
+    <Provider store={store}>
+      <BlocksForm {...data} />
+    </Provider>,
+  );
+  expect(onChangeFormData).toBeCalledWith({
+    blocks: {
+      a: { '@type': 'custom', text: 'a' },
+      b: { '@type': 'custom', text: 'b' },
+    },
+    blocks_layout: { items: ['a', 'b', 'MISSING-YOU-1'] },
+  });
+  expect(onChangeFormData).toBeCalledWith({
+    blocks: {
+      a: { '@type': 'custom', text: 'a' },
+      b: { '@type': 'custom', text: 'b' },
+    },
+    blocks_layout: { items: ['a', 'b', 'MISSING-YOU-2'] },
+  });
+});

--- a/src/components/theme/View/RenderBlocks.jsx
+++ b/src/components/theme/View/RenderBlocks.jsx
@@ -15,6 +15,10 @@ const messages = defineMessages({
     id: 'Unknown Block',
     defaultMessage: 'Unknown Block {block}',
   },
+  invalidBlock: {
+    id: 'Invalid Block',
+    defaultMessage: 'Invalid block - Will be removed on saving',
+  },
 });
 
 const RenderBlocks = (props) => {
@@ -48,12 +52,14 @@ const RenderBlocks = (props) => {
               blocksConfig={blocksConfig}
             />
           </StyleWrapper>
-        ) : (
+        ) : blockData ? (
           <div key={block}>
             {intl.formatMessage(messages.unknownBlock, {
               block: content[blocksFieldname]?.[block]?.['@type'],
             })}
           </div>
+        ) : (
+          <div key={block}>{intl.formatMessage(messages.invalidBlock)}</div>
         );
       })}
     </CustomTag>

--- a/src/components/theme/View/RenderBlocks.test.jsx
+++ b/src/components/theme/View/RenderBlocks.test.jsx
@@ -89,3 +89,44 @@ test('Provides path to blocks', () => {
   );
   expect(container).toMatchSnapshot();
 });
+
+test('Renders invalid blocks', () => {
+  const store = mockStore({
+    intl: {
+      locale: 'en',
+      messages: {},
+    },
+  });
+  const { queryAllByText } = render(
+    <Provider store={store}>
+      <RenderBlocks
+        blocksConfig={{
+          ...config.blocks.blocksConfig,
+          custom: {
+            id: 'custom',
+            view: ({ id, data, path }) => (
+              <div>
+                id: {id} - text: {data.text} - path: {path}
+              </div>
+            ),
+          },
+        }}
+        content={{
+          blocks_layout: {
+            items: ['MISSING-YOU-1', 'a', 'MISSING-YOU-2'],
+          },
+          blocks: {
+            a: {
+              '@type': 'custom',
+              text: 'bar',
+            },
+          },
+        }}
+        path="/foo"
+      />
+    </Provider>,
+  );
+  expect(
+    queryAllByText('Invalid block - Will be removed on saving'),
+  ).toHaveLength(2);
+});

--- a/src/helpers/Blocks/Blocks.js
+++ b/src/helpers/Blocks/Blocks.js
@@ -392,7 +392,8 @@ export function applySchemaDefaults({ data = {}, schema }) {
  * @return {Object} Derived data, with the defaults extracted from the schema
  */
 export function applyBlockDefaults({ data, intl, ...rest }, blocksConfig) {
-  const block_type = data['@type'];
+  // We pay attention to not break on a missing (invalid) block.
+  const block_type = data?.['@type'];
   const { blockSchema } =
     (blocksConfig || config.blocks.blocksConfig)[block_type] || {};
   if (!blockSchema) return data;

--- a/src/helpers/Blocks/Blocks.test.js
+++ b/src/helpers/Blocks/Blocks.test.js
@@ -573,6 +573,11 @@ describe('Blocks', () => {
         variation: 'firstVariation',
       });
     });
+
+    it('Tolerates a missing (invalid) block', () => {
+      const data = {};
+      expect(applyBlockDefaults({ data })).toEqual({});
+    });
   });
   describe('buildStyleClassNamesFromData', () => {
     it('Sets styles classname array according to style values', () => {


### PR DESCRIPTION
Be more robust towards invalid block configuration

Do not fail when the layout contains a block that does not exists.
This happened recently in a project where a bug caused faulty block
configuration in the history.

- Show missing blocks in the layout as "Invalid block ..."
- Remove such blocks when saving the page next