### PR TITLE
Remove inclusion of CHANGELOG.md for volto repo only

### DIFF
--- a/docs/source/release-notes/index.md
+++ b/docs/source/release-notes/index.md
@@ -11,8 +11,3 @@ myst:
 ```{include} ../../../submodules/volto/CHANGELOG.md
 ```
 ````
-
-````{ifconfig} context in ("volto")
-```{include} ../../../CHANGELOG.md
-```
-````

--- a/docs/source/user-manual/copy-paste-blocks.md
+++ b/docs/source/user-manual/copy-paste-blocks.md
@@ -20,7 +20,7 @@ This chapter describes how to do so.
 ## Copy or cut blocks
 
 While in edit mode, you can hold the {kbd}`ctrl` key to select multiple blocks that you want to copy or cut.
-Once blocks are selected, you will have copy <img alt="../_static/copy.svg" src="../_static/copy.svg" class="inline"> and cut <img alt="../_static/cut.svg" src="../_static/cut.svg" class="inline"> options in the toolbar.
+Once blocks are selected, you will have copy <img alt="Copy icon" src="../_static/copy.svg" class="inline"> and cut <img alt="Cut icon" src="../_static/cut.svg" class="inline"> options in the toolbar.
 
 Volto also allows the selection of multiple contiguous blocks.
 This feature can be used by selecting a start block and an end block while holding the {kbd}`shift` key.
@@ -37,7 +37,7 @@ This will select all the blocks between the start and end blocks, allowing you t
 
 Once you copy or cut the blocks, you can paste those blocks on that page or some other page.
 Select an empty block where you want to paste blocks from the clipboard.
-You can click the paste option <img alt="../_static/paste.svg" src="../_static/paste.svg" class="inline"> in the toolbar.
+You can click the paste option <img alt="Paste icon" src="../_static/paste.svg" class="inline"> in the toolbar.
 
 Also if you hold the {kbd}`ctrl` key while clicking the paste button, it keeps the clipboard buffer, allowing you to repeatedly paste it.
 

--- a/news/4404.documentation
+++ b/news/4404.documentation
@@ -1,0 +1,1 @@
+Remove inclusion of CHANGELOG.md for volto repo only. Fixes https://github.com/plone/documentation/issues/1431. @stevepiercy


### PR DESCRIPTION
It still gets included in the main documentation repo.

Fixes https://github.com/plone/documentation/issues/1431

Also improve alt text of inline images in `copy-paste-blocks.md`.

This change results in a lot of the following warnings only in the volto repo, which can be safely ignored. Basically we're shuffling the warnings from one repo to another to deal with this issue. The warning is irrelevant because `CHANGELOG.md` has a title, but Sphinx is not smart enough to recognize that fact.

`/Users/stevepiercy/projects/Plone/documentation/submodules/volto/docs/source/index.md:38: WARNING: toctree contains reference to document 'release-notes/index' that doesn't have a title: no link will be generated`