### PR TITLE
Pin Sphinx<5,>=3 due to sphinx-book-theme 0.3.3 requirement.

### DIFF
--- a/news/4199.documentation
+++ b/news/4199.documentation
@@ -1,0 +1,1 @@
+Pin Sphinx<5,>=3 due to sphinx-book-theme 0.3.3 requirement. [stevepiercy]

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,5 +1,5 @@
 docutils<0.17,>=0.15  # sphinx-book-theme 0.2.0 has requirement docutils<0.17,>=0.15
-Sphinx
+Sphinx<5,>=3  # sphinx-book-theme 0.3.3 has requirement sphinx<5,>=3
 jsx-lexer
 lesscpy
 linkify-it-py


### PR DESCRIPTION
Refs: https://github.com/plone/documentation/issues/1407