### PR TITLE
Bypass reviewdog and install Vale directly

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -46,14 +46,3 @@ jobs:
           git clone https://github.com/errata-ai/Microsoft.git
           cp -r ./Microsoft/Microsoft ./styles
           vale --no-exit ./docs
-
-      # Disable GHA vale checking, it started to fail with a gazillion of
-      # violations. We need to review it closely
-      # - uses: errata-ai/vale-action@reviewdog
-      #   with:
-      #     # debug: true
-      #     files: all
-      #   env:
-      #     # Required, set by GitHub actions automatically:
-      #     # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret
-      #     GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,8 +45,7 @@ jobs:
         run: |
           git clone https://github.com/errata-ai/Microsoft.git
           cp -r ./Microsoft/Microsoft ./styles
-          VALEFILES=$(find -L ./docs/ -type d -prune -false -o -type f -name "*.md" -print)
-          vale --no-exit $VALEFILES
+          vale ./docs
 
       # Disable GHA vale checking, it started to fail with a gazillion of
       # violations. We need to review it closely

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,7 +31,9 @@ jobs:
         run: pip install virtualenv
 
       - name: pip install requirements
-        run: pip install -r requirements-docs.txt
+        run: |
+          pip install -r requirements-docs.txt
+          sudo snap install --edge vale
 
       - name: Check for broken links
         run: make docs-linkcheckbroken

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           git clone https://github.com/errata-ai/Microsoft.git
           cp -r ./Microsoft/Microsoft ./styles
-          vale ./docs
+          vale --no-exit ./docs
 
       # Disable GHA vale checking, it started to fail with a gazillion of
       # violations. We need to review it closely

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,20 +39,12 @@ jobs:
       - name: Build HTML documentation
         run: make docs-html
 
-      - name: Get latest version of Vale
-        id: lastversion
-        uses: dvershinin/lastversion-action@v0.0.3
-        with:
-          repository: errata-ai/vale
-
-      - name: Install Vale
+      - name: Run vale
         run: |
-          wget https://github.com/errata-ai/vale/releases/download/v${{ steps.lastversion.outputs.last_version }}/vale_${{ steps.lastversion.outputs.last_version }}_Linux_64-bit.tar.gz -O vale.tar.gz
-          tar -xvzf vale.tar.gz vale
-          rm vale.tar.gz
-
-      - name: Run Vale
-        run: ./vale --config=.vale.ini *.md
+          git clone https://github.com/errata-ai/Microsoft.git
+          cp -r ./Microsoft/Microsoft ./styles
+          VALEFILES=$(find -L ./docs/ -type d -prune -false -o -type f -name "*.md" -print)
+          vale --no-exit $VALEFILES
 
       # Disable GHA vale checking, it started to fail with a gazillion of
       # violations. We need to review it closely

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,6 +39,21 @@ jobs:
       - name: Build HTML documentation
         run: make docs-html
 
+      - name: Get latest version of Vale
+        id: lastversion
+        uses: dvershinin/lastversion-action@v0.0.3
+        with:
+          repository: errata-ai/vale
+
+      - name: Install Vale
+        run: |
+          wget https://github.com/errata-ai/vale/releases/download/v${{ steps.lastversion.outputs.last_version }}/vale_${{ steps.lastversion.outputs.last_version }}_Linux_64-bit.tar.gz -O vale.tar.gz
+          tar -xvzf vale.tar.gz vale
+          rm vale.tar.gz
+
+      - name: Run Vale
+        run: ./vale --config=.vale.ini *.md
+
       # Disable GHA vale checking, it started to fail with a gazillion of
       # violations. We need to review it closely
       # - uses: errata-ai/vale-action@reviewdog

--- a/docs/source/contributing/branch-policy.md
+++ b/docs/source/contributing/branch-policy.md
@@ -43,7 +43,7 @@ legacy
     Upon the final release of version 16.0.0, the `15.x.x` branch line will become legacy.
 
 ```{todo}
-See https://github.com/plone/volto/issues/5255.
+See https://github.com/plone/volto/issues/5255
 ```
 
 

--- a/docs/source/contributing/branch-policy.md
+++ b/docs/source/contributing/branch-policy.md
@@ -42,6 +42,11 @@ legacy
 :   At the moment of this writing, `15.x.x` is the current stable branch in git.
     Upon the final release of version 16.0.0, the `15.x.x` branch line will become legacy.
 
+```{todo}
+See https://github.com/plone/volto/issues/5255.
+```
+
+
 ## Translation contributing policy
 
 Due to the nature of `main` and `16.x.x` branches, some developments that may land in `main` may not be backported to `16.x.x`. This means that many translations that may come with those developments will be useless in the `16.x.x` branch and thus porting them to `16.x.x` makes no sense.

--- a/news/5256.documentation
+++ b/news/5256.documentation
@@ -1,0 +1,1 @@
+Reenable GHA vale checking, but with configuration from `plone/documentation`. It now runs Vale, but with the flag `--no-exit` which means "Don't return a nonzero exit code on errors." It also eliminates reviewdog as the test runner. @stevepiercy


### PR DESCRIPTION
Resolve failing CI build due to reviewdog breakage. See https://github.com/plone/volto/pull/5253