### PR TITLE
fix: LinkEditor not opening from SlateEditor

### DIFF
--- a/news/4130.bugfix
+++ b/news/4130.bugfix
@@ -1,0 +1,1 @@
+fix LinkEditor not opening from SlateEditor @CannedShroud

--- a/packages/volto-slate/src/editor/plugins/Link/index.js
+++ b/packages/volto-slate/src/editor/plugins/Link/index.js
@@ -98,7 +98,6 @@ const LinkEditor = (props) => {
         }}
         onOverrideContent={(c) => {
           dispatch(setPluginOptions(pid, { show_sidebar_editor: false }));
-          savedPosition.current = null;
         }}
       />
     </PositionedToolbar>


### PR DESCRIPTION
Do not reset savedPosition ref onOverride

ISSUE: #4130