### PR TITLE
fix: restrict moment.js locales to supported languages

### DIFF
--- a/news/5207.bugfix
+++ b/news/5207.bugfix
@@ -1,0 +1,1 @@
+restrict moment.js locales to supported languages @mamico

--- a/package.json
+++ b/package.json
@@ -422,6 +422,7 @@
     "jest": "26.6.3",
     "jest-environment-jsdom": "^26",
     "jsonwebtoken": "9.0.0",
+    "moment-locales-webpack-plugin": "1.2.0",
     "react-error-overlay": "6.0.9",
     "react-is": "^16.13.1",
     "release-it": "^16.1.3",

--- a/razzle.config.js
+++ b/razzle.config.js
@@ -134,8 +134,8 @@ const defaultModify = ({
     }
 
     config.plugins.unshift(
-      // restrict moment.js locales to en/de
-      // see https://github.com/jmblog/how-to-optimize-momentjs-with-webpack for details
+      // restrict moment.js locales to supported languages
+      // see https://momentjs.com/docs/#/use-it/webpack/ for details
       new MomentLocalesPlugin({ localesToKeep: Object.keys(languages) }),
       new LodashModuleReplacementPlugin({
         shorthands: true,

--- a/razzle.config.js
+++ b/razzle.config.js
@@ -13,6 +13,7 @@ const AddonConfigurationRegistry = require('./addon-registry');
 const CircularDependencyPlugin = require('circular-dependency-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
 const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
+const MomentLocalesPlugin = require('moment-locales-webpack-plugin');
 
 const fileLoaderFinder = makeLoaderFinder('file-loader');
 
@@ -135,10 +136,7 @@ const defaultModify = ({
     config.plugins.unshift(
       // restrict moment.js locales to en/de
       // see https://github.com/jmblog/how-to-optimize-momentjs-with-webpack for details
-      new webpack.ContextReplacementPlugin(
-        /moment[/\\]locale$/,
-        new RegExp(Object.keys(languages).join('|')),
-      ),
+      new MomentLocalesPlugin({ localesToKeep: Object.keys(languages) }),
       new LodashModuleReplacementPlugin({
         shorthands: true,
         cloning: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3327,6 +3327,7 @@ __metadata:
     lodash-webpack-plugin: 0.11.6
     mini-css-extract-plugin: 2.7.2
     moment: 2.29.4
+    moment-locales-webpack-plugin: 1.2.0
     object-assign: 4.1.1
     pofile: 1.0.10
     postcss: 8.4.13
@@ -16985,6 +16986,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash.difference@npm:^4.5.0":
+  version: 4.5.0
+  resolution: "lodash.difference@npm:4.5.0"
+  checksum: ecee276aa578f300e79350805a14a51be8d1f12b3c1389a19996d8ab516f814211a5f65c68331571ecdad96522b863ccc484b55504ce8c9947212a29f8857d5a
+  languageName: node
+  linkType: hard
+
 "lodash.escaperegexp@npm:^4.1.2":
   version: 4.1.2
   resolution: "lodash.escaperegexp@npm:4.1.2"
@@ -17834,6 +17842,18 @@ __metadata:
   bin:
     mkdirp: bin/cmd.js
   checksum: 0c91b721bb12c3f9af4b77ebf73604baf350e64d80df91754dc509491ae93bf238581e59c7188360cec7cb62fc4100959245a42cfe01834efedc5e9d068376c2
+  languageName: node
+  linkType: hard
+
+"moment-locales-webpack-plugin@npm:1.2.0":
+  version: 1.2.0
+  resolution: "moment-locales-webpack-plugin@npm:1.2.0"
+  dependencies:
+    lodash.difference: ^4.5.0
+  peerDependencies:
+    moment: ^2.8.0
+    webpack: ^1 || ^2 || ^3 || ^4 || ^5
+  checksum: bb5daebfc2f2bd0c003b9d576893531edc6ac3c884c77fc4c3a7c8d228340c9a26a5c7676c8e4505922eebb1309f2defbcf619a1706d7d7e579039690df2487b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The restriction of moment locales in webpack no longer works, probably after an update of moment.

This is the detail of the current bundle

![image](https://github.com/plone/volto/assets/182599/10cfd167-0a77-4f90-84c8-a350f8805530)

According to the documentation I added a webpack specific plugin, this is the result

![image](https://github.com/plone/volto/assets/182599/d104381e-01bc-41fc-b6f0-88de78ce8400)


