### PR TITLE
Add support for routes with parameters

### DIFF
--- a/src/components/theme/View/View.jsx
+++ b/src/components/theme/View/View.jsx
@@ -284,7 +284,7 @@ export default compose(
       error: state.content.get.error,
       apiError: state.apierror.error,
       connectionRefused: state.apierror.connectionRefused,
-      pathname: props.location.pathname,
+      pathname: props.route['@id'] || props.location.pathname,
       versionId:
         qs.parse(props.location.search) &&
         qs.parse(props.location.search).version,

--- a/src/routes.js
+++ b/src/routes.js
@@ -122,6 +122,39 @@ export function getExternalRoutes() {
   );
 }
 
+export function getRoutesWithParameter({ path, id }) {
+  return [
+    {
+      path: `${path}(add)`,
+      component: Add,
+      exact: true,
+    },
+    {
+      path: `${path}(edit)`,
+      component: Edit,
+      exact: true,
+    },
+    {
+      path: `${path}/add`,
+      '@id': id,
+      component: Add,
+      exact: true,
+    },
+    {
+      path: `${path}/edit`,
+      '@id': id,
+      component: Edit,
+      exact: true,
+    },
+    {
+      path,
+      '@id': id,
+      component: View,
+      exact: true,
+    },
+  ];
+}
+
 export const defaultRoutes = [
   // redirect to external links if path is in blacklist
   ...getExternalRoutes(),


### PR DESCRIPTION
@tiberiuichim @sneridagh 

Note: this is just a draft for now, I want to see the feedback for this idea.

The idea is to have routes with parameters like `/posts/:postId` that will render the content of a specified route (`/posts/post`).
So this pr would add the functionality to make a virtual route with parameters that will show whatever the content of the real route has.

In this case the way that we would specify the virtual route is as follow:

```js
import { getRoutesWithParameter } from "@plone/volto/routes"

export default function applyConfig(config) {
  ...
  config.addonRoutes = [
    ...(config.addonRoutes || []),
    ...getRoutesWithParameter({
       path: '/posts/:postId',
       "@id": /posts/post'
    })
  ]
  return config;
}
```