### PR TITLE
Rearranging value of contextURL in ObjectBroswer so that currentPath …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ See https://6.dev-docs.plone.org/volto/upgrade-guide/index.html for more informa
 - Improve the algorithm that calculates the position of the Slate Toolbar @tiberiuichim
 - The `_unwrapElement` of the volto-slate `ElementEditor` will return an updated range (selection) of the unwrapped element.
 - Replace the main client entry point in `start-client.jsx` anonymous function for a named one. @sneridagh
-- Rearranging value of contextURL in ObjectBroswer so that currentPath take precedence over other value. @iFlameing
+- Fix `currentPath` option for `openObjectBrowser`. @iFlameing
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ See https://6.dev-docs.plone.org/volto/upgrade-guide/index.html for more informa
 - Improve the algorithm that calculates the position of the Slate Toolbar @tiberiuichim
 - The `_unwrapElement` of the volto-slate `ElementEditor` will return an updated range (selection) of the unwrapped element.
 - Replace the main client entry point in `start-client.jsx` anonymous function for a named one. @sneridagh
+- Rearranging value of contextURL in ObjectBroswer so that currentPath take precedence over other value. @iFlameing
 
 ### Internal
 

--- a/src/components/manage/Sidebar/ObjectBrowser.jsx
+++ b/src/components/manage/Sidebar/ObjectBrowser.jsx
@@ -76,9 +76,9 @@ const withObjectBrowser = (WrappedComponent) =>
 
     render() {
       let contextURL =
+        this.state?.currentPath ||
         this.props.pathname ||
-        this.props.location?.pathname ||
-        this.state?.currentPath;
+        this.props.location?.pathname;
 
       return (
         <>


### PR DESCRIPTION
…take precedence over other value.

we are doing this because currentPath is the props that is passed by the developer to set the context URL, putting at the end of or operator is sometimes is buggy.