### PR TITLE
Fix HMR of @plone/volto

### DIFF
--- a/news/4799.bugfix
+++ b/news/4799.bugfix
@@ -1,0 +1,1 @@
+Fix hot module reloading of changes to `@plone/volto`. @davisagli

--- a/razzle.config.js
+++ b/razzle.config.js
@@ -341,6 +341,11 @@ const defaultModify = ({
 
   if (config.devServer) {
     config.devServer.static.watch.ignored = /node_modules\/(?!@plone\/volto)/;
+    config.snapshot = {
+      managedPaths: [
+        /^(.+?[\\/]node_modules[\\/](?!(@plone[\\/]volto))(@.+?[\\/])?.+?)[\\/]/,
+      ],
+    };
   }
 
   return config;


### PR DESCRIPTION
Fixes #4798 

With webpack 5, we need to also exclude node_modules/@plone/volto from the webpack cache, in addition to not ignoring it when watching for file updates. -- based on https://webpack.js.org/configuration/other-options/#managedpaths

Don't backport to volto 16.