### PR TITLE
Don't decode querystring while adding apiExpanders

### DIFF
--- a/news/4718.bugfix
+++ b/news/4718.bugfix
@@ -1,0 +1,1 @@
+Fix fetching API paths with urlencoded characters in the querystring. @davisagli

--- a/src/middleware/api.js
+++ b/src/middleware/api.js
@@ -43,7 +43,7 @@ export function addExpandersToPath(path, type, isAnonymous) {
   const {
     url,
     query: { expand, ...query },
-  } = qs.parseUrl(path);
+  } = qs.parseUrl(path, { decode: false });
 
   const expandersFromConfig = apiExpanders
     .filter((expand) => matchPath(url, expand.match) && expand[type])


### PR DESCRIPTION
addExpandersToPath parses the current querystring, makes modifications, and then stringifies it again. stringify is called with `encode: false` so we need to call parseUrl with `decode: false` to match.

This should be backwards compatible unless there are expanders whose name includes an urlencoded character, or code somewhere which is already doing extra encoding to work around this bug.

Fixes #4718