### PR TITLE
i18n script: use dependency graph sort of addons

### DIFF
--- a/news/4495.breaking
+++ b/news/4495.breaking
@@ -1,0 +1,1 @@
+Improve i18n script ordering of addons, so that addons can override translations from their dependencies. @davisagli

--- a/packages/scripts/i18n.cjs
+++ b/packages/scripts/i18n.cjs
@@ -149,7 +149,7 @@ function poToJson({ registry, addonMode }) {
     if (!addonMode) {
       // Merge addons locales
       if (packageJson.addons) {
-        registry.addonNames.forEach((addon) => {
+        registry.getAddonDependencies().forEach((addon) => {
           const addonlocale = `${registry.packages[addon].modulePath}/../${filename}`;
           if (fs.existsSync(addonlocale)) {
             const addonItems = Pofile.parse(


### PR DESCRIPTION
Fixes #4495 

Targeting volto 17 b/c it's not a backwards-compatible change.