### PR TITLE
Fix issue when using list markdown when list is already active.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Overhaul how block defaults are computed. See https://github.com/plone/volto/pull/3925 for more details @tiberiuichim
 - Fix image tag for Plone 5.2.x, use 5.2.9 for now @sneridagh
 - Cover an additional edge case for defaults @tiberiuichim
+- Fix issue when using list markdown when list is already active (volto-slate) @robgietema
 
 ### Internal
 
@@ -25,7 +26,6 @@
 - Remove `sentryOptions` from settings reference. Clean up `deploying/sentry.md`. @stevepiercy
 - Tidy up `upgrade-guide/index.md`. @stevepiercy
 - Fix some MyST syntax and English grammar. @stevepiercy
-
 
 ## 16.0.0-rc.1 (2022-11-18)
 

--- a/packages/volto-slate/src/editor/plugins/Markdown/constants.js
+++ b/packages/volto-slate/src/editor/plugins/Markdown/constants.js
@@ -16,17 +16,6 @@ export const localToggleList = (editor, format) => {
 };
 
 /**
- * @summary Turns off any list type.
- * @param {Editor} editor The editor to which to apply the change.
- * @returns The result of the inner call to the function `unwrapList`.
- */
-const preFormat = (editor) => {
-  return unwrapList(editor, false, {
-    unwrapFromList: false,
-  });
-};
-
-/**
  * The autoformat rules created by this plugin for the Markdown language.
  *
  * @todo Use constants instead of the remaining hard-coded types (h2, h3 etc.).
@@ -35,17 +24,14 @@ export const autoformatRules = [
   {
     type: 'h2',
     markup: '#',
-    // preFormat,
   },
   {
     type: 'h3',
     markup: '##',
-    // preFormat,
   },
   {
     type: LI,
     markup: ['*', '-', '+'],
-    preFormat,
     format: (editor) => {
       localToggleList(editor, 'ul');
     },
@@ -53,7 +39,6 @@ export const autoformatRules = [
   {
     type: LI,
     markup: ['1.', '1)'],
-    preFormat,
     format: (editor) => {
       localToggleList(editor, 'ol');
     },


### PR DESCRIPTION
This fixes an issue when you try to add a list using markdown syntax but the list is already active. The code tries to unwrap the list which will break and results in removing the entire block. I removed the preFormat for now so it won't be unwrapped. This means the list type will stay the same but the block won't be broken anymore.