### PR TITLE
Emit a proper URL for the Plone root in a listing

### DIFF
--- a/news/5263.bugfix
+++ b/news/5263.bugfix
@@ -1,0 +1,1 @@
+Emit a proper URL for the Plone root in a listing, we use the `config.publicURL` for it @tiberiuichim

--- a/src/components/manage/UniversalLink/UniversalLink.jsx
+++ b/src/components/manage/UniversalLink/UniversalLink.jsx
@@ -30,7 +30,9 @@ const UniversalLink = ({
 
   let url = href;
   if (!href && item) {
-    if (!item['@id']) {
+    if (item['@id'] === '') {
+      url = config.settings.publicURL;
+    } else if (!item['@id']) {
       // eslint-disable-next-line no-console
       console.error(
         'Invalid item passed to UniversalLink',


### PR DESCRIPTION
Not that I think there's any valid use case for it, but at least we avoid a nasty warning