### PR TITLE
fix:blacklisted routes match check

### DIFF
--- a/src/components/manage/UniversalLink/UniversalLink.jsx
+++ b/src/components/manage/UniversalLink/UniversalLink.jsx
@@ -66,10 +66,10 @@ const UniversalLink = ({
     }
   }
 
-  const isBlacklisted =
-    (config.settings.externalRoutes ?? []).find((route) =>
-      matchPath(flattenToAppURL(url), route.match),
-    )?.length > 0;
+  const isBlacklisted = !!(config.settings.externalRoutes ?? []).find((route) =>
+    matchPath(flattenToAppURL(url), route.match),
+  );
+
   const isExternal = !isInternalURL(url) || isBlacklisted;
   const isDownload = (!isExternal && url.includes('@@download')) || download;
   const isDisplayFile =


### PR DESCRIPTION
found a small issue with `isBlacklisted` method of checking an external to Volto route. 

Previous implementation would always show routes from `externalRoutes` as not-blacklisted resulting in non-volto routes being rendered by Volto

