### PR TITLE
Enhance the StyleWrapper classNames generator with generic pluggable extenders

### DIFF
--- a/docs/source/configuration/settings-reference.md
+++ b/docs/source/configuration/settings-reference.md
@@ -234,14 +234,17 @@ styleClassNameConverters
     where the converter is registered here.
 
 styleClassNameExtenders
-    An array containing functions that extends how the StyleWrapper builds a list of styles. These functions have the signature `({ block, content, data })=>resultantStyle`:
+    An array containing functions that extends how the StyleWrapper builds a list of styles. These functions have the signature `({ block, content, data, classNames }) => classNames`:
 
     ```js
     config.settings.styleClassNameExtenders = [
-      ({ block, content, data }) => {
+      ({ block, content, data, classNames }) => {
+        const styles = [];
         if (nextBlock?.['@type']) {
-          return `next--bet--it--is--${nextBlock['@type']}`; // Returns a string
+          styles.push(`next--bet--it--is--${nextBlock['@type']}`);
         }
+
+        return [...classNames, ...styles]; // Return again all resultant classNames plus the additional ones.
       },
     ];
     ```

--- a/docs/source/configuration/settings-reference.md
+++ b/docs/source/configuration/settings-reference.md
@@ -232,6 +232,19 @@ styleClassNameConverters
     data to actual class names. You can customize the generated classname by
     registering fieldnames with names such as `<fieldname>:<converterName>`,
     where the converter is registered here.
+
+additionalLookAroundClassNames
+    An array containing functions that extends the `buildStyleClassNamesLookAround` helper used to build a list of styles depending on the previous/next blocks. These functions have the signature `({data, nextBlock, previousBlock})=>resultantStyle`:
+
+    ```js
+    config.settings.additionalLookAroundClassNames = [
+      ({ data, nextBlock, previousBlock }) => {
+        if (nextBlock?.['@type']) {
+          return `next--bet--it--is--${nextBlock['@type']}`; // Returns a string
+        }
+      },
+    ];
+    ```
 ```
 
 

--- a/docs/source/configuration/settings-reference.md
+++ b/docs/source/configuration/settings-reference.md
@@ -233,12 +233,12 @@ styleClassNameConverters
     registering fieldnames with names such as `<fieldname>:<converterName>`,
     where the converter is registered here.
 
-additionalLookAroundClassNames
-    An array containing functions that extends the `buildStyleClassNamesLookAround` helper used to build a list of styles depending on the previous/next blocks. These functions have the signature `({data, nextBlock, previousBlock})=>resultantStyle`:
+styleClassNameExtenders
+    An array containing functions that extends how the StyleWrapper builds a list of styles. These functions have the signature `({ block, content, data })=>resultantStyle`:
 
     ```js
