### PR TITLE
Add setting unwantedControlPanelsFields and use it in the function filterControlPanelsSchema

### DIFF
--- a/docs/source/configuration/settings-reference.md
+++ b/docs/source/configuration/settings-reference.md
@@ -205,8 +205,11 @@ controlpanels
 
     The group can be one of the default groups 'General', 'Content', 'Security', 'Add-on Configuration', 'Users and Groups' or a custom group.
 
+filterControlPanelsSchema
+    A schema factory for a control panel. It is used internally, to tweak the schemas provided by the controlpanel endpoint, to make them fit for Volto. Uses the ``unwantedControlPanelsFields`` setting.
+
 unwantedControlPanelsFields
-    Control panels fields that are not used on the Volto. It is used internally, to tweak the schemas provided by the controlpanel endpoint, to make them fit for Volto.
+    Control panels fields that are not used on the Volto. It is used internally by ``filterControlPanelsSchema`` function.
 
 errorHandlers
     A list of error handlers that will be called when there is an unhandled exception. Each error handler is a function that

--- a/docs/source/configuration/settings-reference.md
+++ b/docs/source/configuration/settings-reference.md
@@ -205,8 +205,8 @@ controlpanels
 
     The group can be one of the default groups 'General', 'Content', 'Security', 'Add-on Configuration', 'Users and Groups' or a custom group.
 
-filterControlPanelsSchema
-    A schema factory for a control panel. It is used internally, to tweak the schemas provided by the controlpanel endpoint, to make them fit for Volto.
+unwantedControlPanelsFields
+    Control panels fields that are not used on the Volto. It is used internally, to tweak the schemas provided by the controlpanel endpoint, to make them fit for Volto.
 
 errorHandlers
     A list of error handlers that will be called when there is an unhandled exception. Each error handler is a function that

--- a/docs/source/configuration/settings-reference.md
+++ b/docs/source/configuration/settings-reference.md
@@ -206,10 +206,13 @@ controlpanels
     The group can be one of the default groups 'General', 'Content', 'Security', 'Add-on Configuration', 'Users and Groups' or a custom group.
 
 filterControlPanelsSchema
-    A schema factory for a control panel. It is used internally, to tweak the schemas provided by the controlpanel endpoint, to make them fit for Volto. Uses the ``unwantedControlPanelsFields`` setting.
+    A schema factory for a control panel.
+    It is used internally, to tweak the schemas provided by the `@controlpanels` endpoint, making them fit for Volto.
+    It uses the `unwantedControlPanelsFields` setting.
 
 unwantedControlPanelsFields
-    Control panels fields that are not used on the Volto. It is used internally by ``filterControlPanelsSchema`` function.
+    Control panels fields that are not used in Volto.
+    It is used internally by the `filterControlPanelsSchema` function.
 
 errorHandlers
     A list of error handlers that will be called when there is an unhandled exception. Each error handler is a function that

--- a/docs/source/configuration/settings-reference.md
+++ b/docs/source/configuration/settings-reference.md
@@ -211,7 +211,7 @@ filterControlPanelsSchema
     It uses the `unwantedControlPanelsFields` setting.
 
 unwantedControlPanelsFields
-    Control panels fields that are not used in Volto.
+    Control panels' fields that are not used in Volto.
     It is used internally by the `filterControlPanelsSchema` function.
 
 errorHandlers

--- a/packages/volto/news/4819.feature
+++ b/packages/volto/news/4819.feature
@@ -1,0 +1,1 @@
+Replaces ``filterControlPanelsSchema`` setting by ``unwantedControlPanelsFields`. @wesleybl

--- a/packages/volto/news/4819.feature
+++ b/packages/volto/news/4819.feature
@@ -1,1 +1,1 @@
-Replaces ``filterControlPanelsSchema`` setting by ``unwantedControlPanelsFields`. @wesleybl
+Add setting ``unwantedControlPanelsFields`` and use it in the function ``filterControlPanelsSchema``. @wesleybl

--- a/packages/volto/news/4819.feature
+++ b/packages/volto/news/4819.feature
@@ -1,1 +1,1 @@
-Add setting ``unwantedControlPanelsFields`` and use it in the function ``filterControlPanelsSchema``. @wesleybl
+Add setting `unwantedControlPanelsFields` and use it in the function `filterControlPanelsSchema`. @wesleybl

