### PR TITLE
Add message about the status of Volto and Plone 6 Installation docs.

### DIFF
--- a/docs/source/getting-started/install.md
+++ b/docs/source/getting-started/install.md
@@ -11,6 +11,11 @@ myst:
 
 # Getting Started
 
+```{warning}
+This chapter of the documentation has been superseded by the official Plone 6 Documentation chapter {ref}`install-index-label`.
+This chapter contains some legacy information that may be useful to Plone 5.2 development.
+```
+
 
 (frontend-getting-started-installing-volto-label)=
 

--- a/news/4209.documentation
+++ b/news/4209.documentation
@@ -1,0 +1,1 @@
+Add message about the status of Volto and Plone 6 Installation docs, directing the reader to the main Plone 6 docs. [stevepiercy]


### PR DESCRIPTION
See https://github.com/plone/documentation/pull/1413 and https://github.com/plone/volto/issues/3289

This is the first step to incorporating the Volto installation docs into the main Plone 6 Documentation, instead of clicking all over the place. I also tested and cleaned up many of the commands.