### PR TITLE
Exclude included file from sources

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -118,6 +118,7 @@ exclude_patterns = [
     "spelling_wordlist.txt",
     "**/CHANGES.rst",
     "**/LICENSE.rst",
+    "developer-guidelines/branch-policy.md",
 ]
 
 html_extra_path = [

--- a/news/4145.documentation
+++ b/news/4145.documentation
@@ -1,0 +1,1 @@
+Fix Sphinx warning Document headings start at H2, not H1 [myst.header]. @stevepiercy


### PR DESCRIPTION
This PR fixes a Sphinx warning. Sphinx tries to build the file as a separate page, instead of treating it as an included file. It still renders the file where it is included in the docs.

```
WARNING: Document headings start at H2, not H1 [myst.header]
```

Refs: https://github.com/plone/documentation/pull/1388