### PR TITLE
restrict css selector for error message (volto-slate)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Breaking
 
+-  restrict css selector for error message (volto-slate) #3838 @mamico
+
 ### Feature
 
 ### Bugfix

--- a/packages/volto-slate/src/widgets/ErrorBoundary.jsx
+++ b/packages/volto-slate/src/widgets/ErrorBoundary.jsx
@@ -19,7 +19,7 @@ export class ErrorBoundary extends React.Component {
   render() {
     if (this.state.hasError) {
       // You can render any custom fallback UI
-      return <pre className="error">{`ERROR: ${this.props.name}`}</pre>;
+      return <pre className="slate error">{`ERROR: ${this.props.name}`}</pre>;
     }
 
     return this.props.children;

--- a/packages/volto-slate/src/widgets/style.css
+++ b/packages/volto-slate/src/widgets/style.css
@@ -15,7 +15,7 @@
   display: inline;
 }
 
-.error {
+.slate.error {
   color: #f00;
   white-space: normal;
 }


### PR DESCRIPTION
The css selector, in `packages/volto-slate`, for the error message is not specific enough.

As a result, for example, after a validation error in a `form`, the class `error` is added to the `form`  and elements within it unexpectedly turn red.