### PR TITLE
Ignore /.tool-versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,4 @@ public/critical.css
 # Sphinx and MyST
 docs/_build/
 /.python-version
+/.tool-versions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Internal
 
+- Ignore `.tool-versions` file
+
 ### Documentation
 
 ## 16.0.0-alpha.50 (2022-11-15)


### PR DESCRIPTION
I use [asdf](https://asdf-vm.com/) for managing my python and node versions rather than pyenv and nvm. While it can read from the `.python-version` and `.nvmrc` files, it's sometimes easier to use it's own config too which is a `.tool-versions` file.