### PR TITLE
[Visual bugfix] Match the original mockups for PastanagaUI in regards of the error messages in form field elements

### DIFF
--- a/news/5115.bugfix
+++ b/news/5115.bugfix
@@ -1,1 +1,1 @@
-Fix overlap of the error message with the first field in case that the first field is one of the errored fields @sneridagh
+[Visual bugfix] Match the original mockups for PastanagaUI in regards of the error messages in form field elements @sneridagh

--- a/news/5115.bugfix
+++ b/news/5115.bugfix
@@ -1,0 +1,1 @@
+Fix overlap of the error message with the first field in case that the first field is one of the errored fields @sneridagh

--- a/src/components/manage/Widgets/FormFieldWrapper.jsx
+++ b/src/components/manage/Widgets/FormFieldWrapper.jsx
@@ -96,7 +96,7 @@ class FormFieldWrapper extends Component {
         {this.props.children}
 
         {map(error, (message) => (
-          <Label key={message} basic color="red" pointing>
+          <Label key={message} basic color="red" className="form-error-label">
             {message}
           </Label>
         ))}

--- a/src/components/manage/Widgets/__snapshots__/IdWidget.test.jsx.snap
+++ b/src/components/manage/Widgets/__snapshots__/IdWidget.test.jsx.snap
@@ -174,7 +174,7 @@ exports[`IdWidget renders an id widget with an reserved name 1`] = `
             />
           </div>
           <div
-            class="ui red pointing basic label"
+            class="ui red basic label form-error-label"
           >
             This is a reserved name and can't be used
           </div>
@@ -224,7 +224,7 @@ exports[`IdWidget renders an id widget with invalid characters 1`] = `
             />
           </div>
           <div
-            class="ui red pointing basic label"
+            class="ui red basic label form-error-label"
           >
             Only lowercase letters (a-z) without accents, numbers (0-9), and the characters "-", "_", and "." are allowed.
           </div>

--- a/theme/themes/pastanaga/collections/form.overrides
+++ b/theme/themes/pastanaga/collections/form.overrides
@@ -49,6 +49,38 @@
   }
 }
 
+.ui.form .fields.error .field textarea,
+.ui.form .fields.error .field select,
+.ui.form .fields.error .field input:not([type]),
+.ui.form .fields.error .field input[type='date'],
+.ui.form .fields.error .field input[type='datetime-local'],
+.ui.form .fields.error .field input[type='email'],
+.ui.form .fields.error .field input[type='number'],
+.ui.form .fields.error .field input[type='password'],
+.ui.form .fields.error .field input[type='search'],
+.ui.form .fields.error .field input[type='tel'],
+.ui.form .fields.error .field input[type='time'],
+.ui.form .fields.error .field input[type='text'],
+.ui.form .fields.error .field input[type='file'],
+.ui.form .fields.error .field input[type='url'],
+.ui.form .field.error textarea,
+.ui.form .field.error select,
+.ui.form .field.error input:not([type]),
+.ui.form .field.error input[type='date'],
+.ui.form .field.error input[type='datetime-local'],
+.ui.form .field.error input[type='email'],
+.ui.form .field.error input[type='number'],
+.ui.form .field.error input[type='password'],
+.ui.form .field.error input[type='search'],
+.ui.form .field.error input[type='tel'],
+.ui.form .field.error input[type='time'],
+.ui.form .field.error input[type='text'],
+.ui.form .field.error input[type='file'],
+.ui.form .field.error input[type='url'] {
+  border-color: #d01157;
+  background: none;
+}
+
 .ui.form .field > .selection.dropdown {
   height: 60px;
 }

--- a/theme/themes/pastanaga/collections/form.overrides
+++ b/theme/themes/pastanaga/collections/form.overrides
@@ -76,7 +76,21 @@
 .ui.form .field.error input[type='time'],
 .ui.form .field.error input[type='text'],
 .ui.form .field.error input[type='file'],
