### PR TITLE
Fix initial block settings data defaults, improve `applySchemaDefaults` and `ObjectWidget` schema support (#3925)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Overhaul how block defaults are computed. See https://github.com/plone/volto/pull/3925 for more details @tiberiuichim
+
 ### Internal
 
 ### Documentation

--- a/Makefile
+++ b/Makefile
@@ -268,6 +268,10 @@ start-test-acceptance-server-coresandbox test-acceptance-server-coresandbox: ## 
 start-test-acceptance-frontend-coresandbox: ## Start the CoreSandbox Acceptance Frontend Fixture
 	ADDONS=coresandbox RAZZLE_API_PATH=http://localhost:55001/plone yarn build && yarn start:prod
 
+.PHONY: start-test-acceptance-frontend-coresandbox-dev
+start-test-acceptance-frontend-coresandbox-dev: ## Start the CoreSandbox Acceptance Frontend Fixture in dev mode
+	ADDONS=coresandbox RAZZLE_API_PATH=http://localhost:55001/plone yarn start
+
 .PHONY: test-acceptance-coresandbox
 test-acceptance-coresandbox: ## Start CoreSandbox Cypress Acceptance Tests
 	NODE_ENV=production CYPRESS_API=plone $(NODEBIN)/cypress open --config specPattern='cypress/tests/coresandbox/**/*.{js,jsx,ts,tsx}'

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -195,6 +195,30 @@ Cypress.Commands.add('removeContent', ({ path = '' }) => {
   });
 });
 
+// Get content
+Cypress.Commands.add('getContent', ({ path = '' }) => {
+  let api_url, auth;
+  if (Cypress.env('API') === 'guillotina') {
+    api_url = GUILLOTINA_API_URL;
+    auth = {
+      user: 'root',
+      pass: 'root',
+    };
+  } else {
+    api_url = PLONE_API_URL;
+    auth = ploneAuthObj;
+  }
+
+  return cy.request({
+    method: 'get',
+    url: `${api_url}/${path}`,
+    headers: {
+      Accept: 'application/json',
+    },
+    auth: auth,
+  });
+});
+
 // --- Add DX Content-Type ----------------------------------------------------------
 Cypress.Commands.add('addContentType', (name) => {
   let api_url, auth;

--- a/docs/source/blocks/editcomponent.md
+++ b/docs/source/blocks/editcomponent.md
@@ -104,11 +104,11 @@ To render this form and make it available to the edit component:
 
 ```jsx
 import schema from './schema';
-import InlineForm from '@plone/volto/components/manage/Form/InlineForm';
+import BlockDataForm from '@plone/volto/components/manage/Form/BlockDataForm';
 import { Icon } from '@plone/volto/components';
 
 <SidebarPortal selected={this.props.selected}>
-  <InlineForm
+  <BlockDataForm
     icon={<Icon size="24px" name={nameSVG} />}
     schema={schema}
     title={schema.title}
@@ -120,7 +120,9 @@ import { Icon } from '@plone/volto/components';
         [id]: value,
       });
     }}
+    onChangeBlock={onChangeBlock}
     formData={this.props.data}
+    block={block}
   />
 </SidebarPortal>;
 ```

--- a/docs/source/upgrade-guide/index.md
+++ b/docs/source/upgrade-guide/index.md
@@ -521,6 +521,34 @@ You'll have to add a script in your `package.json` file called `prepare`:
 
 After execute it, `husky` will install itself in the `.husky` folder of your project. Then you need to create the default hook scripts in `.husky` that you want to execute. You can copy over the Volto ones (take a look in Volto's `.husky` folder).
 
+### Better defaults handling
+
+````{versionadded} 16.0.0-alpha.51
+Prior to this version we had a default values handling in schemas for blocks settings that was faulty and buggy. The state inferred was not deterministic and depending on the fields with defaults present.
+
+In order to correct this and allow Volto to handle defaults in a correct way we have to pass down an additional prop to the `BlockDataForm` like this:
+
+  ```{code-block} jsx
+  :linenos:
+  :emphasize-lines: 10
+    <BlockDataForm
+      schema={schema}
+      title={schema.title}
+      onChangeField={(id, value) => {
+        this.props.onChangeBlock(this.props.block, {
+          ...this.props.data,
+          [id]: value,
+        });
+      }}
+      onChangeBlock={onChangeBlock}
+      formData={this.props.data}
+      block={block}
+    />
+  ```
+
+whenever we use it in our custom or add-ons code.
+````
+
 (volto-upgrade-guide-15.x.x)=
 
 ## Upgrading to Volto 15.x.x
@@ -2076,7 +2104,9 @@ The blocks engine now takes care of the keyboard navigation of the blocks, so yo
 
 The focus management is also transferred to the engine, so it's not needed for your block to manage the focus. However, if your block does indeed require to manage its own focus, then you should mark it with the `blockHasOwnFocusManagement` property in the blocks configuration object:
 
-``` js hl_lines="10"
+```{code-block} jsx
+:linenos:
+:emphasize-lines: 10
     text: {
       id: 'text',
       title: 'Text',

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "postinstall": "make patches",
     "analyze": "BUNDLE_ANALYZE=true razzle build",
     "start": "razzle start",
+    "start:coresandbox": "ADDONS=coresandbox razzle start",
     "build": "razzle build --noninteractive",
     "prepare": "husky install",
     "test": "razzle test --maxWorkers=50%",

--- a/packages/coresandbox/src/components/Blocks/TestBlock/Data.jsx
+++ b/packages/coresandbox/src/components/Blocks/TestBlock/Data.jsx
@@ -18,6 +18,7 @@ const TestBlockData = (props) => {
           [id]: value,
         });
       }}
+      onChangeBlock={onChangeBlock}
       formData={data}
     />
   );

