### PR TITLE
Improve linked headlines

### DIFF
--- a/cypress/tests/core/blocks/block-anchors.js
+++ b/cypress/tests/core/blocks/block-anchors.js
@@ -3,28 +3,6 @@ import { slateBeforeEach } from '../../../support/volto-slate';
 describe('Block Tests: Anchors', () => {
   beforeEach(slateBeforeEach);
 
-  it('Add Block: Links', () => {
-    // Change page title
-    cy.clearSlateTitle();
-    cy.getSlateTitle().type('Slate Heading Anchors');
-    cy.getSlate().click();
-
-    // Add TOC block
-    cy.get('.ui.basic.icon.button.block-add-button').first().click();
-    cy.get(".blocks-chooser .ui.form .field.searchbox input[type='text']").type(
-      'table of contents',
-    );
-    cy.get('.button.toc').click();
-
-    // Save page
-    cy.get('#toolbar-save').click();
-    cy.url().should('eq', Cypress.config().baseUrl + '/my-page');
-    cy.get('h1.documentFirstHeading')
-      .trigger('mouseover', { eventConstructor: 'MouseEvent' })
-      .children()
-      .should('have.length', 1);
-  });
-
   it('Add Block: add content to TOC', () => {
     // Change page title
     cy.clearSlateTitle();
@@ -67,5 +45,53 @@ describe('Block Tests: Anchors', () => {
     cy.get('h2[id="title-1"]').scrollIntoView().should('be.visible');
     cy.get('.table-of-contents a[href="/my-page#title-2"]').click();
     cy.get('h2[id="title-2"]').scrollIntoView().should('be.visible');
+  });
+
+  it.only('Add Block: add content to TOC with special characters', () => {
+    // Change page title
+    cy.clearSlateTitle();
+    cy.getSlateTitle().type('Slate Heading Anchors with special characters');
+    cy.getSlate().click();
+
+    // Add TOC block
+    cy.get('.ui.basic.icon.button.block-add-button').first().click();
+    cy.get(".blocks-chooser .ui.form .field.searchbox input[type='text']").type(
+      'table of contents',
+    );
+    cy.get('.button.toc').click();
+
+    // Add headings
+    cy.get('.ui.drag.block.inner.slate').click().type('Title 1').click();
+    cy.get('.ui.drag.block.inner.slate span span span').setSelection('Title 1');
+    cy.get('.slate-inline-toolbar .button-wrapper a[title="Title"]').click({
+      force: true,
+    });
+    cy.get('.ui.drag.block.inner.slate').click().type('{enter}');
+
+    cy.get('.ui.drag.block.inner.slate')
+      .eq(1)
+      .click()
+      .type('Title 2 ü à')
+      .click();
+    cy.get('.ui.drag.block.inner.slate span span span')
+      .eq(1)
+      .setSelection('Title 2 ü à');
+    cy.get('.slate-inline-toolbar .button-wrapper a[title="Title"]').click({
+      force: true,
+    });
+    cy.get('.ui.drag.block.inner.slate').eq(1).click().type('{enter}');
+
+    // Save page
+    cy.get('#toolbar-save').click();
+    cy.url().should('eq', Cypress.config().baseUrl + '/my-page');
+
+    // Check if the page contains the TOC and scrolls to each entry on click
+    cy.contains('Slate Heading Anchors');
+    cy.get('h2[id="title-1"]').contains('Title 1');
+    cy.get('h2[id="title-2-u-a"]').contains('Title 2 ü à');
+    cy.get('.table-of-contents a[href="/my-page#title-1"]').click();
+    cy.get('h2[id="title-1"]').scrollIntoView().should('be.visible');
+    cy.get('.table-of-contents a[href="/my-page#title-2-u-a"]').click();
+    cy.get('h2[id="title-2-u-a"]').scrollIntoView().should('be.visible');
   });
 });

--- a/locales/ca/LC_MESSAGES/volto.po
+++ b/locales/ca/LC_MESSAGES/volto.po
@@ -1946,7 +1946,7 @@ msgid "Link"
 msgstr "Enllaç"
 
 #: helpers/MessageLabels/MessageLabels
-# defaultMessage: Link copied to clipboard
+# defaultMessage: Anchor link copied to the clipboard
 msgid "Link copied to clipboard"
 msgstr ""
 

--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -1943,9 +1943,9 @@ msgid "Link"
 msgstr "Link"
 
 #: helpers/MessageLabels/MessageLabels
-# defaultMessage: Link copied to clipboard
+# defaultMessage: Anchor link copied to the clipboard
 msgid "Link copied to clipboard"
-msgstr "Link in Zwischenablage kopiert."
+msgstr "Anker-Link wurde in die Zwischenablage kopiert"
 
 #: components/manage/Blocks/HeroImageLeft/schema
 #: components/manage/Blocks/Listing/schema

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -1937,7 +1937,7 @@ msgid "Link"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
-# defaultMessage: Link copied to clipboard
+# defaultMessage: Anchor link copied to the clipboard
 msgid "Link copied to clipboard"
 msgstr ""
 

--- a/locales/es/LC_MESSAGES/volto.po
+++ b/locales/es/LC_MESSAGES/volto.po
@@ -1948,7 +1948,7 @@ msgid "Link"
 msgstr "Enlace"
 
 #: helpers/MessageLabels/MessageLabels
-# defaultMessage: Link copied to clipboard
+# defaultMessage: Anchor link copied to the clipboard
 msgid "Link copied to clipboard"
 msgstr "Enlace copiado al portapapeles"
 

--- a/locales/eu/LC_MESSAGES/volto.po
+++ b/locales/eu/LC_MESSAGES/volto.po
@@ -1944,7 +1944,7 @@ msgid "Link"
 msgstr "Esteka"
 
 #: helpers/MessageLabels/MessageLabels
-# defaultMessage: Link copied to clipboard
+# defaultMessage: Anchor link copied to the clipboard
 msgid "Link copied to clipboard"
 msgstr ""
 

--- a/locales/fi/LC_MESSAGES/volto.po
+++ b/locales/fi/LC_MESSAGES/volto.po
@@ -1948,7 +1948,7 @@ msgid "Link"
 msgstr "Linkki"
 
 #: helpers/MessageLabels/MessageLabels
-# defaultMessage: Link copied to clipboard
+# defaultMessage: Anchor link copied to the clipboard
 msgid "Link copied to clipboard"
 msgstr ""
 

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -1954,7 +1954,7 @@ msgid "Link"
 msgstr "Lien"
 
 #: helpers/MessageLabels/MessageLabels
-# defaultMessage: Link copied to clipboard
+# defaultMessage: Anchor link copied to the clipboard
 msgid "Link copied to clipboard"
 msgstr ""
 

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -1937,7 +1937,7 @@ msgid "Link"
 msgstr "Link"
 
 #: helpers/MessageLabels/MessageLabels
-# defaultMessage: Link copied to clipboard
+# defaultMessage: Anchor link copied to the clipboard
 msgid "Link copied to clipboard"
 msgstr "Link copiato negli appunti"
 

--- a/locales/ja/LC_MESSAGES/volto.po
+++ b/locales/ja/LC_MESSAGES/volto.po
@@ -1945,7 +1945,7 @@ msgid "Link"
 msgstr "リンク"
 
 #: helpers/MessageLabels/MessageLabels
-# defaultMessage: Link copied to clipboard
+# defaultMessage: Anchor link copied to the clipboard
 msgid "Link copied to clipboard"
 msgstr ""
 

--- a/locales/nl/LC_MESSAGES/volto.po
+++ b/locales/nl/LC_MESSAGES/volto.po
@@ -1956,7 +1956,7 @@ msgid "Link"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
-# defaultMessage: Link copied to clipboard
+# defaultMessage: Anchor link copied to the clipboard
 msgid "Link copied to clipboard"
 msgstr ""
 

--- a/locales/pt/LC_MESSAGES/volto.po
+++ b/locales/pt/LC_MESSAGES/volto.po
@@ -1945,7 +1945,7 @@ msgid "Link"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
-# defaultMessage: Link copied to clipboard
+# defaultMessage: Anchor link copied to the clipboard
 msgid "Link copied to clipboard"
 msgstr ""
 

--- a/locales/pt_BR/LC_MESSAGES/volto.po
+++ b/locales/pt_BR/LC_MESSAGES/volto.po
@@ -1947,7 +1947,7 @@ msgid "Link"
 msgstr "Link"
 
 #: helpers/MessageLabels/MessageLabels
-# defaultMessage: Link copied to clipboard
+# defaultMessage: Anchor link copied to the clipboard
 msgid "Link copied to clipboard"
 msgstr ""
 

--- a/locales/ro/LC_MESSAGES/volto.po
+++ b/locales/ro/LC_MESSAGES/volto.po
@@ -1937,7 +1937,7 @@ msgid "Link"
 msgstr "Legătură"
 
 #: helpers/MessageLabels/MessageLabels
-# defaultMessage: Link copied to clipboard
+# defaultMessage: Anchor link copied to the clipboard
 msgid "Link copied to clipboard"
 msgstr ""
 

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2023-09-25T09:57:59.248Z\n"
+"POT-Creation-Date: 2023-09-26T10:20:03.552Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -39,7 +39,7 @@ msgid "Action changed"
 msgstr ""
 
 #: components/manage/Controlpanels/Rules/ConfigureRule
-# defaultMessage: Action:
+# defaultMessage: Action: 
 msgid "Action: "
 msgstr ""
 
@@ -683,7 +683,7 @@ msgid "Condition changed"
 msgstr ""
 
 #: components/manage/Controlpanels/Rules/ConfigureRule
-# defaultMessage: Condition:
+# defaultMessage: Condition: 
 msgid "Condition: "
 msgstr ""
 

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2023-08-10T11:08:51.764Z\n"
+"POT-Creation-Date: 2023-09-25T09:57:59.248Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -1939,7 +1939,7 @@ msgid "Link"
 msgstr ""
 
 #: helpers/MessageLabels/MessageLabels
-# defaultMessage: Link copied to clipboard
+# defaultMessage: Anchor link copied to the clipboard
 msgid "Link copied to clipboard"
 msgstr ""
 

--- a/locales/zh_CN/LC_MESSAGES/volto.po
+++ b/locales/zh_CN/LC_MESSAGES/volto.po
@@ -1943,7 +1943,7 @@ msgid "Link"
 msgstr "链接"
 
 #: helpers/MessageLabels/MessageLabels
-# defaultMessage: Link copied to clipboard
+# defaultMessage: Anchor link copied to the clipboard
 msgid "Link copied to clipboard"
 msgstr ""
 

--- a/news/5225.breaking
+++ b/news/5225.breaking
@@ -1,0 +1,5 @@
+Improve linked headlines after feedback:
+Disable the feature for anonymous users of the website
+Disable it for the page title
+Change the wording of the notification from "Link copied to clipboard" to "Anchor link copied to the clipboard" to make it more obvious that an anchor link has been copied
+@sneridagh

--- a/news/5225.breaking
+++ b/news/5225.breaking
@@ -2,4 +2,5 @@ Improve linked headlines after feedback:
 Disable the feature for anonymous users of the website
 Disable it for the page title
 Change the wording of the notification from "Link copied to clipboard" to "Anchor link copied to the clipboard" to make it more obvious that an anchor link has been copied
+Normalize the slug to use only ascii characters
 @sneridagh

--- a/packages/volto-slate/src/blocks/Text/TextBlockView.jsx
+++ b/packages/volto-slate/src/blocks/Text/TextBlockView.jsx
@@ -5,6 +5,7 @@ import {
 import config from '@plone/volto/registry';
 import { isEqual } from 'lodash';
 import Slugger from 'github-slugger';
+import { normalizeString } from '@plone/volto/helpers';
 
 const TextBlockView = (props) => {
   const { id, data, styling = {} } = props;
@@ -17,7 +18,7 @@ const TextBlockView = (props) => {
     if (node.type && isEqual(path, [0])) {
       if (topLevelTargetElements.includes(node.type) || override_toc) {
         const text = serializeNodesToText(node?.children || []);
-        const slug = Slugger.slug(text);
+        const slug = Slugger.slug(normalizeString(text));
         res.id = slug || id;
       }
     }

--- a/packages/volto-slate/src/editor/render.jsx
+++ b/packages/volto-slate/src/editor/render.jsx
@@ -190,6 +190,14 @@ export const renderLinkElement = (tagName) => {
             tabIndex={-1}
             href={`#${slug}`}
           >
+            <style>
+              {/* Prettify the unstyled flash of the link icon on development */}
+              {`
+              a.anchor svg {
+                height: var(--anchor-svg-height, 24px);
+              }
+              `}
+            </style>
             <svg
               {...linkSVG.attributes}
               dangerouslySetInnerHTML={{ __html: linkSVG.content }}

--- a/packages/volto-slate/src/editor/render.jsx
+++ b/packages/volto-slate/src/editor/render.jsx
@@ -3,6 +3,7 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { useLocation } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import { useIntl } from 'react-intl';
+import { useSelector } from 'react-redux';
 import { Node, Text } from 'slate';
 import cx from 'classnames';
 import { isEmpty, omit } from 'lodash';
@@ -168,13 +169,14 @@ export const renderLinkElement = (tagName) => {
     const Tag = tagName;
     const slug = attributes.id || '';
     const location = useLocation();
+    const token = useSelector((state) => state.userSession.token);
     const appPathname = addAppURL(location.pathname);
     // eslint-disable-next-line no-unused-vars
     const [copied, copy, setCopied] = useClipboard(
       appPathname.concat(`#${slug}`),
     );
     const intl = useIntl();
-    return slate.useLinkedHeadings === false ? (
+    return !token || slate.useLinkedHeadings === false ? (
       <Tag {...attributes} className={className} tabIndex={0}>
         {children}
       </Tag>

--- a/src/components/manage/Blocks/Listing/ListingBody.jsx
+++ b/src/components/manage/Blocks/Listing/ListingBody.jsx
@@ -7,13 +7,14 @@ import { Icon } from '@plone/volto/components';
 import { renderLinkElement } from '@plone/volto-slate/editor/render';
 import config from '@plone/volto/registry';
 import withQuerystringResults from './withQuerystringResults';
+import { normalizeString } from '@plone/volto/helpers';
 
 import paginationLeftSVG from '@plone/volto/icons/left-key.svg';
 import paginationRightSVG from '@plone/volto/icons/right-key.svg';
 
 const Headline = ({ headlineTag, id, data = {}, listingItems, isEditMode }) => {
   let attr = { id };
-  const slug = Slugger.slug(data.headline);
+  const slug = Slugger.slug(normalizeString(data.headline));
   attr.id = slug || id;
   const LinkedHeadline = useMemo(
     () => renderLinkElement(headlineTag),

--- a/src/components/manage/Blocks/Title/View.jsx
+++ b/src/components/manage/Blocks/Title/View.jsx
@@ -1,42 +1,9 @@
-/**
- * View title/description block.
- * @module volto-slate/blocks/Title/TitleBlockView
- */
-
-import React, { useMemo } from 'react';
-import PropTypes from 'prop-types';
-import Slugger from 'github-slugger';
-import { renderLinkElement } from '@plone/volto-slate/editor/render';
-
-/**
- * View title block component.
- * @class View
- * @extends Component
- */
-const TitleBlockView = ({ properties, metadata, id, children }) => {
-  let attr = { id };
-  const title = (properties || metadata)['title'];
-  const slug = Slugger.slug(title);
-  attr.id = slug || id;
-  const LinkedTitle = useMemo(() => renderLinkElement('h1'), []);
+const TitleBlockView = ({ properties, metadata }) => {
   return (
-    <LinkedTitle
-      mode="view"
-      children={title ?? children}
-      attributes={attr}
-      className={'documentFirstHeading'}
-    />
+    <h1 className="documentFirstHeading">
+      {(metadata || properties)['title'] || ''}
+    </h1>
   );
-};
-
-/**
- * Property types.
- * @property {Object} propTypes Property types.
- * @static
- */
-TitleBlockView.propTypes = {
-  properties: PropTypes.objectOf(PropTypes.any).isRequired,
-  metadata: PropTypes.objectOf(PropTypes.any),
 };
 
 export default TitleBlockView;

--- a/src/components/manage/Blocks/Title/__snapshots__/View.test.jsx.snap
+++ b/src/components/manage/Blocks/Title/__snapshots__/View.test.jsx.snap
@@ -3,30 +3,7 @@
 exports[`renders a view title component 1`] = `
 <h1
   className="documentFirstHeading"
-  id="my-title"
-  tabIndex={0}
 >
   My Title
-  <a
-    aria-hidden="true"
-    className="anchor"
-    href="/#my-title"
-    onClick={[Function]}
-    tabIndex={-1}
-    target={null}
-    title={null}
-  >
-    <svg
-      dangerouslySetInnerHTML={
-        Object {
-          "__html": undefined,
-        }
-      }
-      height={null}
-      onClick={[Function]}
-      viewBox=""
-      xmlns=""
-    />
-  </a>
 </h1>
 `;

--- a/src/components/manage/Blocks/ToC/variations/DefaultTocRenderer.jsx
+++ b/src/components/manage/Blocks/ToC/variations/DefaultTocRenderer.jsx
@@ -10,13 +10,14 @@ import { List } from 'semantic-ui-react';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import Slugger from 'github-slugger';
 import { UniversalLink } from '@plone/volto/components';
+import { normalizeString } from '@plone/volto/helpers';
 
 const RenderListItems = ({ items, data }) => {
   return map(items, (item) => {
     const { id, level, title, override_toc, plaintext } = item;
     const slug = override_toc
-      ? Slugger.slug(plaintext)
-      : Slugger.slug(title) || id;
+      ? Slugger.slug(normalizeString(plaintext))
+      : Slugger.slug(normalizeString(title)) || id;
     return (
       item && (
         <List.Item key={id} className={`item headline-${level}`} as="li">

--- a/src/components/manage/Blocks/ToC/variations/HorizontalMenu.jsx
+++ b/src/components/manage/Blocks/ToC/variations/HorizontalMenu.jsx
@@ -5,13 +5,14 @@ import { Menu, Dropdown } from 'semantic-ui-react';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import AnchorLink from 'react-anchor-link-smooth-scroll';
 import Slugger from 'github-slugger';
+import { normalizeString } from '@plone/volto/helpers';
 
 const RenderMenuItems = ({ items }) => {
   return map(items, (item) => {
     const { id, level, title, override_toc, plaintext } = item;
     const slug = override_toc
-      ? Slugger.slug(plaintext)
-      : Slugger.slug(title) || id;
+      ? Slugger.slug(normalizeString(plaintext))
+      : Slugger.slug(normalizeString(title)) || id;
     return (
       item && (
         <React.Fragment key={id}>

--- a/src/helpers/MessageLabels/MessageLabels.js
+++ b/src/helpers/MessageLabels/MessageLabels.js
@@ -283,7 +283,7 @@ export const messages = defineMessages({
   },
   urlClipboardCopy: {
     id: 'Link copied to clipboard',
-    defaultMessage: 'Link copied to clipboard',
+    defaultMessage: 'Anchor link copied to the clipboard',
   },
   inspectRelations: {
     id: 'Inspect relations',

--- a/src/helpers/Utils/Utils.js
+++ b/src/helpers/Utils/Utils.js
@@ -285,6 +285,16 @@ export const reorderArray = (array, origin, target) => {
 };
 
 /**
+ * Normalize (unicode) string to a normalized plain ascii string
+ * @method normalizeString
+ * @param {string} str The string to be normalized
+ * @returns {string} Normalized plain ascii string
+ */
+export function normalizeString(str) {
+  return str.normalize('NFD').replace(/\p{Diacritic}/gu, '');
+}
+
+/**
  * Slugify a string: remove whitespaces, special chars and replace with _
  * @param {string} string String to be slugified
  * @returns {string} Slugified string

--- a/src/helpers/Utils/Utils.test.js
+++ b/src/helpers/Utils/Utils.test.js
@@ -14,6 +14,7 @@ import {
   safeWrapper,
   slugify,
   cloneDeepSchema,
+  normalizeString,
 } from './Utils';
 import moment from 'moment';
 import deepFreeze from 'deep-freeze';
@@ -383,6 +384,18 @@ describe('Utils tests', () => {
       deepFreeze(array);
       const result = reorderArray(array, 2, 0);
       expect(result).toEqual(['c', 'a', 'b']);
+    });
+  });
+
+  describe('normalizeString', () => {
+    it('normalizeString no diacritics', () => {
+      const str = `my string without diacritics`;
+      expect(normalizeString(str)).toBe('my string without diacritics');
+    });
+
+    it('normalizeString with diacritics', () => {
+      const str = `my Ü Ú é à ñ string with diacritics`;
+      expect(normalizeString(str)).toBe('my U U e a n string with diacritics');
     });
   });
 

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -95,6 +95,7 @@ export {
   reorderArray,
   isInteractiveElement,
   slugify,
+  normalizeString,
 } from '@plone/volto/helpers/Utils/Utils';
 export { messages } from './MessageLabels/MessageLabels';
 export {


### PR DESCRIPTION
Closes: #5174
As discussed in https://github.com/plone/volto/issues/5174

- [x] disable "copy anchor link to clipboard" functionality for anonymous users of the website (this is a feature that no public website has anywhere in the world)
- [x] keep the feature for now for logged-in users, integrators can disable it with a feature toggle
- [x] change the wording of the notification from "Link copied to clipboard" to "Anchor link copied to the clipboard" to make it more obvious that an anchor link has been copied (again, this only works for editors that know the feature)
- [x] fix the bug that the anchor link does not work if your headline has a special character (e.g. "Überschrift")

Unfortunately this is a Chrome issue, it does works well in FF and Safari :( This only happens in SSR. At least, on links, and when the router is present, it does well.

- [x] disable the "copy to anchor link to clipboard" for the page title