### PR TITLE
Support for drilled down current state and updater function from schema in `ObjectListWidget`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Feature
 
+- Support for drilled down current state and updater function from schema in `ObjectListWidget`. This allows to sync the current object selected from the UI and the block settings and viceversa @sneridagh
+
 ### Bugfix
 
 - Overhaul how block defaults are computed. See https://github.com/plone/volto/pull/3925 for more details @tiberiuichim

--- a/src/components/manage/Widgets/ObjectListWidget.jsx
+++ b/src/components/manage/Widgets/ObjectListWidget.jsx
@@ -57,7 +57,9 @@ const messages = defineMessages({
  *      }
  *      mutated.fieldsets[0].fields.push('extraField');
  *      return mutated;
- *    }
+ *    },
+ *    activeObject: 0, // Current active object drilled down from the schema (if present)
+ *    setActiveObject: () => {} // The current active object state updater function drilled down from the schema (if present)
  *  },
  * ```
  */
@@ -71,7 +73,22 @@ const ObjectListWidget = (props) => {
     onChange,
     schemaExtender,
   } = props;
-  const [activeObject, setActiveObject] = React.useState(value.length - 1);
+  const [localActiveObject, setLocalActiveObject] = React.useState(
+    props.activeObject ?? value.length - 1,
+  );
+
+  let activeObject, setActiveObject;
+  if (
+    (props.activeObject || props.activeObject === 0) &&
+    props.setActiveObject
+  ) {
+    activeObject = props.activeObject;
+    setActiveObject = props.setActiveObject;
+  } else {
+    activeObject = localActiveObject;
+    setActiveObject = setLocalActiveObject;
+  }
+
   const intl = useIntl();
 
   function handleChangeActiveObject(e, blockProps) {


### PR DESCRIPTION
So you can do:

```
    {
      title: props.intl.formatMessage(messages.Slider),
      block: 'slider',
      fieldsets: [
        {
          id: 'default',
          title: 'Default',
          fields: ['slides'],
        },
      ],
      properties: {
        slides: {
          widget: 'object_list',
          title: props.intl.formatMessage(messages.items),
          schema: itemSchema(props),
          activeObject: props.activeObject,
          setActiveObject: props.setActiveObject,
          default: [{ '@id': uuid() }],
        },
      },
      required: [],
    }
```

in the edit:

```
        <Sidebar
          {...props}
          data={data}
          block={block}
          onChangeBlock={onChangeBlock}
          activeObject={slideIndex}
          setActiveObject={setSlideIndex}
        />
```

This allows to sync the current object selected from the UI and the block settings and viceversa.