--- a/packages/coresandbox/src/components/Blocks/TestBlock/Edit.jsx
+++ b/packages/coresandbox/src/components/Blocks/TestBlock/Edit.jsx
@@ -3,18 +3,13 @@ import { SidebarPortal } from '@plone/volto/components';
 import Data from './Data';
 
 const TestBlockEdit = (props) => {
-  const { data, onChangeBlock, block, selected } = props;
+  const { selected } = props;
 
   return (
     <>
       <div>Test Block Edit</div>
       <SidebarPortal selected={selected}>
-        <Data
-          {...props}
-          data={data}
-          block={block}
-          onChangeBlock={onChangeBlock}
-        />
+        <Data {...props} />
       </SidebarPortal>
     </>
   );

--- a/packages/coresandbox/src/components/Blocks/TestBlock/schema.js
+++ b/packages/coresandbox/src/components/Blocks/TestBlock/schema.js
@@ -45,7 +45,13 @@ const itemSchema = (props) => {
       {
         id: 'default',
         title: 'Default',
-        fields: ['href', 'title', 'description', 'preview_image'],
+        fields: [
+          'href',
+          'title',
+          'description',
+          'preview_image',
+          'extraDefault',
+        ],
       },
     ],
 
@@ -74,6 +80,10 @@ const itemSchema = (props) => {
         mode: 'image',
         allowExternals: true,
       },
+      extraDefault: {
+        title: 'Extra',
+        default: 'Extra default',
+      },
     },
     required: [],
   };
