### PR TITLE
Prefer resolving DNS to ipv4

### DIFF
--- a/news/5261.bugfix
+++ b/news/5261.bugfix
@@ -1,0 +1,1 @@
+Adjust DNS resolution to prefer IPv4 addresses when both IPv4 and IPv6 are resolved. @davisagli

--- a/src/start-server.js
+++ b/src/start-server.js
@@ -1,10 +1,14 @@
 /* eslint no-console: 0 */
+import dns from 'dns';
 import http from 'http';
 
 import app from './server';
 import debug from 'debug';
 
 export default function server() {
+  // If DNS returns both ipv4 and ipv6 addresses, prefer ipv4
+  dns.setDefaultResultOrder('ipv4first');
+
   const server = http.createServer(app);
   // const host = process.env.HOST || 'localhost';
   const port = process.env.PORT || 3000;


### PR DESCRIPTION
If the OS returns both ipv4 and ipv6 addresses when resolving a hostname, prefer the ipv4 one.

For example, this fixes connection errors that happen when volto is connecting to the backend on `localhost` (the default) but `/etc/hosts` has `::1` listed before `127.0.0.1` as an IP address for localhost.