### PR TITLE
fix: fixed condition to select without vocabulary

### DIFF
--- a/news/4200.bugfix
+++ b/news/4200.bugfix
@@ -1,0 +1,1 @@
+Fixed condition to select without vocabulary @SaraBianchi

--- a/src/components/manage/Widgets/ArrayWidget.jsx
+++ b/src/components/manage/Widgets/ArrayWidget.jsx
@@ -236,7 +236,8 @@ class ArrayWidget extends Component {
       !this.props.items?.choices?.length &&
       !this.props.choices?.length &&
       this.props.vocabLoading === undefined &&
-      !this.props.vocabLoaded
+      !this.props.vocabLoaded &&
+      this.props.vocabBaseUrl
     ) {
       this.props.getVocabulary({
         vocabNameOrURL: this.props.vocabBaseUrl,


### PR DESCRIPTION
In select without vocabulary you could not create more than one item in the form.

<img width="1567" alt="bug-widget-array-select" src="https://user-images.githubusercontent.com/43245702/210067271-e97addff-668f-4477-a8cf-528e09de8a70.png">
