### PR TITLE
Improve matching in keyboard slash menu

### DIFF
--- a/cypress/tests/core/volto-slate/09-block-slate-slashmenu.js
+++ b/cypress/tests/core/volto-slate/09-block-slate-slashmenu.js
@@ -3,16 +3,12 @@ import { slateBeforeEach } from '../../../support/e2e';
 describe('SlashMenu Test: Shortcuts', () => {
   beforeEach(slateBeforeEach);
 
-  it('As editor I can create a Description block using the SlashMenu shortcut', function () {
-    // Use SlashMenu shortcut to create a Description block and type some text in it
-    cy.getSlateEditorAndType('/Desc').type('{enter}');
-    cy.get('.documentDescription').type('This is a description.');
-    cy.get('.documentDescription').type('{enter}');
-
-    // Save
+  it('As editor I can create a Table block using the SlashMenu shortcut', function () {
+    // Use SlashMenu shortcut to create a table block
+    cy.getSlateEditorAndType('/t').type('{enter}');
     cy.toolbarSave();
 
-    // then the page view should contain a Description with the right text in it
-    cy.get('.documentDescription').contains('This is a description.');
+    // then the page view should contain a table
+    cy.get('#page-document table').should('be.visible');
   });
 });

--- a/news/4187.bugfix
+++ b/news/4187.bugfix
@@ -1,0 +1,1 @@
+Improve matching in keyboard slash menu. [davisagli]


### PR DESCRIPTION
Fixes #4173 

This adds matching on any substring (not just at the start of the block title & id), but scores the results so that initial matches are still preferred.