### PR TITLE
Allow passing arbitrary style and props to an Icon's SVG

### DIFF
--- a/src/components/theme/Icon/Icon.jsx
+++ b/src/components/theme/Icon/Icon.jsx
@@ -32,13 +32,28 @@ const defaultSize = '36px';
  *
  * for further reference see {@link https://kitconcept.com/blog/pastanaga-icon-system/ | here}
  */
-const Icon = ({ name, size, color, className, title, onClick }) => (
+const Icon = ({
+  name,
+  size,
+  color,
+  className,
+  title,
+  onClick,
+  style = {},
+  ...props
+}) => (
   <svg
     xmlns={name.attributes && name.attributes.xmlns}
     viewBox={name.attributes && name.attributes.viewBox}
-    style={{ height: size, width: 'auto', fill: color || 'currentColor' }}
+    style={{
+      height: size,
+      width: 'auto',
+      fill: color || 'currentColor',
+      ...style,
+    }}
     className={className ? `icon ${className}` : 'icon'}
     onClick={onClick}
+    {...props}
     dangerouslySetInnerHTML={{
       __html: title ? `<title>${title}</title>${name.content}` : name.content,
     }}


### PR DESCRIPTION
There's many circumstances where we may want to customise the SVG render by an `Icon`, such as passing `aria-hidden` to use it as an icon button, or passing in a style to change the SVG to a block element.