### PR TITLE
#4982 - replaced listing block summary template view <hx> tags with <ul> tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ## 17.0.0-alpha.20 (2023-07-18)
 
+### Breaking
+
+- Replaced `h3` html tags from the Listing Block Summart variation with `ul` tags as can cause confusion in people relying on the page structure with headlines that function of section headers. @tiberiuichim [#4982](https://github.com/plone/volto/issues/4982)
+
 ### Feature
 
 - Use all the apiExpanders in use, so we perform a single request for getting all the required data. @sneridagh [#4946](https://github.com/plone/volto/issues/4946)

--- a/src/components/manage/Blocks/Listing/SummaryTemplate.jsx
+++ b/src/components/manage/Blocks/Listing/SummaryTemplate.jsx
@@ -27,7 +27,9 @@ const SummaryTemplate = ({ items, linkTitle, linkHref, isEditMode }) => {
             <ConditionalLink item={item} condition={!isEditMode}>
               <Component componentName="PreviewImage" item={item} alt="" />
               <div className="listing-body">
-                <h3>{item.title ? item.title : item.id}</h3>
+                <ul className="listing-item-ul">
+                  <li>{item.title ? item.title : item.id}</li>
+                </ul>
                 <p>{item.description}</p>
               </div>
             </ConditionalLink>

--- a/theme/themes/pastanaga/extras/main.less
+++ b/theme/themes/pastanaga/extras/main.less
@@ -645,6 +645,14 @@ body.has-toolbar-collapsed .mobile-menu {
   transition: transform 0.5s cubic-bezier(0.09, 0.11, 0.24, 0.91);
 }
 
+.listing-item-ul {
+  padding: 0;
+  margin: 0;
+  font-size: 1.3em;
+  font-weight: 500;
+  list-style: none;
+}
+
 // Deprecated as per https://github.com/plone/volto/issues/1265
 // @import 'utils';
 @import (multiple) '../extras/fonts';


### PR DESCRIPTION
As [mentioned here](https://github.com/plone/volto/issues/4982) I have updated the html tags for the listing items when using the Summary variation for the Listing block and updated the styling to match the previous <hx> styling. I have also added a changelog entry due to this being a breaking change.