### PR TITLE
WIP: Display password validation error if available; update minimum password length

### DIFF
--- a/src/components/theme/PasswordReset/PasswordReset.jsx
+++ b/src/components/theme/PasswordReset/PasswordReset.jsx
@@ -50,8 +50,8 @@ const messages = defineMessages({
     defaultMessage: 'New password',
   },
   passwordDescription: {
-    id: 'Enter your new password. Minimum 5 characters.',
-    defaultMessage: 'Enter your new password. Minimum 5 characters.',
+    id: 'Enter your new password. Minimum 8 characters.',
+    defaultMessage: 'Enter your new password. Minimum 8 characters.',
   },
   passwordRepeatTitle: {
     id: 'Confirm password',
@@ -227,6 +227,7 @@ class PasswordReset extends Component {
       );
     }
     if (this.props.token) {
+      const errmsg = (this.props.error) ? this.props.error.response.body.error : null;
       return (
         <div id="page-password-reset">
           <Helmet
@@ -238,7 +239,7 @@ class PasswordReset extends Component {
               description={this.props.intl.formatMessage(messages.description)}
               onSubmit={this.onSubmit}
               onCancel={this.onCancel}
-              error={this.state.error || this.props.error}
+              error={this.state.error || errmsg}
               schema={{
                 fieldsets: [
                   {


### PR DESCRIPTION
Since now `plone.restapi` respects the password policy (s. https://github.com/plone/plone.restapi/pull/1630), Volto should display validation errors from the PAS's `PasswordPolicyPlugin` or other plugins, e.g. [Products.PasswordStrength](https://github.com/collective/Products.PasswordStrength). See also https://github.com/plone/Products.PlonePAS/pull/75 which fixes the error message provided by the plugin.

Also update the minimum password length to the new default.