### PR TITLE
Fix linkcheckbroken 301 redirect to https://www.dlr.de/de

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- You should *NOT* be adding new change log entries to this file.
      You should create a file in the news directory instead.
      For helpful instructions, please see:
-     https://6.docs.plone.org/volto/developer-guidelines/contributing.html#create-a-pull-request
+     https://6.docs.plone.org/contributing/index.html#contributing-change-log-label
 -->
 
 <!-- towncrier release notes start -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@
 
 ### Internal
 
-- Add www.dlr.de to "Volto in production" list. @tisto [#5112](https://github.com/plone/volto/pull/5112)
+- Add https://www.dlr.de/de to "Volto in production" list. @tisto [#5112](https://github.com/plone/volto/pull/5112)
 
 ## 17.0.0-alpha.23 (2023-07-28)
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Volto is actively developed since 2017 and used in production since 2018 on the 
 - [Helmholtz-Institut Erlangen-Nürnberg für Erneuerbare Energien (HI-ERN)](https://www.hi-ern.de) (Website for HI ERN, a research institution for renewable energies, developed by [kitconcept GmbH](https://kitconcept.com), 2022)
 - [Lanku](https://www.lanku.eus) (Website for Lanku Kultur Zerbitzuak, a company offering cultural services and improvised Basque verse singing sessions across the Basque Country, developed by [CodeSyntax](https://www.codesyntax.com/en), 2023)
 - [UEU](https://www.ueu.eus) (Website for Udako Euskal Unibertsitatea, a non-profit University offering all its service only in Basque: courses, publications, ... developed by [CodeSyntax](https://www.codesyntax.com/en), 2023)
-- [German Aerospace Center (DLR)](https://dlr.de) (The German Aerospace Center (DLR) is the Federal Republic of Germany's research center for aeronautics. With more than 10.000 employees and a yearly budget of more than 1 billion euros, it is one of the largest research institutions in Germany, developed by [kitconcept GmbH](https://kitconcept.com), 2023)
+- [German Aerospace Center (DLR)](https://www.dlr.de/de) (The German Aerospace Center (DLR) is the Federal Republic of Germany's research center for aeronautics. With more than 10.000 employees and a yearly budget of more than 1 billion euros, it is one of the largest research institutions in Germany, developed by [kitconcept GmbH](https://kitconcept.com), 2023)
 
 Please create a new [issue](https://github.com/plone/volto/issues/new) or [pull request](https://github.com/plone/volto/pulls) to add your Volto-site here!
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -94,6 +94,7 @@ linkcheck_ignore = [
     r"https://github.com/plone/plone.rest#cors",
     r"https://github.com/plone/plone.volto/blob/6f5382c74f668935527e962490b81cb72bf3bc94/src/kitconcept/volto/upgrades.py#L6-L54",
     r"https://github.com/plone/volto/issues/new/choose",
+    r"https://github.com/plone/volto/blob/6fd62cb2860bc7cf3cb7c36ea86bfd8bd03247d9/src/components/manage/Form/Field.jsx#L112",
     r"https://github.com/tc39/proposals/blob/HEAD/finished-proposals.md#finished-proposals",
 ]
 linkcheck_anchors = True

--- a/news/5131.documentation
+++ b/news/5131.documentation
@@ -1,0 +1,1 @@
+Fix linkcheckbroken 301 redirect to https://www.dlr.de/de @stevepiercy


### PR DESCRIPTION
Because we don't include the `CHANGELOG.md` in the build of Volto docs, broken links make it into that automatically generated file. They then show up as broken links in the build of Plone 6 Documentation. The following issue proposed a solution https://github.com/plone/volto/issues/4422, but has not gotten any feedback from a maintainer. @tisto @sneridagh @davisagli I'd do this myself, but I am not sure of how you do a release. In a perfect world, I'd like `CHANGELOG.md` to get copied to `docs/source/release-notes/index.md`, add the `html_meta` stuff for SEO, and remove the include. It would probably be best to add that `html_meta` stuff to `CHANGELOG.md`.