### PR TITLE
Added hide and show feature of volto blocks

### DIFF
--- a/locales/ca/LC_MESSAGES/volto.po
+++ b/locales/ca/LC_MESSAGES/volto.po
@@ -4458,6 +4458,11 @@ msgstr "S'ha enviat la confirmació de restabliment de la contrasenya"
 msgid "hero"
 msgstr "Heroi"
 
+#: components/manage/Blocks/Block/EditBlockWrapper
+# defaultMessage: hide
+msgid "hide"
+msgstr ""
+
 #: config/Blocks
 # defaultMessage: HTML
 msgid "html"
@@ -4795,6 +4800,11 @@ msgstr ""
 #: components/manage/Blocks/Search/components/ViewSwitcher
 # defaultMessage: Select view
 msgid "selectView"
+msgstr ""
+
+#: components/manage/Blocks/Block/EditBlockWrapper
+# defaultMessage: show
+msgid "show"
 msgstr ""
 
 #: components/theme/SkipLinks/SkipLinks

--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -4455,6 +4455,11 @@ msgstr "Bestätigung für das Zurücksetzen des Passwortes wurde gesendet!"
 msgid "hero"
 msgstr "Hero"
 
+#: components/manage/Blocks/Block/EditBlockWrapper
+# defaultMessage: hide
+msgid "hide"
+msgstr ""
+
 #: config/Blocks
 # defaultMessage: HTML
 msgid "html"
@@ -4793,6 +4798,11 @@ msgstr "Auswählen"
 # defaultMessage: Select view
 msgid "selectView"
 msgstr "Ansicht wählen"
+
+#: components/manage/Blocks/Block/EditBlockWrapper
+# defaultMessage: show
+msgid "show"
+msgstr ""
 
 #: components/theme/SkipLinks/SkipLinks
 # defaultMessage: Skip to footer

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -4449,6 +4449,11 @@ msgstr ""
 msgid "hero"
 msgstr ""
 
+#: components/manage/Blocks/Block/EditBlockWrapper
+# defaultMessage: hide
+msgid "hide"
+msgstr ""
+
 #: config/Blocks
 # defaultMessage: HTML
 msgid "html"
@@ -4786,6 +4791,11 @@ msgstr ""
 #: components/manage/Blocks/Search/components/ViewSwitcher
 # defaultMessage: Select view
 msgid "selectView"
+msgstr ""
+
+#: components/manage/Blocks/Block/EditBlockWrapper
+# defaultMessage: show
+msgid "show"
 msgstr ""
 
 #: components/theme/SkipLinks/SkipLinks

--- a/locales/es/LC_MESSAGES/volto.po
+++ b/locales/es/LC_MESSAGES/volto.po
@@ -4460,6 +4460,11 @@ msgstr "Solicitud de confirmación de restablecimiento de contraseña enviada"
 msgid "hero"
 msgstr "Héroe"
 
+#: components/manage/Blocks/Block/EditBlockWrapper
+# defaultMessage: hide
+msgid "hide"
+msgstr ""
+
 #: config/Blocks
 # defaultMessage: HTML
 msgid "html"
@@ -4798,6 +4803,11 @@ msgstr "Menú de selección"
 # defaultMessage: Select view
 msgid "selectView"
 msgstr "Seleccione Vista"
+
+#: components/manage/Blocks/Block/EditBlockWrapper
+# defaultMessage: show
+msgid "show"
+msgstr ""
 
 #: components/theme/SkipLinks/SkipLinks
 # defaultMessage: Skip to footer

--- a/locales/eu/LC_MESSAGES/volto.po
+++ b/locales/eu/LC_MESSAGES/volto.po
@@ -4456,6 +4456,11 @@ msgstr "Pasahitza aldatzeko eskaera bidalia"
 msgid "hero"
 msgstr "Hero"
 
+#: components/manage/Blocks/Block/EditBlockWrapper
+# defaultMessage: hide
+msgid "hide"
+msgstr ""
+
 #: config/Blocks
 # defaultMessage: HTML
 msgid "html"
@@ -4794,6 +4799,11 @@ msgstr "Aukeraketa laukia"
 # defaultMessage: Select view
 msgid "selectView"
 msgstr "Aukeratu bista"
