### PR TITLE
Fix devproxy vh path when the public URL port is null

### DIFF
--- a/src/express-middleware/devproxy.js
+++ b/src/express-middleware/devproxy.js
@@ -73,11 +73,12 @@ export default function () {
     },
     pathRewrite: (path, req) => {
       const { apiPathURL, instancePath } = getEnv();
+      const targetPort = apiPathURL.port ? `:${apiPathURL.port}` : '';
       const target =
         config.settings.proxyRewriteTarget ||
         `/VirtualHostBase/${apiPathURL.protocol.slice(0, -1)}/${
           apiPathURL.hostname
-        }:${apiPathURL.port}${instancePath}/++api++/VirtualHostRoot`;
+        }${targetPort}${instancePath}/++api++/VirtualHostRoot`;
 
       return `${target}${path.replace('/++api++', '')}`;
     },


### PR DESCRIPTION
If volto is being accessed without an explicit port (i.e. default port 80 for http or 443 for https) then apiPathURL.port is null, and we should not include it in the virtual host path sent to the backend.