### PR TITLE
Fix temporary rendering of folder contents while query is loading

### DIFF
--- a/news/4351.bugfix
+++ b/news/4351.bugfix
@@ -1,0 +1,1 @@
+Fix temporary rendering of folder contents while query results are loading. @davisagli

--- a/src/components/manage/Blocks/Listing/withQuerystringResults.jsx
+++ b/src/components/manage/Blocks/Listing/withQuerystringResults.jsx
@@ -54,10 +54,9 @@ export default function withQuerystringResults(WrappedComponent) {
     const hasQuery = querystring?.query?.length > 0;
     const hasLoaded = hasQuery ? querystringResults?.[id]?.loaded : true;
 
-    const listingItems =
-      querystring?.query?.length > 0 && querystringResults?.[id]
-        ? querystringResults?.[id]?.items || []
-        : folderItems;
+    const listingItems = hasQuery
+      ? querystringResults?.[id]?.items || []
+      : folderItems;
 
     const showAsFolderListing = !hasQuery && content?.items_total > b_size;
     const showAsQueryListing =


### PR DESCRIPTION
Fixes https://github.com/plone/volto/issues/4351