### PR TITLE
Add image scale property to Teaser Block schema (#4653)

### DIFF
--- a/locales/ca/LC_MESSAGES/volto.po
+++ b/locales/ca/LC_MESSAGES/volto.po
@@ -1498,6 +1498,11 @@ msgstr "Paper global"
 msgid "Google Maps Embedded Block"
 msgstr "Bloc incrustat de Google Maps"
 
+#: components/manage/Blocks/Teaser/schema
+# defaultMessage: Great
+msgid "Great"
+msgstr ""
+
 #: components/manage/Sharing/Sharing
 # defaultMessage: Group
 msgid "Group"
@@ -1806,6 +1811,7 @@ msgstr "Llenguatge"
 msgid "Language independent field."
 msgstr ""
 
+#: components/manage/Blocks/Teaser/schema
 #: components/manage/Widgets/ImageSizeWidget
 # defaultMessage: Large
 msgid "Large"
@@ -2015,6 +2021,11 @@ msgstr ""
 # defaultMessage: Message
 msgid "Message"
 msgstr "Missatge"
+
+#: components/manage/Blocks/Teaser/schema
+# defaultMessage: Mini
+msgid "Mini"
+msgstr ""
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
@@ -2490,6 +2501,7 @@ msgid "Prettify your code"
 msgstr "Prepareu el vostre codi"
 
 #: components/manage/Blocks/HTML/Edit
+#: components/manage/Blocks/Teaser/schema
 #: components/manage/Contents/ContentsUploadModal
 # defaultMessage: Preview
 msgid "Preview"
@@ -4176,6 +4188,11 @@ msgstr "HTML"
 # defaultMessage: Image
 msgid "image"
 msgstr "Imatge"
+
+#: components/manage/Blocks/Teaser/schema
+# defaultMessage: Image size
+msgid "image_scale"
+msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
 # defaultMessage: Input must be integer

--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -1495,6 +1495,11 @@ msgstr "Globale Rolle"
 msgid "Google Maps Embedded Block"
 msgstr "Google Maps Block"
 
+#: components/manage/Blocks/Teaser/schema
+# defaultMessage: Great
+msgid "Great"
+msgstr ""
+
 #: components/manage/Sharing/Sharing
 # defaultMessage: Group
 msgid "Group"
@@ -1803,6 +1808,7 @@ msgstr "Sprache"
 msgid "Language independent field."
 msgstr "Sprachunabhängiges Feld."
 
+#: components/manage/Blocks/Teaser/schema
 #: components/manage/Widgets/ImageSizeWidget
 # defaultMessage: Large
 msgid "Large"
@@ -2012,6 +2018,11 @@ msgstr "Gruppenmitgliedschaft aktualisiert"
 # defaultMessage: Message
 msgid "Message"
 msgstr "Nachricht"
+
+#: components/manage/Blocks/Teaser/schema
+# defaultMessage: Mini
+msgid "Mini"
+msgstr ""
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
@@ -2487,6 +2498,7 @@ msgid "Prettify your code"
 msgstr "Quellcode aufräumen"
 
 #: components/manage/Blocks/HTML/Edit
+#: components/manage/Blocks/Teaser/schema
 #: components/manage/Contents/ContentsUploadModal
 # defaultMessage: Preview
 msgid "Preview"
@@ -4173,6 +4185,11 @@ msgstr "HTML"
 # defaultMessage: Image
 msgid "image"
 msgstr "Bild"
+
+#: components/manage/Blocks/Teaser/schema
+# defaultMessage: Image size
+msgid "image_scale"
+msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
 # defaultMessage: Input must be integer

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -1489,6 +1489,11 @@ msgstr ""
 msgid "Google Maps Embedded Block"
 msgstr ""
 
+#: components/manage/Blocks/Teaser/schema
+# defaultMessage: Great
+msgid "Great"
+msgstr ""
+
 #: components/manage/Sharing/Sharing
 # defaultMessage: Group
 msgid "Group"
@@ -1797,6 +1802,7 @@ msgstr ""
 msgid "Language independent field."
 msgstr ""
 
+#: components/manage/Blocks/Teaser/schema
 #: components/manage/Widgets/ImageSizeWidget
 # defaultMessage: Large
 msgid "Large"
@@ -2005,6 +2011,11 @@ msgstr ""
 #: components/theme/ContactForm/ContactForm
 # defaultMessage: Message
 msgid "Message"
+msgstr ""
+
+#: components/manage/Blocks/Teaser/schema
+# defaultMessage: Mini
+msgid "Mini"
 msgstr ""
 
 #: components/manage/Form/ModalForm
@@ -2481,6 +2492,7 @@ msgid "Prettify your code"
 msgstr ""
 
 #: components/manage/Blocks/HTML/Edit
+#: components/manage/Blocks/Teaser/schema
 #: components/manage/Contents/ContentsUploadModal
 # defaultMessage: Preview
 msgid "Preview"
@@ -4166,6 +4178,11 @@ msgstr ""
 #: config/Blocks
 # defaultMessage: Image
 msgid "image"
+msgstr ""
+
+#: components/manage/Blocks/Teaser/schema
+# defaultMessage: Image size
+msgid "image_scale"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels

--- a/locales/es/LC_MESSAGES/volto.po
+++ b/locales/es/LC_MESSAGES/volto.po
@@ -1500,6 +1500,11 @@ msgstr "Rol global"
 msgid "Google Maps Embedded Block"
 msgstr "Bloque embebido de Google Maps"
 
+#: components/manage/Blocks/Teaser/schema
+# defaultMessage: Great
+msgid "Great"
+msgstr ""
+
 #: components/manage/Sharing/Sharing
 # defaultMessage: Group
 msgid "Group"
@@ -1808,6 +1813,7 @@ msgstr "Idioma"
 msgid "Language independent field."
 msgstr "Campo independiente de idioma."
 
+#: components/manage/Blocks/Teaser/schema
 #: components/manage/Widgets/ImageSizeWidget
 # defaultMessage: Large
 msgid "Large"
@@ -2017,6 +2023,11 @@ msgstr "Pertenencia actualizada"
 # defaultMessage: Message
 msgid "Message"
 msgstr "Mensaje"
+
+#: components/manage/Blocks/Teaser/schema
+# defaultMessage: Mini
+msgid "Mini"
+msgstr ""
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
@@ -2492,6 +2503,7 @@ msgid "Prettify your code"
 msgstr "Embellezca su código"
 
 #: components/manage/Blocks/HTML/Edit
+#: components/manage/Blocks/Teaser/schema
 #: components/manage/Contents/ContentsUploadModal
 # defaultMessage: Preview
 msgid "Preview"
@@ -4178,6 +4190,11 @@ msgstr "HTML"
 # defaultMessage: Image
 msgid "image"
 msgstr "Imagen"
+
+#: components/manage/Blocks/Teaser/schema
+# defaultMessage: Image size
+msgid "image_scale"
+msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
 # defaultMessage: Input must be integer

--- a/locales/eu/LC_MESSAGES/volto.po
+++ b/locales/eu/LC_MESSAGES/volto.po
@@ -1496,6 +1496,11 @@ msgstr "Rol globala"
 msgid "Google Maps Embedded Block"
 msgstr "Google Maps itsasteko blokea"
 
+#: components/manage/Blocks/Teaser/schema
+# defaultMessage: Great
+msgid "Great"
+msgstr ""
+
 #: components/manage/Sharing/Sharing
 # defaultMessage: Group
 msgid "Group"
@@ -1804,6 +1809,7 @@ msgstr "Hizkuntza"
 msgid "Language independent field."
 msgstr "Hizkuntzarekiko Independentea den eremua."
 
+#: components/manage/Blocks/Teaser/schema
 #: components/manage/Widgets/ImageSizeWidget
 # defaultMessage: Large
 msgid "Large"
@@ -2013,6 +2019,11 @@ msgstr "Kidetza eguneratu da"
 # defaultMessage: Message
 msgid "Message"
 msgstr "Mezua"
+
+#: components/manage/Blocks/Teaser/schema
+# defaultMessage: Mini
+msgid "Mini"
+msgstr ""
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
@@ -2488,6 +2499,7 @@ msgid "Prettify your code"
 msgstr "Garbitu zure kodea"
 
 #: components/manage/Blocks/HTML/Edit
+#: components/manage/Blocks/Teaser/schema
 #: components/manage/Contents/ContentsUploadModal
 # defaultMessage: Preview
 msgid "Preview"
@@ -4174,6 +4186,11 @@ msgstr "HTML"
 # defaultMessage: Image
 msgid "image"
 msgstr "Irudia"
+
+#: components/manage/Blocks/Teaser/schema
+# defaultMessage: Image size
+msgid "image_scale"
+msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
 # defaultMessage: Input must be integer

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -1506,6 +1506,11 @@ msgstr "Rôle global"
 msgid "Google Maps Embedded Block"
 msgstr "Bloc intégré de la carte Google"
 
+#: components/manage/Blocks/Teaser/schema
+# defaultMessage: Great
+msgid "Great"
+msgstr ""
+
 #: components/manage/Sharing/Sharing
 # defaultMessage: Group
 msgid "Group"
@@ -1814,6 +1819,7 @@ msgstr "Langage"
 msgid "Language independent field."
 msgstr "Champ indépendant de la langue."
 
+#: components/manage/Blocks/Teaser/schema
 #: components/manage/Widgets/ImageSizeWidget
 # defaultMessage: Large
 msgid "Large"
@@ -2023,6 +2029,11 @@ msgstr "Adhésion mise à jour"
 # defaultMessage: Message
 msgid "Message"
 msgstr "Message"
+
+#: components/manage/Blocks/Teaser/schema
+# defaultMessage: Mini
+msgid "Mini"
+msgstr ""
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
@@ -2498,6 +2509,7 @@ msgid "Prettify your code"
 msgstr "Embelli votre code"
 
 #: components/manage/Blocks/HTML/Edit
+#: components/manage/Blocks/Teaser/schema
 #: components/manage/Contents/ContentsUploadModal
 # defaultMessage: Preview
 msgid "Preview"
@@ -4184,6 +4196,11 @@ msgstr "html"
 # defaultMessage: Image
 msgid "image"
 msgstr "image"
+
+#: components/manage/Blocks/Teaser/schema
+# defaultMessage: Image size
+msgid "image_scale"
+msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
 # defaultMessage: Input must be integer

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -1489,6 +1489,11 @@ msgstr "Ruolo globale"
 msgid "Google Maps Embedded Block"
 msgstr "Blocco Google Maps incorporata"
 
+#: components/manage/Blocks/Teaser/schema
+# defaultMessage: Great
+msgid "Great"
+msgstr ""
+
 #: components/manage/Sharing/Sharing
 # defaultMessage: Group
 msgid "Group"
@@ -1797,6 +1802,7 @@ msgstr "Lingua"
 msgid "Language independent field."
 msgstr "Campo indipendete dalla lingua"
 
+#: components/manage/Blocks/Teaser/schema
 #: components/manage/Widgets/ImageSizeWidget
 # defaultMessage: Large
 msgid "Large"
@@ -2006,6 +2012,11 @@ msgstr ""
 # defaultMessage: Message
 msgid "Message"
 msgstr "Messaggio"
+
+#: components/manage/Blocks/Teaser/schema
+# defaultMessage: Mini
+msgid "Mini"
+msgstr ""
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
@@ -2481,6 +2492,7 @@ msgid "Prettify your code"
 msgstr "Formatta il tuo codice"
 
 #: components/manage/Blocks/HTML/Edit
+#: components/manage/Blocks/Teaser/schema
 #: components/manage/Contents/ContentsUploadModal
 # defaultMessage: Preview
 msgid "Preview"
@@ -4167,6 +4179,11 @@ msgstr "HTML"
 # defaultMessage: Image
 msgid "image"
 msgstr "Immagine"
+
+#: components/manage/Blocks/Teaser/schema
+# defaultMessage: Image size
+msgid "image_scale"
+msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
 # defaultMessage: Input must be integer

--- a/locales/ja/LC_MESSAGES/volto.po
+++ b/locales/ja/LC_MESSAGES/volto.po
@@ -1497,6 +1497,11 @@ msgstr "グローバルロール"
 msgid "Google Maps Embedded Block"
 msgstr "Googleマップ埋め込みブロック"
 
+#: components/manage/Blocks/Teaser/schema
+# defaultMessage: Great
+msgid "Great"
+msgstr ""
+
 #: components/manage/Sharing/Sharing
 # defaultMessage: Group
 msgid "Group"
@@ -1805,6 +1810,7 @@ msgstr "言語"
 msgid "Language independent field."
 msgstr ""
 
+#: components/manage/Blocks/Teaser/schema
 #: components/manage/Widgets/ImageSizeWidget
 # defaultMessage: Large
 msgid "Large"
@@ -2014,6 +2020,11 @@ msgstr ""
 # defaultMessage: Message
 msgid "Message"
 msgstr "メッセージ"
+
+#: components/manage/Blocks/Teaser/schema
+# defaultMessage: Mini
+msgid "Mini"
+msgstr ""
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
@@ -2489,6 +2500,7 @@ msgid "Prettify your code"
 msgstr "コードの整形"
 
 #: components/manage/Blocks/HTML/Edit
+#: components/manage/Blocks/Teaser/schema
 #: components/manage/Contents/ContentsUploadModal
 # defaultMessage: Preview
 msgid "Preview"
@@ -4175,6 +4187,11 @@ msgstr "HTML"
 # defaultMessage: Image
 msgid "image"
 msgstr "画像"
+
+#: components/manage/Blocks/Teaser/schema
+# defaultMessage: Image size
+msgid "image_scale"
+msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
 # defaultMessage: Input must be integer

--- a/locales/nl/LC_MESSAGES/volto.po
+++ b/locales/nl/LC_MESSAGES/volto.po
@@ -1496,6 +1496,11 @@ msgstr "Globale rol"
 msgid "Google Maps Embedded Block"
 msgstr "Embed blok met Google Maps"
 
+#: components/manage/Blocks/Teaser/schema
+# defaultMessage: Great
+msgid "Great"
+msgstr ""
+
 #: components/manage/Sharing/Sharing
 # defaultMessage: Group
 msgid "Group"
@@ -1804,6 +1809,7 @@ msgstr "Taal"
 msgid "Language independent field."
 msgstr "Taalonafhankelijk veld."
 
+#: components/manage/Blocks/Teaser/schema
 #: components/manage/Widgets/ImageSizeWidget
 # defaultMessage: Large
 msgid "Large"
@@ -2013,6 +2019,11 @@ msgstr ""
 # defaultMessage: Message
 msgid "Message"
 msgstr "Boodschap"
+
+#: components/manage/Blocks/Teaser/schema
+# defaultMessage: Mini
+msgid "Mini"
+msgstr ""
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
@@ -2488,6 +2499,7 @@ msgid "Prettify your code"
 msgstr "Maak je code mooi"
 
 #: components/manage/Blocks/HTML/Edit
+#: components/manage/Blocks/Teaser/schema
 #: components/manage/Contents/ContentsUploadModal
 # defaultMessage: Preview
 msgid "Preview"
@@ -4174,6 +4186,11 @@ msgstr "HTML"
 # defaultMessage: Image
 msgid "image"
 msgstr "Afbeelding"
+
+#: components/manage/Blocks/Teaser/schema
+# defaultMessage: Image size
+msgid "image_scale"
+msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
 # defaultMessage: Input must be integer

--- a/locales/pt/LC_MESSAGES/volto.po
+++ b/locales/pt/LC_MESSAGES/volto.po
@@ -1497,6 +1497,11 @@ msgstr "Papel global"
 msgid "Google Maps Embedded Block"
 msgstr "Bloco Integrado Google Maps"
 
+#: components/manage/Blocks/Teaser/schema
+# defaultMessage: Great
+msgid "Great"
+msgstr ""
+
 #: components/manage/Sharing/Sharing
 # defaultMessage: Group
 msgid "Group"
@@ -1805,6 +1810,7 @@ msgstr "Idioma"
 msgid "Language independent field."
 msgstr ""
 
+#: components/manage/Blocks/Teaser/schema
 #: components/manage/Widgets/ImageSizeWidget
 # defaultMessage: Large
 msgid "Large"
@@ -2014,6 +2020,11 @@ msgstr ""
 # defaultMessage: Message
 msgid "Message"
 msgstr "Mensagem"
+
+#: components/manage/Blocks/Teaser/schema
+# defaultMessage: Mini
+msgid "Mini"
+msgstr ""
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
@@ -2489,6 +2500,7 @@ msgid "Prettify your code"
 msgstr ""
 
 #: components/manage/Blocks/HTML/Edit
+#: components/manage/Blocks/Teaser/schema
 #: components/manage/Contents/ContentsUploadModal
 # defaultMessage: Preview
 msgid "Preview"
@@ -4175,6 +4187,11 @@ msgstr "html"
 # defaultMessage: Image
 msgid "image"
 msgstr "imagem"
+
+#: components/manage/Blocks/Teaser/schema
+# defaultMessage: Image size
+msgid "image_scale"
+msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
 # defaultMessage: Input must be integer

--- a/locales/pt_BR/LC_MESSAGES/volto.po
+++ b/locales/pt_BR/LC_MESSAGES/volto.po
@@ -1499,6 +1499,11 @@ msgstr "Papel global"
 msgid "Google Maps Embedded Block"
 msgstr "Bloco Google Maps"
 
+#: components/manage/Blocks/Teaser/schema
+# defaultMessage: Great
+msgid "Great"
+msgstr ""
+
 #: components/manage/Sharing/Sharing
 # defaultMessage: Group
 msgid "Group"
@@ -1807,6 +1812,7 @@ msgstr "Idioma"
 msgid "Language independent field."
 msgstr "Campo independente da linguagem."
 
+#: components/manage/Blocks/Teaser/schema
 #: components/manage/Widgets/ImageSizeWidget
 # defaultMessage: Large
 msgid "Large"
@@ -2016,6 +2022,11 @@ msgstr ""
 # defaultMessage: Message
 msgid "Message"
 msgstr "Mensagem"
+
+#: components/manage/Blocks/Teaser/schema
+# defaultMessage: Mini
+msgid "Mini"
+msgstr ""
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
@@ -2491,6 +2502,7 @@ msgid "Prettify your code"
 msgstr "Re-formatar seu código"
 
 #: components/manage/Blocks/HTML/Edit
+#: components/manage/Blocks/Teaser/schema
 #: components/manage/Contents/ContentsUploadModal
 # defaultMessage: Preview
 msgid "Preview"
@@ -4177,6 +4189,11 @@ msgstr "HTML"
 # defaultMessage: Image
 msgid "image"
 msgstr "Imagem"
+
+#: components/manage/Blocks/Teaser/schema
+# defaultMessage: Image size
+msgid "image_scale"
+msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
 # defaultMessage: Input must be integer

--- a/locales/ro/LC_MESSAGES/volto.po
+++ b/locales/ro/LC_MESSAGES/volto.po
@@ -1489,6 +1489,11 @@ msgstr "Rolul global"
 msgid "Google Maps Embedded Block"
 msgstr "Bloc te tip Google Maps"
 
+#: components/manage/Blocks/Teaser/schema
+# defaultMessage: Great
+msgid "Great"
+msgstr ""
+
 #: components/manage/Sharing/Sharing
 # defaultMessage: Group
 msgid "Group"
@@ -1797,6 +1802,7 @@ msgstr "Limba"
 msgid "Language independent field."
 msgstr "Câmp independent de limbă."
 
+#: components/manage/Blocks/Teaser/schema
 #: components/manage/Widgets/ImageSizeWidget
 # defaultMessage: Large
 msgid "Large"
@@ -2006,6 +2012,11 @@ msgstr ""
 # defaultMessage: Message
 msgid "Message"
 msgstr "Mesaj"
+
+#: components/manage/Blocks/Teaser/schema
+# defaultMessage: Mini
+msgid "Mini"
+msgstr ""
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
@@ -2481,6 +2492,7 @@ msgid "Prettify your code"
 msgstr "Îmbunătățiți-vă codul"
 
 #: components/manage/Blocks/HTML/Edit
+#: components/manage/Blocks/Teaser/schema
 #: components/manage/Contents/ContentsUploadModal
 # defaultMessage: Preview
 msgid "Preview"
@@ -4167,6 +4179,11 @@ msgstr "HTML"
 # defaultMessage: Image
 msgid "image"
 msgstr "Imagine"
+
+#: components/manage/Blocks/Teaser/schema
+# defaultMessage: Image size
+msgid "image_scale"
+msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
 # defaultMessage: Input must be integer

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2023-04-05T10:12:20.363Z\n"
+"POT-Creation-Date: 2023-04-20T17:40:10.553Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -1491,6 +1491,11 @@ msgstr ""
 msgid "Google Maps Embedded Block"
 msgstr ""
 
+#: components/manage/Blocks/Teaser/schema
+# defaultMessage: Great
+msgid "Great"
+msgstr ""
+
 #: components/manage/Sharing/Sharing
 # defaultMessage: Group
 msgid "Group"
@@ -1799,6 +1804,7 @@ msgstr ""
 msgid "Language independent field."
 msgstr ""
 
+#: components/manage/Blocks/Teaser/schema
 #: components/manage/Widgets/ImageSizeWidget
 # defaultMessage: Large
 msgid "Large"
@@ -2007,6 +2013,11 @@ msgstr ""
 #: components/theme/ContactForm/ContactForm
 # defaultMessage: Message
 msgid "Message"
+msgstr ""
+
+#: components/manage/Blocks/Teaser/schema
+# defaultMessage: Mini
+msgid "Mini"
 msgstr ""
 
 #: components/manage/Form/ModalForm
@@ -2483,6 +2494,7 @@ msgid "Prettify your code"
 msgstr ""
 
 #: components/manage/Blocks/HTML/Edit
+#: components/manage/Blocks/Teaser/schema
 #: components/manage/Contents/ContentsUploadModal
 # defaultMessage: Preview
 msgid "Preview"
@@ -4168,6 +4180,11 @@ msgstr ""
 #: config/Blocks
 # defaultMessage: Image
 msgid "image"
+msgstr ""
+
+#: components/manage/Blocks/Teaser/schema
+# defaultMessage: Image size
+msgid "image_scale"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels

--- a/locales/zh_CN/LC_MESSAGES/volto.po
+++ b/locales/zh_CN/LC_MESSAGES/volto.po
@@ -1495,6 +1495,11 @@ msgstr "全局角色"
 msgid "Google Maps Embedded Block"
 msgstr "Google 地图嵌入块"
 
+#: components/manage/Blocks/Teaser/schema
+# defaultMessage: Great
+msgid "Great"
+msgstr ""
+
 #: components/manage/Sharing/Sharing
 # defaultMessage: Group
 msgid "Group"
@@ -1803,6 +1808,7 @@ msgstr "语言"
 msgid "Language independent field."
 msgstr "语言独立字段"
 
+#: components/manage/Blocks/Teaser/schema
 #: components/manage/Widgets/ImageSizeWidget
 # defaultMessage: Large
 msgid "Large"
@@ -2012,6 +2018,11 @@ msgstr "成员身份更新"
 # defaultMessage: Message
 msgid "Message"
 msgstr "消息"
+
+#: components/manage/Blocks/Teaser/schema
+# defaultMessage: Mini
+msgid "Mini"
+msgstr ""
 
 #: components/manage/Form/ModalForm
 #: helpers/MessageLabels/MessageLabels
@@ -2487,6 +2498,7 @@ msgid "Prettify your code"
 msgstr "美化你的代码"
 
 #: components/manage/Blocks/HTML/Edit
+#: components/manage/Blocks/Teaser/schema
 #: components/manage/Contents/ContentsUploadModal
 # defaultMessage: Preview
 msgid "Preview"
@@ -4173,6 +4185,11 @@ msgstr ""
 # defaultMessage: Image
 msgid "image"
 msgstr "图片"
+
+#: components/manage/Blocks/Teaser/schema
+# defaultMessage: Image size
+msgid "image_scale"
+msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
 # defaultMessage: Input must be integer

--- a/news/4653.bugfix
+++ b/news/4653.bugfix
@@ -1,0 +1,1 @@
+Add a new property called 'image scale' to the schema of the Teaser Block. @cihanandac

--- a/src/components/manage/Blocks/Teaser/DefaultBody.jsx
+++ b/src/components/manage/Blocks/Teaser/DefaultBody.jsx
@@ -27,7 +27,7 @@ const TeaserDefaultTemplate = (props) => {
   const image = data.preview_image?.[0];
   const align = data?.styles?.align;
   const scale = data?.styles?.scale;
-  
+
   const hasImageComponent = config.getComponent('Image').component;
   const Image = config.getComponent('Image').component || DefaultImage;
   const { openExternalLinkInNewTab } = config.settings;

--- a/src/components/manage/Blocks/Teaser/DefaultBody.jsx
+++ b/src/components/manage/Blocks/Teaser/DefaultBody.jsx
@@ -26,12 +26,13 @@ const TeaserDefaultTemplate = (props) => {
   const href = data.href?.[0];
   const image = data.preview_image?.[0];
   const align = data?.styles?.align;
-
+  const scale = data?.styles?.scale;
+  
   const hasImageComponent = config.getComponent('Image').component;
   const Image = config.getComponent('Image').component || DefaultImage;
   const { openExternalLinkInNewTab } = config.settings;
   const defaultImageSrc =
-    href && flattenToAppURL(getTeaserImageURL({ href, image, align }));
+    href && flattenToAppURL(getTeaserImageURL({ href, image, align, scale }));
 
   return (
     <div className={cx('block teaser', className)}>

--- a/src/components/manage/Blocks/Teaser/schema.js
+++ b/src/components/manage/Blocks/Teaser/schema.js
@@ -34,6 +34,10 @@ const messages = defineMessages({
     id: 'Alignment',
     defaultMessage: 'Alignment',
   },
+  scale: {
+    id: 'image_scale',
+    defaultMessage: 'Image size',
+  },
 });
 
 export const TeaserSchema = ({ intl }) => {
@@ -96,8 +100,19 @@ export const TeaserSchema = ({ intl }) => {
     actions: ['left', 'right', 'center'],
     default: 'left',
   };
+  schema.properties.styles.schema.properties.scale = {
+    title: intl.formatMessage(messages.scale),
+    choices: [
+      ['mini', 'Mini'],
+      ['preview', 'Preview'],
+      ['teaser', 'Teaser'],
+      ['large', 'Large'],
+      ['great', 'Great'],
+    ],
+    default: 'teaser',
+  };
 
-  schema.properties.styles.schema.fieldsets[0].fields = ['align'];
+  schema.properties.styles.schema.fieldsets[0].fields = ['align', 'scale'];
 
   return schema;
 };

--- a/src/components/manage/Blocks/Teaser/schema.js
+++ b/src/components/manage/Blocks/Teaser/schema.js
@@ -38,6 +38,22 @@ const messages = defineMessages({
     id: 'image_scale',
     defaultMessage: 'Image size',
   },
+  mini: {
+    id: 'Mini',
+    defaultMessage: 'Mini',
+  },
+  preview: {
+    id: 'Preview',
+    defaultMessage: 'Preview',
+  },
+  large: {
+    id: 'Large',
+    defaultMessage: 'Large',
+  },
+  great: {
+    id: 'Great',
+    defaultMessage: 'Great',
+  },
 });
 
 export const TeaserSchema = ({ intl }) => {
@@ -103,11 +119,11 @@ export const TeaserSchema = ({ intl }) => {
   schema.properties.styles.schema.properties.scale = {
     title: intl.formatMessage(messages.scale),
     choices: [
-      ['mini', 'Mini'],
-      ['preview', 'Preview'],
-      ['teaser', 'Teaser'],
-      ['large', 'Large'],
-      ['great', 'Great'],
+      ['mini', intl.formatMessage(messages.mini)],
+      ['preview', intl.formatMessage(messages.preview)],
+      ['teaser', intl.formatMessage(messages.teaser)],
+      ['large', intl.formatMessage(messages.large)],
+      ['great', intl.formatMessage(messages.great)],
     ],
     default: 'teaser',
   };

--- a/src/components/manage/Blocks/Teaser/utils.js
+++ b/src/components/manage/Blocks/Teaser/utils.js
@@ -1,14 +1,14 @@
 import { isInternalURL } from '@plone/volto/helpers';
 import config from '@plone/volto/registry';
 
-export function getTeaserImageURL({ href, image, align }) {
+export function getTeaserImageURL({ href, image, align, scale }) {
   // The default scale used in teasers is the 'teaser' scale
   // except if it's customized otherwise in the teaser block settings
   // or if the teaser is center (top)
   const imageScale =
     align === 'center'
       ? 'great'
-      : config.blocks.blocksConfig['teaser'].imageScale || 'teaser';
+      : config.blocks.blocksConfig['teaser'].imageScale || scale;
 
   if (image) {
     // If the image is overriden locally in the teaser block

--- a/src/components/manage/Blocks/Teaser/utils.js
+++ b/src/components/manage/Blocks/Teaser/utils.js
@@ -1,7 +1,7 @@
 import { isInternalURL } from '@plone/volto/helpers';
 import config from '@plone/volto/registry';
 
-export function getTeaserImageURL({ href, image, align, scale }) {
+export function getTeaserImageURL({ href, image, align, scale = 'teaser' }) {
   // The default scale used in teasers is the 'teaser' scale
   // except if it's customized otherwise in the teaser block settings
   // or if the teaser is center (top)


### PR DESCRIPTION
This commit adds a new property called 'Image scale' to the schema of the Teaser Block in Volto. This property allows for the size of the image in the block to be adjusted based on its alignment. The default value for it is 'teaser' as it was originally set to this value. If the image align is not center, the scale will be set by this property. If the image align is center, the scale will be set to 'great'. 

Closes #4653