### PR TITLE
Synchronize redundant block id in listing block on pasting: blocks[bl…

### DIFF
--- a/news/4234.bugfix
+++ b/news/4234.bugfix
@@ -1,0 +1,1 @@
+Synchronize redundant block id in listing block on pasting: blocks[blockid].block @ksuess

--- a/src/components/manage/Form/BlocksToolbar.jsx
+++ b/src/components/manage/Form/BlocksToolbar.jsx
@@ -100,7 +100,15 @@ export class BlocksToolbarComponent extends React.Component {
             : [uuid(), blockData]
           : [uuid(), blockData]; // if cut/pasting blocks, we don't clone
       })
-      .filter((info) => !!info); // some blocks may refuse to be copied
+      .filter((info) => !!info) // some blocks may refuse to be copied
+      .map(([id, data]) => {
+        // sync redundant block id in listing block: blocks[blockid].block
+        if (data.block) {
+          let new_data = Object.assign({}, data);
+          new_data.block = id;
+          return [id, new_data];
+        } else return [id, data];
+      });
     const blocksFieldname = getBlocksFieldname(formData);
     const blocksLayoutFieldname = getBlocksLayoutFieldname(formData);
     const selectedIndex =


### PR DESCRIPTION
…ockid].block
fix https://github.com/plone/volto/issues/4234