### PR TITLE
Add CSS marker to MarkdownIntroduction, ShortcutListing

### DIFF
--- a/news/4438.feature
+++ b/news/4438.feature
@@ -1,0 +1,1 @@
+Add CSS marker to Slate MarkdownIntroduction, ShortcutListing @ksuess

--- a/packages/volto-slate/src/blocks/Text/MarkdownIntroduction.jsx
+++ b/packages/volto-slate/src/blocks/Text/MarkdownIntroduction.jsx
@@ -7,7 +7,7 @@ import React from 'react';
  */
 const MarkdownIntroduction = (props) => {
   return (
-    <div>
+    <div className="markdown-introduction">
       <header className="header">
         <h2>Markdown shortcuts</h2>
       </header>

--- a/packages/volto-slate/src/blocks/Text/ShortcutListing.jsx
+++ b/packages/volto-slate/src/blocks/Text/ShortcutListing.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 const ShortcutListing = (props) => {
   const hotkeys = config.settings?.slate?.hotkeys;
   return (
-    <div>
+    <div className="shortcut-listing">
       <header className="header">
         <h2>Editor shortcuts</h2>
       </header>


### PR DESCRIPTION
slate markdown help is valuable but in some cases unwanted

![slate-help](https://user-images.githubusercontent.com/1144737/221683170-28f14f6c-0b10-4037-945c-81e2cfa6aaae.png)
