### PR TITLE
Add option to upload video to the Video block

### DIFF
--- a/src/components/manage/Blocks/Video/Edit.jsx
+++ b/src/components/manage/Blocks/Video/Edit.jsx
@@ -6,7 +6,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { defineMessages, injectIntl } from 'react-intl';
-import { Button, Input, Message } from 'semantic-ui-react';
+import { Button, Input, Message, Loader, Dimmer } from 'semantic-ui-react';
 import cx from 'classnames';
 import { isEqual } from 'lodash';
 
@@ -15,8 +15,20 @@ import clearSVG from '@plone/volto/icons/clear.svg';
 import aheadSVG from '@plone/volto/icons/ahead.svg';
 import videoBlockSVG from '@plone/volto/components/manage/Blocks/Video/block-video.svg';
 import Body from '@plone/volto/components/manage/Blocks/Video/Body';
-import { withBlockExtensions } from '@plone/volto/helpers';
+import { connect } from 'react-redux';
+import {
+  withBlockExtensions,
+  getBaseUrl,
+  flattenToAppURL,
+} from '@plone/volto/helpers';
+import { createContent } from '@plone/volto/actions';
 import { compose } from 'redux';
+import navTreeSVG from '@plone/volto/icons/nav.svg';
+import uploadSVG from '@plone/volto/icons/upload.svg';
+
+import { readAsDataURL } from 'promise-file-reader';
+import loadable from '@loadable/component';
+const Dropzone = loadable(() => import('react-dropzone'));
 
 const messages = defineMessages({
   VideoFormDescription: {
@@ -26,6 +38,10 @@ const messages = defineMessages({
   VideoBlockInputPlaceholder: {
     id: 'Type a Video (YouTube, Vimeo or mp4) URL',
     defaultMessage: 'Type a Video (YouTube, Vimeo or mp4) URL',
+  },
+  UploadingVideo: {
+    id: 'Uploading video',
+    defaultMessage: 'Uploading video',
   },
 });
 
@@ -45,12 +61,18 @@ class Edit extends Component {
     block: PropTypes.string.isRequired,
     index: PropTypes.number.isRequired,
     data: PropTypes.objectOf(PropTypes.any).isRequired,
+    content: PropTypes.objectOf(PropTypes.any).isRequired,
+    request: PropTypes.shape({
+      loading: PropTypes.bool,
+      loaded: PropTypes.bool,
+    }).isRequired,
     onChangeBlock: PropTypes.func.isRequired,
     onSelectBlock: PropTypes.func.isRequired,
     onDeleteBlock: PropTypes.func.isRequired,
     onFocusPreviousBlock: PropTypes.func.isRequired,
     onFocusNextBlock: PropTypes.func.isRequired,
     handleKeyDown: PropTypes.func.isRequired,
+    openObjectBrowser: PropTypes.func.isRequired,
   };
 
   /**
@@ -66,9 +88,65 @@ class Edit extends Component {
     this.onSubmitUrl = this.onSubmitUrl.bind(this);
     this.onKeyDownVariantMenuForm = this.onKeyDownVariantMenuForm.bind(this);
     this.state = {
+      uploading: false,
       url: '',
+      dragging: false,
     };
   }
+
+  /**
+   * Component will receive props
+   * @method componentWillReceiveProps
+   * @param {Object} nextProps Next properties
+   * @returns {undefined}
+   */
+  UNSAFE_componentWillReceiveProps(nextProps) {
+    if (
+      this.props.request.loading &&
+      nextProps.request.loaded &&
+      this.state.uploading
+    ) {
+      this.setState({
+        uploading: false,
+      });
+      this.props.onChangeBlock(this.props.block, {
+        ...this.props.data,
+        url: nextProps.content['@id'],
+        alt: '',
+      });
+    }
+  }
+
+  /**
+   * Upload video handler (not used), but useful in case that we want a button
+   * not powered by react-dropzone
+   * @method onUploadVideo
+   * @returns {undefined}
+   */
+  onUploadVideo = (e) => {
+    e.stopPropagation();
+    const file = e.target.files[0];
+    this.setState({
+      uploading: true,
+    });
+    readAsDataURL(file).then((data) => {
+      const fields = data.match(/^data:(.*);(.*),(.*)$/);
+      this.props.createContent(
+        getBaseUrl(this.props.pathname),
+        {
+          '@type': 'File',
+          title: file.name,
+          file: {
+            data: fields[3],
+            encoding: fields[2],
+            'content-type': fields[1],
+            filename: file.name,
+          },
+        },
+        this.props.block,
+      );
+    });
+  };
 
   /**
    * Change url handler
@@ -103,14 +181,49 @@ class Edit extends Component {
   onSubmitUrl() {
     this.props.onChangeBlock(this.props.block, {
       ...this.props.data,
-      url: this.state.url,
+      url: flattenToAppURL(this.state.url),
     });
   }
+  /**
+   * Drop handler
+   * @method onDrop
+   * @param {array} files File objects
+   * @returns {undefined}
+   */
+  onDrop = (file) => {
+    this.setState({
+      uploading: true,
+    });
+
+    readAsDataURL(file[0]).then((data) => {
+      const fields = data.match(/^data:(.*);(.*),(.*)$/);
+      this.props.createContent(
+        getBaseUrl(this.props.pathname),
+        {
+          '@type': 'File',
+          title: file[0].name,
+          file: {
+            data: fields[3],
+            encoding: fields[2],
+            'content-type': fields[1],
+            filename: file[0].name,
+          },
+        },
+        this.props.block,
+      );
+    });
+  };
 
   resetSubmitUrl = () => {
     this.setState({
       url: '',
     });
+  };
+  onDragEnter = () => {
+    this.setState({ dragging: true });
+  };
+  onDragLeave = () => {
+    this.setState({ dragging: false });
   };
 
   /**
@@ -157,48 +270,98 @@ class Edit extends Component {
         {data.url ? (
           <Body data={this.props.data} isEditMode={true} />
         ) : (
-          <Message>
-            <center>
-              <img src={videoBlockSVG} alt="" />
-              <div className="toolbar-inner">
-                <Input
-                  onKeyDown={this.onKeyDownVariantMenuForm}
-                  onChange={this.onChangeUrl}
-                  placeholder={placeholder}
-                  value={this.state.url}
-                  // Prevents propagation to the Dropzone and the opening
-                  // of the upload browser dialog
-                  onClick={(e) => e.stopPropagation()}
-                />
-                {this.state.url && (
-                  <Button.Group>
-                    <Button
-                      basic
-                      className="cancel"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        this.setState({ url: '' });
-                      }}
-                    >
-                      <Icon name={clearSVG} size="30px" />
-                    </Button>
-                  </Button.Group>
-                )}
-                <Button.Group>
-                  <Button
-                    basic
-                    primary
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      this.onSubmitUrl();
-                    }}
-                  >
-                    <Icon name={aheadSVG} size="30px" />
-                  </Button>
-                </Button.Group>
+          <Dropzone
+            noClick
+            onDrop={this.onDrop}
+            onDragEnter={this.onDragEnter}
+            onDragLeave={this.onDragLeave}
+            className="dropzone"
+          >
+            {({ getRootProps, getInputProps }) => (
+              <div {...getRootProps()}>
+                <Message>
+                  {this.state.dragging && <Dimmer active></Dimmer>}
+                  {this.state.uploading && (
+                    <Dimmer active>
+                      <Loader indeterminate>
+                        {this.props.intl.formatMessage(messages.UploadingVideo)}
+                      </Loader>
+                    </Dimmer>
+                  )}
+                  <img src={videoBlockSVG} alt="" />
+                  <div className="toolbar-inner">
+                    <Button.Group>
+                      <Button
+                        basic
+                        icon
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          e.preventDefault();
+                          this.props.openObjectBrowser({
+                            mode: 'link',
+                            overlay: true,
+                            onSelectItem: (url) => {
+                              this.setState({ url }, this.onSubmitUrl);
+                            },
+                          });
+                        }}
+                      >
+                        <Icon name={navTreeSVG} size="24px" />
+                      </Button>
+                    </Button.Group>
+                    <Button.Group>
+                      <label className="ui button basic icon">
+                        <Icon name={uploadSVG} size="24px" />
+                        <input
+                          {...getInputProps({
+                            type: 'file',
+                            onChange: this.onUploadVideo,
+                            style: { display: 'none' },
+                          })}
+                        />
+                      </label>
+                    </Button.Group>
+                    <Input
+                      onKeyDown={this.onKeyDownVariantMenuForm}
+                      onChange={this.onChangeUrl}
+                      placeholder={placeholder}
+                      value={this.state.url}
+                      // Prevents propagation to the Dropzone and the opening
+                      // of the upload browser dialog
+                      onClick={(e) => e.stopPropagation()}
+                    />
+                    {this.state.url && (
+                      <Button.Group>
+                        <Button
+                          basic
+                          className="cancel"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            this.setState({ url: '' });
+                          }}
+                        >
+                          <Icon name={clearSVG} size="30px" />
+                        </Button>
+                      </Button.Group>
+                    )}
+                    <Button.Group>
+                      <Button
+                        basic
+                        primary
+                        disabled={!this.state.url}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          this.onSubmitUrl();
+                        }}
+                      >
+                        <Icon name={aheadSVG} size="30px" />
+                      </Button>
+                    </Button.Group>
+                  </div>
+                </Message>
               </div>
-            </center>
-          </Message>
+            )}
+          </Dropzone>
         )}
         <SidebarPortal selected={this.props.selected}>
           <VideoSidebar {...this.props} resetSubmitUrl={this.resetSubmitUrl} />
@@ -208,4 +371,14 @@ class Edit extends Component {
   }
 }
 
-export default compose(injectIntl, withBlockExtensions)(Edit);
+export default compose(
+  injectIntl,
+  withBlockExtensions,
+  connect(
+    (state, ownProps) => ({
+      request: state.content.subrequests[ownProps.block] || {},
+      content: state.content.subrequests[ownProps.block]?.data,
+    }),
+    { createContent },
+  ),
+)(Edit);


### PR DESCRIPTION
Following the pattern of the Image block, these changes add the functionality to upload a video from the video block.
Through an internal link or uploading the video directly, maintain coherence with the image block.

![volto-video-image-blocks](https://user-images.githubusercontent.com/26112509/209321942-7ccda731-270c-4a1a-a246-3ab97e0e5548.png)


## Demo uploading a video with drag & drop
https://user-images.githubusercontent.com/26112509/209320244-163f63d4-56fa-4a6c-bfb0-83b50eee97e3.mov


## Demo selecting a video from an internal link
https://user-images.githubusercontent.com/26112509/209321174-8110ab0f-6f4b-47b7-97c6-3c2b73b99c42.mov


