### PR TITLE
Generator is aware of RC and beta versions when canary option is selected (#3923)

### DIFF
--- a/packages/generator-volto/CHANGELOG.md
+++ b/packages/generator-volto/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Generator is aware of `rc`, `beta` and `alphas` as possible releases for canary @sneridagh
+
 ### Internal
 
 ## 6.0.0-alpha.3 (2022-11-16)

--- a/packages/generator-volto/__tests__/app.js
+++ b/packages/generator-volto/__tests__/app.js
@@ -64,6 +64,10 @@ describe('generator-create-volto-app:app with canary option', () => {
       fs.readFileSync(path.join(tmpDir, 'test-volto/package.json'), 'utf8'),
     );
 
-    expect(packageJSON.dependencies['@plone/volto']).toContain('alpha');
+    expect(
+      packageJSON.dependencies['@plone/volto'].includes(['rc']) ||
+        packageJSON.dependencies['@plone/volto'].includes(['beta']) ||
+        packageJSON.dependencies['@plone/volto'].includes(['alpha']),
+    ).toBe(true);
   });
 });

--- a/packages/generator-volto/generators/app/utils.js
+++ b/packages/generator-volto/generators/app/utils.js
@@ -69,7 +69,11 @@ async function getLatestCanaryVoltoVersion() {
           });
           resp.on('end', () => {
             const res = JSON.parse(data.join(''));
-            resolve(res['dist-tags'].alpha);
+            resolve(
+              res['dist-tags'].rc ||
+                res['dist-tags'].beta ||
+                res['dist-tags'].alpha,
+            );
           });
         },
       )


### PR DESCRIPTION
* Generator is aware of RC and beta versions when canary option is selected

* Fix tests