### PR TITLE
fix: unresponsive content page

### DIFF
--- a/news/4493.bugfix
+++ b/news/4493.bugfix
@@ -1,0 +1,2 @@
+The menu for the contents page was unresponsive on mobile devices. Fixed this by changing the menu overflow to scroll.
+In `theme/themes/pastanaga/extras/contents.less` file added a `overflow-x: scroll;` to make overflow content to scroll.

--- a/news/4493.bugfix
+++ b/news/4493.bugfix
@@ -1,2 +1,2 @@
 The menu for the contents page was unresponsive on mobile devices. Fixed this by changing the menu overflow to scroll.
-In `theme/themes/pastanaga/extras/contents.less` file added a `overflow-x: scroll;` to make overflow content to scroll. @sudhanshu1309
+In `theme/themes/pastanaga/extras/contents.less` file added a `overflow-x: scroll;` to make overflow content to scroll.  @sudhanshu1309

--- a/news/4493.bugfix
+++ b/news/4493.bugfix
@@ -1,2 +1,2 @@
 The menu for the contents page was unresponsive on mobile devices. Fixed this by changing the menu overflow to scroll.
-In `theme/themes/pastanaga/extras/contents.less` file added a `overflow-x: scroll;` to make overflow content to scroll.
+In `theme/themes/pastanaga/extras/contents.less` file added a `overflow-x: scroll;` to make overflow content to scroll. @sudhanshu1309

--- a/theme/themes/pastanaga/extras/contents.less
+++ b/theme/themes/pastanaga/extras/contents.less
@@ -38,6 +38,7 @@
   .ui.menu.top-menu {
     padding: 10px 0;
     border-bottom: 4px solid #c7d5d8;
+    overflow-x: scroll;
   }
 
   .ui.menu .menu.top-menu-menu {


### PR DESCRIPTION
The menu for the contents page was unresponsive on mobile devices Fixed this by changing the menu overflow to scroll.
closes #4492 