### PR TITLE
WIP Fix drag handler alignment for screen width < largeMonitorBreakpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ See https://6.dev-docs.plone.org/volto/upgrade-guide/index.html for more informa
 - Replace the main client entry point in `start-client.jsx` anonymous function for a named one. @sneridagh
 - Fix updating the listing block when the variation is changed while editing @tiberiuichim
 - fix(warning): StyleMenu dropdown item to use data-attr instead of custom @nileshgulia1
+- Fix drag handler alignment for screen width < largeMonitorBreakpoint @reebalazs
 
 ### Internal
 

--- a/theme/themes/pastanaga/elements/container.overrides
+++ b/theme/themes/pastanaga/elements/container.overrides
@@ -80,6 +80,27 @@
       display: none !important;
     }
   }
+
+  .drag.handle.wrapper,
+  // need to repeat specific rule to ensure override for width < 1224px
+  body.has-toolbar.has-sidebar .drag.handle.wrapper {
+    margin-left: -34px !important;
+  }
+
+  // need to repeat specific rule to ensure override for width < 1224px
+  @media only screen and (max-width: @largeMonitorBreakpoint + @offset) {
+    .block .delete-button,
+    body.has-toolbar.has-sidebar .block .delete-button {
+      margin-right: -25px !important;
+    }
+  }
+
+  // correction for title
+  .block.title .delete-button,
+  // need to repeat specific rule to ensure override for width < 1224px
+  body.has-toolbar.has-sidebar .block.title .delete-button {
+    margin-right: -42px !important;
+  }
 }
 
 body:not(.has-toolbar):not(.has-sidebar):not(.has-toolbar-collapsed):not(.has-sidebar-collapsed) {
@@ -110,15 +131,7 @@ body.has-toolbar-collapsed.has-sidebar-collapsed {
   .contentWidth(@collapsedWidth + @collapsedWidth);
 }
 
-.drag.handle.wrapper {
-  margin-left: -15px !important;
-}
-
-.block .delete-button {
-  margin-right: -25px !important;
-}
-
-/* Hack for escape the blocks container in blocks full width */
+// Hack for escape the blocks container in blocks full width
 .full-width {
   position: relative;
   right: 50%;


### PR DESCRIPTION
Below 1224px, Both the drag handler and the delete button were pushed inside the block editing border. This fix places them back outside like they should be in all resolutions. Making sure that alignment is the same both with normal blocks and the title block.


Note that the main part of this fix is fixing an override that was not
doing the override (so an explicit bug), but when I was there I also adjusted both icons in
all resolutions correctly.