### PR TITLE
Search block: Allow site viewers to select 'Relevance' as a sort option

### DIFF
--- a/src/components/manage/Blocks/Search/components/SortOn.jsx
+++ b/src/components/manage/Blocks/Search/components/SortOn.jsx
@@ -62,18 +62,17 @@ const SortOn = (props) => {
 
   const activeSortOn = sortOn || data?.query?.sort_on || '';
 
-  const { sortOnOptions = [] } = data;
+  const noValueLabel = searchedText
+    ? intl.formatMessage(messages.relevance)
+    : intl.formatMessage(messages.unsorted);
+
   const value = {
     value: activeSortOn,
     label:
       activeSortOn && sortable_indexes
         ? sortable_indexes[activeSortOn]?.title
-        : activeSortOn || searchedText
-        ? intl.formatMessage(messages.relevance)
-        : intl.formatMessage(messages.unsorted),
+        : noValueLabel,
   };
-
-  debugger;
 
   return (
     <div className="search-sort-wrapper">
@@ -91,10 +90,10 @@ const SortOn = (props) => {
           theme={selectTheme}
           components={{ DropdownIndicator, Option }}
           options={[
-            { value: '', label: 'Relevance' },
+            { value: '', label: noValueLabel },
             ...sortOnOptions.map((k) => ({
               value: k,
-              label: sortable_indexes[k]?.title || k,
+              label: k === '' ? noValueLabel : sortable_indexes[k]?.title || k,
             })),
           ]}
           value={value}

--- a/src/components/manage/Blocks/Search/components/SortOn.jsx
+++ b/src/components/manage/Blocks/Search/components/SortOn.jsx
@@ -102,34 +102,38 @@ const SortOn = (props) => {
           }}
         />
       </div>
-      <Button
-        icon
-        basic
-        compact
-        title={intl.formatMessage(messages.ascending)}
-        className={cx({
-          active: sortOrder === 'ascending',
-        })}
-        onClick={() => {
-          !isEditMode && setSortOrder('ascending');
-        }}
-      >
-        <Icon name={upSVG} size="25px" />
-      </Button>
-      <Button
-        icon
-        basic
-        compact
-        title={intl.formatMessage(messages.descending)}
-        className={cx({
-          active: sortOrder === 'descending',
-        })}
-        onClick={() => {
-          !isEditMode && setSortOrder('descending');
-        }}
-      >
-        <Icon name={downSVG} size="25px" />
-      </Button>
+      {activeSortOn ? (
+        <>
+          <Button
+            icon
+            basic
+            compact
+            title={intl.formatMessage(messages.ascending)}
+            className={cx({
+              active: sortOrder === 'ascending',
+            })}
+            onClick={() => {
+              !isEditMode && setSortOrder('ascending');
+            }}
+          >
+            <Icon name={upSVG} size="25px" />
+          </Button>
+          <Button
+            icon
+            basic
+            compact
+            title={intl.formatMessage(messages.descending)}
+            className={cx({
+              active: sortOrder === 'descending',
+            })}
+            onClick={() => {
+              !isEditMode && setSortOrder('descending');
+            }}
+          >
+            <Icon name={downSVG} size="25px" />
+          </Button>
+        </>
+      ) : null}
     </div>
   );
 };

--- a/src/components/manage/Blocks/Search/components/SortOn.jsx
+++ b/src/components/manage/Blocks/Search/components/SortOn.jsx
@@ -1,23 +1,27 @@
-import React from 'react';
-import { Button } from 'semantic-ui-react';
-import { defineMessages, injectIntl } from 'react-intl';
-import cx from 'classnames';
-import { compose } from 'redux';
 import { Icon } from '@plone/volto/components';
 import {
-  Option,
   DropdownIndicator,
+  Option,
 } from '@plone/volto/components/manage/Widgets/SelectStyling';
 import { injectLazyLibs } from '@plone/volto/helpers/Loadable/Loadable';
+import cx from 'classnames';
+import React from 'react';
+import { defineMessages, injectIntl } from 'react-intl';
+import { compose } from 'redux';
+import { Button } from 'semantic-ui-react';
 import { selectTheme, sortOnSelectStyles } from './SelectStyling';
 
