### PR TITLE
4110 - default values in ToC

### DIFF
--- a/news/4110.bugfix
+++ b/news/4110.bugfix
@@ -1,0 +1,1 @@
+Added block prop to BlockDataForm in the Edit component of ToC. If block is not passed, OnChangeBlock will be called with undefined block id. @tedw87

--- a/src/components/manage/Blocks/ToC/Edit.jsx
+++ b/src/components/manage/Blocks/ToC/Edit.jsx
@@ -26,6 +26,7 @@ class Edit extends Component {
             }}
             onChangeBlock={this.props.onChangeBlock}
             formData={this.props.data}
+            block={this.props.block}
           />
         </SidebarPortal>
       </>


### PR DESCRIPTION
https://github.com/plone/volto/issues/4110
Added `block` prop to `BlockDataForm` in the `Edit` component of ToC. If `block` is not passed, `OnChangeBlock` will be called with `undefined` block id. 
