### PR TITLE
Fix whitespace in locales created by the generator

### DIFF
--- a/packages/generator-volto/generators/app/templates/locales/de/LC_MESSAGES/volto.po
+++ b/packages/generator-volto/generators/app/templates/locales/de/LC_MESSAGES/volto.po
@@ -1,13 +1,4 @@
-# Translation of plone.pot to German
-# Jan Ulrich Hasecke <jan.ulrich@hasecke.com>, 2003-2010.
-# Simon Eisenmann <simon@struktur.de>, 2003.
-# Hanno Schlichting <plone@hannosch.info>, 2003-2008.
-# Dominik Bittl <dominik@umount.org>, 2005.
-# Christian Ullrich <chris@chrullrich.de>, 2005.
-# Thomas Lotze <tl@gocept.com>, 2005-2008.
-# Sven Deichmann <deichmann@werkbank.com>, 2008-2010.
-# Harald Friessnegger <harald@webmeisterei.com>, 2011.
-# Andreas Jung <info@zopyx.com>, 2012
+# Translation of volto.pot to German
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"

--- a/packages/generator-volto/generators/app/templates/locales/es/LC_MESSAGES/volto.po
+++ b/packages/generator-volto/generators/app/templates/locales/es/LC_MESSAGES/volto.po
@@ -1,6 +1,3 @@
-# Gettext Message File for Plone
-# Translators:
-# Leonardo J. Caballero G. <leonardocaballero@gmail.com>, 2019.
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
@@ -20,3 +17,5 @@ msgstr ""
 "Preferred-Encodings: utf-8\n"
 "Domain: volto\n"
 "X-Is-Fallback-For: es-ar es-bo es-cl es-co es-cr es-do es-ec es-es es-sv es-gt es-hn es-mx es-ni es-pa es-py es-pe es-pr es-us es-uy es-ve\n"
+
+

--- a/packages/generator-volto/generators/app/templates/locales/eu/LC_MESSAGES/volto.po
+++ b/packages/generator-volto/generators/app/templates/locales/eu/LC_MESSAGES/volto.po
@@ -1,4 +1,4 @@
-# Translation of plone.pot to EU
+# Translation of volto.pot to EU
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
@@ -15,3 +15,5 @@ msgstr ""
 "Language-Code: eu\n"
 "Language-Name: eu\n"
 "Preferred-Encodings: utf-8 latin1\n"
+
+

--- a/packages/generator-volto/generators/app/templates/locales/fr/LC_MESSAGES/volto.po
+++ b/packages/generator-volto/generators/app/templates/locales/fr/LC_MESSAGES/volto.po
@@ -1,13 +1,4 @@
-# Translation of plone.pot to French
-# French Translation Team <plone-i18n@lists.sourceforge.net>, 2003-2006.
-# Sebastien Douche <sdouche@gmail.com>, 2005-2007.
-# Encolpe Degoute <encolpe.degoute@ingeniweb.com>, 2006, 2007, 2008.
-# Gilles Lenfant <gilles.lenfant@ingeniweb.com>, 2008.
-# Encolpe Degoute <encolpe@gmail.com>, 2008.
-# Vincent Fretin <vincent.fretin@gmail.com>, 2009.
-# Kevin Deldycke <kevin@deldycke.com>, 2009.
-# JeanMichel FRANCOIS <toutpt@gmail.com>, 2010.
-# Denis Bitouzé <denis.bitouze@univ-littoral.fr>, 2019.
+# Translation of volto.pot to French
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
@@ -25,3 +16,5 @@ msgstr ""
 "Language-Name: French\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "X-Is-Fallback-For: fr-be fr-ca fr-lu fr-mc fr-ch fr-fr\n"
+
+

--- a/packages/generator-volto/generators/app/templates/locales/it/LC_MESSAGES/volto.po
+++ b/packages/generator-volto/generators/app/templates/locales/it/LC_MESSAGES/volto.po
@@ -10,3 +10,5 @@ msgstr ""
 "Content-Type: \n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+