+
+#: components/manage/Blocks/Block/EditBlockWrapper
+# defaultMessage: show
+msgid "show"
+msgstr ""
 
 #: components/theme/SkipLinks/SkipLinks
 # defaultMessage: Skip to footer

--- a/locales/fi/LC_MESSAGES/volto.po
+++ b/locales/fi/LC_MESSAGES/volto.po
@@ -4460,6 +4460,11 @@ msgstr "Sähköposti salasanan vaihtamiseksi lähetetty"
 msgid "hero"
 msgstr "nosto"
 
+#: components/manage/Blocks/Block/EditBlockWrapper
+# defaultMessage: hide
+msgid "hide"
+msgstr ""
+
 #: config/Blocks
 # defaultMessage: HTML
 msgid "html"
@@ -4798,6 +4803,11 @@ msgstr "Valitse"
 # defaultMessage: Select view
 msgid "selectView"
 msgstr "Valitse näkymä"
+
+#: components/manage/Blocks/Block/EditBlockWrapper
+# defaultMessage: show
+msgid "show"
+msgstr ""
 
 #: components/theme/SkipLinks/SkipLinks
 # defaultMessage: Skip to footer

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -4466,6 +4466,11 @@ msgstr "Procédure de réinitialisation de mot de passe envoyée"
 msgid "hero"
 msgstr "hero"
 
+#: components/manage/Blocks/Block/EditBlockWrapper
+# defaultMessage: hide
+msgid "hide"
+msgstr "Masquer"
+
 #: config/Blocks
 # defaultMessage: HTML
 msgid "html"
@@ -4804,6 +4809,11 @@ msgstr "List de sélection"
 # defaultMessage: Select view
 msgid "selectView"
 msgstr "Sélectionner une vue"
+
+#: components/manage/Blocks/Block/EditBlockWrapper
+# defaultMessage: show
+msgid "show"
+msgstr "Afficher"
 
 #: components/theme/SkipLinks/SkipLinks
 # defaultMessage: Skip to footer

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -4449,6 +4449,11 @@ msgstr "Richiesta di conferma reimpostazione password spedita"
 msgid "hero"
 msgstr "Hero"
 
+#: components/manage/Blocks/Block/EditBlockWrapper
+# defaultMessage: hide
+msgid "hide"
+msgstr "Nascondi"
+
 #: config/Blocks
 # defaultMessage: HTML
 msgid "html"
@@ -4787,6 +4792,11 @@ msgstr "Seleziona"
 # defaultMessage: Select view
 msgid "selectView"
 msgstr "Seleziona la vista"
+
+#: components/manage/Blocks/Block/EditBlockWrapper
+# defaultMessage: show
+msgid "show"
+msgstr "Mostra"
 
 #: components/theme/SkipLinks/SkipLinks
 # defaultMessage: Skip to footer

--- a/locales/ja/LC_MESSAGES/volto.po
+++ b/locales/ja/LC_MESSAGES/volto.po
@@ -4457,6 +4457,11 @@ msgstr "パスワード再設定の確認が送られました"
 msgid "hero"
 msgstr "ヒーロー"
 
+#: components/manage/Blocks/Block/EditBlockWrapper
+# defaultMessage: hide
+msgid "hide"
+msgstr ""
+
 #: config/Blocks
 # defaultMessage: HTML
 msgid "html"
@@ -4794,6 +4799,11 @@ msgstr ""
 #: components/manage/Blocks/Search/components/ViewSwitcher
 # defaultMessage: Select view
 msgid "selectView"
+msgstr ""
+
+#: components/manage/Blocks/Block/EditBlockWrapper
+# defaultMessage: show
+msgid "show"
 msgstr ""
 
 #: components/theme/SkipLinks/SkipLinks

--- a/locales/nl/LC_MESSAGES/volto.po
+++ b/locales/nl/LC_MESSAGES/volto.po
@@ -4468,6 +4468,11 @@ msgstr ""
 msgid "hero"
 msgstr ""
 
+#: components/manage/Blocks/Block/EditBlockWrapper
+# defaultMessage: hide
+msgid "hide"
+msgstr ""
+
 #: config/Blocks
 # defaultMessage: HTML
 msgid "html"
