### PR TITLE
Reset value of input field of SearchWidget.

### DIFF
--- a/news/4028.bugfix
+++ b/news/4028.bugfix
@@ -1,0 +1,1 @@
+reset value of search field after submit. [@MAX-786]

--- a/news/4028.bugfix
+++ b/news/4028.bugfix
@@ -1,1 +1,1 @@
-reset value of search field after submit. [@MAX-786]
+Reset value of search field after submit. [@MAX-786]

--- a/src/components/theme/SearchWidget/SearchWidget.jsx
+++ b/src/components/theme/SearchWidget/SearchWidget.jsx
@@ -81,6 +81,9 @@ class SearchWidget extends Component {
     this.props.history.push(
       `/search?SearchableText=${encodeURIComponent(this.state.text)}${path}`,
     );
+    this.setState({
+      text: '',
+    });
     event.preventDefault();
   }
 

--- a/src/components/theme/SearchWidget/SearchWidget.jsx
+++ b/src/components/theme/SearchWidget/SearchWidget.jsx
@@ -81,6 +81,7 @@ class SearchWidget extends Component {
     this.props.history.push(
       `/search?SearchableText=${encodeURIComponent(this.state.text)}${path}`,
     );
+    // reset input value 
     this.setState({
       text: '',
     });

--- a/src/components/theme/SearchWidget/SearchWidget.jsx
+++ b/src/components/theme/SearchWidget/SearchWidget.jsx
@@ -81,7 +81,7 @@ class SearchWidget extends Component {
     this.props.history.push(
       `/search?SearchableText=${encodeURIComponent(this.state.text)}${path}`,
     );
-    // reset input value 
+    // reset input value
     this.setState({
       text: '',
     });


### PR DESCRIPTION
fixes #4028 

## Approach
reset the value of text using setState() :
```js
  onSubmit(event) {
    const path =
      this.props.pathname?.length > 0
        ? `&path=${encodeURIComponent(this.props.pathname)}`
        : '';
    this.props.history.push(
      `/search?SearchableText=${encodeURIComponent(this.state.text)}${path}`,
    );
 // *** reset value of input field
    this.setState({
      text: '',
    });
 // ***
    event.preventDefault();
  }

```
## Demo:

https://user-images.githubusercontent.com/99530996/206274415-094fda89-88e9-4254-b48a-b66d48cad208.mp4


### OS: Any

Feedback Welcome.