### PR TITLE
Remove clean-css from the CSS minimizing step

### DIFF
--- a/news/4115.bugfix
+++ b/news/4115.bugfix
@@ -1,0 +1,1 @@
+Remove clean-css from the CSS minimizing step, use css-minimizer-webpack-plugin one instead @sneridagh

--- a/razzle.config.js
+++ b/razzle.config.js
@@ -93,6 +93,9 @@ const defaultModify = ({
       ? 'static/js/[name].js'
       : 'static/js/[name].[chunkhash:8].js';
 
+    const TerserPlugin = require('terser-webpack-plugin');
+    const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
+
     config.optimization = Object.assign({}, config.optimization, {
       runtimeChunk: true,
       splitChunks: {
@@ -109,6 +112,25 @@ const defaultModify = ({
         },
       },
     });
+
+    // This is needed to override Razzle use of the unmaintained CleanCSS
+    // which does not have support for recently CSS features (container queries).
+    // Using the default provided (cssnano) by css-minimizer-webpack-plugin
+    // should be enough see:
+    // (https://github.com/clean-css/clean-css/discussions/1209)
+    if (!dev) {
+      config.optimization = Object.assign({}, config.optimization, {
+        minimizer: [
+          new TerserPlugin(options.webpackOptions.terserPluginOptions),
+          new CssMinimizerPlugin({
+            sourceMap: options.razzleOptions.enableSourceMaps,
+            minimizerOptions: {
+              sourceMap: options.razzleOptions.enableSourceMaps,
+            },
+          }),
+        ],
+      });
+    }
 
     config.plugins.unshift(
       // restrict moment.js locales to en/de

--- a/razzle.config.js
+++ b/razzle.config.js
@@ -10,6 +10,8 @@ const RelativeResolverPlugin = require('./webpack-plugins/webpack-relative-resol
 const createAddonsLoader = require('./create-addons-loader');
 const AddonConfigurationRegistry = require('./addon-registry');
 const CircularDependencyPlugin = require('circular-dependency-plugin');
+const TerserPlugin = require('terser-webpack-plugin');
+const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
 
 const fileLoaderFinder = makeLoaderFinder('file-loader');
 
@@ -92,9 +94,6 @@ const defaultModify = ({
     config.output.filename = dev
       ? 'static/js/[name].js'
       : 'static/js/[name].[chunkhash:8].js';
-
-    const TerserPlugin = require('terser-webpack-plugin');
-    const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
 
     config.optimization = Object.assign({}, config.optimization, {
       runtimeChunk: true,


### PR DESCRIPTION
This removes CleanCSS from the minimiser build step in production mode. The project is unmaintained: 
https://github.com/clean-css/clean-css/discussions/1209

There was a problem when using container queries (@container) since it was unrecognising it, they were wiped out.

Razzle was using it (no clue why) instead of using cssnano (the default in css-minimizer-webpack-plugin). This change relies on it for the minimising step instead.

Also the build now seems to be improved by 600B 😱

```
 114.61 KB (-691 B)    build/public/static/css/client.2a553559.chunk.css
```

So good riddance...