### PR TITLE
Fix order of row of long table  in edit and view mode.

### DIFF
--- a/news/4473.bugfix
+++ b/news/4473.bugfix
@@ -1,0 +1,1 @@
+Fix order of row of long table in edit and view mode @iFlameing

--- a/packages/volto-slate/src/blocks/Table/TableBlockView.jsx
+++ b/packages/volto-slate/src/blocks/Table/TableBlockView.jsx
@@ -33,13 +33,13 @@ const View = ({ data }) => {
   }, [data.table.rows]);
 
   const rows = useMemo(() => {
-    const items = {};
-    if (!data.table.rows) return {};
+    const items = [];
+    if (!data.table.rows) return [];
     data.table.rows.forEach((row, index) => {
       if (index > 0) {
-        items[row.key] = [];
+        items[index] = [];
         row.cells.forEach((cell, cellIndex) => {
-          items[row.key][cellIndex] = {
+          items[index][cellIndex] = {
             ...cell,
             value:
               cell.value && Node.string({ children: cell.value }).length > 0


### PR DESCRIPTION
If we have a very large table in Volto. In view mode when we are iterating using an object.Keys it is giving us the wrong order of table rows. Because object. keys don't give us keys in order of properties but it is different, which causes different rows in the edit as compared to the view.

Fixes #4473