### PR TITLE
Backport master docs to 16.x.x.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -604,7 +604,7 @@
 - Enable the use of yarn 3 in the build by default @sneridagh
 - The `ContentsBreadcrumbs` component now renders the whole language name of the language root folder (if any) instead of just the `id` (before: `de`, now: `Deutsch`) @sneridagh
 
-See https://6.dev-docs.plone.org/volto/upgrade-guide/index.html for more information.
+See https://6.docs.plone.org/volto/upgrade-guide/index.html for more information.
 
 ### Feature
 
@@ -1099,7 +1099,7 @@ See https://6.dev-docs.plone.org/volto/upgrade-guide/index.html for more informa
 - Moved all sentry-related code from Volto to the `@plone-collective/volto-sentry` package. @tiberiuichim
 - The listing block icon has been improved to avoid confusion with the normal text list. @sneridagh
 
-See https://6.dev-docs.plone.org/volto/upgrade-guide/index.html for more information.
+See https://6.docs.plone.org/volto/upgrade-guide/index.html for more information.
 
 ### Feature
 
@@ -1209,7 +1209,7 @@ See https://6.dev-docs.plone.org/volto/upgrade-guide/index.html for more informa
 
 - Sentry integration is now lazy-loaded. The `sentryOptions` key from the `settings` registry becomes a callable that passes resolved sentry libraries. @tiberiuichim
 
-  See https://6.dev-docs.plone.org/volto/upgrade-guide/index.html for more information.
+  See https://6.docs.plone.org/volto/upgrade-guide/index.html for more information.
 
 ### Feature
 
@@ -1273,7 +1273,7 @@ See https://6.dev-docs.plone.org/volto/upgrade-guide/index.html for more informa
 - Upgrade to Razzle 4 @davisagli
 - Jest downgraded from 27 to 26 @davisagli
 
-See https://6.dev-docs.plone.org/volto/upgrade-guide/index.html for more information.
+See https://6.docs.plone.org/volto/upgrade-guide/index.html for more information.
 
 ### Internal
 
@@ -1313,7 +1313,7 @@ See https://6.dev-docs.plone.org/volto/upgrade-guide/index.html for more informa
 ### Breaking
 
 - `react-window` no longer a Volto dependency @sneridagh
-  See https://6.dev-docs.plone.org/volto/upgrade-guide/index.html for more information.
+  See https://6.docs.plone.org/volto/upgrade-guide/index.html for more information.
 
 ### Bugfix
 
@@ -1352,7 +1352,7 @@ See https://6.dev-docs.plone.org/volto/upgrade-guide/index.html for more informa
 ### Breaking
 
 - Move Layout constants to `config.views.layoutViewsNamesMapping`. Complete the list. i18n the list. Improve Display component. @sneridagh
-  See https://6.dev-docs.plone.org/volto/upgrade-guide/index.html for more information.
+  See https://6.docs.plone.org/volto/upgrade-guide/index.html for more information.
 
 ### Feature
 
@@ -1398,7 +1398,7 @@ Undo html_static_path configuration in `plone/documentation`, and restore image 
 ### Breaking
 
 - Main workflow change menu changed from Pastanaga UI simplification to classic Plone implementation. @sneridagh
-  See https://6.dev-docs.plone.org/volto/upgrade-guide/index.html for more information.
+  See https://6.docs.plone.org/volto/upgrade-guide/index.html for more information.
 
 ### Feature
 
@@ -1494,7 +1494,7 @@ Undo html_static_path configuration in `plone/documentation`, and restore image 
 - change password-reset url to be consistent with Plone configuration @erral
 - Simplify over the existing Component Registry API. The `component` key has been flattened for simplification and now it's mapped directly to the `component` argument of `registerComponent`. @sneridagh
 
-See https://6.dev-docs.plone.org/volto/upgrade-guide/index.html for more information.
+See https://6.docs.plone.org/volto/upgrade-guide/index.html for more information.
 
 ### Feature
 
