### PR TITLE
Fix use of CSS modules in webpack 5

### DIFF
--- a/news/5019.bugfix
+++ b/news/5019.bugfix
@@ -1,0 +1,1 @@
+Fix use of CSS modules in webpack 5. @wesleybl


### PR DESCRIPTION
In `webpack 5`, when we use the plugin `mini-css-extract-plugin`, the variable `loaderContext._module.matchResource` is filled. This variable is considered when generating the hash of the CSS class name. However, in Volto, the `mini-css-extract-plugin` plugin is only used in the client build. So the CSS class name looked different on the client and the server.

Then, the function that generates the class name was customized, so as not to consider the `loaderContext._module.matchResource` variable.

fixes #5019