### PR TITLE
Add displayName when registering a component in the component registry

### DIFF
--- a/news/4282.feature
+++ b/news/4282.feature
@@ -1,0 +1,1 @@
+Add displayName when registering a component @sneridagh

--- a/src/registry.js
+++ b/src/registry.js
@@ -121,9 +121,13 @@ class Config {
 
       this._data.components[componentName] = { component };
       // Try to set a displayName (useful for React dev tools) for the registered component
-      // Only if it's a function
+      // Only if it's a function and it's not set previously
       try {
+        const displayName = this._data.components[componentName].component
+          .displayName;
+
         if (
+          !displayName &&
           typeof this._data.components[componentName].component === 'function'
         ) {
           this._data.components[componentName].component.displayName = name;

--- a/src/registry.js
+++ b/src/registry.js
@@ -120,6 +120,20 @@ class Config {
       const componentName = `${name}${depsString ? `|${depsString}` : ''}`;
 
       this._data.components[componentName] = { component };
+      // Try to set a displayName (useful for React dev tools) for the registered component
+      // Only if it's a function
+      try {
+        if (
+          typeof this._data.components[componentName].component === 'function'
+        ) {
+          this._data.components[componentName].component.displayName = name;
+        }
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.warning(
+          `Not setting the component displayName because ${error}`,
+        );
+      }
     }
   }
 }

--- a/src/registry.test.js
+++ b/src/registry.test.js
@@ -1,5 +1,4 @@
 import config from './registry';
-import { Contents } from '@plone/volto/components';
 
 config.set('components', {
   Toolbar: { component: 'this is the Toolbar component' },
@@ -54,10 +53,22 @@ describe('registry', () => {
   it('registers and gets a component by name (as an object) - check displayName', () => {
     config.registerComponent({
       name: 'Toolbar.Bar',
-      component: Contents,
+      component: (props) => <div>Hello</div>,
     });
     expect(config.getComponent('Toolbar.Bar').component.displayName).toEqual(
       'Toolbar.Bar',
+    );
+  });
+  it('registers and gets a component by name (as an object) - check displayName if it has already one, it does not overwrite it', () => {
+    const TestComponent = (props) => <div>Hello</div>;
+    TestComponent.displayName = 'DisplayNameAlreadySet';
+    config.registerComponent({
+      name: 'Toolbar.Bar',
+      component: TestComponent,
+    });
+
+    expect(config.getComponent('Toolbar.Bar').component.displayName).toEqual(
+      'DisplayNameAlreadySet',
     );
   });
   it('registers and gets a component by name (as an object) - check displayName - do not break if it is a normal function', () => {

--- a/src/registry.test.js
+++ b/src/registry.test.js
@@ -1,4 +1,5 @@
 import config from './registry';
+import { Contents } from '@plone/volto/components';
 
 config.set('components', {
   Toolbar: { component: 'this is the Toolbar component' },
@@ -48,6 +49,28 @@ describe('registry', () => {
     });
     expect(config.getComponent({ name: 'Toolbar.Bar' }).component).toEqual(
       'this is a Bar component',
+    );
+  });
+  it('registers and gets a component by name (as an object) - check displayName', () => {
+    config.registerComponent({
+      name: 'Toolbar.Bar',
+      component: Contents,
+    });
+    expect(config.getComponent('Toolbar.Bar').component.displayName).toEqual(
+      'Toolbar.Bar',
+    );
+  });
+  it('registers and gets a component by name (as an object) - check displayName - do not break if it is a normal function', () => {
+    function myFunction() {
+      return 'true';
+    }
+
+    config.registerComponent({
+      name: 'Toolbar.Bar',
+      component: myFunction,
+    });
+    expect(config.getComponent('Toolbar.Bar').component.displayName).toEqual(
+      'Toolbar.Bar',
     );
   });
   it('registers a component by name with dependencies', () => {


### PR DESCRIPTION
This fixes this pattern in React dev tools was showing `Anonymous` as the name of the component.

```
  const Image = config.getComponent('Image').component || DefaultImage;
```

Then in JSX

```
<Image .../>
```