### PR TITLE
Fix `FormValidation` error object, use field `id` instead of field `title`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugfix
 
 - Load core add-ons configuration as any other add-on. @sneridagh
+- Fix `FormValidation` error object, use field `id` instead of field `title` @sneridagh
 
 ### Internal
 

--- a/src/components/manage/Form/Form.jsx
+++ b/src/components/manage/Form/Form.jsx
@@ -441,7 +441,11 @@ class Form extends Component {
         () => {
           Object.keys(errors).forEach((err) =>
             toast.error(
-              <Toast error title={err} content={errors[err].join(', ')} />,
+              <Toast
+                error
+                title={this.props.schema.properties[err].title || err}
+                content={errors[err].join(', ')}
+              />,
             ),
           );
         },

--- a/src/helpers/FormValidation/FormValidation.js
+++ b/src/helpers/FormValidation/FormValidation.js
@@ -210,10 +210,8 @@ const validateRequiredFields = (
       !schema.properties[requiredField].readonly &&
       isEmpty
     ) {
-      const requiredFieldName =
-        schema.properties[requiredField].title || requiredField;
-      errors[requiredFieldName] = [];
-      errors[requiredFieldName].push(formatMessage(messages.required));
+      errors[requiredField] = [];
+      errors[requiredField].push(formatMessage(messages.required));
     }
   });
 

--- a/src/helpers/FormValidation/FormValidation.test.js
+++ b/src/helpers/FormValidation/FormValidation.test.js
@@ -61,7 +61,7 @@ describe('FormValidation', () => {
           formatMessage,
         }),
       ).toEqual({
-        Username: [messages.required.defaultMessage],
+        username: [messages.required.defaultMessage],
       });
     });
 


### PR DESCRIPTION
While developing the widgets for Quanta, I've found that the errors wasn't drilling down...