@@ -85,7 +95,13 @@ export const SliderSchema = (props) => ({
     {
       id: 'default',
       title: 'Default',
-      fields: ['slides', 'fieldAfterObjectList', 'href'],
+      fields: [
+        'slides',
+        'fieldAfterObjectList',
+        'href',
+        'firstWithDefault',
+        'style',
+      ],
     },
   ],
   properties: {
@@ -108,6 +124,30 @@ export const SliderSchema = (props) => ({
         'headtitle',
       ],
       allowExternals: true,
+    },
+    firstWithDefault: {
+      title: 'Field with default',
+      default: 'Some default value',
+    },
+    style: {
+      widget: 'object',
+      schema: {
+        title: 'Style',
+        fieldsets: [
+          {
+            id: 'default',
+            fields: ['color'],
+            title: 'Default',
+          },
+        ],
+        properties: {
+          color: {
+            title: 'Color',
+            default: 'red',
+          },
+        },
+        required: [],
+      },
     },
   },
   required: [],

--- a/packages/generator-volto/CHANGELOG.md
+++ b/packages/generator-volto/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Generator is aware of `rc`, `beta` and `alphas` as possible releases for canary @sneridagh
+
 ### Internal
 
 ## 6.0.0-alpha.3 (2022-11-16)

--- a/packages/generator-volto/__tests__/app.js
+++ b/packages/generator-volto/__tests__/app.js
@@ -64,6 +64,10 @@ describe('generator-create-volto-app:app with canary option', () => {
       fs.readFileSync(path.join(tmpDir, 'test-volto/package.json'), 'utf8'),
     );
 
-    expect(packageJSON.dependencies['@plone/volto']).toContain('alpha');
+    expect(
+      packageJSON.dependencies['@plone/volto'].includes(['rc']) ||
+        packageJSON.dependencies['@plone/volto'].includes(['beta']) ||
+        packageJSON.dependencies['@plone/volto'].includes(['alpha']),
+    ).toBe(true);
   });
 });

--- a/packages/generator-volto/generators/app/utils.js
+++ b/packages/generator-volto/generators/app/utils.js
@@ -69,7 +69,11 @@ async function getLatestCanaryVoltoVersion() {
           });
           resp.on('end', () => {
             const res = JSON.parse(data.join(''));
-            resolve(res['dist-tags'].alpha);
+            resolve(
+              res['dist-tags'].rc ||
+                res['dist-tags'].beta ||
+                res['dist-tags'].alpha,
+            );
           });
         },
       )

