### PR TITLE
Add XSendfile headers to files and images middleware

### DIFF
--- a/news/4984.bugfix
+++ b/news/4984.bugfix
@@ -1,0 +1,1 @@
+Add XSendfile headers to files and images middleware @instification

--- a/src/express-middleware/files.js
+++ b/src/express-middleware/files.js
@@ -2,13 +2,13 @@ import express from 'express';
 import { getAPIResourceWithAuth } from '@plone/volto/helpers';
 
 const HEADERS = [
-  'Accept-Ranges',
-  'Cache-Control',
-  'Content-Disposition',
-  'Content-Range',
-  'Content-Type',
-  'X-Sendfile',
-  'X-Accell-Redirect',
+  'accept-ranges',
+  'cache-control',
+  'content-disposition',
+  'content-range',
+  'content-type',
+  'x-sendfile',
+  'x-accel-redirect',
 ];
 
 function filesMiddlewareFn(req, res, next) {
@@ -16,7 +16,7 @@ function filesMiddlewareFn(req, res, next) {
     .then((resource) => {
       // Just forward the headers that we need
       HEADERS.forEach((header) => {
-        if (resource.get(header)) {
+        if (resource.headers[header]) {
           res.set(header, resource.get(header));
         }
       });

--- a/src/express-middleware/files.js
+++ b/src/express-middleware/files.js
@@ -8,7 +8,7 @@ const HEADERS = [
   'Content-Range',
   'Content-Type',
   'X-Sendfile',
-  'X-Accell-Redirect'
+  'X-Accell-Redirect',
 ];
 
 function filesMiddlewareFn(req, res, next) {

--- a/src/express-middleware/files.js
+++ b/src/express-middleware/files.js
@@ -7,6 +7,8 @@ const HEADERS = [
   'Content-Disposition',
   'Content-Range',
   'Content-Type',
+  'X-Sendfile',
+  'X-Accell-Redirect'
 ];
 
 function filesMiddlewareFn(req, res, next) {

--- a/src/express-middleware/images.js
+++ b/src/express-middleware/images.js
@@ -1,7 +1,13 @@
 import express from 'express';
 import { getAPIResourceWithAuth } from '@plone/volto/helpers';
 
-const HEADERS = ['content-type', 'content-disposition', 'cache-control'];
+const HEADERS = [
+  'content-type',
+  'content-disposition',
+  'cache-control',
+  'X-Sendfile',
+  'X-Accel-Redirect'
+];
 
 function imageMiddlewareFn(req, res, next) {
   getAPIResourceWithAuth(req)

--- a/src/express-middleware/images.js
+++ b/src/express-middleware/images.js
@@ -5,8 +5,8 @@ const HEADERS = [
   'content-type',
   'content-disposition',
   'cache-control',
-  'X-Sendfile',
-  'X-Accel-Redirect',
+  'x-sendfile',
+  'x-accel-redirect',
 ];
 
 function imageMiddlewareFn(req, res, next) {

--- a/src/express-middleware/images.js
+++ b/src/express-middleware/images.js
@@ -6,7 +6,7 @@ const HEADERS = [
   'content-disposition',
   'cache-control',
   'X-Sendfile',
-  'X-Accel-Redirect'
+  'X-Accel-Redirect',
 ];
 
 function imageMiddlewareFn(req, res, next) {


### PR DESCRIPTION
Existing middleware for files and images only add specific headers to the response.

When using [collective.xsendfile](https://github.com/collective/collective.xsendfile), upstream servers rely on the X-Accel-Redirect or X-Sendfile headers.

This PR:
 - adds `x-sendfile` and `x-accel-redirect` headers to the list that are added to the response. 
 - normalises `files.js` to use `request.headers[header]` instead of `request.get(header)` which ensures comparisons are case insensitive.

Main reason for using xsendfile is that middleware responses get buffered in memory by node, which for large files creates 2 issues:

 - Increased memory usage
 - Noticeable delay before the file is served to the client while it is buffered from the backend

xsendfile means that only a tiny response is sent and the serving of large files can be handled by nginx or other XSendfile capable proxies.