### PR TITLE
Fix for externalRoutes short version not working anymore 

### DIFF
--- a/news/4182.bugfix
+++ b/news/4182.bugfix
@@ -1,0 +1,1 @@
+Fixed externalRoutes short version @pnicolli

--- a/src/routes.js
+++ b/src/routes.js
@@ -2,6 +2,8 @@
  * Routes.
  * @module routes
  */
+import debug from 'debug';
+import { compact } from 'lodash';
 import {
   Add,
   AddonsControlpanel,
@@ -95,10 +97,30 @@ export const multilingualRoutes = [
 
 export const defaultRoutes = [
   // redirect to external links if path is in blacklist
-  ...(config.settings?.externalRoutes || []).map((route) => ({
-    ...route.match,
-    component: NotFound,
-  })),
+  ...compact(
+    (config.settings?.externalRoutes || []).map((route) => {
+      const newRoute = {
+        component: NotFound,
+      };
+      if (typeof route.match === 'string') {
+        newRoute.path = route.match;
+        return newRoute;
+      } else if (
+        typeof route.match === 'object' &&
+        !Array.isArray(route.match)
+      ) {
+        return {
+          ...newRoute,
+          ...route.match,
+        };
+      } else {
+        debug('routes')(
+          'Got invalid externalRoute, please check the configuration.',
+        );
+        return null;
+      }
+    }),
+  ),
   ...((config.settings?.isMultilingual && multilingualRoutes) || []),
   {
     path: '/',

--- a/src/routes.js
+++ b/src/routes.js
@@ -95,9 +95,8 @@ export const multilingualRoutes = [
   },
 ];
 
-export const defaultRoutes = [
-  // redirect to external links if path is in blacklist
-  ...compact(
+export function getExternalRoutes() {
+  return compact(
     (config.settings?.externalRoutes || []).map((route) => {
       const newRoute = {
         component: NotFound,
@@ -120,7 +119,12 @@ export const defaultRoutes = [
         return null;
       }
     }),
-  ),
+  );
+}
+
+export const defaultRoutes = [
+  // redirect to external links if path is in blacklist
+  ...getExternalRoutes(),
   ...((config.settings?.isMultilingual && multilingualRoutes) || []),
   {
     path: '/',

--- a/src/routes.test.js
+++ b/src/routes.test.js
@@ -1,0 +1,34 @@
+import config from './registry';
+import { getExternalRoutes } from './routes';
+
+describe('externalRoutes', () => {
+  it('computes regular externalRoutes correctly', () => {
+    config.settings.externalRoutes = [
+      {
+        match: {
+          path: '/test',
+        },
+      },
+    ];
+    const testRoute = getExternalRoutes().find((r) => r.path === '/test');
+    expect(testRoute).not.toBeUndefined();
+  });
+  it('computes shorthand externalRoutes correctly', () => {
+    config.settings.externalRoutes = [{ match: '/test' }];
+    const testRoute = getExternalRoutes().find((r) => r.path === '/test');
+    expect(testRoute).not.toBeUndefined();
+  });
+  it('ignores invalid routes', () => {
+    config.settings.externalRoutes = [
+      '/test',
+      { '/test': true },
+      ['/test'],
+      { match: ['/test'] },
+      { match: 123 },
+    ];
+    const externalRoutes = getExternalRoutes();
+    const testRoute = externalRoutes.find((r) => r.path === '/test');
+    expect(testRoute).toBeUndefined();
+    expect(externalRoutes.length).toEqual(0);
+  });
+});


### PR DESCRIPTION
Spreading `...route.match` inside the routes array works only if `route.match` is an object, but the documentation defines a simpler version of routes as valid:

![image](https://user-images.githubusercontent.com/14176608/209354047-74f0cea5-7daf-4b16-afcb-49c689bc952c.png)

Using this kind of short routes with the current implementation leads to an SSR that returns 404 for every url.

This PR fixes that and also adds a few tests to try and prevent regressions.