### PR TITLE
Fix creating user issue 5031

### DIFF
--- a/src/components/manage/Controlpanels/Users/UsersControlpanel.jsx
+++ b/src/components/manage/Controlpanels/Users/UsersControlpanel.jsx
@@ -123,7 +123,7 @@ class UsersControlpanel extends Component {
     }
   };
 
-  // Because username field needs to be disabled if email login is enabled so we need a way of knowing if email login is enabled.
+  // Because username field needs to be disabled if email login is enabled.
   checkLoginUsingEmailStatus = async () => {
     await this.props.getControlpanel('security');
     this.setState({

--- a/src/components/manage/Controlpanels/Users/UsersControlpanel.jsx
+++ b/src/components/manage/Controlpanels/Users/UsersControlpanel.jsx
@@ -123,7 +123,7 @@ class UsersControlpanel extends Component {
     }
   };
 
-  // Because username field needs to be disabled if email login is enabled.
+  // Because username field needs to be disabled if email login is enabled!
   checkLoginUsingEmailStatus = async () => {
     await this.props.getControlpanel('security');
     this.setState({

--- a/src/components/manage/Controlpanels/Users/UsersControlpanel.jsx
+++ b/src/components/manage/Controlpanels/Users/UsersControlpanel.jsx
@@ -107,6 +107,7 @@ class UsersControlpanel extends Component {
       isClient: false,
       currentPage: 0,
       pageSize: 10,
+      loginUsingEmail: false,
     };
   }
 
@@ -122,6 +123,14 @@ class UsersControlpanel extends Component {
     }
   };
 
+  // Because username field needs to be disabled if email login is enabled so we need a way of knowing if email login is enabled.
+  checkLoginUsingEmailStatus = async () => {
+    await this.props.getControlpanel('security');
+    this.setState({
+      loginUsingEmail: this.props.controlPanelData.data.use_email_as_login,
+    });
+  };
+
   /**
    * Component did mount
    * @method componentDidMount
@@ -132,6 +141,7 @@ class UsersControlpanel extends Component {
       isClient: true,
     });
     this.fetchData();
+    this.checkLoginUsingEmailStatus();
   }
 
   UNSAFE_componentWillReceiveProps(nextProps) {
@@ -299,8 +309,8 @@ class UsersControlpanel extends Component {
           entry.id === name && !entry.roles.includes(value)
             ? [...entry.roles, value]
             : entry.id !== name
-            ? entry.roles
-            : pull(entry.roles, value),
+              ? entry.roles
+              : pull(entry.roles, value),
       })),
     });
   }
@@ -425,7 +435,7 @@ class UsersControlpanel extends Component {
                     id: 'default',
                     title: 'FIXME: User Data',
                     fields: [
-                      'username',
+                      ...(!this.state.loginUsingEmail ? ['username'] : []),
                       'fullname',
                       'email',
                       'password',
@@ -436,15 +446,17 @@ class UsersControlpanel extends Component {
                   },
                 ],
                 properties: {
-                  username: {
-                    title: this.props.intl.formatMessage(
-                      messages.addUserFormUsernameTitle,
-                    ),
-                    type: 'string',
-                    description: this.props.intl.formatMessage(
-                      messages.addUserFormUsernameDescription,
-                    ),
-                  },
+                  ...(!this.state.loginUsingEmail
+                    ? {
+                      username: {
+                        title: this.props.intl.formatMessage(messages.addUserFormUsernameTitle),
+                        type: 'string',
+                        description: this.props.intl.formatMessage(
+                          messages.addUserFormUsernameDescription,
+                        ),
+                      },
+                    }
+                    : {}),
                   fullname: {
                     title: this.props.intl.formatMessage(
                       messages.addUserFormFullnameTitle,
@@ -670,6 +682,7 @@ export default compose(
       createRequest: state.users.create,
       loadRolesRequest: state.roles,
       inheritedRole: state.authRole.authenticatedRole,
+      controlPanelData: state.controlpanels?.controlpanel,
     }),
     (dispatch) =>
       bindActionCreators(

--- a/yarn.lock
+++ b/yarn.lock
@@ -11923,7 +11923,7 @@ __metadata:
 
 "fsevents@patch:fsevents@^1.2.7#~builtin<compat/fsevents>":
   version: 1.2.13
-  resolution: "fsevents@patch:fsevents@npm%3A1.2.13#~builtin<compat/fsevents>::version=1.2.13&hash=18f3a7"
+  resolution: "fsevents@patch:fsevents@npm%3A1.2.13#~builtin<compat/fsevents>::version=1.2.13&hash=d11327"
   dependencies:
     bindings: ^1.5.0
     nan: ^2.12.1
@@ -11933,7 +11933,7 @@ __metadata:
 
 "fsevents@patch:fsevents@^2.1.2#~builtin<compat/fsevents>, fsevents@patch:fsevents@~2.3.2#~builtin<compat/fsevents>":
   version: 2.3.2
-  resolution: "fsevents@patch:fsevents@npm%3A2.3.2#~builtin<compat/fsevents>::version=2.3.2&hash=18f3a7"
+  resolution: "fsevents@patch:fsevents@npm%3A2.3.2#~builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"
   dependencies:
     node-gyp: latest
   conditions: os=darwin
@@ -21193,7 +21193,7 @@ __metadata:
 
 "resolve@patch:resolve@^1.1.6#~builtin<compat/resolve>, resolve@patch:resolve@^1.10.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.12.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.14.2#~builtin<compat/resolve>, resolve@patch:resolve@^1.15.1#~builtin<compat/resolve>, resolve@patch:resolve@^1.17.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.18.1#~builtin<compat/resolve>, resolve@patch:resolve@^1.19.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.20.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.3.2#~builtin<compat/resolve>":
   version: 1.22.1
-  resolution: "resolve@patch:resolve@npm%3A1.22.1#~builtin<compat/resolve>::version=1.22.1&hash=07638b"
+  resolution: "resolve@patch:resolve@npm%3A1.22.1#~builtin<compat/resolve>::version=1.22.1&hash=c3c19d"
   dependencies:
     is-core-module: ^2.9.0
     path-parse: ^1.0.7


### PR DESCRIPTION

When email was set to be the username field, the actual username field still appeared and the registration was broken.

I fixed it by showing the username field conditionally based on whether this setting was enabled.

I used the following to get our desired boolean value and stored it in a state, which was used to conditionally render the username input element.
```
  checkLoginUsingEmailStatus = async () => {
    await this.props.getControlpanel('security');
    this.setState({
      loginUsingEmail: this.props.controlPanelData.data.use_email_as_login,
    });
  };
  ```
  
  Feel free to let me know if I need to make changes regarding this PR. Thanks!