-.ui.form .field.error input[type='url'] {
+.ui.form .field.error input[type='url'],
+.ui.form .field.error textarea:focus,
+.ui.form .field.error select:focus,
+.ui.form .field.error input:not([type]):focus,
+.ui.form .field.error input[type='date']:focus,
+.ui.form .field.error input[type='datetime-local']:focus,
+.ui.form .field.error input[type='email']:focus,
+.ui.form .field.error input[type='number']:focus,
+.ui.form .field.error input[type='password']:focus,
+.ui.form .field.error input[type='search']:focus,
+.ui.form .field.error input[type='tel']:focus,
+.ui.form .field.error input[type='time']:focus,
+.ui.form .field.error input[type='text']:focus,
+.ui.form .field.error input[type='file']:focus,
+.ui.form .field.error input[type='url']:focus {
   border-color: #d01157;
   background: none;
 }

--- a/theme/themes/pastanaga/collections/message.overrides
+++ b/theme/themes/pastanaga/collections/message.overrides
@@ -12,9 +12,5 @@
 }
 
 .ui.attached.message {
-  // This fixes the overlap when the first field is one of the errored fields. It seems
-  // that the attached prop in SemanticUI React Message component was not the most
-  // appropiate for this kind of message and was intended for another use case (see
-  // docs).
-  margin: 1em 0;
+  margin: 0;
 }

--- a/theme/themes/pastanaga/collections/message.overrides
+++ b/theme/themes/pastanaga/collections/message.overrides
@@ -12,5 +12,9 @@
 }
 
 .ui.attached.message {
-  margin: 0;
+  // This fixes the overlap when the first field is one of the errored fields. It seems
+  // that the attached prop in SemanticUI React Message component was not the most
+  // appropiate for this kind of message and was intended for another use case (see
+  // docs).
+  margin: 1em 0;
 }

--- a/theme/themes/pastanaga/elements/input.overrides
+++ b/theme/themes/pastanaga/elements/input.overrides
@@ -6,6 +6,12 @@
   font-weight: @inputFontWeight;
 }
 
+/* This aligns the height of the field name label to the other side in case
+of an error is present, it overrides a default from SemanticUI grid definitions. */
+.ui.grid > .stretched.row > .column > .wrapper {
+  flex-grow: 0;
+}
+
 .inline.field {
   .wrapper {
     display: flex;

--- a/theme/themes/pastanaga/elements/label.overrides
+++ b/theme/themes/pastanaga/elements/label.overrides
@@ -6,3 +6,17 @@
     margin: 0em 0em 0em 0.75em;
   }
 }
+
+.ui.form {
+  .ui.pointing.label:before {
+    content: initial;
+  }
+
+  .ui.basic.red.label {
+    padding-left: 0;
+    border: none;
+    margin-top: 0;
+    color: #d01157 !important;
+    font-weight: normal;
+  }
+}

--- a/theme/themes/pastanaga/elements/label.overrides
+++ b/theme/themes/pastanaga/elements/label.overrides
@@ -8,11 +8,7 @@
 }
 
 .ui.form {
-  .ui.pointing.label:before {
-    content: initial;
-  }
-
-  .ui.basic.red.label {
+  .ui.basic.red.label.form-error-label {
     padding-left: 0;
     border: none;
     margin-top: 0;


### PR DESCRIPTION
## Bug

**Edit:** It seems that we overlooked the original error messages in PastanagaUI form fields elements for over six years (shame on us) without noticing (or caring).

We realised (about time), when trying to fix this overlap:

<img width="1201" alt="image" src="https://github.com/plone/volto/assets/486927/084a85b0-1f71-4049-82e4-e284842adcdf">

## Original mockup

This is the original mockup from the original PastanagaUI mocks:

<img width="1334" alt="image" src="https://github.com/plone/volto/assets/486927/60487211-329b-4343-a7b9-8fe730f26950">

## Fixed version

<img width="1163" alt="image" src="https://github.com/plone/volto/assets/486927/514840d3-ca3a-4d8e-8290-313eb379720f">
