### PR TITLE
feat: add canonical link

### DIFF
--- a/news/5215.feature
+++ b/news/5215.feature
@@ -1,0 +1,1 @@
+add canonical link @mamico

--- a/src/components/theme/ContentMetadataTags/ContentMetadataTags.jsx
+++ b/src/components/theme/ContentMetadataTags/ContentMetadataTags.jsx
@@ -83,6 +83,10 @@ const ContentMetadataTags = (props) => {
     <>
       <Helmet>
         <title>{getTitle()?.replace(/\u00AD/g, '')}</title>
+        <link
+          rel="canonical"
+          href={seo_canonical_url || toPublicURL(props.content['@id'])}
+        />
         <meta name="description" content={seo_description || description} />
         <meta
           property="og:title"


### PR DESCRIPTION
Add the canonical link tag in the head, the data were already managed for the meta `og:url`.