@@ -2072,14 +2072,14 @@ Use next release instead: https://github.com/plone/volto/releases/tag/16.0.0-alp
 ### Breaking
 
 - Upgrade `react-cookie` to the latest version. @sneridagh @robgietema
-  See https://6.dev-docs.plone.org/volto/upgrade-guide/index.html for more information.
+  See https://6.docs.plone.org/volto/upgrade-guide/index.html for more information.
 - Language Switcher no longer takes care of the change of the language on the Redux Store. This responsibility has been unified in the API Redux middleware @sneridagh
 - Markup change in `LinkView` component.
 - Rename `core-sandbox` to `coresandbox` for sake of consistency @sneridagh
 - Extend the original intent and rename `RAZZLE_TESTING_ADDONS` to `ADDONS`. @sneridagh
-  See https://6.dev-docs.plone.org/volto/upgrade-guide/index.html for more information.
+  See https://6.docs.plone.org/volto/upgrade-guide/index.html for more information.
 - Lazyload Draft.js library. See the upgrade guide on how that impacts you, in case you have extended the rich text editor configuration @tiberiuichim @kreafox
-  See https://6.dev-docs.plone.org/volto/upgrade-guide/index.html for more information.
+  See https://6.docs.plone.org/volto/upgrade-guide/index.html for more information.
 - Deprecating `lang` cookie in favor of Plone official one `I18N_LANGUAGE` @sneridagh
 
 ### Feature
@@ -5025,7 +5025,7 @@ https://6.docs.plone.org/volto/upgrade-guide/index.html
 - Added item type as a tooltip in contents @nzambello
 - Added Italian translations and translated array, token and select widget. @giuliaghisini
 - Added uploading image preview in FileWidget @iFlameing
