### PR TITLE
fixed Responsive Error in login page #3250

### DIFF
--- a/theme/themes/pastanaga/extras/login.less
+++ b/theme/themes/pastanaga/extras/login.less
@@ -38,4 +38,6 @@
   .ui.segment.form {
     padding-top: 1rem;
   }
+  display: flex;
+  justify-content: center;
 }


### PR DESCRIPTION
closes https://github.com/plone/volto/issues/3250

this happens on the smaller screens less than 766px , the login portal goes left side of screen which is not responsive , so  I add flex property which is working perfect 