### PR TITLE
Change issue_format to link to pull requests instead of issues

### DIFF
--- a/news/4149.internal
+++ b/news/4149.internal
@@ -1,0 +1,1 @@
+Change the issue_format to generate links to pull requests instead of issues. @stevepiercy

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -5,7 +5,7 @@ title_format = "## {version} ({project_date})"
 underlines = ["", "", ""]
 template = "packages/scripts/templates/towncrier_template.jinja"
 start_string = "<!-- towncrier release notes start -->\n"
-issue_format = "[#{issue}](https://github.com/plone/volto/issues/{issue})"
+issue_format = "[#{issue}](https://github.com/plone/volto/pull/{issue})"
 
 [[tool.towncrier.type]]
 directory = "breaking"


### PR DESCRIPTION
Change the output template to generate links to pull requests instead of issues, as every change must have a pull request, but not necessarily have an issue. This will also reduce the number of redirects of issues to pull requests.