### PR TITLE
fix: override of breadcrumps, navigation and types when subrequest getContent triggers

### DIFF
--- a/news/4891.bug
+++ b/news/4891.bug
@@ -1,0 +1,1 @@
+- Fix override of breadcrumps, navigation and types when subrequest getContent triggers - @razvanMiu

--- a/src/reducers/breadcrumbs/breadcrumbs.js
+++ b/src/reducers/breadcrumbs/breadcrumbs.js
@@ -41,6 +41,7 @@ export default function breadcrumbs(state = initialState, action = {}) {
         loading: true,
       };
     case `${GET_CONTENT}_SUCCESS`:
+      if (action.subrequest) return state;
       hasExpander = hasApiExpander(
         'breadcrumbs',
         getBaseUrl(flattenToAppURL(action.result['@id'])),

--- a/src/reducers/navigation/navigation.js
+++ b/src/reducers/navigation/navigation.js
@@ -56,6 +56,7 @@ export default function navigation(state = initialState, action = {}) {
         loading: true,
       };
     case `${GET_CONTENT}_SUCCESS`:
+      if (action.subrequest) return state;
       hasExpander = hasApiExpander(
         'navigation',
         getBaseUrl(flattenToAppURL(action.result['@id'])),

--- a/src/reducers/types/types.js
+++ b/src/reducers/types/types.js
@@ -35,6 +35,7 @@ export default function types(state = initialState, action = {}) {
         loaded: false,
       };
     case `${GET_CONTENT}_SUCCESS`:
+      if (action.subrequest) return state;
       hasExpander = hasApiExpander(
         'types',
         getBaseUrl(flattenToAppURL(action.result['@id'])),


### PR DESCRIPTION
Closes #4891 