@@ -4805,6 +4810,11 @@ msgstr ""
 #: components/manage/Blocks/Search/components/ViewSwitcher
 # defaultMessage: Select view
 msgid "selectView"
+msgstr ""
+
+#: components/manage/Blocks/Block/EditBlockWrapper
+# defaultMessage: show
+msgid "show"
 msgstr ""
 
 #: components/theme/SkipLinks/SkipLinks

--- a/locales/pt/LC_MESSAGES/volto.po
+++ b/locales/pt/LC_MESSAGES/volto.po
@@ -4457,6 +4457,11 @@ msgstr "título_senha_enviada"
 msgid "hero"
 msgstr "herói"
 
+#: components/manage/Blocks/Block/EditBlockWrapper
+# defaultMessage: hide
+msgid "hide"
+msgstr ""
+
 #: config/Blocks
 # defaultMessage: HTML
 msgid "html"
@@ -4794,6 +4799,11 @@ msgstr ""
 #: components/manage/Blocks/Search/components/ViewSwitcher
 # defaultMessage: Select view
 msgid "selectView"
+msgstr ""
+
+#: components/manage/Blocks/Block/EditBlockWrapper
+# defaultMessage: show
+msgid "show"
 msgstr ""
 
 #: components/theme/SkipLinks/SkipLinks

--- a/locales/pt_BR/LC_MESSAGES/volto.po
+++ b/locales/pt_BR/LC_MESSAGES/volto.po
@@ -4459,6 +4459,11 @@ msgstr "Sua solicitação de redefinição de senha foi enviada"
 msgid "hero"
 msgstr "Herói"
 
+#: components/manage/Blocks/Block/EditBlockWrapper
+# defaultMessage: hide
+msgid "hide"
+msgstr ""
+
 #: config/Blocks
 # defaultMessage: HTML
 msgid "html"
@@ -4797,6 +4802,11 @@ msgstr "Seleção"
 # defaultMessage: Select view
 msgid "selectView"
 msgstr "Escolha a visão"
+
+#: components/manage/Blocks/Block/EditBlockWrapper
+# defaultMessage: show
+msgid "show"
+msgstr ""
 
 #: components/theme/SkipLinks/SkipLinks
 # defaultMessage: Skip to footer

--- a/locales/ro/LC_MESSAGES/volto.po
+++ b/locales/ro/LC_MESSAGES/volto.po
@@ -4449,6 +4449,11 @@ msgstr "Confirmare schimbare parolă trimisă cu succes"
 msgid "hero"
 msgstr "Hero"
 
+#: components/manage/Blocks/Block/EditBlockWrapper
+# defaultMessage: hide
+msgid "hide"
+msgstr ""
+
 #: config/Blocks
 # defaultMessage: HTML
 msgid "html"
@@ -4786,6 +4791,11 @@ msgstr ""
 #: components/manage/Blocks/Search/components/ViewSwitcher
 # defaultMessage: Select view
 msgid "selectView"
+msgstr ""
+
+#: components/manage/Blocks/Block/EditBlockWrapper
+# defaultMessage: show
+msgid "show"
 msgstr ""
 
 #: components/theme/SkipLinks/SkipLinks

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2023-08-10T11:08:51.764Z\n"
+"POT-Creation-Date: 2023-09-04T12:58:57.404Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -4451,6 +4451,11 @@ msgstr ""
 msgid "hero"
 msgstr ""
 
+#: components/manage/Blocks/Block/EditBlockWrapper
+# defaultMessage: hide
+msgid "hide"
+msgstr ""
+
 #: config/Blocks
 # defaultMessage: HTML
 msgid "html"
@@ -4788,6 +4793,11 @@ msgstr ""
 #: components/manage/Blocks/Search/components/ViewSwitcher
 # defaultMessage: Select view
 msgid "selectView"
+msgstr ""
+
+#: components/manage/Blocks/Block/EditBlockWrapper
+# defaultMessage: show
+msgid "show"
 msgstr ""
 
 #: components/theme/SkipLinks/SkipLinks

