### PR TITLE
Fix user search by full name in users control panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Bugfix
 
 - Fix jest moduleNameMapper for `@plone/volto/babel` @tiberiuichim
+- Fix user search by full name in users control panel @reebalazs
 
 ### Internal
 
@@ -274,7 +275,7 @@ See https://6.dev-docs.plone.org/volto/upgrade-guide/index.html for more informa
 - Fix image tag for Plone 5.2.x, use 5.2.9 for now @sneridagh
 - Cover an additional edge case for defaults @tiberiuichim
 - Fix issue when using list markdown when list is already active (volto-slate) @robgietema
-- Fix translation spelling of toggle  @iFlameing
+- Fix translation spelling of toggle @iFlameing
 - Fix keyboard accessibility issue of Clear button in Folder content view @iFlameing
 
 ### Internal
@@ -382,7 +383,7 @@ See https://6.dev-docs.plone.org/volto/upgrade-guide/index.html for more informa
 
 - Fix keyboard accessibility issue of Clear button in Folder content view @iFlameing
 - Fix issue when using list markdown when list is already active (volto-slate) @robgietema
-- Fix translation spelling of toggle  @iFlameing
+- Fix translation spelling of toggle @iFlameing
 
 ### Documentation
 

--- a/src/components/manage/Controlpanels/Users/UsersControlpanel.jsx
+++ b/src/components/manage/Controlpanels/Users/UsersControlpanel.jsx
@@ -140,7 +140,7 @@ class UsersControlpanel extends Component {
       (this.props.createRequest.loading && nextProps.createRequest.loaded)
     ) {
       this.props.listUsers({
-        query: this.state.search,
+        search: this.state.search,
       });
     }
     if (this.props.createRequest.loading && nextProps.createRequest.loaded) {
@@ -172,7 +172,7 @@ class UsersControlpanel extends Component {
   onSearch(event) {
     event.preventDefault();
     this.props.listUsers({
-      query: this.state.search,
+      search: this.state.search,
     });
   }
 


### PR DESCRIPTION
Follow up on https://github.com/plone/plone.restapi/commit/6760d55d5fd5ce10adae86b8c79612d5b5545910

This is actually already implemented in the actions but the calling place still missed the change

In short, we want containment search in full name (`search` parameter) and not in the id (`query` parameter, the old way kept for compatibility)