### PR TITLE
restricted searching if nothing is passed

### DIFF
--- a/news/4552.bugfix
+++ b/news/4552.bugfix
@@ -1,0 +1,1 @@
+Restricted search if nothing is passed as search parameter. @sudhanshu1309

--- a/src/components/theme/SearchWidget/SearchWidget.jsx
+++ b/src/components/theme/SearchWidget/SearchWidget.jsx
@@ -74,6 +74,10 @@ class SearchWidget extends Component {
    * @returns {undefined}
    */
   onSubmit(event) {
+    event.preventDefault();
+    if (this.state.text === '') {
+      return;
+    }
     const path =
       this.props.pathname?.length > 0
         ? `&path=${encodeURIComponent(this.props.pathname)}`
@@ -85,7 +89,6 @@ class SearchWidget extends Component {
     this.setState({
       text: '',
     });
-    event.preventDefault();
   }
 
   /**


### PR DESCRIPTION
Searching is restricted if nothing is passed as a search parameter.
closes #4552 