### PR TITLE
document the querystringSearchGet setting

### DIFF
--- a/docs/source/configuration/settings-reference.md
+++ b/docs/source/configuration/settings-reference.md
@@ -445,7 +445,8 @@ querystringSearchGet
     Volto uses `HTTP POST` requests to query the `@querystring-search` endpoint.
     This can create a lot of traffic between Volto and the backend, and can also create a lot of cache misses.
 
-    By modifying this configuration setting and setting it to `true` the endpoint queries will be executed as `HTTP GET` requests and thus any proxy-cache in between Volto and the backend may cache those queries making your site performance better.
+    By modifying this configuration setting and setting it to `true`, the endpoint queries will be executed as `HTTP GET` requests.
+    Thus any proxy cache in between Volto and the backend may cache those queries, improving your site performance.
 
     Please, be aware that this could break some other functionality in your site or some of your queries may break because they contain a lot of parameters (there is an HTTP spec that puts a limit on the lenght of a URL). Please test this setting properly before enabling in a production site.
 

--- a/docs/source/configuration/settings-reference.md
+++ b/docs/source/configuration/settings-reference.md
@@ -448,7 +448,9 @@ querystringSearchGet
     By modifying this configuration setting and setting it to `true`, the endpoint queries will be executed as `HTTP GET` requests.
     Thus any proxy cache in between Volto and the backend may cache those queries, improving your site performance.
 
-    Please, be aware that this could break some other functionality in your site or some of your queries may break because they contain a lot of parameters (there is an HTTP spec that puts a limit on the lenght of a URL). Please test this setting properly before enabling in a production site.
+    Please be aware that this could break some other functionality in your site, or some of your queries may break, when they contain more than 2000 characters.
+    [See an explanation of character limits in URLs](https://stackoverflow.com/a/417184/2214933).
+    Please test this setting properly before enabling in a production site.
 
 ```
 

--- a/docs/source/configuration/settings-reference.md
+++ b/docs/source/configuration/settings-reference.md
@@ -441,6 +441,14 @@ siteTitleFormat
         }
     ```
 
+querystringSearchGet
+    Volto uses `HTTP POST` requests to query the `@querystring-search` endpoint.
+    This can create a lot of traffic between Volto and the backend, and can also create a lot of cache misses.
+
+    By modifying this configuration setting and setting it to `true` the endpoint queries will be executed as `HTTP GET` requests and thus any proxy-cache in between Volto and the backend may cache those queries making your site performance better.
+
+    Please, be aware that this could break some other functionality in your site or some of your queries may break because they contain a lot of parameters (there is an HTTP spec that puts a limit on the lenght of a URL). Please test this setting properly before enabling in a production site.
+
 ```
 
 ## Views settings

--- a/docs/source/configuration/settings-reference.md
+++ b/docs/source/configuration/settings-reference.md
@@ -449,7 +449,7 @@ querystringSearchGet
     Thus any proxy cache in between Volto and the backend may cache those queries, improving your site performance.
 
     Please be aware that this could break some other functionality in your site, or some of your queries may break, when they contain more than 2000 characters.
-    [See an explanation of character limits in URLs](https://stackoverflow.com/a/417184/2214933).
+    [See an explanation of character limits in URLs](https://stackoverflow.com/questions/417142/what-is-the-maximum-length-of-a-url-in-different-browsers/417184#417184).
     Please test this setting properly before enabling in a production site.
 
 ```

--- a/news/5206.documentation
+++ b/news/5206.documentation
@@ -1,0 +1,1 @@
+Document the `querystringSearchGet` setting @erral


### PR DESCRIPTION
See https://github.com/plone/volto/pull/4658 and https://github.com/plone/plone.restapi/issues/1252

The setting is not documented in the setting reference, and it is worth to have it there.