### PR TITLE
Fix: Fixed paste issue in table block and added cypress test for it

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -11,6 +11,11 @@ const PLONE_API_URL =
 const SLATE_SELECTOR = '.content-area .slate-editor [contenteditable=true]';
 const SLATE_TITLE_SELECTOR = '.block.inner.title [contenteditable="true"]';
 
+const TABLE_SLATE_SELECTOR =
+  '.celled.fixed.table tbody tr:nth-child(1) td:first-child() [contenteditable="true"]';
+const TABLE_HEAD_SLATE_SELECTOR =
+  '.celled.fixed.table thead tr th:first-child() [contenteditable="true"]';
+
 const ploneAuthObj = {
   user: ploneAuth[0],
   pass: ploneAuth[1],
@@ -824,3 +829,23 @@ Cypress.Commands.add('settings', (key, value) => {
   return cy.window().its('settings');
 });
 Cypress.Commands.add('getIfExists', getIfExists);
+
+Cypress.Commands.add('getTableSlate', (header = false) => {
+  let slate;
+
+  cy.addNewBlock('table');
+  cy.wait(2000);
+
+  const selector = header ? TABLE_HEAD_SLATE_SELECTOR : TABLE_SLATE_SELECTOR;
+
+  cy.getIfExists(
+    selector,
+    () => {
+      slate = cy.get(selector).last();
+    },
+    () => {
+      slate = cy.get(selector, { timeout: 10000 }).last();
+    },
+  );
+  return slate;
+});

--- a/cypress/tests/core/volto-slate/28-table-block-slate-paste.js
+++ b/cypress/tests/core/volto-slate/28-table-block-slate-paste.js
@@ -1,0 +1,52 @@
+import { slateBeforeEach } from '../../../support/volto-slate';
+
+describe('Block Tests: pasting content in table block', () => {
+  beforeEach(slateBeforeEach);
+
+  it('should paste text', function () {
+    // Paste
+    cy.getTableSlate(true)
+      .focus()
+      .click()
+      .pasteClipboard('Some Text from Clipboard');
+
+    cy.getTableSlate()
+      .focus()
+      .click()
+      .pasteClipboard('Some Text from Clipboard');
+
+    // Save
+    cy.toolbarSave();
+
+    // View
+    cy.get(
+      '.celled.fixed.table thead tr th:first-child() [contenteditable="true"]',
+    ).contains('Some Text from Clipboard');
+    cy.get(
+      '.celled.fixed.table tbody tr:nth-child(1) td:first-child() [contenteditable="true"]',
+    ).contains('Some Text from Clipboard');
+  });
+
+  it('should paste external text containing html', function () {
+    // Paste
+    cy.getTableSlate(true)
+      .focus()
+      .click()
+      .pasteClipboard(
+        '<p>For simplicity, emissions arising (CRF 3B) were presented for all livestock type h CH<sub>4</sub> and N<sub>2</sub>O), e CO<sub>2</sub>e value.single CO<sub>2</sub>e figure.</p>',
+      );
+
+    cy.getTableSlate()
+      .focus()
+      .click()
+      .pasteClipboard(
+        '<p>For simplicity, emissions arising (CRF 3B) were presented for all livestock type h CH<sub>4</sub> and N<sub>2</sub>O), e CO<sub>2</sub>e value.single CO<sub>2</sub>e figure.</p>',
+      );
+
+    // Save
+    cy.toolbarSave();
+
+    // View
+    cy.get('[id="page-document"] p').should('have.length', 2);
+  });
+});

--- a/news/4301.bugfix
+++ b/news/4301.bugfix
@@ -1,0 +1,1 @@
+Fixed paste issue in Table Block and added cypress test for pasting text in Table Block.

--- a/packages/volto-slate/src/blocks/Table/index.js
+++ b/packages/volto-slate/src/blocks/Table/index.js
@@ -2,6 +2,7 @@ import TableBlockEdit from './TableBlockEdit';
 import TableBlockView from './TableBlockView';
 import { extractTables } from './deconstruct';
 import { normalizeTable } from './extensions/normalizeTable';
+import { normalizeExternalData } from '../Text/extensions';
 
 import tableSVG from '@plone/volto/icons/table.svg';
 
@@ -25,6 +26,7 @@ export default function install(config) {
       // withDeserializers,
       // breakList,
       normalizeTable,
+      normalizeExternalData,
     ],
   };
 


### PR DESCRIPTION
**Fix:** Fixed pasting content in Table Block returns an error.
Also added cypress test for pasting text in Table Block.

**Issue:** #4301

**Before:**
![table-paste-issue-before](https://user-images.githubusercontent.com/58589519/224469668-7f0d5215-03cc-4dd6-80a8-daa65b9b803c.gif)

**After:**
![table-paste-issue-after](https://user-images.githubusercontent.com/58589519/224469709-3519da3c-e6c1-431d-8ed0-8a0009771283.gif)

**What I did:**
I turned on the **normalizeExternalData** extension for Table Block.