### PR TITLE
change hotkey for strikethrough in Slate editor

### DIFF
--- a/news/4196.bugfix
+++ b/news/4196.bugfix
@@ -1,0 +1,1 @@
+fix Slate editor "ctrl+s" hotkey causes conflicts with it's default behaviour. @MAX-786

--- a/packages/volto-slate/src/editor/config.jsx
+++ b/packages/volto-slate/src/editor/config.jsx
@@ -207,7 +207,7 @@ export const hotkeys = {
   'mod+b': { format: 'strong', type: 'inline' },
   'mod+i': { format: 'em', type: 'inline' },
   'mod+u': { format: 'u', type: 'inline' },
-  'mod+s': { format: 'del', type: 'inline' },
+  'mod+d': { format: 'del', type: 'inline' },
   // 'mod+`': { format: 'code', type: 'inline' },
   // TODO: more hotkeys, including from plugins!
 };


### PR DESCRIPTION
fix #4196 
Change hotkey from `ctrl+s` to `ctrl+d`