### PR TITLE
Force the resolution of the `react-error-overlay` package to `6.0.9`

### DIFF
--- a/packages/generator-volto/generators/app/templates/package.json.tpl
+++ b/packages/generator-volto/generators/app/templates/package.json.tpl
@@ -154,5 +154,8 @@
     "stylelint-config-prettier": "8.0.1",
     "stylelint-prettier": "1.1.2"
   },
+  "resolutions": {
+    "react-error-overlay": "6.0.9"
+  },
   "packageManager": "yarn@3.2.3"
 }

--- a/packages/generator-volto/news/4687.bugfix
+++ b/packages/generator-volto/news/4687.bugfix
@@ -1,0 +1,1 @@
+Force the resolution of the `react-error-overlay` package to `6.0.9` @sneridagh


### PR DESCRIPTION
When an error occurs, the screen appears to be frozen, but the thing is that an empty iframe is covering the whole page, making impossible to click on anything. This is caused by `react-error-overlay` > `6.0.9` in latests Razzle. 

A console log is also there: `Uncaught ReferenceError: process is not defined`.

The latests versions of `react-error-overlay` only works well together with `react-scripts` which Razzle is not using. So we are on our own on this one. 

All projects using Volto 16 onwards should update their `package.json` to use it.