### PR TITLE
chore(docker-compose) update traefik config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
 
   reverse-proxy:
     # The official v2 Traefik docker image
-    image: traefik:v2.8
+    image: traefik:v2.9
     # Enables the web UI and tells Traefik to listen to docker
     command: --api.insecure=true --providers.docker
     ports:
@@ -57,7 +57,7 @@ services:
       - "8888:8080"
     volumes:
       # So that Traefik can listen to the Docker events
-      - /var/run/docker.sock:/var/run/docker.sock
+      - /var/run/docker.sock:/var/run/docker.sock:ro
     labels:
       - traefik.http.middlewares.gzip.compress=true
       - traefik.http.middlewares.gzip.compress.excludedcontenttypes=image/png, image/jpeg, font/woff2

--- a/news/4067.feature
+++ b/news/4067.feature
@@ -1,0 +1,1 @@
+Update Traefik version and make volume mount (docker-compose) read-only


### PR DESCRIPTION
This PR:

- Update Traefik to `v2.9`
- Update Traefik volume 'docker socket' to read-only 