### PR TITLE
Set contents property Exclude from navigation for #4855

### DIFF
--- a/news/4855.bugfix
+++ b/news/4855.bugfix
@@ -1,1 +1,1 @@
-Fix Volto contents - set properties Exclude from navigation - bad request
+Fix Volto contents - set properties Exclude from navigation - bad request, set exclude_from_nav to boolean

--- a/news/4855.bugfix
+++ b/news/4855.bugfix
@@ -1,0 +1,1 @@
+Fix Volto contents - set properties Exclude from navigation - bad request

--- a/src/components/manage/Contents/ContentsPropertiesModal.jsx
+++ b/src/components/manage/Contents/ContentsPropertiesModal.jsx
@@ -209,11 +209,7 @@ class ContentsPropertiesModal extends Component {
                 title: this.props.intl.formatMessage(
                   messages.excludeFromNavTitle,
                 ),
-                type: 'array',
-                choices: [
-                  [true, this.props.intl.formatMessage(messages.yes)],
-                  [false, this.props.intl.formatMessage(messages.no)],
-                ],
+                type: 'boolean',
               },
             },
             required: [],


### PR DESCRIPTION
Volto contents - set properties Exclude from navigation - bad request.
Since in the metadata the of the page `exclude_from_nav` is `boolean`, I set it to `boolean` also in `ContentsPropertiesModal`.
Solves the #4855.