### PR TITLE
(fix):Object.normaliseMail: Cannot read properties of null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,18 @@
 - Fix English and MyST grammar and syntax from PR #4285 @stevepiercy [#4331](https://github.com/plone/volto/issues/4331)
 - Use a universal static path for both documentation and volto repos. @stevepiercy [#4376](https://github.com/plone/volto/issues/4376)
 
+
+## 16.17.1 (2023-03-16)
+
+ ### Bugfix
+
+ - Fix Search is case sensitive in Block chooser @iRohitSingh [#4526](https://github.com/plone/volto/issues/4526)
+
+ ### Documentation
+
+ - Deleted duplicate import and fixed training URLs. @yahya-cloud [#4523](https://github.com/plone/volto/issues/4523)
+
+
 ## 16.17.0 (2023-03-15)
 
 ### Feature

--- a/news/4558.bugfix
+++ b/news/4558.bugfix
@@ -1,0 +1,2 @@
+
+(fix):Object.normaliseMail: Cannot read properties of null @dobri1408

--- a/news/4558.bugfix
+++ b/news/4558.bugfix
@@ -1,2 +1,1 @@
-
 (fix):Object.normaliseMail: Cannot read properties of null @dobri1408

--- a/src/helpers/Url/Url.js
+++ b/src/helpers/Url/Url.js
@@ -264,14 +264,14 @@ export function isTelephone(text) {
 }
 
 export function normaliseMail(email) {
-  if (email.toLowerCase().startsWith('mailto:')) {
+  if (email?.toLowerCase()?.startsWith('mailto:')) {
     return email;
   }
   return `mailto:${email}`;
 }
 
 export function normalizeTelephone(tel) {
-  if (tel.toLowerCase().startsWith('tel:')) {
+  if (tel?.toLowerCase()?.startsWith('tel:')) {
     return tel;
   }
   return `tel:${tel}`;
@@ -294,7 +294,7 @@ export function checkAndNormalizeUrl(url) {
     res.url = URLUtils.normalizeTelephone(url);
   } else {
     //url
-    if (!res.url.startsWith('/') && !res.url.startsWith('#')) {
+    if (res.url && !res.url.startsWith('/') && !res.url.startsWith('#')) {
       res.url = URLUtils.normalizeUrl(url);
       if (!URLUtils.isUrl(res.url)) {
         res.isValid = false;

--- a/src/helpers/Url/Url.js
+++ b/src/helpers/Url/Url.js
@@ -300,7 +300,7 @@ export function checkAndNormalizeUrl(url) {
         res.isValid = false;
       }
     }
-    if (res.url == undefined || res.url == null) res.isValid = false;
+    if (res.url === undefined || res.url === null) res.isValid = false;
   }
   return res;
 }

--- a/src/helpers/Url/Url.js
+++ b/src/helpers/Url/Url.js
@@ -300,6 +300,7 @@ export function checkAndNormalizeUrl(url) {
         res.isValid = false;
       }
     }
+    if (res.url == undefined || res.url == null) res.isValid = false;
   }
   return res;
 }

--- a/src/helpers/Url/Url.js
+++ b/src/helpers/Url/Url.js
@@ -310,7 +310,11 @@ export function checkAndNormalizeUrl(url) {
     res.url = URLUtils.normalizeTelephone(url);
   } else {
     //url
-    if (res.url && !res.url.startsWith('/') && !res.url.startsWith('#')) {
+    if (
+      res.url?.length >= 0 &&
+      !res.url.startsWith('/') &&
+      !res.url.startsWith('#')
+    ) {
       res.url = URLUtils.normalizeUrl(url);
       if (!URLUtils.isUrl(res.url)) {
         res.isValid = false;

--- a/src/helpers/Url/Url.test.js
+++ b/src/helpers/Url/Url.test.js
@@ -14,6 +14,9 @@ import {
   removeProtocol,
   addAppURL,
   expandToBackendURL,
+  checkAndNormalizeUrl,
+  normaliseMail,
+  normalizeTelephone,
 } from './Url';
 
 beforeEach(() => {
@@ -60,6 +63,17 @@ describe('Url', () => {
     });
     it('return empty string if no url is empty string', () => {
       expect(getBaseUrl('')).toBe('');
+    });
+    it('return a null/undefined mailto adress ', () => {
+      expect(normaliseMail(null)).toBe('mailto:null');
+      expect(normaliseMail(undefined)).toBe('mailto:undefined');
+    });
+    it('return a null/undefined telephone number', () => {
+      expect(normalizeTelephone(null)).toBe('tel:null');
+      expect(normalizeTelephone(undefined)).toBe('tel:undefined');
+    });
+    it('null returns an invalid link', () => {
+      expect(checkAndNormalizeUrl(null).isValid).toBe(false);
     });
   });
 


### PR DESCRIPTION
I found out that if somehow it happens that a link has a null value, it can be caused by a faulty copy-paste, this error can happen. This is due to the fact that the "email"/"telephone" is null or "res.url" is null.
<img width="1094" alt="Captură de ecran din 2023-03-16 la 14 54 56" src="https://user-images.githubusercontent.com/50819975/225623338-02c9c23e-0d09-4b32-8c04-9d30cf583487.png">
