### PR TITLE
Update link to Yarn 3 Workspaces to avoid redirect to Yarn Classic 1.x.

### DIFF
--- a/docs/source/addons/index.md
+++ b/docs/source/addons/index.md
@@ -330,9 +330,7 @@ export default applyConfig;
 
 ## Add third-party dependencies to your add-on
 
-If you're developing the add-on and you wish to add an external dependency,
-you'll have to switch your project to be a [Yarn Workspaces
-root](https://yarnpkg.com/en/docs/workspaces/).
+If you're developing the add-on and you wish to add an external dependency, you'll have to switch your project to be a [Yarn Workspaces root](https://yarnpkg.com/features/workspaces).
 
 So you'll need to add, in your Volto project's `package.json`:
 

--- a/news/4441.documentation
+++ b/news/4441.documentation
@@ -1,0 +1,1 @@
+Update link to Yarn 3 Workspaces to avoid redirect to Yarn Classic 1.x. @stevepiercy


### PR DESCRIPTION
Closes #4441