### PR TITLE
Fix default toc renderer for nested entries

### DIFF
--- a/src/components/manage/Blocks/ToC/variations/DefaultTocRenderer.jsx
+++ b/src/components/manage/Blocks/ToC/variations/DefaultTocRenderer.jsx
@@ -12,7 +12,9 @@ import { useHistory } from 'react-router-dom';
 import AnchorLink from 'react-anchor-link-smooth-scroll';
 import Slugger from 'github-slugger';
 
-const RenderListItems = ({ items, data, history }) => {
+const RenderListItems = ({ items, data }) => {
+  const history = useHistory();
+
   return map(items, (item) => {
     const { id, level, title, override_toc, plaintext } = item;
     const slug = override_toc
@@ -50,7 +52,6 @@ const RenderListItems = ({ items, data, history }) => {
  * @extends Component
  */
 const View = ({ data, tocEntries }) => {
-  const history = useHistory();
   return (
     <>
       {data.title && !data.hide_title ? (
@@ -70,7 +71,7 @@ const View = ({ data, tocEntries }) => {
         bulleted={!data.ordered}
         as={data.ordered ? 'ol' : 'ul'}
       >
-        <RenderListItems items={tocEntries} data={data} history={history} />
+        <RenderListItems items={tocEntries} data={data} />
       </List>
     </>
   );

--- a/src/components/manage/Blocks/ToC/variations/DefaultTocRenderer.test.jsx
+++ b/src/components/manage/Blocks/ToC/variations/DefaultTocRenderer.test.jsx
@@ -1,0 +1,44 @@
+import renderer from 'react-test-renderer';
+import configureStore from 'redux-mock-store';
+import { Provider } from 'react-intl-redux';
+import { MemoryRouter } from 'react-router-dom';
+import DefaultTocRenderer from './DefaultTocRenderer';
+
+const mockStore = configureStore();
+
+const data = { '@type': 'toc', variation: 'default' };
+
+const tocEntries = [
+  {
+    level: 2,
+    title: 'Hello this is a sample page',
+    items: [
+      {
+        level: 3,
+        title: 'Test level 3',
+        items: [],
+        id: 'be612682-6df9-4a5e-b3a1-9dec5d82ae14',
+        parentId: '3a8bff13-3245-44f6-8a35-e0defef5898e',
+      },
+    ],
+    id: '3a8bff13-3245-44f6-8a35-e0defef5898e',
+  },
+];
+
+test('renders a default toc renderer component', () => {
+  const store = mockStore({
+    intl: {
+      locale: 'en',
+      messages: {},
+    },
+  });
+  const component = renderer.create(
+    <Provider store={store}>
+      <MemoryRouter>
+        <DefaultTocRenderer data={data} tocEntries={tocEntries} />
+      </MemoryRouter>
+    </Provider>,
+  );
+  const json = component.toJSON();
+  expect(json).toMatchSnapshot();
+});

--- a/src/components/manage/Blocks/ToC/variations/__snapshots__/DefaultTocRenderer.test.jsx.snap
+++ b/src/components/manage/Blocks/ToC/variations/__snapshots__/DefaultTocRenderer.test.jsx.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders a default toc renderer component 1`] = `
+Array [
+  "",
+  <ul
+    className="ui bulleted list"
+    role="list"
+  >
+    <li
+      className="item headline-2"
+      onClick={[Function]}
+      role="listitem"
+    >
+      <a
+        href="#hello-this-is-a-sample-page"
+        onClick={[Function]}
+      >
+        Hello this is a sample page
+      </a>
+      <ul
+        className="ui bulleted list"
+        role="list"
+      >
+        <li
+          className="item headline-3"
+          onClick={[Function]}
+          role="listitem"
+        >
+          <a
+            href="#test-level-3"
+            onClick={[Function]}
+          >
+            Test level 3
+          </a>
+        </li>
+      </ul>
+    </li>
+  </ul>,
+]
+`;


### PR DESCRIPTION
Nested entries were not receiving `history` therefore breaking when running `history.push`.