--- a/locales/zh_CN/LC_MESSAGES/volto.po
+++ b/locales/zh_CN/LC_MESSAGES/volto.po
@@ -4455,6 +4455,11 @@ msgstr "密码重置确认邮件已发送"
 msgid "hero"
 msgstr ""
 
+#: components/manage/Blocks/Block/EditBlockWrapper
+# defaultMessage: hide
+msgid "hide"
+msgstr ""
+
 #: config/Blocks
 # defaultMessage: HTML
 msgid "html"
@@ -4793,6 +4798,11 @@ msgstr ""
 # defaultMessage: Select view
 msgid "selectView"
 msgstr "选择视图"
+
+#: components/manage/Blocks/Block/EditBlockWrapper
+# defaultMessage: show
+msgid "show"
+msgstr ""
 
 #: components/theme/SkipLinks/SkipLinks
 # defaultMessage: Skip to footer

--- a/news/5157.feature
+++ b/news/5157.feature
@@ -1,0 +1,1 @@
+Added hide and show feature of Volto blocks. @SaraBianchi

--- a/src/components/manage/Blocks/Block/Edit.jsx
+++ b/src/components/manage/Blocks/Block/Edit.jsx
@@ -161,6 +161,7 @@ export class Edit extends Component {
             className={cx('block', type, this.props.data.variation, {
               selected: this.props.selected || this.props.multiSelected,
               multiSelected: this.props.multiSelected,
+              hidden: this.props.data.hidden,
             })}
             style={{ outline: 'none' }}
             ref={this.blockNode}
@@ -199,7 +200,9 @@ export class Edit extends Component {
                     )
                 : null
             }
-            className={cx(`block ${type}`, { selected: this.props.selected })}
+            className={cx(`block ${type}`, {
+              selected: this.props.selected,
+            })}
             style={{ outline: 'none' }}
             ref={this.blockNode}
             // The tabIndex is required for the keyboard navigation

