### PR TITLE
Change from links to inline literals in `CHANGELOG.md` to fix linkche…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,11 +72,11 @@
 - Add the intl string 'Uploading image' to the image block @bipoza [#4180](https://github.com/plone/volto/issues/4180)
 - Fix link integrity overlay is too narrowed @iFlameing [#4399](https://github.com/plone/volto/issues/4399)
 - Fix External link Icon shows up in Grid-text block @iRohitSingh [#4400](https://github.com/plone/volto/issues/4400)
-- Fix broken links: babeljs.io/… @ksuess [#4414](https://github.com/plone/volto/issues/4414)
+- Fix broken links: `babeljs.io/…` @ksuess [#4414](https://github.com/plone/volto/issues/4414)
 
 ### Documentation
 
-- Remove inclusion of CHANGELOG.md for volto repo only. Fixes https://github.com/plone/documentation/issues/1431. @stevepiercy [#4404](https://github.com/plone/volto/issues/4404)
+- Remove inclusion of `CHANGELOG.md` for volto repo only. Fixes https://github.com/plone/documentation/issues/1431. @stevepiercy [#4404](https://github.com/plone/volto/issues/4404)
 
 
 ## 16.11.0 (2023-02-13)

--- a/news/4470.documentation
+++ b/news/4470.documentation
@@ -1,0 +1,1 @@
+Change from links to inline literals in `CHANGELOG.md` to fix linkcheckbroken. @stevepiercy


### PR DESCRIPTION
…ckbroken.

Volto 16.12 news items introduced two broken links that we caught only after trying to build the main documentation.