### PR TITLE
4301 pasting something in table block is throwing error

### DIFF
--- a/news/4301.bugfix
+++ b/news/4301.bugfix
@@ -1,0 +1,1 @@
+Fixed paste issue in Table Block.

--- a/packages/volto-slate/src/blocks/Table/index.js
+++ b/packages/volto-slate/src/blocks/Table/index.js
@@ -1,3 +1,4 @@
+import { normalizeExternalData } from '../Text/extensions';
 import TableBlockEdit from './TableBlockEdit';
 import TableBlockView from './TableBlockView';
 import { extractTables } from './deconstruct';
@@ -25,6 +26,7 @@ export default function install(config) {
       // withDeserializers,
       // breakList,
       normalizeTable,
+      normalizeExternalData,
     ],
   };
 


### PR DESCRIPTION
**Fix:** Fixed pasting content in Table Block returns an error.

**Issue:** #4301

**Before:**
![table-paste-issue-before](https://user-images.githubusercontent.com/58589519/224469668-7f0d5215-03cc-4dd6-80a8-daa65b9b803c.gif)

**After:**
![table-paste-issue-after](https://user-images.githubusercontent.com/58589519/224469709-3519da3c-e6c1-431d-8ed0-8a0009771283.gif)

**What I did:**
I turned on the **normalizeExternalData** extension for Table Block.