### PR TITLE
Strip `++api++` from in-browser location changes

### DIFF
--- a/src/middleware/blacklistRoutes.js
+++ b/src/middleware/blacklistRoutes.js
@@ -8,18 +8,30 @@ const blacklistRoutes = ({ dispatch, getState }) => (next) => (action) => {
 
   switch (action.type) {
     case '@@router/LOCATION_CHANGE':
-      const { pathname } = action.payload.location;
+      let { pathname } = action.payload.location;
       const { externalRoutes = [] } = config.settings;
 
       const route = externalRoutes.find((route) =>
         matchPath(pathname, route.match),
       );
 
+      let actionToSend = action;
+      if (pathname.startsWith('/++api++')) {
+        actionToSend.payload.location.pathname = actionToSend.payload.location.pathname.substring(
+          8,
+        );
+        // To handle the `window.location.replace`
+        pathname = actionToSend.payload.location.pathname;
+        if (window.history) {
+          window.history.replaceState(window.history.state, '', pathname);
+        }
+      }
+
       if (!route) {
-        return next(action);
+        return next(actionToSend);
       } else {
         window.location.replace(
-          route.url ? route.url(action.payload) : pathname,
+          route.url ? route.url(actionToSend.payload) : pathname,
         );
       }
       break;


### PR DESCRIPTION
Solves the Volto part of #4800. We're stripping the `++api++` if it is in a location change as we probably don't want to ever navigate directly to a page with `++api++` in it in the browser. Change the action causes the redux store to be correct, but the URL updating occurs earlier in the react-router stack, and so we also manually update the URL to not have `++api++` in it. History is still preserved correctly (`++api++` pages aren't in the history stack but we can still go back and forwards normally).

The logic is currently mixed in with the `blacklistRoutes` middleware while I get some feedback, but this logic should probably be its own middleware for readability. 