--- a/packages/volto-slate/src/blocks/Text/DefaultTextBlockEditor.jsx
+++ b/packages/volto-slate/src/blocks/Text/DefaultTextBlockEditor.jsx
@@ -279,6 +279,7 @@ export const DefaultTextBlockEditor = (props) => {
                 block={block}
                 schema={schema}
                 title={schema.title}
+                onChangeBlock={onChangeBlock}
                 onChangeField={(id, value) => {
                   onChangeBlock(block, {
                     ...data,

--- a/packages/volto-slate/src/elementEditor/PluginEditor.jsx
+++ b/packages/volto-slate/src/elementEditor/PluginEditor.jsx
@@ -82,6 +82,7 @@ const PluginEditor = (props) => {
             }
             return onChangeValues(id, value, formData, setFormData);
           }}
+          onChangeFormData={setFormData}
           formData={formData}
           headerActions={
             <>

--- a/src/components/manage/Blocks/Block/BlocksForm.jsx
+++ b/src/components/manage/Blocks/Block/BlocksForm.jsx
@@ -1,7 +1,12 @@
 import React from 'react';
+import { useIntl } from 'react-intl';
 import EditBlock from './Edit';
 import { DragDropList } from '@plone/volto/components';
-import { getBlocks } from '@plone/volto/helpers';
+import {
+  getBlocks,
+  getBlocksFieldname,
+  applyBlockDefaults,
+} from '@plone/volto/helpers';
 import {
   addBlock,
   insertBlock,
@@ -42,6 +47,7 @@ const BlocksForm = (props) => {
   const blockList = getBlocks(properties);
 
   const dispatch = useDispatch();
+  const intl = useIntl();
 
   const ClickOutsideListener = () => {
     onSelectBlock(null);
@@ -117,6 +123,16 @@ const BlocksForm = (props) => {
       current,
       config.experimental.addBlockButton.enabled ? 1 : 0,
     );
+
+    const blocksFieldname = getBlocksFieldname(newFormData);
+    const blockData = newFormData[blocksFieldname][newId];
+    newFormData[blocksFieldname][newId] = applyBlockDefaults({
+      data: blockData,
+      intl,
+      metadata,
+      properties,
+    });
+
     onChangeFormData(newFormData);
     return newId;
   };
@@ -124,6 +140,14 @@ const BlocksForm = (props) => {
   const onAddBlock = (type, index) => {
     if (editable) {
       const [id, newFormData] = addBlock(properties, type, index);
+      const blocksFieldname = getBlocksFieldname(newFormData);
+      const blockData = newFormData[blocksFieldname][id];
+      newFormData[blocksFieldname][id] = applyBlockDefaults({
+        data: blockData,
+        intl,
+        metadata,
+        properties,
+      });
       onChangeFormData(newFormData);
       return id;
     }

--- a/src/components/manage/Form/BlockDataForm.jsx
+++ b/src/components/manage/Form/BlockDataForm.jsx
@@ -1,6 +1,28 @@
+import React from 'react';
 import { InlineForm } from '@plone/volto/components';
 import { withVariationSchemaEnhancer } from '@plone/volto/helpers';
 
-const BlockDataForm = withVariationSchemaEnhancer(InlineForm);
+const EnhancedBlockDataForm = withVariationSchemaEnhancer(InlineForm);
 
-export default BlockDataForm;
+export default function BlockDataForm(props) {
+  const { onChangeBlock, block } = props;
+
+  if (!onChangeBlock) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      'BlockDataForm component is used without passing down onChangeBlock as props',
+    );
+  }
+
+  const onChangeFormData = React.useCallback(
+    (data) => onChangeBlock(block, data),
+    [block, onChangeBlock],
+  );
+
+  return (
+    <EnhancedBlockDataForm
+      {...props}
+      onChangeFormData={onChangeBlock ? onChangeFormData : undefined}
+    />
+  );
+}

--- a/src/components/manage/Form/BlockDataForm.test.jsx
+++ b/src/components/manage/Form/BlockDataForm.test.jsx
@@ -8,6 +8,24 @@ import { Provider } from 'react-intl-redux';
 
 const mockStore = configureStore();
 
+const withStateManagement = (Component) => ({ ...props }) => {
+  const [formData, onChangeFormData] = React.useState(props.formData || {});
+  const onChangeField = (id, value) => {
+    onChangeFormData({ ...formData, [id]: value });
+  };
+
+  // NOTE: onChangeBlock here is not "really" implemented
+
+  return (
+    <Component
+      {...props}
+      onChangeField={onChangeField}
+      onChangeBlock={(block, data) => onChangeFormData(data)}
+      formData={formData}
+    />
+  );
+};
+
 beforeAll(() => {
   config.widgets = {
     id: {},
@@ -55,6 +73,7 @@ beforeAll(() => {
 
 describe('BlockDataForm', () => {
   it('should does not add variations to schema when unneeded', () => {
+    const WrappedBlockDataForm = withStateManagement(BlockDataForm);
     const store = mockStore({
       intl: {
         locale: 'en',
@@ -71,7 +90,7 @@ describe('BlockDataForm', () => {
     };
     const { container } = render(
       <Provider store={store}>
-        <BlockDataForm
+        <WrappedBlockDataForm
           formData={formData}
           schema={testSchema}
           onChangeField={(id, value) => {}}
@@ -85,6 +104,7 @@ describe('BlockDataForm', () => {
   });
 
   it('should does not add variations when only one variation', () => {
+    const WrappedBlockDataForm = withStateManagement(BlockDataForm);
     const store = mockStore({
       intl: {
         locale: 'en',
@@ -101,7 +121,7 @@ describe('BlockDataForm', () => {
     };
     const { container } = render(
       <Provider store={store}>
-        <BlockDataForm
+        <WrappedBlockDataForm
           formData={formData}
           schema={testSchema}
           onChangeField={(id, value) => {}}
@@ -115,6 +135,7 @@ describe('BlockDataForm', () => {
   });
 
   it('should add variations to schema', () => {
+    const WrappedBlockDataForm = withStateManagement(BlockDataForm);
     const store = mockStore({
       intl: {
         locale: 'en',
@@ -131,7 +152,7 @@ describe('BlockDataForm', () => {
     };
     const { container } = render(
       <Provider store={store}>
-        <BlockDataForm
+        <WrappedBlockDataForm
           formData={formData}
           schema={testSchema}
           onChangeField={(id, value) => {}}

--- a/src/components/manage/Form/Field.jsx
+++ b/src/components/manage/Form/Field.jsx
@@ -232,17 +232,9 @@ const DndConnectedField = injectLazyLibs(['reactDnd'])(UnconnectedField);
 
 const Field = (props) =>
   props.onOrder ? (
-    <DndConnectedField
-      {...props}
-      defaultValue={undefined}
-      value={props.value ?? props.default ?? props.defaultValue}
-    />
+    <DndConnectedField {...props} />
   ) : (
-    <UnconnectedField
-      {...props}
-      defaultValue={undefined}
-      value={props.value ?? props.default ?? props.defaultValue}
-    />
+    <UnconnectedField {...props} />
   );
 
 /**

--- a/src/components/manage/Form/InlineForm.jsx
+++ b/src/components/manage/Form/InlineForm.jsx
@@ -6,6 +6,7 @@ import AnimateHeight from 'react-animate-height';
 import { keys, map, isEqual } from 'lodash';
 
 import { Field, Icon } from '@plone/volto/components';
+import { applySchemaDefaults } from '@plone/volto/helpers';
 
 import upSVG from '@plone/volto/icons/up-key.svg';
 import downSVG from '@plone/volto/icons/down-key.svg';
@@ -32,6 +33,7 @@ const InlineForm = (props) => {
     error, // Such as {message: "It's not good"}
     errors = {},
     formData,
+    onChangeFormData,
     onChangeField,
     schema,
     title,
@@ -49,26 +51,22 @@ const InlineForm = (props) => {
     // Will set field values from schema, by matching the default values
 
     const objectSchema = typeof schema === 'function' ? schema(props) : schema;
-    const initialData = {
-      ...Object.keys(objectSchema.properties).reduce(
-        (accumulator, currentField) => {
-          return objectSchema.properties[currentField].default
-            ? {
-                ...accumulator,
-                [currentField]: objectSchema.properties[currentField].default,
-              }
-            : accumulator;
-        },
-        {},
-      ),
-      ...formData,
-    };
 
-    Object.keys(initialData).forEach((k) => {
-      if (!isEqual(initialData[k], formData?.[k])) {
-        onChangeField(k, initialData[k]);
-      }
+    const initialData = applySchemaDefaults({
+      data: formData,
+      schema: objectSchema,
+      intl,
     });
+
+    if (onChangeFormData) {
+      onChangeFormData(initialData);
+    } else {
+      Object.keys(initialData).forEach((k) => {
+        if (!isEqual(initialData[k], formData?.[k])) {
+          onChangeField(k, initialData[k]);
+        }
+      });
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/src/components/manage/Form/InlineForm.test.jsx
+++ b/src/components/manage/Form/InlineForm.test.jsx
@@ -20,13 +20,18 @@ function NewBaseWidget(name) {
 }
 
 const withStateManagement = (Component) => ({ ...props }) => {
-  const [formData, setFormData] = React.useState(props.formData || {});
+  const [formData, onChangeFormData] = React.useState(props.formData || {});
   const onChangeField = (id, value) => {
-    setFormData({ ...formData, [id]: value });
+    onChangeFormData({ ...formData, [id]: value });
   };
 
   return (
-    <Component {...props} onChangeField={onChangeField} formData={formData} />
+    <Component
+      {...props}
+      onChangeField={onChangeField}
+      onChangeFormData={onChangeFormData}
+      formData={formData}
+    />
   );
 };
 
@@ -114,6 +119,7 @@ describe('Form', () => {
 
     expect(container).toMatchSnapshot();
   });
+
   it('renders a form component with defaults in the schema - Checkboxes', () => {
     const store = mockStore({
       intl: {
@@ -163,7 +169,6 @@ describe('Form', () => {
         />
       </Provider>,
     );
-
     expect(container).toMatchSnapshot();
   });
   it('renders a form component with defaults in the schema - Number field', () => {

--- a/src/components/manage/Widgets/ObjectListWidget.jsx
+++ b/src/components/manage/Widgets/ObjectListWidget.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import { Accordion, Button, Segment } from 'semantic-ui-react';
 import { DragDropList, FormFieldWrapper, Icon } from '@plone/volto/components';
+import { applySchemaDefaults } from '@plone/volto/helpers';
 import ObjectWidget from '@plone/volto/components/manage/Widgets/ObjectWidget';
 
 import upSVG from '@plone/volto/icons/up-key.svg';
@@ -70,14 +71,14 @@ const ObjectListWidget = (props) => {
     onChange,
     schemaExtender,
   } = props;
-  const [activeColumn, setActiveColumn] = React.useState(value.length - 1);
+  const [activeObject, setActiveObject] = React.useState(value.length - 1);
   const intl = useIntl();
 
-  function handleChangeColumn(e, blockProps) {
+  function handleChangeActiveObject(e, blockProps) {
     const { index } = blockProps;
-    const newIndex = activeColumn === index ? -1 : index;
+    const newIndex = activeObject === index ? -1 : index;
 
-    setActiveColumn(newIndex);
+    setActiveObject(newIndex);
   }
   const objectSchema = typeof schema === 'function' ? schema(props) : schema;
 
@@ -98,18 +99,25 @@ const ObjectListWidget = (props) => {
             }
             onClick={(e) => {
               e.preventDefault();
-              onChange(id, [
-                ...value,
-                {
-                  '@id': uuid(),
-                },
-              ]);
-              setActiveColumn(value.length);
+              const data = {
+                '@id': uuid(),
+              };
+              const objSchema = schemaExtender
+                ? schemaExtender(schema, data, intl)
+                : objectSchema;
+              const dataWithDefaults = applySchemaDefaults({
+                data,
+                schema: objSchema,
+                intl,
+              });
+
+              onChange(id, [...value, dataWithDefaults]);
+              setActiveObject(value.length);
             }}
           >
             <Icon name={addSVG} size="18px" />
             &nbsp;
-            {/* Custom addMessage in schema, else default to english */}
+            {/* Custom addMessage in schema, else default to English */}
             {objectSchema.addMessage ||
               `${intl.formatMessage(messages.add)} ${objectSchema.title}`}
           </Button>
@@ -158,11 +166,11 @@ const ObjectListWidget = (props) => {
             >
               <Accordion key={index} fluid styled>
                 <Accordion.Title
-                  active={activeColumn === index}
+                  active={activeObject === index}
                   index={index}
-                  onClick={handleChangeColumn}
+                  onClick={handleChangeActiveObject}
                   aria-label={`${
-                    activeColumn === index
+                    activeObject === index
                       ? intl.formatMessage(messages.labelCollapseItem)
                       : intl.formatMessage(messages.labelShowItem)
                   } #${index + 1}`}
@@ -195,14 +203,14 @@ const ObjectListWidget = (props) => {
                     >
                       <Icon name={deleteSVG} size="20px" color="#e40166" />
                     </button>
-                    {activeColumn === index ? (
+                    {activeObject === index ? (
                       <Icon name={upSVG} size="20px" />
                     ) : (
                       <Icon name={downSVG} size="20px" />
                     )}
                   </div>
                 </Accordion.Title>
-                <Accordion.Content active={activeColumn === index}>
+                <Accordion.Content active={activeObject === index}>
                   <Segment>
                     <ObjectWidget
                       id={`${id}-${index}`}

--- a/src/helpers/Blocks/Blocks.test.js
+++ b/src/helpers/Blocks/Blocks.test.js
@@ -165,6 +165,147 @@ config.blocks.blocksConfig.enhancedBlockCase2 = {
   }),
 };
 
+const itemSchema = (props) => {
+  return {
+    title: 'Item',
+    addMessage: 'Add',
+    fieldsets: [
+      {
+        id: 'default',
+        title: 'Default',
+        fields: [
+          'href',
+          'title',
+          'description',
+          'preview_image',
+          'extraDefault',
+        ],
+      },
+    ],
+
+    properties: {
+      href: {
+        title: 'Source',
+        widget: 'object_browser',
+        mode: 'link',
+        selectedItemAttrs: [
+          'Title',
+          'Description',
+          'hasPreviewImage',
+          'headtitle',
+        ],
+        allowExternals: true,
+      },
+      title: {
+        title: 'title',
+      },
+      description: {
+        title: 'description',
+      },
+      preview_image: {
+        title: 'Image Override',
+        widget: 'object_browser',
+        mode: 'image',
+        allowExternals: true,
+      },
+      extraDefault: {
+        title: 'Extra',
+        default: 'Extra default',
+      },
+    },
+    required: [],
+  };
+};
+
+config.blocks.blocksConfig.slider = {
+  id: 'slider',
+  title: 'Slider',
+  group: 'Special',
+  restricted: false,
+  mostUsed: false,
+  blockHasOwnFocusManagement: true,
+  blockSchema: (props) => ({
+    title: 'slider',
+    fieldsets: [
+      {
+        id: 'default',
+        title: 'Default',
+        fields: [
+          'slides',
+          'fieldAfterObjectList',
+          'href',
+          'firstWithDefault',
+          'style',
+          'anotherWithDefault',
+          'yetAnotherWithDefault',
+        ],
+      },
+    ],
+    properties: {
+      slides: {
+        widget: 'object_list',
+        schema: itemSchema,
+        default: [
+          {
+            '@id': 'asdasdasd-qweqwe-zxczxc',
+            extraDefault:
+              'Extra default (Manual in parent slider widget default)',
+          },
+        ],
+      },
+      fieldAfterObjectList: {
+        title: 'Field after OL',
+      },
+      href: {
+        widget: 'object_browser',
+        mode: 'link',
+        selectedItemAttrs: [
+          'Title',
+          'Description',
+          'hasPreviewImage',
+          'headtitle',
+        ],
+        allowExternals: true,
+      },
+      firstWithDefault: {
+        title: 'Field with default',
+        default: 'Some default value',
+      },
+      style: {
+        widget: 'object',
+        schema: {
+          title: 'Style',
+          fieldsets: [
+            {
+              id: 'default',
+              fields: ['color'],
+              title: 'Default',
+            },
+          ],
+          properties: {
+            color: {
+              title: 'Color',
+              default: 'red',
+            },
+          },
+          required: [],
+        },
+      },
+      anotherWithDefault: {
+        title: 'Field with default 2',
+        default: 2,
+        type: 'number',
+      },
+      yetAnotherWithDefault: {
+        title: 'Field with default 3',
+        default: ['one', 'two'],
+        type: 'array',
+      },
+    },
+    required: [],
+  }),
+};
+
 config.settings.defaultBlockType = 'text';
 
 describe('Blocks', () => {
@@ -506,6 +647,44 @@ describe('Blocks', () => {
         booleanField: false,
         title: 'Default title',
         description: 'already filled',
+      });
+    });
+    it('Sets data according to schema default values, top level and styling wrapper object field', () => {
+      const data = {
+        '@type': 'slider',
+      };
+      const schema = config.blocks.blocksConfig.slider.blockSchema({ data });
+
+      // if you don't pass down intl, the ObjectWidget defaults are not applied
+      expect(applySchemaDefaults({ schema, data })).toEqual({
+        '@type': 'slider',
+        anotherWithDefault: 2,
+        slides: [
+          {
+            '@id': 'asdasdasd-qweqwe-zxczxc',
+            extraDefault:
+              'Extra default (Manual in parent slider widget default)',
+          },
+        ],
+        firstWithDefault: 'Some default value',
+        yetAnotherWithDefault: ['one', 'two'],
+      });
+
+      expect(applySchemaDefaults({ schema, data, intl: {} })).toEqual({
+        '@type': 'slider',
+        anotherWithDefault: 2,
+        slides: [
+          {
+            '@id': 'asdasdasd-qweqwe-zxczxc',
+            extraDefault:
+              'Extra default (Manual in parent slider widget default)',
+          },
+        ],
+        firstWithDefault: 'Some default value',
+        style: {
+          color: 'red',
+        },
+        yetAnotherWithDefault: ['one', 'two'],
       });
     });
   });

--- a/src/helpers/Blocks/Blocks.test.js
+++ b/src/helpers/Blocks/Blocks.test.js
@@ -278,7 +278,7 @@ config.blocks.blocksConfig.slider = {
           fieldsets: [
             {
               id: 'default',
-              fields: ['color'],
+              fields: ['color', 'theme'],
               title: 'Default',
             },
           ],
@@ -286,6 +286,10 @@ config.blocks.blocksConfig.slider = {
             color: {
               title: 'Color',
               default: 'red',
+            },
+            theme: {
+              title: 'Theme',
+              default: 'primary',
             },
           },
           required: [],
@@ -683,8 +687,59 @@ describe('Blocks', () => {
         firstWithDefault: 'Some default value',
         style: {
           color: 'red',
+          theme: 'primary',
         },
         yetAnotherWithDefault: ['one', 'two'],
+      });
+    });
+
+    it('Sets data according to schema default values, keeps existing data', () => {
+      const schema = {
+        properties: {
+          style: {
+            widget: 'object',
+            schema: {
+              title: 'Style',
+              fieldsets: [
+                {
+                  id: 'default',
+                  fields: ['color', 'theme'],
+                  title: 'Default',
+                },
+              ],
+              properties: {
+                color: {
+                  title: 'Color',
+                  default: 'red',
+                },
+                theme: {
+                  title: 'Theme',
+                  default: 'primary',
+                },
+              },
+              required: [],
+            },
+          },
+        },
+      };
+
+      expect(
+        applySchemaDefaults({
+          schema,
+          data: {
+            '@type': 'slider',
+            style: {
+              theme: 'secondary',
+            },
+          },
+          intl: {},
+        }),
+      ).toEqual({
+        '@type': 'slider',
+        style: {
+          color: 'red',
+          theme: 'secondary',
+        },
       });
     });
   });


### PR DESCRIPTION
* Init data with block defaults

* Add start:coresandbox command; add some fields with default values

* WIP on cypress test

* Rest of test

* Add cy.wait

* Roll back changes to Field, no longer pass explicitely defaults; this is the job on the code that instantiates a new form, it needs to applySchemaDefaults

* Use onChangeFormData in InlineForm

* Pass down onChangeFormData from BlockDataForm

* Only pass down onChangeFormData if we have onChangeBlock

* Fix test block

* Fix defaults for ObjectListWidget

* Don't pass onChangeFormData

* Cleanup tests

* Remove comment

* Add ObjectWidget case

* Add cy.getContent; finish test for objectwidget / objectlistwidget defaults

* Code formatting

* Add changelog

* No need for async here

* One more test for the applySchemaDefaults helper

* Improve docs, add warning in upgrade guide

* Add console.warn notice in BlockDataForm if no onChangeBlock is passed down.

* More tests with different types of fields/widgets

* More resilient Cypress test

* BBB with applySchemaDefaults without intl passed down

Co-authored-by: Victor Fernandez de Alba <sneridagh@gmail.com>