### PR TITLE
make selectedView and className props available for Search block

### DIFF
--- a/news/4997.feature
+++ b/news/4997.feature
@@ -1,1 +1,1 @@
-Made selectedView prop available as className in the SearchBlockView.jsx to improve styling development. @danalvrz
+Made selectedView and className props available in the SearchBlockView.jsx to improve styling development. @danalvrz

--- a/news/4997.feature
+++ b/news/4997.feature
@@ -1,0 +1,1 @@
+Made selectedView prop available as className in the SearchBlockView.jsx to improve styling development. @danalvrz

--- a/src/components/manage/Blocks/Search/SearchBlockView.jsx
+++ b/src/components/manage/Blocks/Search/SearchBlockView.jsx
@@ -9,6 +9,7 @@ import { withSearch, withQueryString } from './hocs';
 import { compose } from 'redux';
 import { useSelector } from 'react-redux';
 import { isEqual, isFunction } from 'lodash';
+import cx from 'classnames';
 
 const getListingBodyVariation = (data) => {
   const { variations } = config.blocks.blocksConfig.listing;
@@ -81,7 +82,7 @@ const SearchBlockView = (props) => {
   const listingBodyVariation = variations.find(({ id }) => id === selectedView);
 
   return (
-    <div className="block search">
+    <div className={cx('block search', selectedView)}>
       <Layout
         {...props}
         isEditMode={mode === 'edit'}

--- a/src/components/manage/Blocks/Search/SearchBlockView.jsx
+++ b/src/components/manage/Blocks/Search/SearchBlockView.jsx
@@ -58,7 +58,7 @@ const applyDefaults = (data, root) => {
 };
 
 const SearchBlockView = (props) => {
-  const { id, data, searchData, mode = 'view', variation } = props;
+  const { id, data, searchData, mode = 'view', variation, className } = props;
 
   const Layout = variation.view;
 
@@ -82,7 +82,7 @@ const SearchBlockView = (props) => {
   const listingBodyVariation = variations.find(({ id }) => id === selectedView);
 
   return (
-    <div className={cx('block search', selectedView)}>
+    <div className={cx('block search', selectedView, className)}>
       <Layout
         {...props}
         isEditMode={mode === 'edit'}


### PR DESCRIPTION
Made `selectedView` and `className` props available to the `SearchBlockView.jsx`, following the behavior of Listing Block, to improve styling development. 