-- Allow custom express middleware declared with `settings.expressMiddleware`. See [Custom Express middleware](https://6.dev-docs.plone.org/volto/recipes/express.html) @tiberiuichim
+- Allow custom express middleware declared with `settings.expressMiddleware`. See [Custom Express middleware](https://6.docs.plone.org/volto/recipes/express.html) @tiberiuichim
 
 ### Bugfix
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 # Contributing to Volto
 
-See [Contributing to Volto](https://6.dev-docs.plone.org/volto/developer-guidelines/contributing.html).
+See [Contributing to Volto](https://6.docs.plone.org/volto/developer-guidelines/contributing.html).

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Please create a new [issue](https://github.com/plone/volto/issues/new) or [pull 
 
 ## Documentation
 
-You can find the latest (in-progress) documentation in [https://6.dev-docs.plone.org/](https://6.dev-docs.plone.org/volto/index.html)
+You can find the latest documentation in [https://6.docs.plone.org/](https://6.docs.plone.org/volto/index.html)
 
 ## Training
 
@@ -243,7 +243,7 @@ We do not guarantee that deprecated browsers (e.g., Internet Explorer 11) are su
 
 ## Upgrades
 
-You can find the upgrade guide here: https://6.dev-docs.plone.org/volto/upgrade-guide/index.html
+You can find the upgrade guide here: https://6.docs.plone.org/volto/upgrade-guide/index.html
 
 ## Volto Development
 
@@ -318,11 +318,11 @@ yarn test
 
 Here you can find a guide on how acceptance testing is done in Volto:
 
-https://6.dev-docs.plone.org/volto/developer-guidelines/acceptance-tests.html
+https://6.docs.plone.org/volto/developer-guidelines/acceptance-tests.html
 
 ## Translations
 
-If you would like contribute to translate Volto into several languages, please, read the [Internationalization (i18n) guide](https://6.dev-docs.plone.org/volto/recipes/i18n.html).
+If you would like contribute to translate Volto into several languages, please, read the [Internationalization (i18n) guide](https://6.docs.plone.org/volto/recipes/i18n.html).
 
 ## Contributors
 

--- a/docs/source/configuration/settings-reference.md
+++ b/docs/source/configuration/settings-reference.md
@@ -296,8 +296,9 @@ styleClassNameExtenders
         },
       ];
     ```
+
 apiExpanders
-    You can configure the API expanders Volto uses using the `settings.apiExpanders` like:
+    You can configure the API expanders in Volto using `settings.apiExpanders`, as in the following example.
 
     ```jsx
     import { GET_CONTENT } from '@plone/volto/constants/ActionTypes';
@@ -326,7 +327,7 @@ apiExpanders
     }
     ```
 
-    If you want that Volto only does a single request and concentrate all the expanders in it then configure `apiExpanders` like:
+    If you want Volto to make only a single request, combining all the expanders in it, then configure `apiExpanders` as shown.
 
     ```jsx
     config.settings.apiExpanders = [

--- a/docs/source/contributing/style-guide.md
+++ b/docs/source/contributing/style-guide.md
@@ -27,7 +27,7 @@ Volto adopted some time ago [Storybook](https://storybook.js.org), a tool that i
 
 Not all Volto's visual components are covered yet in Storybook, but it has already a good foundation.
 
-You can find the current Storybook build in: https://6.dev-docs.plone.org/storybook
+You can find the current Storybook build in: https://6.docs.plone.org/storybook
 
 ## Quanta, the design system for Plone 6
 

--- a/docs/source/getting-started/install.md
+++ b/docs/source/getting-started/install.md
@@ -28,7 +28,10 @@ Volto can be installed in any operating system assuming that the following pre-r
 - [Docker](https://www.docker.com/get-started) (if using the Plone docker images)
 
 ```{note}
-*UPDATE 2022-10-25*: Since 2022-10-25, NodeJS 18 is in LTS state (https://github.com/nodejs/release#release-schedule). However, due to changes in internal SSL libraries, some Volto dependencies have been deprecated and need to be updated in order to continue working in NodeJS 18, mainly Webpack 4 (see: https://github.com/webpack/webpack/issues/14532#issuecomment-947525539 for further information). You can still use it, but NodeJS should be run under a special flag: `NODE_OPTIONS=--openssl-legacy-provider`. See also Volto's PR: https://github.com/plone/volto/pull/3699 for more information.
+*UPDATE 2022-10-25*: Since 2022-10-25, NodeJS 18 is in LTS state (https://github.com/nodejs/release#release-schedule).
+However, due to changes in internal SSL libraries, some Volto dependencies have been deprecated and need to be updated in order to continue working in NodeJS 18, mainly Webpack 4 (see: https://github.com/webpack/webpack/issues/14532#issuecomment-947525539 for further information).
+You can still use it, but NodeJS should be run under a special flag: `NODE_OPTIONS=--openssl-legacy-provider`.
+See also Volto's PR: https://github.com/plone/volto/pull/3699 for more information.
 ```
 
 The versions of Python that are supported in Volto depend on the version of Plone that you use.
@@ -192,7 +195,8 @@ docker run -it --rm --name=plone \
 ```
 
 ```{tip}
-This setup is meant only for demonstration and quick testing purposes (since it destroys the container on exit (--rm)). In case you need production ready deployment, check the latest [Plone Deployment Training](https://training.plone.org/5/plone-deployment/index.html).
+This setup is meant only for demonstration and quick testing purposes, since it destroys the container on exit (`--rm`).
+In case you need production-ready deployment, check the latest [Plone Deployment Training](https://training.plone.org/plone-deployment/index.html).
 ```
 
 ```{note}
@@ -222,7 +226,7 @@ You may choose to install the canary version, which is the latest alpha release,
 
 1.  Open a terminal and execute:
 
-    ```bash
+    ```shell
     npm install -g yo @plone/generator-volto
     # install latest stable release
     yo @plone/volto
@@ -230,12 +234,13 @@ You may choose to install the canary version, which is the latest alpha release,
     yo @plone/volto --canary
     ```
 
-2.  Answer to the prompted questions and provide the name of the new app (folder) to be created. For the sake of this documentation, provide `myvoltoproject` as project name then.
+2.  Answer the questions when prompted, and provide the name of the new app (folder) to be created.
+    For the sake of this documentation, provide `myvoltoproject` as the project name.
 
     ````{note}
     You can run the generator with parameters to tailor your requirements.
 
-    ```bash
+    ```shell
     yo @plone/volto --help
     ```
 

--- a/docs/source/getting-started/install.md
+++ b/docs/source/getting-started/install.md
@@ -234,6 +234,8 @@ You may choose to install the canary version, which is the latest alpha release,
     yo @plone/volto --canary
     ```
 
+    See {doc}`../recipes/creating-project` for more advanced options that can be passed to the generator.
+
 2.  Answer the questions when prompted, and provide the name of the new app (folder) to be created.
     For the sake of this documentation, provide `myvoltoproject` as the project name.
 

--- a/docs/source/getting-started/others.md
+++ b/docs/source/getting-started/others.md
@@ -11,19 +11,16 @@ myst:
 
 ## Plone Trainings
 
-On the [Plone Trainings Website](https://training.plone.org) you'll find
-Volto-dedicated open training materials plus React and other
-Javascript-centered trainings.
+On the [Plone Training website](https://training.plone.org), you'll find Volto-dedicated training materials, plus other JavaScript-centered trainings.
 
 - [Mastering Plone 6 Development](https://training.plone.org/mastering-plone/)
   The comprehensive training on Plone 6 with best practice tips for developers and integrators.
-- [Volto](https://training.plone.org/5/volto/index.html)
-  A detailed training on how to create your own website using Volto frontend.
 - [Volto Hands-On](https://training.plone.org/voltohandson/index.html)
 - [Volto Add-ons Development](https://training.plone.org/voltoaddons/index.html)
-- [Plone Deployment](https://training.plone.org/5/plone-deployment/index.html)
-- [React](https://training.plone.org/react/index.html)
-- [JavaScript For Plone Developers](https://training.plone.org/5/javascript/index.html)
+- [Effective Volto](https://training.plone.org/effective-volto/index.html)
+- [Plone Deployment](https://training.plone.org/plone-deployment/index.html)
+- [Volto](https://2022.training.plone.org/volto/index.html) (archived)
+- [JavaScript For Plone Developers](https://2022.training.plone.org/javascript/index.html) (archived)
 
 ## How does it work under the hood
 
@@ -31,29 +28,37 @@ You can watch the talk during the World Plone Day 2021:
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/kHec4MXH8vo" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-## Presentations at the last two PloneConf's
+## Presentations at Plone Conferences (PloneConf) and other events
 
-In recent years the new Volto frontend for Plone has been presented in more and more talks from
-our yearly Conferences:
+In recent years the React based Volto frontend for Plone has been presented in more and more talks at our yearly Conferences.
 
-- [PloneConf 2021 Playlist on YouTube](https://www.youtube.com/playlist?list=PLGN9BI-OAQkQDLQinBwdEXpebDTQCwdGi)
+### PloneConf 2022
 
-- [PloneConf 2020 Playlist on YouTube](https://www.youtube.com/playlist?list=PLGN9BI-OAQkTJPayNdKIZ8lLDm5RVOLV3)
+[PloneConf 2022 full Playlist on Youtube](https://www.youtube.com/playlist?list=PLGN9BI-OAQkQxqQcCZeJefMC8XlA_qv3Z)
+
+Plone 6 site presentations:
+
+- [Rai Way: Plone6 supporting the world of italian information, sports and entertainment](https://www.youtube.com/watch?v=hHHGlSjf5O4&list=PLGN9BI-OAQkQxqQcCZeJefMC8XlA_qv3Z)
+- [How Plone Powers Hundreds of Websites at one of the Largest Research Institutions in Europe](https://www.youtube.com/watch?v=bxWt-GEmPcc&list=PLGN9BI-OAQkQxqQcCZeJefMC8XlA_qv3Z)
+
+Developer/intergrator talks:
+
+- [Anatomy of a Volto project](https://www.youtube.com/watch?v=JtNufyFlgc8&list=PLGN9BI-OAQkQxqQcCZeJefMC8XlA_qv3Z)
+- [Creating a Volto Theme](https://www.youtube.com/watch?v=AMHN74Jr27Y&list=PLGN9BI-OAQkQxqQcCZeJefMC8XlA_qv3Z)
+- [A Deep Dive Into Internals Of Volto](https://www.youtube.com/watch?v=sMeTDRgp3uI&list=PLGN9BI-OAQkQxqQcCZeJefMC8XlA_qv3Z)
+- [DevOps Bird's Eye View on the Plone 6 Backend](https://www.youtube.com/watch?v=L5PvGwWC9P4&list=PLGN9BI-OAQkQxqQcCZeJefMC8XlA_qv3Z)
+
+## Previous PloneConfs
+
+- [PloneConf 2021 full Playlist on YouTube](https://www.youtube.com/playlist?list=PLGN9BI-OAQkQDLQinBwdEXpebDTQCwdGi)
+- [PloneConf 2020 full Playlist on YouTube](https://www.youtube.com/playlist?list=PLGN9BI-OAQkTJPayNdKIZ8lLDm5RVOLV3)
 
 
-## PloneConf 2019
+## World Plone Day 2022
 
-PloneConf 2019 and other events have several Volto-relevant presentations, but not stored in a
-single playlist:
-### Howtos
+World Plone Day is a 24-hour streaming event, with the goal was to promote and educate the public about the benefits of using Plone and of being part of the Plone community. [Full World Plone Day 2022 playlist on Youtube](https://www.youtube.com/playlist?list=PLGN9BI-OAQkQmEqf6O8jeyoFY1b2hD1uL)
 
-- [Rob Gietema - How to create your own Volto site!](https://www.youtube.com/watch?v=3QLN8tsjjf4)
-- [Rodrigo Ferreira de Souza - Data migration to Plone 5.2 and Volto](https://www.youtube.com/watch?v=kb9SEsnllqE)
-
-### Panels and discussions
-
-- [Timo Stollenwerk - Breaking New Grounds](https://www.youtube.com/watch?v=9nRxgeCuIDs)
-- [Panel - Ask me anything on Volto](https://www.youtube.com/watch?v=jwbpXJlDVOs)
-- [Luca Pisani - Plone and React.js: An interview to Volto](https://www.youtube.com/watch?v=JZFUOG843no)
-- [Victor Fernandez de Alba - Plone Beyond 2020: Jump into Volto today!](https://www.youtube.com/watch?v=8QrGOgXo1Js)
-- [Nicola Zambello - A Volto story: building a website by prototyping](https://www.youtube.com/watch?v=xtxJURICkWc)
+- [Plone 6 Volto's Seamless Mode](https://www.youtube.com/watch?v=Mj8pHRBls-w&list=PLGN9BI-OAQkQmEqf6O8jeyoFY1b2hD1uL)
+- [Volto add ons separator and carousel](https://www.youtube.com/watch?v=eyTMI5TYcVg&list=PLGN9BI-OAQkQmEqf6O8jeyoFY1b2hD1uL)
+- [Weekly Volto Live – Retrospective](https://www.youtube.com/watch?v=WT6OjkSrB20&list=PLGN9BI-OAQkQmEqf6O8jeyoFY1b2hD1uL)
+- [Migrating from Classic to Volto](https://www.youtube.com/watch?v=09fg456T90s&list=PLGN9BI-OAQkQmEqf6O8jeyoFY1b2hD1uL)

--- a/docs/source/recipes/creating-project.md
+++ b/docs/source/recipes/creating-project.md
@@ -9,16 +9,28 @@ myst:
 
 # Creating a new Volto project
 
-For using Volto for a project (i.e. use Volto as a library), You should use Volto's project generator `@plone/generator-volto`. It's a boilerplate generator based in Yeoman that will provide you with the basic files and folder structure to bootstrap a Volto site. In addition to bootstrapping standalone Volto projects, it can also bootstrap Volto addons.
+For using Volto for a project—in other words, use Volto as a library—you should use Volto's project generator `@plone/generator-volto`.
+It's a boilerplate generator based in Yeoman that will provide you with the basic files and folder structure to bootstrap a Volto site.
+In addition to bootstrapping stand-alone Volto projects, it can also bootstrap Volto add-ons.
 
 1.  Open a terminal and execute:
 
     ```shell
     npm install -g yo @plone/generator-volto
+    # Install the latest and stable release of Volto with the following command
     yo @plone/volto
+    # or you can install the "canary" release, including any alpha release
+    yo @plone/volto --canary
+    # or you can install any specific released version
+    yo @plone/volto --volto=15.0.0
+    # you can even pass a GitHub repo and specific branch
+    yo @plone/volto --volto=plone/volto#16.0.0
+    # you can bootstrap with add-ons
+    yo @plone/volto --addon=volto-form-block
     ```
 
-2.  Answer to the prompted questions and provide the name of the new app (folder) to be created. For the sake of this documentation, provide `myvoltoproject` as project name then.
+2.  Answer the questions when prompted, and provide the name of the new app (folder) to be created.
+    For the sake of this documentation, provide `myvoltoproject` as the project name then.
 
     ````{note}
     You can run the generator with parameters to tailor your requirements.

--- a/docs/source/upgrade-guide/index.md
+++ b/docs/source/upgrade-guide/index.md
@@ -518,7 +518,7 @@ If you are extending an existing one, you should add it as a normal `schemaEnhan
 ```
 
 ```{seealso}
-See https://6.dev-docs.plone.org/volto/blocks/block-style-wrapper.html for more documentation.
+See https://6.docs.plone.org/volto/blocks/block-style-wrapper.html for more documentation.
 ```
 
 ### Sentry integration moved from Volto core to add-on

--- a/docs/source/user-manual/copy-paste-blocks.md
+++ b/docs/source/user-manual/copy-paste-blocks.md
@@ -14,6 +14,7 @@ myst:
 Volto supports copying and cutting of blocks from one page, and pasting them to another page.
 This chapter describes how to do so.
 
+
 (copy-cut-blocks-label)=
 
 ## Copy or cut blocks
@@ -27,6 +28,7 @@ This will select all the blocks between the start and end blocks, allowing you t
 
 ```{video} /_static/user-manual/blocks/block-copy-cut.mp4
 ```
+
 
 (paste-blocks-label)=
 

--- a/news/4727.documentation
+++ b/news/4727.documentation
@@ -1,0 +1,1 @@
+Backport most documentation differences from `master` to `16.x.x`. @stevepiercy

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -65,7 +65,7 @@
 
 - Removed `Razzle` as dependency, leave only the `babel-preset-razzle` one which is enough.
 
-  See https://6.dev-docs.plone.org/volto/upgrade-guide/index.html for more information.
+  See https://6.docs.plone.org/volto/upgrade-guide/index.html for more information.
 
 ## 1.6.0 (2022-08-05)
 

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -6,7 +6,7 @@ This package is a library of scripts that are useful to automate certain tasks w
 
 It scans and detects i18n messages from the code and adds them to the i18n machinery.
 
-See https://6.dev-docs.plone.org/volto/recipes/i18n.html for more information.
+See https://6.docs.plone.org/volto/recipes/i18n.html for more information.
 
 This script is installed in the `node_modules/.bin` directory and can be called via `yarn i18n` or directly in the `scripts` `package.json` part.
 


### PR DESCRIPTION
This PR backports most of the differences in docs from `master` to `16.x.x`.

A few differences will remain after this is merged, and they should be reviewed for accuracy. Sorry, I don't follow releases closely enough to advise.