### PR TITLE
Upgrade slate versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Internal
 
-- Upgrade dependencies to latest released slate libraries @tiberiuichim
+- Upgrade dependencies to latest released slate libraries. Make sure to pass down `ref` to rendered slate elements, as ref is now a function @tiberiuichim
 
 ### Documentation
 
@@ -19,7 +19,6 @@
 ### Bugfix
 
 - Ensure the view component is always replaced after navigating to a different page. @davisagli
-- Make sure to pass down `ref` to rendered slate elements @tiberiuichim
 
 ## 16.0.0-alpha.47 (2022-11-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Internal
 
+- Upgrade dependencies to latest released slate libraries @tiberiuichim
+
 ### Documentation
 
 ## 16.0.0-alpha.48 (2022-11-03)
@@ -17,6 +19,7 @@
 ### Bugfix
 
 - Ensure the view component is always replaced after navigating to a different page. @davisagli
+- Make sure to pass down `ref` to rendered slate elements @tiberiuichim
 
 ## 16.0.0-alpha.47 (2022-11-02)
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     }
   ],
   "license": "MIT",
-  "version": "16.0.0-alpha.46",
+  "version": "16.0.0-alpha.48",
   "repository": {
     "type": "git",
     "url": "git@github.com:plone/volto.git"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     }
   ],
   "license": "MIT",