-import upSVG from '@plone/volto/icons/sort-up.svg';
 import downSVG from '@plone/volto/icons/sort-down.svg';
+import upSVG from '@plone/volto/icons/sort-up.svg';
 
 const messages = defineMessages({
-  noSelection: {
-    id: 'No selection',
-    defaultMessage: 'No selection',
+  unsorted: {
+    id: 'Unsorted',
+    defaultMessage: 'Unsorted',
+  },
+  relevance: {
+    id: 'Relevance',
+    defaultMessage: 'Relevance',
   },
   sortOn: {
     id: 'Sort on',
@@ -36,6 +40,7 @@ const messages = defineMessages({
 const SortOn = (props) => {
   const {
     data = {},
+    searchedText,
     reactSelect,
     sortOn = null,
     sortOrder = null,
@@ -52,12 +57,16 @@ const SortOn = (props) => {
 
   const { sortOnOptions = [] } = data;
   const value = {
-    value: activeSortOn || intl.formatMessage(messages.noSelection),
+    value: activeSortOn,
     label:
       activeSortOn && sortable_indexes
         ? sortable_indexes[activeSortOn]?.title
-        : activeSortOn || intl.formatMessage(messages.noSelection),
+        : activeSortOn || searchedText
+        ? intl.formatMessage(messages.relevance)
+        : intl.formatMessage(messages.unsorted),
   };
+
+  debugger;
 
   return (
     <div className="search-sort-wrapper">
@@ -75,6 +84,7 @@ const SortOn = (props) => {
           theme={selectTheme}
           components={{ DropdownIndicator, Option }}
           options={[
+            { value: '', label: 'Relevance' },
             ...sortOnOptions.map((k) => ({
               value: k,
               label: sortable_indexes[k]?.title || k,

--- a/src/components/manage/Blocks/Search/components/SortOn.jsx
+++ b/src/components/manage/Blocks/Search/components/SortOn.jsx
@@ -50,6 +50,13 @@ const SortOn = (props) => {
     querystring = {},
     intl,
   } = props;
+  const { sortOnOptions = [] } = data;
+
+  // We don't want to show sorting options if there is only 1 way to sort
+  if (!sortOnOptions || sortOnOptions.length < 1) {
+    return null;
+  }
+
   const { sortable_indexes } = querystring;
   const Select = reactSelect.default;
 

--- a/src/components/manage/Blocks/Search/layout/LeftColumnFacets.jsx
+++ b/src/components/manage/Blocks/Search/layout/LeftColumnFacets.jsx
@@ -115,6 +115,7 @@ const LeftColumnFacets = (props) => {
             <div className="sort-views-wrapper">
               {data.showSortOn && (
                 <SortOn
+                  searchedText={searchedText}
                   querystring={querystring}
                   data={data}
                   isEditMode={isEditMode}

--- a/src/components/manage/Blocks/Search/layout/RightColumnFacets.jsx
+++ b/src/components/manage/Blocks/Search/layout/RightColumnFacets.jsx
@@ -95,6 +95,7 @@ const RightColumnFacets = (props) => {
             <div className="sort-views-wrapper">
               {data.showSortOn && (
                 <SortOn
+                  searchedText={searchedText}
                   data={data}
                   querystring={querystring}
                   isEditMode={isEditMode}

--- a/src/components/manage/Blocks/Search/layout/TopSideFacets.jsx
+++ b/src/components/manage/Blocks/Search/layout/TopSideFacets.jsx
@@ -89,6 +89,7 @@ const TopSideFacets = (props) => {
 
             {data.showSortOn && (
               <SortOn
+                searchedText={searchedText}
                 data={data}
                 querystring={querystring}
                 isEditMode={isEditMode}


### PR DESCRIPTION
Changes the 'No selection' option in the 'Sort on' for the search block to instead be a selectable 'Relevance' option. If no text has been searched for, this is displayed as 'Unsorted'. Also includes the following minor changes to make the 'Relevance' option make more sense:

- The 'Sort direction' buttons will be hidden if we're using 'Relevance/ unsorted'
- The sorter won't be displayed if no options are set in 'Sort on options'


https://user-images.githubusercontent.com/30210785/210405052-f7569308-2ab7-48b7-9b33-224b864eaf5c.mov

Closes #4000