--- a/packages/generator-volto/generators/app/templates/locales/ja/LC_MESSAGES/volto.po
+++ b/packages/generator-volto/generators/app/templates/locales/ja/LC_MESSAGES/volto.po
@@ -1,5 +1,3 @@
-# Manabu TERADA <terada@cmscom.jp> 2019
-# Peacock <peacock0803sz@gmail.com> 2019
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
@@ -17,3 +15,5 @@ msgstr ""
 "Language-Name: Japanese\n"
 "Preferred-Encodings: utf-8\n"
 "X-Is-Fallback-For: ja-jp\n"
+
+

--- a/packages/generator-volto/generators/app/templates/locales/nl/LC_MESSAGES/volto.po
+++ b/packages/generator-volto/generators/app/templates/locales/nl/LC_MESSAGES/volto.po
@@ -1,18 +1,3 @@
-# Translators:
-# Fred van Dijk <info@zestsoftware.nl>, 2016
-# Coen van der Kamp <c.van.der.kamp@zestsoftware.nl>, 2015
-# Danny Bloemendaal <danny.bloemendaal@informaat.nl>, 2007
-# Diederik Veeze <diederik_24@hotmail.com>, 2015
-# Duco Dokter <dokter@w20e.com>, 2007
-# Esther Ladage <e.ladage@zestsoftware.nl>, 2005
-# Jean-Paul Ladage <j.ladage@zestsoftware.nl>, 2017
-# Kees Hink <hink@gw20e.com>, 2010
-# Maarten Kling <maarten@fourdigits.nl>, 2013
-# Mark van Lent <m.vanlent@zestsoftware.nl>, 2007
-# Mirella van Teulingen <m.van.teulingen@zestsoftware.nl>, 2005
-# Reinout van Rees <reinout@zestsoftware.nl>, 2008
-# Roel Bruggink <roel@fourdigits.nl>, 2009
-# Wietze Helmantel <helmantel@goldmund-wyldebeast-wunderliebe.com>, 2007
 msgid ""
 msgstr ""
 "Project-Id-Version: PlonenPOT-Creation-Date: 2017-04-27T19:30:59.079Z\n"

--- a/packages/generator-volto/generators/app/templates/locales/pt/LC_MESSAGES/volto.po
+++ b/packages/generator-volto/generators/app/templates/locales/pt/LC_MESSAGES/volto.po
@@ -1,6 +1,3 @@
-# Translators:
-# Emanuel de Jesus <emanuel.angelo@gmail.com>, 2019
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
@@ -18,3 +15,5 @@ msgstr ""
 "Language-Code: pt\n"
 "Language-Name: Portuguese\n"
 "Preferred-Encodings: utf-8\n"
+
+

--- a/packages/generator-volto/generators/app/templates/locales/pt_BR/LC_MESSAGES/volto.po
+++ b/packages/generator-volto/generators/app/templates/locales/pt_BR/LC_MESSAGES/volto.po
@@ -1,5 +1,3 @@
-# Translators:
-# Léu Almeida <leo@webid.net.br>, 2019
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
@@ -16,3 +14,5 @@ msgstr ""
 "Language-Code: pt-br\n"
 "Language-Name: Português do Brasil\n"
 "Preferred-Encodings: utf-8\n"
+
+

--- a/packages/generator-volto/generators/app/templates/locales/ro/LC_MESSAGES/volto.po
+++ b/packages/generator-volto/generators/app/templates/locales/ro/LC_MESSAGES/volto.po
@@ -1,5 +1,3 @@
-# Translation of plone.pot to Romanian
-# Alin Voinea <avoinea@plone.org>, 2020.
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"

--- a/packages/generator-volto/generators/app/templates/locales/volto.pot
+++ b/packages/generator-volto/generators/app/templates/locales/volto.pot
@@ -12,3 +12,5 @@ msgstr ""
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8\n"
 "Domain: volto\n"
+
+

--- a/packages/generator-volto/news/4737.bugfix
+++ b/packages/generator-volto/news/4737.bugfix
@@ -1,0 +1,1 @@
+Fix whitespace in empty locales created by the generator. @davisagli


### PR DESCRIPTION
This avoids creation of changes when i18n is synced, which causes the i18n check in a plone cookiecutter project to fail. Fixes https://github.com/collective/cookiecutter-plone-starter/issues/63

Also removed the translator names from the empty locale files, since these are locales for a new project, not the existing translations that those people worked on.