### PR TITLE
Fixes #5105; For the Sitemap component, don't hardcode root as navigation action path

### DIFF
--- a/news/5106.bugfix
+++ b/news/5106.bugfix
@@ -1,0 +1,2 @@
+For folders inside navigation roots, properly fetch navigation from the
+navroot, rather then the site root  @tiberiuichim

--- a/src/components/theme/Sitemap/Sitemap.jsx
+++ b/src/components/theme/Sitemap/Sitemap.jsx
@@ -22,6 +22,13 @@ const messages = defineMessages({
     defaultMessage: 'Sitemap',
   },
 });
+
+export function getSitemapPath(pathname = '', lang) {
+  const prefix = pathname.replace(/\/sitemap$/gm, '').replace(/^\//, '');
+  const path = prefix || lang || '';
+  return path;
+}
+
 /**
  * Sitemap class.
  * @class Sitemap
@@ -39,11 +46,13 @@ class Sitemap extends Component {
 
   componentDidMount() {
     const { settings } = config;
-    if (settings.isMultilingual) {
-      this.props.getNavigation(`${toBackendLang(this.props.lang)}`, 4);
-    } else {
-      this.props.getNavigation('', 4);
-    }
+
+    const lang = settings.isMultilingual
+      ? `${toBackendLang(this.props.lang)}`
+      : null;
+
+    const path = getSitemapPath(this.props.location.pathname, lang);
+    this.props.getNavigation(path, 4);
   }
 
   /**
@@ -105,15 +114,17 @@ export default compose(
     {
       key: 'navigation',
       promise: ({ location, store: { dispatch, getState } }) => {
+        if (!__SERVER__) return;
         const { settings } = config;
-        const lang = getState().intl.locale;
-        if (settings.isMultilingual) {
-          return (
-            __SERVER__ && dispatch(getNavigation(`${toBackendLang(lang)}`, 4))
-          );
-        } else {
-          return __SERVER__ && dispatch(getNavigation('', 4));
-        }
+
+        const path = getSitemapPath(
+          location.pathname,
+          settings.isMultilingual
+            ? toBackendLang(getState().intl.locale)
+            : null,
+        );
+
+        return dispatch(getNavigation(path, 4));
       },
     },
   ]),

--- a/src/components/theme/Sitemap/Sitemap.test.jsx
+++ b/src/components/theme/Sitemap/Sitemap.test.jsx
@@ -4,7 +4,7 @@ import configureStore from 'redux-mock-store';
 import { Provider } from 'react-intl-redux';
 import { MemoryRouter } from 'react-router-dom';
 
-import { __test__ as Sitemap } from './Sitemap';
+import { __test__ as Sitemap, getSitemapPath } from './Sitemap';
 
 const mockStore = configureStore();
 
@@ -46,11 +46,32 @@ describe('Sitemap', () => {
     const component = renderer.create(
       <Provider store={store}>
         <MemoryRouter>
-          <Sitemap />
+          <Sitemap location={{ pathname: '/page-1' }} />
         </MemoryRouter>
       </Provider>,
     );
     const json = component.toJSON();
     expect(json).toMatchSnapshot();
+  });
+});
+
+describe('getSitemapPath', () => {
+  it('accepts empty path', () => {
+    expect(getSitemapPath('', null)).toBe('');
+  });
+
+  it('accepts a path', () => {
+    expect(getSitemapPath('/page-1/sitemap', null)).toBe('page-1');
+  });
+  it('accepts a path', () => {
+    expect(getSitemapPath('/page-1/sitemap', null)).toBe('page-1');
+  });
+
+  it('uses a language as default root', () => {
+    expect(getSitemapPath('/', 'de')).toBe('de');
+  });
+
+  it('accepts language-rooted paths', () => {
+    expect(getSitemapPath('/de/mission', 'de')).toBe('de/mission');
   });
 });


### PR DESCRIPTION
The plone.restapi navigation endpoint will compute a navigation root from a context path, but the problem is that Volto will trigger the navigation endpoint either on root or on the lang folder. 

https://github.com/plone/plone.restapi/blob/ed070e0769c4ac3efda05448db8846f61dae255c/src/plone/restapi/services/navigation/get.py#L40

https://github.com/plone/volto/blob/4523b13d6586891b9dad7db1caedaab5f6f7dd4b/src/components/theme/Sitemap/Sitemap.jsx#L115C21-L115C21

https://github.com/plone/volto/blob/4523b13d6586891b9dad7db1caedaab5f6f7dd4b/src/actions/navigation/navigation.js#L21