### PR TITLE
Configure Jest's moduleNameMapper with AddonConfigurationRegistry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@ lighthouse-report.html
 .vscode/
 .#*
 *~
+/.settings/
+.*project
 
 # Python
 /api/.installed.cfg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Internal
 
+- Configure Jest's `moduleNameMapper` with `AddonConfigurationRegistry`. Fix https://github.com/plone/volto/issues/3870 @wesleybl
 - Ignore `.tool-versions` file
 - Minor updates to dependencies
 - Update Cypress 11 @sneridagh

--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "moduleNameMapper": {
       "@plone/volto/package.json": "<rootDir>/package.json",
       "@plone/volto/(.*)$": "<rootDir>/src/$1",
-      "@plone/volto-slate": "<rootDir>/packages/volto-slate/src",
       "~/config": "<rootDir>/src/config",
       "~/../locales/${lang}.json": "<rootDir>/locales/en.json",
       "(.*)/locales/(.*)": "<rootDir>/locales/$2",

--- a/razzle.config.js
+++ b/razzle.config.js
@@ -21,6 +21,12 @@ const packageJson = require(path.join(projectRootPath, 'package.json'));
 
 const registry = new AddonConfigurationRegistry(projectRootPath);
 
+const addonCustomizationPaths = registry.getAddonCustomizationPaths();
+const addonsFromEnvVarCustomizationPaths = registry.getAddonsFromEnvVarCustomizationPaths();
+const projectCustomizationPaths = registry.getProjectCustomizationPaths();
+const resolveAliases = registry.getResolveAliases();
+
+
 const defaultModify = ({
   env: { target, dev },
   webpackConfig: config,
@@ -203,14 +209,14 @@ const defaultModify = ({
   ];
 
   config.resolve.alias = {
-    ...registry.getAddonCustomizationPaths(),
-    ...registry.getAddonsFromEnvVarCustomizationPaths(),
-    ...registry.getProjectCustomizationPaths(),
+    ...addonCustomizationPaths,
+    ...addonsFromEnvVarCustomizationPaths,
+    ...projectCustomizationPaths,
     ...config.resolve.alias,
     '../../theme.config$': `${projectRootPath}/theme/theme.config`,
     'volto-themes': `${registry.voltoPath}/theme/themes`,
     'load-volto-addons': addonsLoaderPath,
-    ...registry.getResolveAliases(),
+    ...resolveAliases,
     '@plone/volto': `${registry.voltoPath}/src`,
     // to be able to reference path uncustomized by webpack
     '@plone/volto-original': `${registry.voltoPath}/src`,
@@ -316,6 +322,13 @@ module.exports = {
   plugins,
   modifyJestConfig: ({ jestConfig }) => {
     jestConfig.testEnvironment = 'jsdom';
+    jestConfig.moduleNameMapper = {
+      ...addonCustomizationPaths,
+      ...addonsFromEnvVarCustomizationPaths,
+      ...projectCustomizationPaths,
+      ...resolveAliases,
+      ...jestConfig.moduleNameMapper,
+    };
     return jestConfig;
   },
   modifyWebpackConfig: ({


### PR DESCRIPTION
Thus, customizations made in Volto projects will be considered in the tests.

Fixes #3870 