### PR TITLE
Remove node requirements in generator-volto, add try-catch clause in code that seems to break in release mode

### DIFF
--- a/packages/generator-volto/generators/app/index.js
+++ b/packages/generator-volto/generators/app/index.js
@@ -243,8 +243,10 @@ Run "npm install -g @plone/generator-volto" to update.`,
       this.globals,
     );
 
-    this.fs.delete(this.destinationPath(base, 'package.json.tpl'));
-    this.fs.delete(this.destinationPath(base, '.gitignorefile'));
+    try {
+      this.fs.delete(this.destinationPath(base, 'package.json.tpl'));
+      this.fs.delete(this.destinationPath(base, '.gitignorefile'));
+    } catch (error) {}
   }
 
   install() {

--- a/packages/generator-volto/news/5230.bugfix
+++ b/packages/generator-volto/news/5230.bugfix
@@ -1,0 +1,1 @@
+Remove node requirements in generator-volto, add try-catch clause in code that seems to break in release mode @sneridagh

--- a/packages/generator-volto/package.json
+++ b/packages/generator-volto/package.json
@@ -95,9 +95,6 @@
       "pre-commit": "lint-staged"
     }
   },
-  "engines": {
-    "node": "^12 || ^14 || ^16"
-  },
   "dependencies": {
     "ansi-escapes": "2.0.0",
     "chalk": "^2.1.0",


### PR DESCRIPTION
Let's see if that works (blind here, since locally, generating the app folder works well). Should be a released package thing.