### PR TITLE
[Do not merge] POC for @plone/client integration with Volto

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,9 @@
     ]
   },
   "jest": {
+    "testEnvironmentOptions": {
+      "url": "http://localhost:8080"
+    },
     "modulePathIgnorePatterns": [
       "api",
       "packages"

--- a/package.json
+++ b/package.json
@@ -92,7 +92,8 @@
       "@root/config": "<rootDir>/jest-addons-loader.js",
       "@root/(.*)$": "<rootDir>/src/$1",
       "@voltoconfig": "<rootDir>/jest-addons-loader.js",
-      "\\.(css|less|scss|sass)$": "identity-obj-proxy"
+      "\\.(css|less|scss|sass)$": "identity-obj-proxy",
+      "axios": "<rootDir>/node_modules/@plone/client/node_modules/axios/dist/node/axios.cjs"
     },
     "coverageThreshold": {
       "global": {
@@ -238,6 +239,7 @@
     "@loadable/component": "5.14.1",
     "@loadable/server": "5.14.0",
     "@loadable/webpack-plugin": "5.15.2",
+    "@plone/client": "1.0.0-alpha.3",
     "@plone/scripts": "3.0.0",
     "@testing-library/cypress": "9.0.0",
     "@testing-library/jest-dom": "5.16.4",
@@ -419,6 +421,7 @@
     "jest": "26.6.3",
     "jest-environment-jsdom": "^26",
     "jsonwebtoken": "9.0.0",
+    "nock": "13.3.3",
     "react-error-overlay": "6.0.9",
     "react-is": "^16.13.1",
     "release-it": "^16.1.3",

--- a/src/components/theme/App/App.jsx
+++ b/src/components/theme/App/App.jsx
@@ -20,6 +20,7 @@ import config from '@plone/volto/registry';
 import { PluggablesProvider } from '@plone/volto/components/manage/Pluggable';
 import { visitBlocks } from '@plone/volto/helpers/Blocks/Blocks';
 import { injectIntl } from 'react-intl';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import Error from '@plone/volto/error';
 
@@ -331,4 +332,12 @@ export function connectAppComponent(AppComponent) {
   )(AppComponent);
 }
 
-export default connectAppComponent(App);
+const queryClient = new QueryClient();
+
+export const AppWithQueryClient = (props) => (
+  <QueryClientProvider client={queryClient}>
+    <App {...props} />
+  </QueryClientProvider>
+);
+
+export default connectAppComponent(AppWithQueryClient);

--- a/src/components/theme/Breadcrumbs/Breadcrumbs.jsx
+++ b/src/components/theme/Breadcrumbs/Breadcrumbs.jsx
@@ -28,16 +28,10 @@ const messages = defineMessages({
 const BreadcrumbsComponent = ({ pathname }) => {
   const intl = useIntl();
 
-  const { data, isLoading, isFetching } = useQuery(
-    getBreadcrumbsQuery(pathname),
-  );
+  const { data } = useQuery(getBreadcrumbsQuery({ path: pathname }));
 
   const items = data?.items || [];
   const root = data?.root || '/';
-
-  console.log('loading', isLoading);
-  console.log('fetching', isFetching);
-  console.log('abc', data);
 
   return (
     <Segment

--- a/src/components/theme/Breadcrumbs/Breadcrumbs.jsx
+++ b/src/components/theme/Breadcrumbs/Breadcrumbs.jsx
@@ -4,11 +4,15 @@ import { Link } from 'react-router-dom';
 import { Breadcrumb, Container, Segment } from 'semantic-ui-react';
 import { defineMessages, useIntl } from 'react-intl';
 import { useDispatch, useSelector, shallowEqual } from 'react-redux';
-
+import { useQuery } from '@tanstack/react-query';
 import { getBreadcrumbs } from '@plone/volto/actions';
+import ploneClient from '@root/plone-client';
+
 import { getBaseUrl, hasApiExpander } from '@plone/volto/helpers';
 import { Icon } from '@plone/volto/components';
 import homeSVG from '@plone/volto/icons/home.svg';
+
+const { getBreadcrumbsQuery } = ploneClient;
 
 const messages = defineMessages({
   home: {
@@ -23,16 +27,17 @@ const messages = defineMessages({
 
 const BreadcrumbsComponent = ({ pathname }) => {
   const intl = useIntl();
-  const dispatch = useDispatch();
 
-  const items = useSelector((state) => state.breadcrumbs.items, shallowEqual);
-  const root = useSelector((state) => state.breadcrumbs.root);
+  const { data, isLoading, isFetching } = useQuery(
+    getBreadcrumbsQuery(pathname),
+  );
 
-  useEffect(() => {
-    if (!hasApiExpander('breadcrumbs', getBaseUrl(pathname))) {
-      dispatch(getBreadcrumbs(getBaseUrl(pathname)));
-    }
-  }, [dispatch, pathname]);
+  const items = data?.items || [];
+  const root = data?.root || '/';
+
+  console.log('loading', isLoading);
+  console.log('fetching', isFetching);
+  console.log('abc', data);
 
   return (
     <Segment

--- a/src/components/theme/Breadcrumbs/Breadcrumbs.test.jsx
+++ b/src/components/theme/Breadcrumbs/Breadcrumbs.test.jsx
@@ -1,35 +1,37 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
 import configureStore from 'redux-mock-store';
 import { Provider } from 'react-intl-redux';
 import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { screen, waitFor, render } from '@testing-library/react';
 
 import Breadcrumbs from './Breadcrumbs';
 
 const mockStore = configureStore();
 
+const queryClient = new QueryClient();
+
 describe('Breadcrumbs', () => {
-  it('renders a breadcrumbs component', () => {
+  it('renders a breadcrumbs component', async () => {
     const store = mockStore({
-      breadcrumbs: {
-        items: [
-          { title: 'Blog', url: '/blog' },
-          { title: 'My first blog', url: '/blog/my-first-blog' },
-        ],
-      },
       intl: {
         locale: 'en',
         messages: {},
       },
     });
-    const component = renderer.create(
+    const component = render(
       <Provider store={store}>
         <MemoryRouter>
-          <Breadcrumbs pathname="/blog" />
+          <QueryClientProvider client={queryClient}>
+            <Breadcrumbs pathname="/blog" />
+          </QueryClientProvider>
         </MemoryRouter>
       </Provider>,
     );
-    const json = component.toJSON();
-    expect(json).toMatchSnapshot();
+    await waitFor(() =>
+      expect(screen.getByText('My first blog')).toBeInTheDocument(),
+    );
+    // const json = component.toJSON();
+    // expect(json).toMatchSnapshot();
   });
 });

--- a/src/components/theme/Breadcrumbs/__snapshots__/Breadcrumbs.test.jsx.snap
+++ b/src/components/theme/Breadcrumbs/__snapshots__/Breadcrumbs.test.jsx.snap
@@ -1,43 +1,53 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Breadcrumbs renders a breadcrumbs component 1`] = `
-<div
-  aria-label="Breadcrumbs"
-  className="ui secondary vertical segment breadcrumbs"
-  role="navigation"
->
+<DocumentFragment>
   <div
-    className="ui container"
+    aria-label="Breadcrumbs"
+    class="ui secondary vertical segment breadcrumbs"
+    role="navigation"
   >
     <div
-      className="ui breadcrumb"
+      class="ui container"
     >
-      <a
-        className="section"
-        href="/"
-        onClick={[Function]}
-        title="Home"
+      <div
+        class="ui breadcrumb"
       >
-        <svg
-          className="icon"
-          dangerouslySetInnerHTML={
-            Object {
-              "__html": undefined,
-            }
-          }
-          onClick={null}
-          style={
-            Object {
-              "fill": "currentColor",
-              "height": "18px",
-              "width": "auto",
-            }
-          }
-          viewBox=""
-          xmlns=""
-        />
-      </a>
+        <a
+          class="section"
+          href="/"
+          title="Home"
+        >
+          <svg
+            class="icon"
+            style="height: 18px; width: auto; fill: currentColor;"
+            viewBox=""
+            xmlns=""
+          />
+        </a>
+        <div
+          class="divider"
+        >
+          /
+        </div>
+        <a
+          class="section"
+          href="/blog"
+        >
+          Blog
+        </a>
+        <div
+          class="divider"
+        >
+          /
+        </div>
+        <div
+          class="active section"
+        >
+          My first blog
+        </div>
+      </div>
     </div>
   </div>
-</div>
+</DocumentFragment>
 `;

--- a/src/components/theme/Breadcrumbs/__snapshots__/Breadcrumbs.test.jsx.snap
+++ b/src/components/theme/Breadcrumbs/__snapshots__/Breadcrumbs.test.jsx.snap
@@ -37,29 +37,6 @@ exports[`Breadcrumbs renders a breadcrumbs component 1`] = `
           xmlns=""
         />
       </a>
-      <div
-        className="divider"
-      >
-        /
-      </div>
-      <a
-        className="section"
-        href="/blog"
-        onClick={[Function]}
-      >
-        Blog
-      </a>
-      <div
-        className="divider"
-      >
-        /
-      </div>
-      <div
-        className="active section"
-        onClick={[Function]}
-      >
-        My first blog
-      </div>
     </div>
   </div>
 </div>

--- a/src/plone-client.js
+++ b/src/plone-client.js
@@ -1,0 +1,14 @@
+import ploneClient from '@plone/client';
+
+/*
+ * Initialize the Plone client with the API path.
+ * Here we are creating a singleton to be used across the application.
+ *
+ * To use mutations, you would need to `await client.log(username, password)` first in
+ * a useEffect hook in the main app.
+ */
+const client = ploneClient.initialize({
+  apiPath: 'http://localhost:8080/Plone',
+});
+
+export default client;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2624,6 +2624,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@plone/client@npm:1.0.0-alpha.3":
+  version: 1.0.0-alpha.3
+  resolution: "@plone/client@npm:1.0.0-alpha.3"
+  dependencies:
+    "@tanstack/react-query": 4.29.1
+    axios: ^1.4.0
+    query-string: ^8.1.0
+    universal-cookie: ^4.0.4
+    zod: ^3.21.4
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+  peerDependenciesMeta:
+    react-dom:
+      optional: true
+  checksum: f8d0ad283c65b6bf15c044f8e4ef0b1f76f7059168a494e2a718932d43081a1cc250e5b8e4aee978d900d2978c5520a36af106b2db41a2722a320c714d33a723
+  languageName: node
+  linkType: hard
+
 "@plone/scripts@npm:3.0.0":
   version: 3.0.0
   resolution: "@plone/scripts@npm:3.0.0"
@@ -2661,6 +2680,7 @@ __metadata:
     "@loadable/component": 5.14.1
     "@loadable/server": 5.14.0
     "@loadable/webpack-plugin": 5.15.2
+    "@plone/client": 1.0.0-alpha.3
     "@plone/scripts": 3.0.0
     "@storybook/addon-actions": ^6.5.15
     "@storybook/addon-controls": 6.5.15
@@ -2749,6 +2769,7 @@ __metadata:
     lodash-webpack-plugin: 0.11.6
     mini-css-extract-plugin: 2.7.2
     moment: 2.29.4
+    nock: 13.3.3
     object-assign: 4.1.1
     pofile: 1.0.10
     postcss: 8.4.13
@@ -4258,6 +4279,32 @@ __metadata:
   dependencies:
     defer-to-connect: ^2.0.1
   checksum: fc9cb993e808806692e4a3337c90ece0ec00c89f4b67e3652a356b89730da98bc824273a6d67ca84d5f33cd85f317dcd5ce39d8cc0a2f060145a608a7cb8ce92
+  languageName: node
+  linkType: hard
+
+"@tanstack/query-core@npm:4.29.1":
+  version: 4.29.1
+  resolution: "@tanstack/query-core@npm:4.29.1"
+  checksum: e7a5a73e5e743411e39348bee3ded4b6c5dd3a70009e72e067e257d5f3d612bfe8df0998cddff6ad7a078e0bcf7a3c92ded669758ca697055472ce910e23a368
+  languageName: node
+  linkType: hard
+
+"@tanstack/react-query@npm:4.29.1":
+  version: 4.29.1
+  resolution: "@tanstack/react-query@npm:4.29.1"
+  dependencies:
+    "@tanstack/query-core": 4.29.1
+    use-sync-external-store: ^1.2.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-native: "*"
+  peerDependenciesMeta:
+    react-dom:
+      optional: true
+    react-native:
+      optional: true
+  checksum: 39417ffd3a6298b376f1d739dc2fe4c042c416902c216f61dff9b26dc80d68872770c90ac276db581c1094368f0b9038a34fab8b7df89b018f3960c938d73a57
   languageName: node
   linkType: hard
 
@@ -6294,6 +6341,17 @@ __metadata:
   dependencies:
     follow-redirects: ^1.14.4
   checksum: 468cf496c08a6aadfb7e699bebdac02851e3043d4e7d282350804ea8900e30d368daa6e3cd4ab83b8ddb5a3b1e17a5a21ada13fc9cebd27b74828f47a4236316
+  languageName: node
+  linkType: hard
+
+"axios@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "axios@npm:1.4.0"
+  dependencies:
+    follow-redirects: ^1.15.0
+    form-data: ^4.0.0
+    proxy-from-env: ^1.1.0
+  checksum: 7fb6a4313bae7f45e89d62c70a800913c303df653f19eafec88e56cea2e3821066b8409bc68be1930ecca80e861c52aa787659df0ffec6ad4d451c7816b9386b
   languageName: node
   linkType: hard
 
@@ -9183,6 +9241,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"decode-uri-component@npm:^0.4.1":
+  version: 0.4.1
+  resolution: "decode-uri-component@npm:0.4.1"
+  checksum: 0473924860986fb6ca19ee65a2af13e08801b4f3660475b058500ea8479ed715c919884a026b6bf4296dbb640d3cea74fadf45490b2439152fc548271d0201ec
+  languageName: node
+  linkType: hard
+
 "decompress-response@npm:^6.0.0":
   version: 6.0.0
   resolution: "decompress-response@npm:6.0.0"
@@ -11471,6 +11536,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"filter-obj@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "filter-obj@npm:5.1.0"
+  checksum: ba7c24d9b2c0552ee87d268e07eca74483af61fb740545ffa809f7e9e5294de38cf163ecc55af0e8a40020af9a49512c32f4022de2a858b110420fc8bffa7c9c
+  languageName: node
+  linkType: hard
+
 "finalhandler@npm:1.2.0":
   version: 1.2.0
   resolution: "finalhandler@npm:1.2.0"
@@ -11639,7 +11711,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.0.0, follow-redirects@npm:^1.14.0, follow-redirects@npm:^1.14.4":
+"follow-redirects@npm:^1.0.0, follow-redirects@npm:^1.14.0, follow-redirects@npm:^1.14.4, follow-redirects@npm:^1.15.0":
   version: 1.15.2
   resolution: "follow-redirects@npm:1.15.2"
   peerDependenciesMeta:
@@ -11754,6 +11826,17 @@ __metadata:
     combined-stream: ^1.0.8
     mime-types: ^2.1.12
   checksum: b019e8d35c8afc14a2bd8a7a92fa4f525a4726b6d5a9740e8d2623c30e308fbb58dc8469f90415a856698933c8479b01646a9dff33c87cc4e76d72aedbbf860d
+  languageName: node
+  linkType: hard
+
+"form-data@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "form-data@npm:4.0.0"
+  dependencies:
+    asynckit: ^0.4.0
+    combined-stream: ^1.0.8
+    mime-types: ^2.1.12
+  checksum: 01135bf8675f9d5c61ff18e2e2932f719ca4de964e3be90ef4c36aacfc7b9cb2fceb5eca0b7e0190e3383fe51c5b37f4cb80b62ca06a99aaabfcfd6ac7c9328c
   languageName: node
   linkType: hard
 
@@ -15278,7 +15361,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json-stringify-safe@npm:~5.0.1":
+"json-stringify-safe@npm:^5.0.1, json-stringify-safe@npm:~5.0.1":
   version: 5.0.1
   resolution: "json-stringify-safe@npm:5.0.1"
   checksum: 48ec0adad5280b8a96bb93f4563aa1667fd7a36334f79149abd42446d0989f2ddc58274b479f4819f1f00617957e6344c886c55d05a4e15ebb4ab931e4a6a8ee
@@ -16908,6 +16991,18 @@ __metadata:
     lower-case: ^2.0.2
     tslib: ^2.0.3
   checksum: 0b2ebc113dfcf737d48dde49cfebf3ad2d82a8c3188e7100c6f375e30eafbef9e9124aadc3becef237b042fd5eb0aad2fd78669c20972d045bbe7fea8ba0be5c
+  languageName: node
+  linkType: hard
+
+"nock@npm:13.3.3":
+  version: 13.3.3
+  resolution: "nock@npm:13.3.3"
+  dependencies:
+    debug: ^4.1.0
+    json-stringify-safe: ^5.0.1
+    lodash: ^4.17.21
+    propagate: ^2.0.0
+  checksum: e3e4f0fb777ac63d74f89bbb7aebe8e815b891b64ac71983d91686f725fdab856fe189cf2fe23d4add9f5dd5da53f3568106a61116a771ce0f4ed0f5ad7b035b
   languageName: node
   linkType: hard
 
@@ -19124,6 +19219,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"propagate@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "propagate@npm:2.0.1"
+  checksum: c4febaee2be0979e82fb6b3727878fd122a98d64a7fa3c9d09b0576751b88514a9e9275b1b92e76b364d488f508e223bd7e1dcdc616be4cdda876072fbc2a96c
+  languageName: node
+  linkType: hard
+
 "property-information@npm:^5.0.0, property-information@npm:^5.3.0":
   version: 5.6.0
   resolution: "property-information@npm:5.6.0"
@@ -19354,6 +19456,17 @@ __metadata:
     split-on-first: ^1.0.0
     strict-uri-encode: ^2.0.0
   checksum: f2c7347578fa0f3fd4eaace506470cb4e9dc52d409a7ddbd613f614b9a594d750877e193b5d5e843c7477b3b295b857ec328903c943957adc41a3efb6c929449
+  languageName: node
+  linkType: hard
+
+"query-string@npm:^8.1.0":
+  version: 8.1.0
+  resolution: "query-string@npm:8.1.0"
+  dependencies:
+    decode-uri-component: ^0.4.1
+    filter-obj: ^5.1.0
+    split-on-first: ^3.0.0
+  checksum: 16fe49ab714f2b802bd31bc417876a38a82cd49bea01c0d6c37ca3439604c774752c8c66f9eda5ee33c268de2fc2a65e0e0e27aa97d8d98159af5c1fc838a017
   languageName: node
   linkType: hard
 
@@ -22394,6 +22507,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"split-on-first@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "split-on-first@npm:3.0.0"
+  checksum: 75dc27ecbac65cfbeab9a3b90cf046307220192d3d7a30e46aa0f19571cc9b4802aac813f3de2cc9b16f2e46aae72f275659b5d2614bb5369c77724d739e5f73
+  languageName: node
+  linkType: hard
+
 "split-string@npm:^3.0.1, split-string@npm:^3.0.2":
   version: 3.1.0
   resolution: "split-string@npm:3.1.0"
@@ -24176,7 +24296,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"universal-cookie@npm:4.0.4, universal-cookie@npm:^4.0.0":
+"universal-cookie@npm:4.0.4, universal-cookie@npm:^4.0.0, universal-cookie@npm:^4.0.4":
   version: 4.0.4
   resolution: "universal-cookie@npm:4.0.4"
   dependencies:
@@ -24392,6 +24512,15 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
   checksum: 8f08eba26d69406b61bb4b8dacdd5a92bd6aef5b53d346dfe87954f7330ee10ecabc937cc7854635155d46053828e85c10b5a5aff7a04720e6a97b9f42999bac
+  languageName: node
+  linkType: hard
+
+"use-sync-external-store@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "use-sync-external-store@npm:1.2.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: 5c639e0f8da3521d605f59ce5be9e094ca772bd44a4ce7322b055a6f58eeed8dda3c94cabd90c7a41fb6fa852210092008afe48f7038792fd47501f33299116a
   languageName: node
   linkType: hard
 
@@ -25546,6 +25675,13 @@ __metadata:
   version: 0.1.0
   resolution: "yocto-queue@npm:0.1.0"
   checksum: f77b3d8d00310def622123df93d4ee654fc6a0096182af8bd60679ddcdfb3474c56c6c7190817c84a2785648cdee9d721c0154eb45698c62176c322fb46fc700
+  languageName: node
+  linkType: hard
+
+"zod@npm:^3.21.4":
+  version: 3.22.2
+  resolution: "zod@npm:3.22.2"
+  checksum: 231e2180c8eabb56e88680d80baff5cf6cbe6d64df3c44c50ebe52f73081ecd0229b1c7215b9552537f537a36d9e36afac2737ddd86dc14e3519bdbc777e82b9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR adds a POC  for `@plone/client` integration with the Breadcrumbs component and updates the tests accordingly.

`@plone/client` provides react-hooks and `@tanstack/react-query` query objects to fetch data and call mutations for various actions,

This POC currently uses an older version of `@plone/client`. I will update the POC when the latest version is published.

## Some callouts for this PR:

### Issue with axios import (used by `@plone/client` internally)
Jest requires cjs version of axios to work, so I have linked to the cjs version directly in the jest "moduleNameMapper" - apparently latest version of jest should work out of the box though so we can consider upgrading jest and other jest-related dependencies of volto (ref: https://stackoverflow.com/a/74020536)

### Mocking API calls
Previously the tests were written by updating the redux `store` object with a mocked value that would resolve to props in the components being tested. With `@tanstack/react-query` we don't need the redux store anymore, as it maintains its own data store internally based on the query keys. Consequently, we need to mock the API call being made by `@plone/client` to get the data.

There are 2 ways to do it:
1. mock the `axios` object - this is non-trivial because `axios` is a transitive dependency for volto (volto => @plone/client => axios) and that makes it hard to do. I have tried multiple ways to do this with no success. We can definitely do it if we make `axios` a peer-dependency of `@plone/client` instead of a direct dependency.
2. use a global http interceptor for nodejs like `nock` - this is a fairly simple solution and it is implemented in this POC

There are some improvements to be made to `@plone/client` to make sure that the integration with volto (and other non-react) projects is smoother. More info on this will be added to `@plone/client` readme.