### PR TITLE
Fix video block can't be re-selected once it has been clicked on

### DIFF
--- a/src/components/manage/Blocks/Video/Body.jsx
+++ b/src/components/manage/Blocks/Video/Body.jsx
@@ -3,7 +3,7 @@
  * @module components/manage/Blocks/Video/Body
  */
 
-import React from 'react';
+import React, {useState} from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { Embed, Message } from 'semantic-ui-react';
@@ -15,7 +15,7 @@ import { isInternalURL, flattenToAppURL } from '@plone/volto/helpers';
  * @class Body
  * @extends Component
  */
-const Body = ({ data, isEditMode }) => {
+const Body = ({ data, isEditMode,selected }) => {
   let placeholder = data.preview_image
     ? isInternalURL(data.preview_image)
       ? `${flattenToAppURL(data.preview_image)}/@@images/image`
@@ -59,12 +59,13 @@ const Body = ({ data, isEditMode }) => {
   const embedSettings = {
     placeholder: placeholder,
     icon: 'play',
-    defaultActive: false,
+    // defaultActive: false,
     autoplay: false,
     aspectRatio: '16:9',
     tabIndex: 0,
     onKeyPress: onKeyDown,
     ref: ref,
+    active: selected,
   };
 
   return (

--- a/src/components/manage/Blocks/Video/Body.jsx
+++ b/src/components/manage/Blocks/Video/Body.jsx
@@ -15,7 +15,7 @@ import { isInternalURL, flattenToAppURL } from '@plone/volto/helpers';
  * @class Body
  * @extends Component
  */
-const Body = ({ data, isEditMode,selected }) => {
+const Body = ({ data, isEditMode, selected }) => {
   let placeholder = data.preview_image
     ? isInternalURL(data.preview_image)
       ? `${flattenToAppURL(data.preview_image)}/@@images/image`

--- a/src/components/manage/Blocks/Video/Body.jsx
+++ b/src/components/manage/Blocks/Video/Body.jsx
@@ -3,7 +3,7 @@
  * @module components/manage/Blocks/Video/Body
  */
 
-import React, {useState} from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { Embed, Message } from 'semantic-ui-react';

--- a/src/components/manage/Blocks/Video/Edit.jsx
+++ b/src/components/manage/Blocks/Video/Edit.jsx
@@ -155,7 +155,7 @@ class Edit extends Component {
         )}
       >
         {data.url ? (
-          <Body data={this.props.data} isEditMode={true} />
+          <Body data={this.props.data} isEditMode={true} selected={this.props.selected} />
         ) : (
           <Message>
             <center>

--- a/src/components/manage/Blocks/Video/Edit.jsx
+++ b/src/components/manage/Blocks/Video/Edit.jsx
@@ -155,7 +155,11 @@ class Edit extends Component {
         )}
       >
         {data.url ? (
-          <Body data={this.props.data} isEditMode={true} selected={this.props.selected} />
+          <Body
+            data={this.props.data}
+            isEditMode={true}
+            selected={this.props.selected}
+          />
         ) : (
           <Message>
             <center>


### PR DESCRIPTION
fixes #4117 
## Approach

By passing an extra prop (`selected=boolean`) from `Edit.jsx` to `Body.jsx`. And also we were using `defaultActive` prop of `<Embed />` which I replaced with `Active` prop.

## Screenshots

https://user-images.githubusercontent.com/99530996/208292113-50d4e373-8c02-4b11-9846-62ad8155ba25.mp4