--- a/packages/volto/src/components/manage/Controlpanels/Controlpanel.jsx
+++ b/packages/volto/src/components/manage/Controlpanels/Controlpanel.jsx
@@ -54,6 +54,39 @@ const messages = defineMessages({
   },
 });
 
+// Filters props.controlpanel.schema to only valid/relevant fields
+const filterControlPanelsSchema = (controlpanel) => {
+  const panelType = controlpanel['@id'].split('/').pop();
+
+  const { unwantedControlPanelsFields } = config.settings;
+
+  // Creates modified version of properties object
+  const newPropertiesObj = Object.fromEntries(
+    Object.entries(controlpanel.schema.properties).filter(
+      ([key, _val]) =>
+        !(unwantedControlPanelsFields[panelType] || []).includes(key),
+    ),
+  );
+  // Filters props.controlpanel.schema.fieldsets.fields to only valid/relevant fields
+  const filterFields = (fields) => {
+    return fields.filter(
+      (field) =>
+        !(unwantedControlPanelsFields[panelType] || []).includes(field),
+    );
+  };
+  // Creates modified version of fieldsets array
+  const newFieldsets = controlpanel.schema.fieldsets.map((fieldset) => {
+    return { ...fieldset, fields: filterFields(fieldset.fields) };
+  });
+
+  // Returns clone of props.controlpanel.schema, with updated properties/fieldsets
+  return {
+    ...controlpanel.schema,
+    properties: newPropertiesObj,
+    fieldsets: newFieldsets,
+  };
+};
+
 /**
  * Controlpanel class.
  * @class Controlpanel
@@ -188,8 +221,6 @@ class Controlpanel extends Component {
    * @returns {string} Markup for the component.
    */
   render() {
-    const { filterControlPanelsSchema } = config.settings;
-
     if (this.props.controlpanel) {
       return (
         <div id="page-controlpanel">

--- a/packages/volto/src/components/manage/Controlpanels/Controlpanel.jsx
+++ b/packages/volto/src/components/manage/Controlpanels/Controlpanel.jsx
@@ -54,39 +54,6 @@ const messages = defineMessages({
   },
 });
 
-// Filters props.controlpanel.schema to only valid/relevant fields
-const filterControlPanelsSchema = (controlpanel) => {
-  const panelType = controlpanel['@id'].split('/').pop();
-
-  const { unwantedControlPanelsFields } = config.settings;
-
-  // Creates modified version of properties object
-  const newPropertiesObj = Object.fromEntries(
-    Object.entries(controlpanel.schema.properties).filter(
-      ([key, _val]) =>
-        !(unwantedControlPanelsFields[panelType] || []).includes(key),
-    ),
-  );
-  // Filters props.controlpanel.schema.fieldsets.fields to only valid/relevant fields
-  const filterFields = (fields) => {
-    return fields.filter(
-      (field) =>
-        !(unwantedControlPanelsFields[panelType] || []).includes(field),
-    );
-  };
-  // Creates modified version of fieldsets array
-  const newFieldsets = controlpanel.schema.fieldsets.map((fieldset) => {
-    return { ...fieldset, fields: filterFields(fieldset.fields) };
-  });
-
-  // Returns clone of props.controlpanel.schema, with updated properties/fieldsets
-  return {
-    ...controlpanel.schema,
-    properties: newPropertiesObj,
-    fieldsets: newFieldsets,
-  };
-};
-
 /**
  * Controlpanel class.
  * @class Controlpanel
@@ -221,6 +188,8 @@ class Controlpanel extends Component {
    * @returns {string} Markup for the component.
    */
   render() {
+    const { filterControlPanelsSchema } = config.settings;
+
     if (this.props.controlpanel) {
       return (
         <div id="page-controlpanel">

--- a/packages/volto/src/config/ControlPanels.js
+++ b/packages/volto/src/config/ControlPanels.js
@@ -19,6 +19,7 @@ import rulesSVG from '@plone/volto/icons/content-existing.svg';
 import undoControlPanelSVG from '@plone/volto/icons/undo-control-panel.svg';
 import linkSVG from '@plone/volto/icons/link.svg';
 import relationsSVG from '@plone/volto/icons/ahead.svg';
+import config from '@plone/volto/registry';
 
 export const controlPanelsIcons = {
   default: settingsSVG,
@@ -93,4 +94,37 @@ export const unwantedControlPanelsFields = {
     'sort_tabs_reversed',
     'sitemap_depth',
   ],
+};
+
+// Filters props.controlpanel.schema to only valid/relevant fields
+export const filterControlPanelsSchema = (controlpanel) => {
+  const panelType = controlpanel['@id'].split('/').pop();
+
+  const { unwantedControlPanelsFields } = config.settings;
+
+  // Creates modified version of properties object
+  const newPropertiesObj = Object.fromEntries(
+    Object.entries(controlpanel.schema.properties).filter(
+      ([key, _val]) =>
+        !(unwantedControlPanelsFields[panelType] || []).includes(key),
+    ),
+  );
+  // Filters props.controlpanel.schema.fieldsets.fields to only valid/relevant fields
+  const filterFields = (fields) => {
+    return fields.filter(
+      (field) =>
+        !(unwantedControlPanelsFields[panelType] || []).includes(field),
+    );
+  };
+  // Creates modified version of fieldsets array
+  const newFieldsets = controlpanel.schema.fieldsets.map((fieldset) => {
+    return { ...fieldset, fields: filterFields(fieldset.fields) };
+  });
+
+  // Returns clone of props.controlpanel.schema, with updated properties/fieldsets
+  return {
+    ...controlpanel.schema,
+    properties: newPropertiesObj,
+    fieldsets: newFieldsets,
+  };
 };

--- a/packages/volto/src/config/ControlPanels.js
+++ b/packages/volto/src/config/ControlPanels.js
@@ -53,73 +53,44 @@ export const filterControlPanels = (controlpanels = []) => {
   );
 };
 
-// Filters props.controlpanel.schema to only valid/relevant fields
-export const filterControlPanelsSchema = (controlpanel) => {
-  const panelType = controlpanel['@id'].split('/').pop();
-
-  const unwantedSettings = {
-    language: ['display_flags', 'always_show_selector'],
-    search: ['enable_livesearch'],
-    site: [
-      'display_publication_date_in_byline',
-      'icon_visibility',
-      'thumb_visibility',
-      'no_thumbs_portlet',
-      'no_thumbs_lists',
-      'no_thumbs_summary',
-      'no_thumbs_tables',
-      'thumb_scale_portlet',
-      'thumb_scale_listing',
-      'thumb_scale_table',
-      'thumb_scale_summary',
-      'toolbar_position',
-      'toolbar_logo',
-      'default_page',
-      'site_favicon',
-      'site_favicon_mimetype',
-      'exposeDCMetaTags',
-      'enable_sitemap',
-      'robots_txt',
-      'webstats_js',
-    ],
-    editing: ['available_editors', 'default_editor', 'ext_editor'],
-    imaging: [
-      'highpixeldensity_scales',
-      'quality_2x',
-      'quality_3x',
-      'picture_variants',
-      'image_captioning',
-    ],
-    navigation: [
-      'generate_tabs',
-      'navigation_depth',
-      'sort_tabs_on',
-      'sort_tabs_reversed',
-      'sitemap_depth',
-    ],
-  };
-
-  // Creates modified version of properties object
-  const newPropertiesObj = Object.fromEntries(
-    Object.entries(controlpanel.schema.properties).filter(
-      ([key, val]) => !(unwantedSettings[panelType] || []).includes(key),
-    ),
-  );
-  // Filters props.controlpanel.schema.fieldsets.fields to only valid/relevant fields
-  const filterFields = (fields) => {
-    return fields.filter(
-      (field) => !(unwantedSettings[panelType] || []).includes(field),
-    );
-  };
-  // Creates modified version of fieldsets array
-  const newFieldsets = controlpanel.schema.fieldsets.map((fieldset) => {
-    return { ...fieldset, fields: filterFields(fieldset.fields) };
-  });
-
-  // Returns clone of props.controlpanel.schema, with updated properties/fieldsets
-  return {
-    ...controlpanel.schema,
-    properties: newPropertiesObj,
-    fieldsets: newFieldsets,
-  };
+export const unwantedControlPanelsFields = {
+  language: ['display_flags', 'always_show_selector'],
+  search: ['enable_livesearch'],
+  site: [
+    'display_publication_date_in_byline',
+    'icon_visibility',
+    'thumb_visibility',
+    'no_thumbs_portlet',
+    'no_thumbs_lists',
+    'no_thumbs_summary',
+    'no_thumbs_tables',
+    'thumb_scale_portlet',
+    'thumb_scale_listing',
+    'thumb_scale_table',
+    'thumb_scale_summary',
+    'toolbar_position',
+    'toolbar_logo',
+    'default_page',
+    'site_favicon',
+    'site_favicon_mimetype',
+    'exposeDCMetaTags',
+    'enable_sitemap',
+    'robots_txt',
+    'webstats_js',
+  ],
+  editing: ['available_editors', 'default_editor', 'ext_editor'],
+  imaging: [
+    'highpixeldensity_scales',
+    'quality_2x',
+    'quality_3x',
+    'picture_variants',
+    'image_captioning',
+  ],
+  navigation: [
+    'generate_tabs',
+    'navigation_depth',
+    'sort_tabs_on',
+    'sort_tabs_reversed',
+    'sitemap_depth',
+  ],
 };

--- a/packages/volto/src/config/index.js
+++ b/packages/volto/src/config/index.js
@@ -24,6 +24,7 @@ import { styleClassNameConverters, styleClassNameExtenders } from './Style';
 import {
   controlPanelsIcons,
   filterControlPanels,
+  filterControlPanelsSchema,
   unwantedControlPanelsFields,
 } from './ControlPanels';
 
@@ -152,6 +153,7 @@ let config = {
     controlpanels: [],
     controlPanelsIcons,
     filterControlPanels,
+    filterControlPanelsSchema,
     unwantedControlPanelsFields,
     externalRoutes: [
       // URL to be considered as external

--- a/packages/volto/src/config/index.js
+++ b/packages/volto/src/config/index.js
@@ -24,7 +24,7 @@ import { styleClassNameConverters, styleClassNameExtenders } from './Style';
 import {
   controlPanelsIcons,
   filterControlPanels,
-  filterControlPanelsSchema,
+  unwantedControlPanelsFields,
 } from './ControlPanels';
 
 import applyAddonConfiguration, { addonsInfo } from 'load-volto-addons';
@@ -152,7 +152,7 @@ let config = {
     controlpanels: [],
     controlPanelsIcons,
     filterControlPanels,
-    filterControlPanelsSchema,
+    unwantedControlPanelsFields,
     externalRoutes: [
       // URL to be considered as external
       // {

--- a/packages/volto/test-setup-config.jsx
+++ b/packages/volto/test-setup-config.jsx
@@ -19,7 +19,7 @@ import {
 import {
   controlPanelsIcons,
   filterControlPanels,
-  filterControlPanelsSchema,
+  unwantedControlPanelsFields,
 } from '@plone/volto/config/ControlPanels';
 
 import ListingBlockSchema from '@plone/volto/components/manage/Blocks/Listing/schema';
@@ -48,7 +48,7 @@ config.set('settings', {
   },
   controlPanelsIcons,
   filterControlPanels,
-  filterControlPanelsSchema,
+  unwantedControlPanelsFields,
   apiExpanders: [],
   downloadableObjects: ['File'],
   viewableInBrowserObjects: [],

--- a/packages/volto/test-setup-config.jsx
+++ b/packages/volto/test-setup-config.jsx
@@ -19,6 +19,7 @@ import {
 import {
   controlPanelsIcons,
   filterControlPanels,
+  filterControlPanelsSchema,
   unwantedControlPanelsFields,
 } from '@plone/volto/config/ControlPanels';
 
@@ -48,6 +49,7 @@ config.set('settings', {
   },
   controlPanelsIcons,
   filterControlPanels,
+  filterControlPanelsSchema,
   unwantedControlPanelsFields,
   apiExpanders: [],
   downloadableObjects: ['File'],


### PR DESCRIPTION
`filterControlPanelsSchema` has been migrated to `Controlpanel.jsx` and uses the `unwantedControlPanelsFields` setting. So, if any portal wants to add fields in the Control Panel, it will be necessary to customize only the `unwantedControlPanelsFields` configuration, instead of customizing the entire `filterControlPanelsSchema` function.

This is an improvement for #3904