### PR TITLE
Support RelationList field with StaticCatalogVocabulary and SelectWidget.

### DIFF
--- a/docs/source/recipes/widget.md
+++ b/docs/source/recipes/widget.md
@@ -167,9 +167,8 @@ directives.widget(
 )
 ```
 
-
 It is recommended to define the vocabulary as a named `StaticCatalogVocabulary` with the field/relation name as its name.  
-This allowes the relations control panel to respect the defined restrictions to potential relation targets.
+This allows the {guilabel}`relations` control panel to respect the defined restrictions to potential relation targets.
 
 {file}`vocabularies.py`
 ```python
@@ -196,7 +195,6 @@ def ExamplesVocabularyFactory(context=None):
   component="example.contenttype.vocabularies.ExamplesVocabularyFactory"
   />
 ```
-
 
 The directive is by now default and can be ommitted.
 

--- a/docs/source/recipes/widget.md
+++ b/docs/source/recipes/widget.md
@@ -146,11 +146,22 @@ const applyConfig = (config) => {
 Based on this setup, Volto will render this field with the `TokenWidget`.
 
 
+(widget-relation-field-label)=
+
 ## Relation fields
+
+A relation field is either a single relation field to hold at most one content object, `RelationChoice`, or a multi relation field `RelationList`, that can hold more than one content object.
+
+Relation fields can be edited and rendered with the `Select` widget.
+The restriction on content types, workflow states, e.a. can be done with a `StaticCatalogVocabulary`.
+
+There are other vocabulary types and other widgets like the `ObjectBrowser` widget.
+
+(widget-relation-field-single-label)=
 
 ### Single relation field
 
-Relation field with named `StaticCatalogVocabulary`and `Select` widget:
+Relation field (`RelationChoice`) with a named `StaticCatalogVocabulary` and `Select` widget:
 
 ```python
 relationchoice_field_named_staticcatalogvocabulary = RelationChoice(
@@ -176,7 +187,6 @@ from plone.app.vocabularies.catalog import StaticCatalogVocabulary
 from zope.interface import provider
 from zope.schema.interfaces import IVocabularyFactory
 
-
 @provider(IVocabularyFactory)
 def ExamplesVocabularyFactory(context=None):
     return StaticCatalogVocabulary(
@@ -196,7 +206,8 @@ def ExamplesVocabularyFactory(context=None):
   />
 ```
 
-The directive is by now default and can be ommitted.
+The `Select` widget is currently the default for `RelationChoice` fields with vocabulary.
+Therefore the directive can be ommitted.
 
 ```python
 relationchoice_field_named_staticcatalogvocabulary = RelationChoice(
@@ -207,10 +218,11 @@ relationchoice_field_named_staticcatalogvocabulary = RelationChoice(
 )
 ```
 
+(widget-relation-field-multi-label)=
 
 ### Multi relation field
 
-Multi relation field with named `StaticCatalogVocabulary`and `Select` widget:
+Multi relation field (`RelationList`) with a named `StaticCatalogVocabulary`and `Select` widget:
 
 ```python
 relationlist_field_named_staticcatalogvocabulary = RelationList(

--- a/docs/source/recipes/widget.md
+++ b/docs/source/recipes/widget.md
@@ -146,13 +146,101 @@ const applyConfig = (config) => {
 Based on this setup, Volto will render this field with the `TokenWidget`.
 
 
-```{seealso}
-See [storybook](https://6.dev-docs.plone.org/storybook) with available widgets.
+## Relation fields
+
+### Single relation field
+
+Relation field with named `StaticCatalogVocabulary`and `Select` widget:
+
+```python
+relationchoice_field_named_staticcatalogvocabulary = RelationChoice(
+    title="RelationChoice – named StaticCatalogVocabulary – Select widget",
+    description="field/relation: relationchoice_field_named_staticcatalogvocabulary",
+    vocabulary="relationchoice_field_named_staticcatalogvocabulary",
+    required=False,
+)
+directives.widget(
+    "relationchoice_field_named_staticcatalogvocabulary",
+    frontendOptions={
+        "widget": "select",
+    },
+)
 ```
+
+
+It is recommended to define the vocabulary as a named `StaticCatalogVocabulary` with the field/relation name as its name.  
+This allowes the relations control panel to respect the defined restrictions to potential relation targets.
+
+{file}`vocabularies.py`
+```python
+from plone.app.vocabularies.catalog import StaticCatalogVocabulary
+from zope.interface import provider
+from zope.schema.interfaces import IVocabularyFactory
+
+
+@provider(IVocabularyFactory)
+def ExamplesVocabularyFactory(context=None):
+    return StaticCatalogVocabulary(
+        {
+            "portal_type": ["example"],
+            "review_state": "published",
+            "sort_on": "sortable_title",
+        }
+    )
+```
+
+{file}`configure.zcml`
+```xml
+<utility
+  name="relationchoice_field_named_staticcatalogvocabulary"
+  component="example.contenttype.vocabularies.ExamplesVocabularyFactory"
+  />
+```
+
+
+The directive is by now default and can be ommitted.
+
+```python
+relationchoice_field_named_staticcatalogvocabulary = RelationChoice(
+    title="RelationChoice – named StaticCatalogVocabulary – Select widget",
+    description="field/relation: relationchoice_field_named_staticcatalogvocabulary",
+    vocabulary="relationchoice_field_named_staticcatalogvocabulary",
+    required=False,
+)
+```
+
+
+### Multi relation field
+
+Multi relation field with named `StaticCatalogVocabulary`and `Select` widget:
+
+```python
+relationlist_field_named_staticcatalogvocabulary = RelationList(
+    title="RelationList – named StaticCatalogVocabulary – Select widget",
+    description="field/relation: relationlist_field_named_staticcatalogvocabulary",
+    value_type=RelationChoice(
+        vocabulary="relationlist_field_named_staticcatalogvocabulary",
+    ),
+    required=False,
+)
+directives.widget(
+    "relationlist_field_named_staticcatalogvocabulary",
+    frontendOptions={
+        "widget": "select",
+    },
+)
+```
+
 
 ## Widget `isDisabled` Props
 
 We can disable the input of a widget by passing props `isDisabled: true`.
+
+
+## Available widgets
+
+See [Storybook](https://6.docs.plone.org/storybook) with available widgets.
+
 
 ## Write a new widget
 

--- a/docs/source/recipes/widget.md
+++ b/docs/source/recipes/widget.md
@@ -150,12 +150,12 @@ Based on this setup, Volto will render this field with the `TokenWidget`.
 
 ## Relation fields
 
-A relation field is either a single relation field to hold at most one content object, `RelationChoice`, or a multi relation field `RelationList`, that can hold more than one content object.
+A relation field is either a single relation field to hold at most one content object, `RelationChoice`, or a multi relation field, `RelationList`, that can hold more than one content object.
 
 Relation fields can be edited and rendered with the `Select` widget.
-The restriction on content types, workflow states, e.a. can be done with a `StaticCatalogVocabulary`.
+The restriction on content types, workflow states, and so on can be done with a `StaticCatalogVocabulary`.
 
-There are other vocabulary types and other widgets like the `ObjectBrowser` widget.
+There are other vocabulary types and other widgets, including the `ObjectBrowser` widget.
 
 (widget-relation-field-single-label)=
 
@@ -207,7 +207,7 @@ def ExamplesVocabularyFactory(context=None):
 ```
 
 The `Select` widget is currently the default for `RelationChoice` fields with vocabulary.
-Therefore the directive can be ommitted.
+Therefore the directive can be omitted.
 
 ```python
 relationchoice_field_named_staticcatalogvocabulary = RelationChoice(

--- a/news/4614.feature
+++ b/news/4614.feature
@@ -1,0 +1,1 @@
+Support RelationList field with named StaticCatalogVocabulary and SelectWidget. @ksuess

--- a/src/components/manage/Widgets/SelectUtils.js
+++ b/src/components/manage/Widgets/SelectUtils.js
@@ -54,7 +54,7 @@ export function normalizeSingleSelectOption(value, intl) {
     throw new Error(`Unknown value type of select widget: ${value}`);
   }
 
-  const token = value.token ?? value.value ?? 'no-value';
+  const token = value.token ?? value.value ?? value.UID ?? 'no-value';
   const label =
     (value.title && value.title !== 'None' ? value.title : undefined) ??
     value.label ??

--- a/src/components/manage/Widgets/SelectWidget.jsx
+++ b/src/components/manage/Widgets/SelectWidget.jsx
@@ -202,7 +202,7 @@ class SelectWidget extends Component {
 
     const isMulti = this.props.isMulti
       ? this.props.isMulti
-      : id === 'roles' || id === 'groups';
+      : id === 'roles' || id === 'groups' || this.props.type === 'array';
 
     return (
       <FormFieldWrapper {...this.props}>

--- a/src/config/Widgets.jsx
+++ b/src/config/Widgets.jsx
@@ -98,6 +98,7 @@ export const widgetMapping = {
     select_querystring_field: SelectMetadataWidget,
     autocomplete: SelectAutoComplete,
     color_picker: ColorPickerWidget,
+    select: SelectWidget,
   },
   vocabulary: {
     'plone.app.vocabularies.Catalog': ObjectBrowserWidget,


### PR DESCRIPTION
**Please test with https://github.com/plone/plone.restapi/pull/1605**

---
See example.contenttype https://github.com/collective/example.contenttype for example content type with relation fields for testing purpose.

![image](https://user-images.githubusercontent.com/1144737/229072282-ba05eabf-21da-42ac-9203-2b5ed545e6fa.png)


---

See also https://github.com/plone/volto/issues/3355