### PR TITLE
Fix search block in edit mode re-queries multiple blocks with an empty search text

### DIFF
--- a/news/4697.bugfix
+++ b/news/4697.bugfix
@@ -1,0 +1,1 @@
+Fix search block in edit mode re-queries multiple blocks with an empty search text @reebalazs

--- a/src/components/manage/Blocks/Search/SearchBlockEdit.jsx
+++ b/src/components/manage/Blocks/Search/SearchBlockEdit.jsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import useDeepCompareEffect from 'use-deep-compare-effect';
+import React, { useEffect } from 'react';
 import { defineMessages } from 'react-intl';
 import { compose } from 'redux';
 
@@ -60,9 +59,11 @@ const SearchBlockEdit = (props) => {
   };
 
   const { query = {} } = data || {};
-  useDeepCompareEffect(() => {
+  // We don't need deep compare here, as this is just json serializable data.
+  const deepQuery = JSON.stringify(query);
+  useEffect(() => {
     onTriggerSearch();
-  }, [query, onTriggerSearch]);
+  }, [deepQuery, onTriggerSearch]);
 
   return (
     <>

--- a/src/components/manage/Blocks/Search/hocs/withSearch.jsx
+++ b/src/components/manage/Blocks/Search/hocs/withSearch.jsx
@@ -114,15 +114,19 @@ function normalizeState({
     block: id,
   };
 
-  // TODO: need to check if SearchableText facet is not already in the query
-  // Ideally the searchtext functionality should be restructured as being just
-  // another facet
-  params.query = params.query.reduce(
-    // Remove SearchableText from query
-    (acc, kvp) => (kvp.i === 'SearchableText' ? acc : [...acc, kvp]),
-    [],
-  );
+  // Note Ideally the searchtext functionality should be restructured as being just
+  // another facet. But right now it's the same. This means that if a searchText
+  // is provided, it will override the SearchableText facet.
+  // If there is no searchText, the SearchableText in the query remains in effect.
+  // TODO eventually the searchText should be a distinct facet from SearchableText, and
+  // the two conditions could be combined, in comparison to the current state, when
+  // one overrides the other.
   if (searchText) {
+    params.query = params.query.reduce(
+      // Remove SearchableText from query
+      (acc, kvp) => (kvp.i === 'SearchableText' ? acc : [...acc, kvp]),
+      [],
+    );
     params.query.push({
       i: 'SearchableText',
       o: 'plone.app.querystring.operation.string.contains',

--- a/src/components/manage/Blocks/Search/hocs/withSearch.jsx
+++ b/src/components/manage/Blocks/Search/hocs/withSearch.jsx
@@ -279,7 +279,12 @@ const withSearch = (options) => (WrappedComponent) => {
     const facetSettings = data?.facets;
 
     const onTriggerSearch = React.useCallback(
-      (toSearchText, toSearchFacets, toSortOn, toSortOrder) => {
+      (
+        toSearchText = undefined,
+        toSearchFacets = undefined,
+        toSortOn = undefined,
+        toSortOrder = undefined,
+      ) => {
         if (timeoutRef.current) clearTimeout(timeoutRef.current);
         timeoutRef.current = setTimeout(
           () => {
@@ -287,7 +292,7 @@ const withSearch = (options) => (WrappedComponent) => {
               id,
               query: data.query || {},
               facets: toSearchFacets || facets,
-              searchText: toSearchText,
+              searchText: toSearchText || searchText,
               sortOn: toSortOn || sortOn,
               sortOrder: toSortOrder || sortOrder,
               facetSettings,
@@ -306,6 +311,7 @@ const withSearch = (options) => (WrappedComponent) => {
         facets,
         id,
         setLocationSearchData,
+        searchText,
         sortOn,
         sortOrder,
         facetSettings,

--- a/src/components/manage/Blocks/Search/hocs/withSearch.jsx
+++ b/src/components/manage/Blocks/Search/hocs/withSearch.jsx
@@ -278,6 +278,7 @@ const withSearch = (options) => (WrappedComponent) => {
     const timeoutRef = React.useRef();
     const facetSettings = data?.facets;
 
+    const deepQuery = JSON.stringify(data.query);
     const onTriggerSearch = React.useCallback(
       (
         toSearchText = undefined,
@@ -306,8 +307,10 @@ const withSearch = (options) => (WrappedComponent) => {
           toSearchFacets ? inputDelay / 3 : inputDelay,
         );
       },
+      // eslint-disable-next-line react-hooks/exhaustive-deps
       [
-        data.query,
+        // Use deep comparison of data.query
+        deepQuery,
         facets,
         id,
         setLocationSearchData,


### PR DESCRIPTION
Multiple issues fixed:

# Fix search block search text re-query

SearchBlockEdit calls onTriggerSearch without parameters. But
onTriggerSearch does not ignore toSearchText in case it's not specified
in the call.

If there are multiple blocks in the page, this causes the search text
of all the other block's reset and re-queried with the wrong condition.

# Performance optimize onTriggerSearch

Previous to this fix, onTriggerSearch triggered 28 times during loading
and edit page with two search blocks in it. After the fix, it's just 2
times.

The fix is that the deep comparison condition for the query also has to
be applied in withSearch.jsx. Without that, the deep comparison in
SearchBlockEdit.jsx has no effect. This is because the onTriggerSearch
function will be regenerated each time there is an identity change in
data.query anyway. So the hook guard in SearchBlockEdit will be
triggered anyway because onTriggerSearch has changed.

In addition, I personally find it better to use JSON.stringify for the
deep comparison and skip using the useDeepCompareEffect hook. This uses
dequal under the hood which is capable to compare a lot of other data
types, but with pure json data it has no advantage to a string
comparison with JSON.stringify. (That said it would also work with
useDeepCompareEffect but perhaps a bit slower.)

# Remove SearchableText from the query only if there is a searchtext

Previously, the SearchableText was removed within normalizeState, even
if there was no searchText. This is wrong, the searchText should only
replace SearchableText condition if searchText is provided.

In the edit page this caused the following, in case a SearchableText
is specified as a condition to the block:

- Upon loading the edit page
- First the search blocks were loaded with correct results
- Then a second set of query was issued, but with the SearchableText
  condition stripped out. This means that the query result was wrong.

The current fix fixes the double querying, and the faulty condition in
the second query that results in faulty results.

The current fix still does not address the fact that eventually the
searchText should be a distinct facet from SearchableText, and the two
conditions could be combined, in comparison to the current state, when
one overrides the other.