### PR TITLE
Export App and its connectorAppComponent as standalone

### DIFF
--- a/news/4413.internal
+++ b/news/4413.internal
@@ -1,0 +1,1 @@
+Expose a named export for the App component, separate its default wrappers as a separate `connectAppComponent` function. @tiberiuichim

--- a/packages/generator-volto/generators/app/templates/src/routes.js
+++ b/packages/generator-volto/generators/app/templates/src/routes.js
@@ -15,7 +15,7 @@ import config from '@plone/volto/registry';
 const routes = [
   {
     path: '/',
-    component: App, // Change this if you want a different component
+    component: config.getComponent('App').component, // Change this if you want a different component
     routes: [
       // Add your routes here
       ...(config.addonRoutes || []),

--- a/packages/generator-volto/news/4413.internal
+++ b/packages/generator-volto/news/4413.internal
@@ -1,0 +1,1 @@
+Get the App component from the registry. This makes it possible to add wrappers over the App@tiberiuichim

--- a/src/components/theme/App/App.jsx
+++ b/src/components/theme/App/App.jsx
@@ -57,7 +57,7 @@ import LockingToastsFactory from '@plone/volto/components/manage/LockingToastsFa
  * @class App
  * @extends {Component}
  */
-class App extends Component {
+export class App extends Component {
   /**
    * Property types.
    * @property {Object} propTypes Property types.
@@ -259,72 +259,76 @@ export const fetchContent = async ({ store, location }) => {
   return content;
 };
 
-export default compose(
-  asyncConnect([
-    {
-      key: 'breadcrumbs',
-      promise: ({ location, store: { dispatch } }) => {
-        // Do not trigger the breadcrumbs action if the expander is present
-        if (
-          __SERVER__ &&
-          !hasApiExpander('breadcrumbs', getBaseUrl(location.pathname))
-        ) {
-          return dispatch(getBreadcrumbs(getBaseUrl(location.pathname)));
-        }
+export function connectAppComponent(AppComponent) {
+  return compose(
+    asyncConnect([
+      {
+        key: 'breadcrumbs',
+        promise: ({ location, store: { dispatch } }) => {
+          // Do not trigger the breadcrumbs action if the expander is present
+          if (
+            __SERVER__ &&
+            !hasApiExpander('breadcrumbs', getBaseUrl(location.pathname))
+          ) {
+            return dispatch(getBreadcrumbs(getBaseUrl(location.pathname)));
+          }
+        },
       },
-    },
-    {
-      key: 'content',
-      promise: ({ location, store }) =>
-        __SERVER__ && fetchContent({ store, location }),
-    },
-    {
-      key: 'navigation',
-      promise: ({ location, store: { dispatch } }) => {
-        // Do not trigger the navigation action if the expander is present
-        if (
-          __SERVER__ &&
-          !hasApiExpander('navigation', getBaseUrl(location.pathname))
-        ) {
-          return dispatch(
-            getNavigation(
-              getBaseUrl(location.pathname),
-              config.settings.navDepth,
-            ),
-          );
-        }
+      {
+        key: 'content',
+        promise: ({ location, store }) =>
+          __SERVER__ && fetchContent({ store, location }),
       },
-    },
-    {
-      key: 'types',
-      promise: ({ location, store: { dispatch } }) => {
-        // Do not trigger the types action if the expander is present
-        if (
-          __SERVER__ &&
-          !hasApiExpander('types', getBaseUrl(location.pathname))
-        ) {
-          return dispatch(getTypes(getBaseUrl(location.pathname)));
-        }
+      {
+        key: 'navigation',
+        promise: ({ location, store: { dispatch } }) => {
+          // Do not trigger the navigation action if the expander is present
+          if (
+            __SERVER__ &&
+            !hasApiExpander('navigation', getBaseUrl(location.pathname))
+          ) {
+            return dispatch(
+              getNavigation(
+                getBaseUrl(location.pathname),
+                config.settings.navDepth,
+              ),
+            );
+          }
+        },
       },
-    },
-    {
-      key: 'workflow',
-      promise: ({ location, store: { dispatch } }) =>
-        __SERVER__ && dispatch(getWorkflow(getBaseUrl(location.pathname))),
-    },
-  ]),
-  injectIntl,
-  connect(
-    (state, props) => ({
-      pathname: props.location.pathname,
-      token: state.userSession.token,
-      userId: state.userSession.token
-        ? jwtDecode(state.userSession.token).sub
-        : '',
-      content: state.content.data,
-      apiError: state.apierror.error,
-      connectionRefused: state.apierror.connectionRefused,
-    }),
-    null,
-  ),
-)(App);
+      {
+        key: 'types',
+        promise: ({ location, store: { dispatch } }) => {
+          // Do not trigger the types action if the expander is present
+          if (
+            __SERVER__ &&
+            !hasApiExpander('types', getBaseUrl(location.pathname))
+          ) {
+            return dispatch(getTypes(getBaseUrl(location.pathname)));
+          }
+        },
+      },
+      {
+        key: 'workflow',
+        promise: ({ location, store: { dispatch } }) =>
+          __SERVER__ && dispatch(getWorkflow(getBaseUrl(location.pathname))),
+      },
+    ]),
+    injectIntl,
+    connect(
+      (state, props) => ({
+        pathname: props.location.pathname,
+        token: state.userSession.token,
+        userId: state.userSession.token
+          ? jwtDecode(state.userSession.token).sub
+          : '',
+        content: state.content.data,
+        apiError: state.apierror.error,
+        connectionRefused: state.apierror.connectionRefused,
+      }),
+      null,
+    ),
+  );
+}
+
+export default connectAppComponent(App);

--- a/src/components/theme/App/App.jsx
+++ b/src/components/theme/App/App.jsx
@@ -328,7 +328,7 @@ export function connectAppComponent(AppComponent) {
       }),
       null,
     ),
-  );
+  )(AppComponent);
 }
 
 export default connectAppComponent(App);

--- a/src/config/Components.jsx
+++ b/src/config/Components.jsx
@@ -1,5 +1,6 @@
-import { PreviewImage } from '@plone/volto/components';
+import { App, PreviewImage } from '@plone/volto/components';
 
 export const components = {
   PreviewImage: { component: PreviewImage },
+  App: { component: App },
 };


### PR DESCRIPTION
With this it's possible to wrap the App in additional context providers. To do this, you need to:

- override the default app component registration:

```
config.registerComponent({name: 'App', component: MyApp})
```

- write your own component:

```
import { App, connectAppComponent} from '@plone/volto/components/theme/App/App';

const MyAppComponent = (props) => <MyContextProvider><App {...props} /><MyContextProvider>;
export default connectAppComponent(MyAppComponent)
```

The benefit of doing it like this is that the `MyApp` component is wrapped in asyncConnect so it has access to the store.