--- a/src/components/manage/Blocks/Block/EditBlockWrapper.jsx
+++ b/src/components/manage/Blocks/Block/EditBlockWrapper.jsx
@@ -104,7 +104,7 @@ const EditBlockWrapper = (props) => {
               <Button
                 icon
                 basic
-                color={!data.hidden ? '' : 'red'}
+                color={!data.hidden ? 'grey' : 'red'}
                 onClick={() =>
                   onChangeBlock(block, {
                     ...data,

--- a/src/components/manage/Blocks/Block/EditBlockWrapper.jsx
+++ b/src/components/manage/Blocks/Block/EditBlockWrapper.jsx
@@ -14,11 +14,21 @@ import config from '@plone/volto/registry';
 import { BlockChooserButton } from '@plone/volto/components';
 
 import trashSVG from '@plone/volto/icons/delete.svg';
+import hideSVG from '@plone/volto/icons/hide.svg';
+import showSVG from '@plone/volto/icons/show.svg';
 
 const messages = defineMessages({
   delete: {
     id: 'delete',
     defaultMessage: 'delete',
+  },
+  show: {
+    id: 'show',
+    defaultMessage: 'show',
+  },
+  hide: {
+    id: 'hide',
+    defaultMessage: 'hide',
   },
 });
 
@@ -81,15 +91,34 @@ const EditBlockWrapper = (props) => {
         <div className={`ui drag block inner ${type}`}>
           {children}
           {selected && !required && editable && (
-            <Button
-              icon
-              basic
-              onClick={() => onDeleteBlock(block, true)}
-              className="delete-button"
-              aria-label={intl.formatMessage(messages.delete)}
-            >
-              <Icon name={trashSVG} size="18px" />
-            </Button>
+            <>
+              <Button
+                icon
+                basic
+                onClick={() => onDeleteBlock(block, true)}
+                className="delete-button"
+                aria-label={intl.formatMessage(messages.delete)}
+              >
+                <Icon name={trashSVG} size="18px" />
+              </Button>
+              <Button
+                icon
+                basic
+                color={!data.hidden ? '' : 'red'}
+                onClick={() =>
+                  onChangeBlock(block, {
+                    ...data,
+                    hidden: !data.hidden,
+                  })
+                }
+                className="hide-show-button"
+                aria-label={intl.formatMessage(
+                  !data.hidden ? messages.hide : messages.show,
+                )}
+              >
+                <Icon name={!data.hidden ? hideSVG : showSVG} size="18px" />
+              </Button>
+            </>
           )}
           {config.experimental.addBlockButton.enabled && showBlockChooser && (
             <BlockChooserButton

--- a/src/components/manage/Blocks/Block/__snapshots__/BlocksForm.test.jsx.snap
+++ b/src/components/manage/Blocks/Block/__snapshots__/BlocksForm.test.jsx.snap
@@ -65,6 +65,17 @@ exports[`Allow override of blocksConfig 1`] = `
                   xmlns=""
                 />
               </button>
+              <button
+                aria-label="hide"
+                class="ui grey basic icon button hide-show-button"
+              >
+                <svg
+                  class="icon"
+                  style="height: 18px; width: auto; fill: currentColor;"
+                  viewBox=""
+                  xmlns=""
+                />
+              </button>
             </div>
           </div>
         </div>

--- a/src/components/theme/View/RenderBlocks.jsx
+++ b/src/components/theme/View/RenderBlocks.jsx
@@ -46,7 +46,7 @@ const RenderBlocks = (props) => {
           properties: content,
         });
 
-        if (blockData.hidden) {
+        if (blockData?.hidden) {
           return null;
         }
 

--- a/src/components/theme/View/RenderBlocks.jsx
+++ b/src/components/theme/View/RenderBlocks.jsx
@@ -46,6 +46,10 @@ const RenderBlocks = (props) => {
           properties: content,
         });
 
+        if (blockData.hidden) {
+          return null;
+        }
+
         if (content[blocksFieldname]?.[block]?.['@type'] === 'empty') {
           return (
             <MaybeWrap

--- a/theme/themes/pastanaga/extras/blocks.less
+++ b/theme/themes/pastanaga/extras/blocks.less
@@ -42,6 +42,18 @@
   border-color: rgba(120, 192, 215, 0.75);
 }
 
+.block .block.selected.hidden:not(.description) {
+  opacity: 0.65;
+}
+
+.block .block.selected.hidden.description {
+  opacity: 0.9;
+}
+
+.block .block.hidden {
+  opacity: 0.3;
+}
+
 .block .block:hover::before {
   border-color: rgba(120, 192, 215, 0.375);
 }
@@ -501,20 +513,37 @@ body.has-toolbar.has-sidebar-collapsed .ui.wrapper > .ui.inner.block.full {
   }
 }
 
-.block .ui.basic.button.delete-button {
-  position: absolute;
-  top: 0;
-  right: 0;
-  padding: 0;
-  border: none;
-  -webkit-box-shadow: none;
-  box-shadow: none;
-
-  &:hover,
-  &:focus {
+.block .ui.basic.button {
+  &.delete-button,
+  &.hide-show-button {
+    position: absolute;
+    right: 0;
+    padding: 0;
+    border: none;
     -webkit-box-shadow: none;
     box-shadow: none;
-    color: #e40166 !important;
+
+    &:hover,
+    &:focus {
+      -webkit-box-shadow: none;
+      box-shadow: none;
+    }
+  }
+
+  &.delete-button {
+    top: -10px;
+  }
+
+  &.hide-show-button {
+    top: 12px;
+    margin-right: -31px;
+  }
+
+  &.delete-button {
+    &:hover,
+    &:focus {
+      color: #e40166 !important;
+    }
   }
 }
 


### PR DESCRIPTION
New feature to hide and show Volto blocks.

In Edit: the hide/show icons have been added below the "delete" button, if a block is hidden but selected, it has an opacity of 65% and "eye" icon keep red, except for the "Description" block which has a different text color and isn't accessible. If the blocks aren't selected they remain opaque by 30%.

![screen-edit-show-hide](https://github.com/plone/volto/assets/43245702/99b2d81c-06fb-4016-a28d-9af0e69ae808)


In View: `RenderBlocks` has been changed, if the `hidden` property exists, the block doesn't render.

![screen-view-show-hide](https://github.com/plone/volto/assets/43245702/98bc2eb7-8c93-4084-94d2-2c9c2a988663)

