### PR TITLE
Fix regressions from v17a22

### DIFF
--- a/news/5039.bugfix
+++ b/news/5039.bugfix
@@ -1,0 +1,5 @@
+Fix regression from v17a22: It was not possible to select a block in a grid
+column unless the grid was already selected. @davisagli
+
+Fix regression from v17a22: Block outline was blocking clicks in some cases.
+@davisagli

--- a/src/components/manage/Blocks/Container/EditBlockWrapper.jsx
+++ b/src/components/manage/Blocks/Container/EditBlockWrapper.jsx
@@ -49,7 +49,7 @@ const EditBlockWrapper = (props) => {
         role="presentation"
         className="cell-wrapper"
         onClick={(e) => {
-          e.stopPropagation();
+          e.block = block;
           onSelectBlock(block);
         }}
       >

--- a/src/components/manage/Blocks/Grid/Edit.jsx
+++ b/src/components/manage/Blocks/Grid/Edit.jsx
@@ -21,7 +21,9 @@ const GridBlockEdit = (props) => {
       })}
       // This is required to enabling a small "in-between" clickable area
       // for bringing the Grid sidebar alive once you have selected an inner block
-      onClick={(e) => setSelectedBlock(null)}
+      onClick={(e) => {
+        if (!e.block) setSelectedBlock(null);
+      }}
       role="presentation"
     >
       <ContainerEdit

--- a/theme/themes/pastanaga/extras/blocks.less
+++ b/theme/themes/pastanaga/extras/blocks.less
@@ -22,7 +22,7 @@
 
 .block .block:not(.inner)::before {
   position: absolute;
-  z-index: auto;
+  z-index: -1;
   top: -9px;
   left: -9px;
   width: ~'calc(100% + 18px)';


### PR DESCRIPTION
1. It was no longer possible to select a block in a grid column by clicking unless the grid was already selected.
2. Setting the z-index of the block outline to auto was blocking clicks in some cases.