### PR TITLE
Include `CHANGELOG.md` at the correct path, depending on context of e…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4500,7 +4500,7 @@ https://docs.voltocms.com/upgrade-guide/
 - Added item type as a tooltip in contents @nzambello
 - Added Italian translations and translated array, token and select widget. @giuliaghisini
 - Added uploading image preview in FileWidget @iFlameing
-- Allow custom express middleware declared with `settings.expressMiddleware`. See [Customizing Express](docs/source/customizing/express.md) @tiberiuichim
+- Allow custom express middleware declared with `settings.expressMiddleware`. See [Custom Express middleware](https://6.dev-docs.plone.org/volto/recipes/express.html) @tiberiuichim
 
 ### Bugfix
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -56,6 +56,7 @@ templates_path = ["_templates"]
 extensions = [
     "myst_parser",
     "sphinx.ext.autodoc",
+    "sphinx.ext.ifconfig",
     "sphinx.ext.intersphinx",
     "sphinx.ext.todo",
     "sphinx_copybutton",
@@ -246,3 +247,6 @@ latex_documents = [
 # The name of an image file (relative to this directory) to place at the top of
 # the title page.
 latex_logo = "_static/logo_2x.png"
+
+def setup(app):
+    app.add_config_value("context", "volto", "env")

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -48,4 +48,5 @@ backend/index
 deploying/index
 upgrade-guide/index
 developer-guidelines/index
+release-notes/index
 ```

--- a/docs/source/release-notes/index.md
+++ b/docs/source/release-notes/index.md
@@ -1,0 +1,22 @@
+---
+myst:
+  html_meta:
+    "description": "Volto Release Notes"
+    "property=og:description": "Volto Release Notes for Plone content management system"
+    "property=og:title": "Volto Release Notes"
+    "keywords": "Volto, Plone, frontend, Release Notes"
+---
+
+(release-notes-label)=
+
+# Volto Release Notes
+
+````{ifconfig} context in ("documentation")
+```{include} ../../../submodules/volto/CHANGELOG.md
+```
+````
+
+````{ifconfig} context in ("volto")
+```{include} ../../../CHANGELOG.md
+```
+````

--- a/news/3992.documentation
+++ b/news/3992.documentation
@@ -1,0 +1,1 @@
+Include `CHANGELOG.md` at the correct path, depending on context of entire Plone 6 documentation or only Volto documentation. @stevepiercy


### PR DESCRIPTION
…ntire Plone 6 documentation or only Volto documentation.

Closes https://github.com/plone/volto/issues/3992
See https://github.com/plone/documentation/pull/1364