-    config.settings.additionalLookAroundClassNames = [
-      ({ data, nextBlock, previousBlock }) => {
+    config.settings.styleClassNameExtenders = [
+      ({ block, content, data }) => {
         if (nextBlock?.['@type']) {
           return `next--bet--it--is--${nextBlock['@type']}`; // Returns a string
         }

--- a/docs/source/configuration/settings-reference.md
+++ b/docs/source/configuration/settings-reference.md
@@ -234,20 +234,69 @@ styleClassNameConverters
     where the converter is registered here.
 
 styleClassNameExtenders
-    An array containing functions that extends how the StyleWrapper builds a list of styles. These functions have the signature `({ block, content, data, classNames }) => classNames`:
+    An array containing functions that extends how the StyleWrapper builds a list of styles. These functions have the signature `({ block, content, data, classNames }) => classNames`. Here some examples of useful ones, for simpliciy, they are compacted in one extender:
 
     ```js
-    config.settings.styleClassNameExtenders = [
-      ({ block, content, data, classNames }) => {
-        const styles = [];
-        if (nextBlock?.['@type']) {
-          styles.push(`next--bet--it--is--${nextBlock['@type']}`);
-        }
+      import { getPreviousNextBlock } from '@plone/volto/helpers';
 
-        return [...classNames, ...styles]; // Return again all resultant classNames plus the additional ones.
-      },
-    ];
+      config.settings.styleClassNameExtenders = [
+        ({ block, content, data, classNames }) => {
+          let styles = [];
+          const [previousBlock, nextBlock] = getPreviousNextBlock({
+            content,
+            block,
+          });
+
+          // Inject a class depending of which type is the next block
+          if (nextBlock?.['@type']) {
+            styles.push(`next--is--${nextBlock['@type']}`);
+          }
+
+          // Inject a class depending if previous is the same type of block
+          if (data?.['@type'] === previousBlock?.['@type']) {
+            styles.push('previous--is--same--block-type');
+          }
+
+          // Inject a class depending if next is the same type of block
+          if (data?.['@type'] === nextBlock?.['@type']) {
+            styles.push('next--is--same--block-type');
+          }
+
+          // Inject a class depending if it's the first of block type
+          if (data?.['@type'] !== previousBlock?.['@type']) {
+            styles.push('is--first--of--block-type');
+          }
+
+          // Inject a class depending if it's the last of block type
+          if (data?.['@type'] !== nextBlock?.['@type']) {
+            styles.push('is--last--of--block-type');
+          }
+
+          // Given a StyleWrapper defined `backgroundColor` style
+          const previousColor =
+            previousBlock?.styles?.backgroundColor ?? 'transparent';
+          const currentColor = data?.styles?.backgroundColor ?? 'transparent';
+          const nextColor = nextBlock?.styles?.backgroundColor ?? 'transparent';
+
+          // Inject a class depending if the previous block has the same `backgroundColor`
+          if (currentColor === previousColor) {
+            styles.push('previous--has--same--backgroundColor');
+          } else if (currentColor !== previousColor) {
+            styles.push('previous--has--different--backgroundColor');
+          }
+
+          // Inject a class depending if the next block has the same `backgroundColor`
+          if (currentColor === nextColor) {
+            styles.push('next--has--same--backgroundColor');
+          } else if (currentColor !== nextColor) {
+            styles.push('next--has--different--backgroundColor');
+          }
+
+          return [...classNames, ...styles];
+        },
+      ];
     ```
+
 ```
 
 

--- a/news/4260.feature
+++ b/news/4260.feature
@@ -1,0 +1,1 @@
+Enhance the StyleWrapper classNames generator by adding look around classNames depending on the sorounding previous/next blocks. @sneridagh

--- a/src/components/manage/Blocks/Block/StyleWrapper.jsx
+++ b/src/components/manage/Blocks/Block/StyleWrapper.jsx
@@ -6,19 +6,21 @@ import {
 } from '@plone/volto/helpers';
 
 const StyleWrapper = (props) => {
+  let classNames = [];
   const { children, content, data = {}, block } = props;
-  const styles = buildStyleClassNamesFromData(data.styles);
+  classNames = buildStyleClassNamesFromData(data.styles);
 
-  const styleExtenders = buildStyleClassNamesExtenders({
+  classNames = buildStyleClassNamesExtenders({
     block,
     content,
     data,
+    classNames,
   });
   const rewrittenChildren = React.Children.map(children, (child) => {
     if (React.isValidElement(child)) {
       const childProps = {
         ...props,
-        className: cx([child.props.className, ...styles, ...styleExtenders]),
+        className: cx([child.props.className, ...classNames]),
       };
       return React.cloneElement(child, childProps);
     }

--- a/src/components/manage/Blocks/Block/StyleWrapper.jsx
+++ b/src/components/manage/Blocks/Block/StyleWrapper.jsx
@@ -1,15 +1,35 @@
 import React from 'react';
 import cx from 'classnames';
-import { buildStyleClassNamesFromData } from '@plone/volto/helpers';
+import {
+  buildStyleClassNamesFromData,
+  buildStyleClassNamesLookAround,
+} from '@plone/volto/helpers';
 
 const StyleWrapper = (props) => {
-  const { children, data = {} } = props;
+  const { children, content, data = {}, id } = props;
   const styles = buildStyleClassNamesFromData(data.styles);
+  const nextBlock =
+    content['blocks'][
+      content['blocks_layout'].items[
+        content['blocks_layout'].items.indexOf(id) + 1
+      ]
+    ];
+  const previousBlock =
+    content['blocks'][
+      content['blocks_layout'].items[
+        content['blocks_layout'].items.indexOf(id) - 1
+      ]
+    ];
+  const lookAroundStyles = buildStyleClassNamesLookAround({
+    data,
+    nextBlock,
+    previousBlock,
+  });
   const rewrittenChildren = React.Children.map(children, (child) => {
     if (React.isValidElement(child)) {
       const childProps = {
         ...props,
-        className: cx([child.props.className, ...styles]),
+        className: cx([child.props.className, ...styles, ...lookAroundStyles]),
       };
       return React.cloneElement(child, childProps);
     }

--- a/src/components/manage/Blocks/Block/StyleWrapper.jsx
+++ b/src/components/manage/Blocks/Block/StyleWrapper.jsx
@@ -2,34 +2,23 @@ import React from 'react';
 import cx from 'classnames';
 import {
   buildStyleClassNamesFromData,
-  buildStyleClassNamesLookAround,
+  buildStyleClassNamesExtenders,
 } from '@plone/volto/helpers';
 
 const StyleWrapper = (props) => {
-  const { children, content, data = {}, id } = props;
+  const { children, content, data = {}, block } = props;
   const styles = buildStyleClassNamesFromData(data.styles);
-  const nextBlock =
-    content['blocks'][
-      content['blocks_layout'].items[
-        content['blocks_layout'].items.indexOf(id) + 1
-      ]
-    ];
-  const previousBlock =
-    content['blocks'][
-      content['blocks_layout'].items[
-        content['blocks_layout'].items.indexOf(id) - 1
-      ]
-    ];
-  const lookAroundStyles = buildStyleClassNamesLookAround({
+
+  const styleExtenders = buildStyleClassNamesExtenders({
+    block,
+    content,
     data,
-    nextBlock,
-    previousBlock,
   });
   const rewrittenChildren = React.Children.map(children, (child) => {
     if (React.isValidElement(child)) {
       const childProps = {
         ...props,
-        className: cx([child.props.className, ...styles, ...lookAroundStyles]),
+        className: cx([child.props.className, ...styles, ...styleExtenders]),
       };
       return React.cloneElement(child, childProps);
     }

--- a/src/config/Style.jsx
+++ b/src/config/Style.jsx
@@ -7,3 +7,5 @@ export const styleClassNameConverters = {
   noprefix: (name, value) => value,
   bool: (name, value) => (value ? name : ''),
 };
+
+export const styleClassNameExtenders = [];

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -24,7 +24,7 @@ import { loadables } from './Loadables';
 import { workflowMapping } from './Workflows';
 
 import { contentIcons } from './ContentIcons';
-import { styleClassNameConverters } from './Style';
+import { styleClassNameConverters, styleClassNameExtenders } from './Style';
 import {
   controlPanelsIcons,
   filterControlPanels,
@@ -169,6 +169,7 @@ let config = {
     workflowMapping,
     errorHandlers: [], // callables for unhandled errors
     styleClassNameConverters,
+    styleClassNameExtenders,
   },
   experimental: {
     addBlockButton: {

--- a/src/helpers/Blocks/Blocks.js
+++ b/src/helpers/Blocks/Blocks.js
@@ -481,3 +481,90 @@ export const buildStyleClassNamesFromData = (obj = {}, prefix = '') => {
     )
     .filter((v) => !!v);
 };
+
+/**
+ * Generate classNames from looking around (previous/next blocks)
+ *
+ * - Next block type
+ * - Previous is same block type (boolean)
+ * - Next is same block type (boolean)
+ * - Current is the first of this block type (boolean)
+ * - Current is the last of this block type (boolean)
+ * - Current has `headline` as data (the block has heading) or the previous one type is `heading` (boolean)
+ * - Provided the block has a StyleWrapper style called `backgroundColor`, compare between previous/next blocks
+ *   - Previous has the same background color (boolean)
+ *   - Previous has the different background color (boolean)
+ *   - Next has the same background color (boolean)
+ *   - Next has the different background color (boolean)
+ *
+ * @function buildStyleClassNamesLookAround
+ * @param {Object} params An object with data, nextBlock and previousBlock
+ * @return {Array} LookAround classNames resultant array
+ */
+export const buildStyleClassNamesLookAround = ({
+  data,
+  nextBlock,
+  previousBlock,
+}) => {
+  let resultantStyles = [];
+
+  if (nextBlock?.['@type']) {
+    resultantStyles.push(`next--is--${nextBlock['@type']}`);
+  }
+
+  if (data?.['@type'] === previousBlock?.['@type']) {
+    resultantStyles.push('previous--is--same--block-type');
+  }
+
+  if (data?.['@type'] === nextBlock?.['@type']) {
+    resultantStyles.push('next--is--same--block-type');
+  }
+
+  if (data?.['@type'] !== previousBlock?.['@type']) {
+    resultantStyles.push('is--first--of--block-type');
+  }
+
+  if (data?.['@type'] !== nextBlock?.['@type']) {
+    resultantStyles.push('is--last--of--block-type');
+  }
+
+  if (data?.headline || previousBlock?.['@type'] === 'heading') {
+    resultantStyles.push('has--headline');
+  }
+  const previousColor = previousBlock?.styles?.backgroundColor ?? 'transparent';
+  const currentColor = data?.styles?.backgroundColor ?? 'transparent';
+  const nextColor = nextBlock?.styles?.backgroundColor ?? 'transparent';
+
+  if (currentColor === previousColor) {
+    resultantStyles.push('previous--is--same--backgroundColor');
+  } else if (currentColor !== previousColor) {
+    resultantStyles.push('previous--is--different--backgroundColor');
+  }
+
+  if (currentColor === nextColor) {
+    resultantStyles.push('next--is--same--backgroundColor');
+  } else if (currentColor !== nextColor) {
+    resultantStyles.push('next--is--different--backgroundColor');
+  }
+
+  if (config.settings.additionalLookAroundClassNames) {
+    // config.settings.additionalLookAroundClassNames contains
+    // an array of functions with the signature ({data, nextBlock, previousBlock})=>resultantStyle
+    resultantStyles = [
+      ...resultantStyles,
+      ...config.settings.additionalLookAroundClassNames.reduce(
+        (acc, func) => [
+          ...acc,
+          func({
+            data,
+            nextBlock,
+            previousBlock,
+          }),
+        ],
+        [],
+      ),
+    ];
+  }
+
+  return resultantStyles;
+};

--- a/src/helpers/Blocks/Blocks.js
+++ b/src/helpers/Blocks/Blocks.js
@@ -495,3 +495,27 @@ export const buildStyleClassNamesExtenders = ({ block, content, data }) => {
     [],
   );
 };
+
+/**
+ * Return previous/next blocks given the content object and the current block id
+ *
+ * @function getPreviousNextBlock
+ * @param {Object} params An object with the content object and block (current block id)
+ * @return {Array} An array with the signature [previousBlock, nextBlock]
+ */
+export const getPreviousNextBlock = ({ content, block }) => {
+  const previousBlock =
+    content['blocks'][
+      content['blocks_layout'].items[
+        content['blocks_layout'].items.indexOf(block) - 1
+      ]
+    ];
+  const nextBlock =
+    content['blocks'][
+      content['blocks_layout'].items[
+        content['blocks_layout'].items.indexOf(block) + 1
+      ]
+    ];
+
+  return [previousBlock, nextBlock];
+};

--- a/src/helpers/Blocks/Blocks.js
+++ b/src/helpers/Blocks/Blocks.js
@@ -483,88 +483,15 @@ export const buildStyleClassNamesFromData = (obj = {}, prefix = '') => {
 };
 
 /**
- * Generate classNames from looking around (previous/next blocks)
+ * Generate classNames from extenders
  *
- * - Next block type
- * - Previous is same block type (boolean)
- * - Next is same block type (boolean)
- * - Current is the first of this block type (boolean)
- * - Current is the last of this block type (boolean)
- * - Current has `headline` as data (the block has heading) or the previous one type is `heading` (boolean)
- * - Provided the block has a StyleWrapper style called `backgroundColor`, compare between previous/next blocks
- *   - Previous has the same background color (boolean)
- *   - Previous has the different background color (boolean)
- *   - Next has the same background color (boolean)
- *   - Next has the different background color (boolean)
- *
- * @function buildStyleClassNamesLookAround
- * @param {Object} params An object with data, nextBlock and previousBlock
- * @return {Array} LookAround classNames resultant array
+ * @function buildStyleClassNamesExtenders
+ * @param {Object} params An object with data, content and block (current block id)
+ * @return {Array} Extender classNames resultant array
  */
-export const buildStyleClassNamesLookAround = ({
-  data,
-  nextBlock,
-  previousBlock,
-}) => {
-  let resultantStyles = [];
-
-  if (nextBlock?.['@type']) {
-    resultantStyles.push(`next--is--${nextBlock['@type']}`);
-  }
-
-  if (data?.['@type'] === previousBlock?.['@type']) {
-    resultantStyles.push('previous--is--same--block-type');
-  }
-
-  if (data?.['@type'] === nextBlock?.['@type']) {
-    resultantStyles.push('next--is--same--block-type');
-  }
-
-  if (data?.['@type'] !== previousBlock?.['@type']) {
-    resultantStyles.push('is--first--of--block-type');
-  }
-
-  if (data?.['@type'] !== nextBlock?.['@type']) {
-    resultantStyles.push('is--last--of--block-type');
-  }
-
-  if (data?.headline || previousBlock?.['@type'] === 'heading') {
-    resultantStyles.push('has--headline');
-  }
-  const previousColor = previousBlock?.styles?.backgroundColor ?? 'transparent';
-  const currentColor = data?.styles?.backgroundColor ?? 'transparent';
-  const nextColor = nextBlock?.styles?.backgroundColor ?? 'transparent';
-
-  if (currentColor === previousColor) {
-    resultantStyles.push('previous--is--same--backgroundColor');
-  } else if (currentColor !== previousColor) {
-    resultantStyles.push('previous--is--different--backgroundColor');
-  }
-
-  if (currentColor === nextColor) {
-    resultantStyles.push('next--is--same--backgroundColor');
-  } else if (currentColor !== nextColor) {
-    resultantStyles.push('next--is--different--backgroundColor');
-  }
-
-  if (config.settings.additionalLookAroundClassNames) {
-    // config.settings.additionalLookAroundClassNames contains
-    // an array of functions with the signature ({data, nextBlock, previousBlock})=>resultantStyle
-    resultantStyles = [
-      ...resultantStyles,
-      ...config.settings.additionalLookAroundClassNames.reduce(
-        (acc, func) => [
-          ...acc,
-          func({
-            data,
-            nextBlock,
-            previousBlock,
-          }),
-        ],
-        [],
-      ),
-    ];
-  }
-
-  return resultantStyles;
+export const buildStyleClassNamesExtenders = ({ block, content, data }) => {
+  return config.settings.styleClassNameExtenders.reduce(
+    (acc, extender) => extender({ block, content, data, classNames: acc }),
+    [],
+  );
 };

--- a/src/helpers/Blocks/Blocks.test.js
+++ b/src/helpers/Blocks/Blocks.test.js
@@ -17,6 +17,7 @@ import {
   applyBlockDefaults,
   applySchemaDefaults,
   buildStyleClassNamesFromData,
+  buildStyleClassNamesLookAround,
 } from './Blocks';
 
 import config from '@plone/volto/registry';
@@ -986,6 +987,149 @@ describe('Blocks', () => {
         },
       };
       expect(buildStyleClassNamesFromData(styles)).toEqual([]);
+    });
+  });
+
+  describe('buildStyleClassNamesLookAround', () => {
+    it('slate grey + slate + slate grey ', () => {
+      const previousBlock = {
+        '@type': 'slate',
+        styles: {
+          backgroundColor: 'grey',
+        },
+      };
+      const data = {
+        '@type': 'slate',
+      };
+      const nextBlock = {
+        '@type': 'slate',
+        styles: {
+          backgroundColor: 'grey',
+        },
+      };
+      expect(
+        buildStyleClassNamesLookAround({ data, nextBlock, previousBlock }),
+      ).toStrictEqual([
+        'next--is--slate',
+        'previous--is--same--block-type',
+        'next--is--same--block-type',
+        'previous--is--different--backgroundColor',
+        'next--is--different--backgroundColor',
+      ]);
+    });
+
+    it('slate grey + slate grey + slate grey ', () => {
+      const previousBlock = {
+        '@type': 'slate',
+        styles: {
+          backgroundColor: 'grey',
+        },
+      };
+      const data = {
+        '@type': 'slate',
+        styles: {
+          backgroundColor: 'grey',
+        },
+      };
+      const nextBlock = {
+        '@type': 'slate',
+        styles: {
+          backgroundColor: 'grey',
+        },
+      };
+      expect(
+        buildStyleClassNamesLookAround({ data, nextBlock, previousBlock }),
+      ).toStrictEqual([
+        'next--is--slate',
+        'previous--is--same--block-type',
+        'next--is--same--block-type',
+        'previous--is--same--backgroundColor',
+        'next--is--same--backgroundColor',
+      ]);
+    });
+
+    it('grid + slate grey + slate grey ', () => {
+      const previousBlock = {
+        '@type': '__grid',
+      };
+      const data = {
+        '@type': 'slate',
+        styles: {
+          backgroundColor: 'grey',
+        },
+      };
+      const nextBlock = {
+        '@type': 'slate',
+        styles: {
+          backgroundColor: 'grey',
+        },
+      };
+      expect(
+        buildStyleClassNamesLookAround({ data, nextBlock, previousBlock }),
+      ).toStrictEqual([
+        'next--is--slate',
+        'next--is--same--block-type',
+        'is--first--of--block-type',
+        'previous--is--different--backgroundColor',
+        'next--is--same--backgroundColor',
+      ]);
+    });
+
+    it('grid + grid + slate grey ', () => {
+      const previousBlock = {
+        '@type': '__grid',
+      };
+      const data = {
+        '@type': '__grid',
+      };
+      const nextBlock = {
+        '@type': 'slate',
+        styles: {
+          backgroundColor: 'grey',
+        },
+      };
+      expect(
+        buildStyleClassNamesLookAround({ data, nextBlock, previousBlock }),
+      ).toStrictEqual([
+        'next--is--slate',
+        'previous--is--same--block-type',
+        'is--last--of--block-type',
+        'previous--is--same--backgroundColor',
+        'next--is--different--backgroundColor',
+      ]);
+    });
+
+    it('grid + grid + slate grey with additional config.settings.additionalLookAroundClassNames', () => {
+      config.settings.additionalLookAroundClassNames = [
+        ({ data, nextBlock, previousBlock }) => {
+          if (nextBlock?.['@type']) {
+            return `next--bet--it--is--${nextBlock['@type']}`;
+          }
+        },
+      ];
+
+      const previousBlock = {
+        '@type': '__grid',
+      };
+      const data = {
+        '@type': '__grid',
+      };
+      const nextBlock = {
+        '@type': 'slate',
+        styles: {
+          backgroundColor: 'grey',
+        },
+      };
+      expect(
+        buildStyleClassNamesLookAround({ data, nextBlock, previousBlock }),
+      ).toStrictEqual([
+        'next--is--slate',
+        'previous--is--same--block-type',
+        'is--last--of--block-type',
+        'previous--is--same--backgroundColor',
+        'next--is--different--backgroundColor',
+        'next--bet--it--is--slate',
+      ]);
     });
   });
 });

--- a/src/helpers/Blocks/Blocks.test.js
+++ b/src/helpers/Blocks/Blocks.test.js
@@ -18,6 +18,7 @@ import {
   applySchemaDefaults,
   buildStyleClassNamesFromData,
   buildStyleClassNamesExtenders,
+  getPreviousNextBlock,
 } from './Blocks';
 
 import config from '@plone/volto/registry';
@@ -990,24 +991,51 @@ describe('Blocks', () => {
     });
   });
 
+  describe('getPreviousNextBlock', () => {
+    it('basic functionality', () => {
+      const content = {
+        blocks: {
+          1: {
+            '@type': 'slate',
+            styles: {
+              backgroundColor: 'grey',
+            },
+          },
+          2: {
+            '@type': 'slate',
+          },
+          3: {
+            '@type': 'slate',
+            styles: {
+              backgroundColor: 'grey',
+            },
+          },
+        },
+        blocks_layout: {
+          items: [1, 2, 3],
+        },
+      };
+      const block = 2;
+      const [previousBlock, nextBlock] = getPreviousNextBlock({
+        content,
+        block,
+      });
+      expect(previousBlock).toEqual({
+        '@type': 'slate',
+        styles: {
+          backgroundColor: 'grey',
+        },
+      });
+      expect(nextBlock).toEqual({
+        '@type': 'slate',
+        styles: {
+          backgroundColor: 'grey',
+        },
+      });
+    });
+  });
+
   describe('buildStyleClassNamesExtenders', () => {
-    const getPreviousNextBlock = ({ content, block }) => {
-      const previousBlock =
-        content['blocks'][
-          content['blocks_layout'].items[
-            content['blocks_layout'].items.indexOf(block) - 1
-          ]
-        ];
-      const nextBlock =
-        content['blocks'][
-          content['blocks_layout'].items[
-            content['blocks_layout'].items.indexOf(block) + 1
-          ]
-        ];
-
-      return [previousBlock, nextBlock];
-    };
-
     beforeAll(() => {
       // Example styleClassNameExtenders
       config.settings.styleClassNameExtenders = [

--- a/src/helpers/Blocks/Blocks.test.js
+++ b/src/helpers/Blocks/Blocks.test.js
@@ -17,7 +17,7 @@ import {
   applyBlockDefaults,
   applySchemaDefaults,
   buildStyleClassNamesFromData,
-  buildStyleClassNamesLookAround,
+  buildStyleClassNamesExtenders,
 } from './Blocks';
 
 import config from '@plone/volto/registry';
@@ -990,145 +990,221 @@ describe('Blocks', () => {
     });
   });
 
-  describe('buildStyleClassNamesLookAround', () => {
+  describe('buildStyleClassNamesExtenders', () => {
+    const getPreviousNextBlock = ({ content, block }) => {
+      const previousBlock =
+        content['blocks'][
+          content['blocks_layout'].items[
+            content['blocks_layout'].items.indexOf(block) - 1
+          ]
+        ];
+      const nextBlock =
+        content['blocks'][
+          content['blocks_layout'].items[
+            content['blocks_layout'].items.indexOf(block) + 1
+          ]
+        ];
+
+      return [previousBlock, nextBlock];
+    };
+
+    beforeAll(() => {
+      // Example styleClassNameExtenders
+      config.settings.styleClassNameExtenders = [
+        ({ block, content, data, classNames }) => {
+          let styles = [];
+          const [previousBlock, nextBlock] = getPreviousNextBlock({
+            content,
+            block,
+          });
+
+          if (nextBlock?.['@type']) {
+            styles.push(`next--is--${nextBlock['@type']}`);
+          }
+
+          if (data?.['@type'] === previousBlock?.['@type']) {
+            styles.push('previous--is--same--block-type');
+          }
+
+          if (data?.['@type'] === nextBlock?.['@type']) {
+            styles.push('next--is--same--block-type');
+          }
+
+          if (data?.['@type'] !== previousBlock?.['@type']) {
+            styles.push('is--first--of--block-type');
+          }
+
+          if (data?.['@type'] !== nextBlock?.['@type']) {
+            styles.push('is--last--of--block-type');
+          }
+
+          const previousColor =
+            previousBlock?.styles?.backgroundColor ?? 'transparent';
+          const currentColor = data?.styles?.backgroundColor ?? 'transparent';
+          const nextColor = nextBlock?.styles?.backgroundColor ?? 'transparent';
+
+          if (currentColor === previousColor) {
+            styles.push('previous--has--same--backgroundColor');
+          } else if (currentColor !== previousColor) {
+            styles.push('previous--has--different--backgroundColor');
+          }
+
+          if (currentColor === nextColor) {
+            styles.push('next--has--same--backgroundColor');
+          } else if (currentColor !== nextColor) {
+            styles.push('next--has--different--backgroundColor');
+          }
+
+          return [...classNames, ...styles];
+        },
+      ];
+    });
+
     it('slate grey + slate + slate grey ', () => {
-      const previousBlock = {
-        '@type': 'slate',
-        styles: {
-          backgroundColor: 'grey',
+      const content = {
+        blocks: {
+          1: {
+            '@type': 'slate',
+            styles: {
+              backgroundColor: 'grey',
+            },
+          },
+          2: {
+            '@type': 'slate',
+          },
+          3: {
+            '@type': 'slate',
+            styles: {
+              backgroundColor: 'grey',
+            },
+          },
+        },
+        blocks_layout: {
+          items: [1, 2, 3],
         },
       };
-      const data = {
-        '@type': 'slate',
-      };
-      const nextBlock = {
-        '@type': 'slate',
-        styles: {
-          backgroundColor: 'grey',
-        },
-      };
+      const block = 2;
+      const data = content['blocks'][2];
+
       expect(
-        buildStyleClassNamesLookAround({ data, nextBlock, previousBlock }),
+        buildStyleClassNamesExtenders({ block, content, data }),
       ).toStrictEqual([
         'next--is--slate',
         'previous--is--same--block-type',
         'next--is--same--block-type',
-        'previous--is--different--backgroundColor',
-        'next--is--different--backgroundColor',
+        'previous--has--different--backgroundColor',
+        'next--has--different--backgroundColor',
       ]);
     });
 
     it('slate grey + slate grey + slate grey ', () => {
-      const previousBlock = {
-        '@type': 'slate',
-        styles: {
-          backgroundColor: 'grey',
+      const content = {
+        blocks: {
+          1: {
+            '@type': 'slate',
+            styles: {
+              backgroundColor: 'grey',
+            },
+          },
+          2: {
+            '@type': 'slate',
+            styles: {
+              backgroundColor: 'grey',
+            },
+          },
+          3: {
+            '@type': 'slate',
+            styles: {
+              backgroundColor: 'grey',
+            },
+          },
+        },
+        blocks_layout: {
+          items: [1, 2, 3],
         },
       };
-      const data = {
-        '@type': 'slate',
-        styles: {
-          backgroundColor: 'grey',
-        },
-      };
-      const nextBlock = {
-        '@type': 'slate',
-        styles: {
-          backgroundColor: 'grey',
-        },
-      };
+      const block = 2;
+      const data = content['blocks'][2];
+
       expect(
-        buildStyleClassNamesLookAround({ data, nextBlock, previousBlock }),
+        buildStyleClassNamesExtenders({ block, content, data }),
       ).toStrictEqual([
         'next--is--slate',
         'previous--is--same--block-type',
         'next--is--same--block-type',
-        'previous--is--same--backgroundColor',
-        'next--is--same--backgroundColor',
+        'previous--has--same--backgroundColor',
+        'next--has--same--backgroundColor',
       ]);
     });
 
     it('grid + slate grey + slate grey ', () => {
-      const previousBlock = {
-        '@type': '__grid',
-      };
-      const data = {
-        '@type': 'slate',
-        styles: {
-          backgroundColor: 'grey',
+      const content = {
+        blocks: {
+          1: {
+            '@type': '__grid',
+          },
+          2: {
+            '@type': 'slate',
+            styles: {
+              backgroundColor: 'grey',
+            },
+          },
+          3: {
+            '@type': 'slate',
+            styles: {
+              backgroundColor: 'grey',
+            },
+          },
+        },
+        blocks_layout: {
+          items: [1, 2, 3],
         },
       };
-      const nextBlock = {
-        '@type': 'slate',
-        styles: {
-          backgroundColor: 'grey',
-        },
-      };
+      const block = 2;
+      const data = content['blocks'][2];
+
       expect(
-        buildStyleClassNamesLookAround({ data, nextBlock, previousBlock }),
+        buildStyleClassNamesExtenders({ block, content, data }),
       ).toStrictEqual([
         'next--is--slate',
         'next--is--same--block-type',
         'is--first--of--block-type',
-        'previous--is--different--backgroundColor',
-        'next--is--same--backgroundColor',
+        'previous--has--different--backgroundColor',
+        'next--has--same--backgroundColor',
       ]);
     });
 
     it('grid + grid + slate grey ', () => {
-      const previousBlock = {
-        '@type': '__grid',
-      };
-      const data = {
-        '@type': '__grid',
-      };
-      const nextBlock = {
-        '@type': 'slate',
-        styles: {
-          backgroundColor: 'grey',
+      const content = {
+        blocks: {
+          1: {
+            '@type': '__grid',
+          },
+          2: {
+            '@type': '__grid',
+          },
+          3: {
+            '@type': 'slate',
+            styles: {
+              backgroundColor: 'grey',
+            },
+          },
+        },
+        blocks_layout: {
+          items: [1, 2, 3],
         },
       };
+      const block = 2;
+      const data = content['blocks'][2];
+
       expect(
-        buildStyleClassNamesLookAround({ data, nextBlock, previousBlock }),
+        buildStyleClassNamesExtenders({ block, content, data }),
       ).toStrictEqual([
         'next--is--slate',
         'previous--is--same--block-type',
         'is--last--of--block-type',
-        'previous--is--same--backgroundColor',
-        'next--is--different--backgroundColor',
-      ]);
-    });
-
-    it('grid + grid + slate grey with additional config.settings.additionalLookAroundClassNames', () => {
-      config.settings.additionalLookAroundClassNames = [
-        ({ data, nextBlock, previousBlock }) => {
-          if (nextBlock?.['@type']) {
-            return `next--bet--it--is--${nextBlock['@type']}`;
-          }
-        },
-      ];
-
-      const previousBlock = {
-        '@type': '__grid',
-      };
-      const data = {
-        '@type': '__grid',
-      };
-      const nextBlock = {
-        '@type': 'slate',
-        styles: {
-          backgroundColor: 'grey',
-        },
-      };
-      expect(
-        buildStyleClassNamesLookAround({ data, nextBlock, previousBlock }),
-      ).toStrictEqual([
-        'next--is--slate',
-        'previous--is--same--block-type',
-        'is--last--of--block-type',
-        'previous--is--same--backgroundColor',
-        'next--is--different--backgroundColor',
-        'next--bet--it--is--slate',
+        'previous--has--same--backgroundColor',
+        'next--has--different--backgroundColor',
       ]);
     });
   });

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -57,6 +57,7 @@ export {
   applySchemaDefaults,
   buildStyleClassNamesFromData,
   buildStyleClassNamesExtenders,
+  getPreviousNextBlock,
 } from '@plone/volto/helpers/Blocks/Blocks';
 export BodyClass from '@plone/volto/helpers/BodyClass/BodyClass';
 export ScrollToTop from '@plone/volto/helpers/ScrollToTop/ScrollToTop';

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -56,6 +56,7 @@ export {
   applyBlockDefaults,
   applySchemaDefaults,
   buildStyleClassNamesFromData,
+  buildStyleClassNamesLookAround,
 } from '@plone/volto/helpers/Blocks/Blocks';
 export BodyClass from '@plone/volto/helpers/BodyClass/BodyClass';
 export ScrollToTop from '@plone/volto/helpers/ScrollToTop/ScrollToTop';

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -56,7 +56,7 @@ export {
   applyBlockDefaults,
   applySchemaDefaults,
   buildStyleClassNamesFromData,
-  buildStyleClassNamesLookAround,
+  buildStyleClassNamesExtenders,
 } from '@plone/volto/helpers/Blocks/Blocks';
 export BodyClass from '@plone/volto/helpers/BodyClass/BodyClass';
 export ScrollToTop from '@plone/volto/helpers/ScrollToTop/ScrollToTop';

--- a/test-setup-config.js
+++ b/test-setup-config.js
@@ -20,7 +20,10 @@ import {
 } from '@plone/volto/config/RichTextEditor/Blocks';
 import FromHTMLCustomBlockFn from '@plone/volto/config/RichTextEditor/FromHTML';
 import { contentIcons } from '@plone/volto/config/ContentIcons';
-import { styleClassNameConverters } from '@plone/volto/config/Style';
+import {
+  styleClassNameConverters,
+  styleClassNameExtenders,
+} from '@plone/volto/config/Style';
 
 import {
   controlPanelsIcons,
@@ -76,6 +79,7 @@ config.set('settings', {
   downloadableObjects: ['File'],
   viewableInBrowserObjects: [],
   styleClassNameConverters,
+  styleClassNameExtenders,
 });
 config.set('blocks', {
   blocksConfig: {


### PR DESCRIPTION
We've been using this to fine adjust the vertical spacing in our last projects. I had doubts about to push this for core, but I decided that could be beneficial for Volto. The drawback is that they could add quite a lot of classnames to the block, but still, my experience and feedback is quite good. Any help that could come from the code in order to style the blocks is welcomed. 