-  "version": "16.0.0-alpha.48",
+  "version": "16.0.0-alpha.46",
   "repository": {
     "type": "git",
     "url": "git@github.com:plone/volto.git"
@@ -362,10 +362,10 @@
     "semantic-ui-react": "2.0.3",
     "semver": "5.6.0",
     "serialize-javascript": "3.1.0",
-    "slate": "0.78.0",
-    "slate-history": "0.66.0",
-    "slate-hyperscript": "0.77.0",
-    "slate-react": "0.78.1",
+    "slate": "0.84.0",
+    "slate-history": "0.81.3",
+    "slate-hyperscript": "0.81.3",
+    "slate-react": "0.83.2",
     "start-server-and-test": "1.14.0",
     "stylelint": "14.0.1",
     "stylelint-config-idiomatic-order": "8.1.0",

--- a/packages/volto-slate/src/editor/SlateEditor.jsx
+++ b/packages/volto-slate/src/editor/SlateEditor.jsx
@@ -4,7 +4,6 @@ import { isEqual } from 'lodash';
 import { Transforms, Editor } from 'slate'; // , Transforms
 import { Slate, Editable, ReactEditor } from 'slate-react';
 import React, { Component } from 'react'; // , useState
-import { connect } from 'react-redux';
 import { v4 as uuid } from 'uuid';
 
 import config from '@plone/volto/registry';
@@ -363,10 +362,7 @@ SlateEditor.defaultProps = {
   className: '',
 };
 
-export default connect((state, props) => {
-  return {};
-})(
-  __CLIENT__ && window?.Cypress
-    ? withTestingFeatures(SlateEditor)
-    : SlateEditor,
-);
+// May be needed to wrap in React.memo(), it used to be wrapped in connect()
+export default __CLIENT__ && window?.Cypress
+  ? withTestingFeatures(SlateEditor)
+  : SlateEditor;

--- a/packages/volto-slate/src/editor/config.jsx
+++ b/packages/volto-slate/src/editor/config.jsx
@@ -244,9 +244,7 @@ export const elements = {
   },
 
   div: ({ attributes, children }) => <div {...attributes}>{children}</div>,
-  p: ({ attributes, children }) => {
-    return <p {...attributes}>{children}</p>;
-  },
+  p: ({ attributes, children, element }) => <p {...attributes}>{children}</p>,
 
   // While usual slate editor consider these to be Leafs, we treat them as
   // inline elements because they can sometimes contain elements (ex:

--- a/packages/volto-slate/src/editor/render.jsx
+++ b/packages/volto-slate/src/editor/render.jsx
@@ -14,18 +14,19 @@ export const Element = ({ element, attributes = {}, extras, ...rest }) => {
   const { elements } = slate;
   const El = elements[element.type] || elements['default'];
 
-  const out = Object.assign(
+  const attrs = Object.assign(
     element.styleName ? { className: element.styleName } : {},
     ...Object.keys(attributes || {}).map((k) =>
       !isEmpty(attributes[k]) ? { [k]: attributes[k] } : {},
     ),
   );
+  attrs.ref = attributes.ref; // never remove the ref
 
   return (
     <El
       element={element}
       {...omit(rest, OMITTED)}
-      attributes={out}
+      attributes={attrs}
       extras={extras}
     />
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -15268,24 +15268,24 @@ slash@^4.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-4.0.0.tgz#2422372176c4c6c5addb5e2ada885af984b396a7"
   integrity sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==
 
-slate-history@0.66.0:
-  version "0.66.0"
-  resolved "https://registry.yarnpkg.com/slate-history/-/slate-history-0.66.0.tgz#ac63fddb903098ceb4c944433e3f75fe63acf940"
-  integrity sha512-6MWpxGQZiMvSINlCbMW43E2YBSVMCMCIwQfBzGssjWw4kb0qfvj0pIdblWNRQZD0hR6WHP+dHHgGSeVdMWzfng==
+slate-history@0.81.3:
+  version "0.81.3"
+  resolved "https://registry.yarnpkg.com/slate-history/-/slate-history-0.81.3.tgz#4668e447ffb06f30e3d3dc92205ba3850ccc9b64"
+  integrity sha512-imzIVVLwp5hDvWTDawwT6EJrDM3BPKKM9mITDRQGA25qCOVaMborSj9w0IdxkvrNnolID3wXx2gP9XE9EKNw3Q==
   dependencies:
     is-plain-object "^5.0.0"
 
-slate-hyperscript@0.77.0:
-  version "0.77.0"
-  resolved "https://registry.yarnpkg.com/slate-hyperscript/-/slate-hyperscript-0.77.0.tgz#72c1c0fbd54dc6b6210ecd81d020c8d3d0ab8eae"
-  integrity sha512-M6uRpttwKnosniQORNPYQABHQ9XWC7qaSr/127LWWPjTOR5MSSwrHGrghN81BhZVqpICHrI7jkPA2813cWdHNA==
+slate-hyperscript@0.81.3:
+  version "0.81.3"
+  resolved "https://registry.yarnpkg.com/slate-hyperscript/-/slate-hyperscript-0.81.3.tgz#0c8f446d6bef717d2fe855239fb86a000ba2d0d2"
+  integrity sha512-A/jvoLTAgeRcJaUPQCYOikCJxSws6+/jkL7mM+QuZljNd7EA5YqafGA7sVBJRFpcoSsDRUIah1yNiC/7vxZPYg==
   dependencies:
     is-plain-object "^5.0.0"
 
-slate-react@0.78.1:
-  version "0.78.1"
-  resolved "https://registry.yarnpkg.com/slate-react/-/slate-react-0.78.1.tgz#c6d5e334ff79251823d8005d94fbab3c3b252b10"
-  integrity sha512-RxOZx22dP1YTgGjr9zDZ0XuSZ/PLlpr9LgAApmzWgSC0bBE+jw9D8ml23pyY2oAAylxiczPx06UgKDCx6Or94Q==
+slate-react@0.83.2:
+  version "0.83.2"
+  resolved "https://registry.yarnpkg.com/slate-react/-/slate-react-0.83.2.tgz#7099db1607b79c95cc2a41e2df1e04982b7e26a5"
+  integrity sha512-V5qtPsCOiDVCMU3ovj/CWndxx9/as5/wGJxnbJDRVzuazSh+NVw/YuGTlus1fCt+Nlt6UHOhFvM7C9pXYaftPA==
   dependencies:
     "@types/is-hotkey" "^0.1.1"
     "@types/lodash" "^4.14.149"
@@ -15296,10 +15296,10 @@ slate-react@0.78.1:
     scroll-into-view-if-needed "^2.2.20"
     tiny-invariant "1.0.6"
 
-slate@0.78.0:
-  version "0.78.0"
-  resolved "https://registry.yarnpkg.com/slate/-/slate-0.78.0.tgz#cd0328d22b0a99c543987d2a2dd30903bb950ee9"
-  integrity sha512-VwQ0RafT3JPf9SFrXI02Dh3S4Iz9en7d1nn50C/LJjjqjfgv+a2ORbgWMdYjhycPYldaxJwcI3OpP9D1g4SXEg==
+slate@0.84.0:
+  version "0.84.0"
+  resolved "https://registry.yarnpkg.com/slate/-/slate-0.84.0.tgz#dae3d86f16a4b97dbcd32c55acfcb78a57f8ed01"
+  integrity sha512-jAxK10V9nAtAFr6PpCfLdLi+VYNmAOMKC/PIaOWH2HGTrmZEY2XxJt4kbnRNVEbUHkQ1dqaBImVLsVzdoUL8/w==
   dependencies:
     immer "^9.0.6"
     is-plain-object "^5.0.0"


### PR DESCRIPTION
This is just to clearly separate the slate packages upgrade

There's actually a bug somewhere, triggered by a change in slate-react 0.82.2 https://github.com/ianstormtaylor/slate/blob/main/packages/slate-react/CHANGELOG.md#0822

When clicking at the end of a slate block, there's a nasty error raised.

![image](https://user-images.githubusercontent.com/141568/200057719-436bcfb0-8b3d-42b3-ae8f-8c1310d99939.png)
