### PR TITLE
ListingBody (and export it) separated from the withQuerystringResults…

### DIFF
--- a/news/4341.enhancement
+++ b/news/4341.enhancement
@@ -1,0 +1,1 @@
+ListingBody (and export it) separated from the withQuerystringResults call @prithvi009

--- a/src/components/manage/Blocks/Listing/ListingBody.jsx
+++ b/src/components/manage/Blocks/Listing/ListingBody.jsx
@@ -8,7 +8,7 @@ import withQuerystringResults from './withQuerystringResults';
 import paginationLeftSVG from '@plone/volto/icons/left-key.svg';
 import paginationRightSVG from '@plone/volto/icons/right-key.svg';
 
-const ListingBody = withQuerystringResults((props) => {
+const ListingBody = (props) => {
   const {
     data = {},
     isEditMode,
@@ -111,6 +111,6 @@ const ListingBody = withQuerystringResults((props) => {
       </Dimmer>
     </div>
   );
-});
+};
 
-export default injectIntl(ListingBody);
+export default injectIntl(withQuerystringResults(ListingBody));


### PR DESCRIPTION
#4341 ListingBody (and export it) separately from the withQuerystringResults call and export default the withQuerystringResults(ListingBodyComponent)


