### PR TITLE
Make URL a literal string to fix broken link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,7 +143,7 @@
 
 ### Documentation
 
-- Fix broken links at ReactJS.org. @stevepiercy [#4569](https://github.com/plone/volto/issues/4569)
+- Fix broken links at `ReactJS.org`. @stevepiercy [#4569](https://github.com/plone/volto/issues/4569)
 - Fix video warnings and link errors. @stevepiercy [#4578](https://github.com/plone/volto/issues/4578)
 
 

--- a/news/4667.documentation
+++ b/news/4667.documentation
@@ -1,0 +1,1 @@
+Fix broken link to `ReactJS.org`. @stevepiercy


### PR DESCRIPTION
This is the third time I have fixed this link to `ReactJS.org`. I don't have any clue why it does not stay fixed.