### PR TITLE
Accessibility management for Slate blocks and keyboard navigation focus

### DIFF
--- a/packages/volto-slate/src/blocks/Text/keyboard/traverseBlocks.js
+++ b/packages/volto-slate/src/blocks/Text/keyboard/traverseBlocks.js
@@ -74,8 +74,8 @@ export function goDown({ editor, event }) {
 }
 
 export function traverseBlocks(opts) {
-  const { event } = opts;
-  event.preventDefault();
+  // const { event } = opts;
+  // event.preventDefault();
   // return event.shiftKey ? goUp(opts) : goDown(opts);
-  return true;
+  return false;
 }

--- a/src/components/manage/Blocks/Block/EditBlockWrapper.jsx
+++ b/src/components/manage/Blocks/Block/EditBlockWrapper.jsx
@@ -68,18 +68,18 @@ const EditBlockWrapper = (props) => {
       })}
     >
       <div style={{ position: 'relative' }}>
-        <div
-          style={{
-            visibility: visible ? 'visible' : 'hidden',
-            display: 'inline-block',
-          }}
-          {...draginfo.dragHandleProps}
-          className="drag handle wrapper"
-        >
-          <Icon name={dragSVG} size="18px" />
-        </div>
         <div className={`ui drag block inner ${type}`}>
           {children}
+          <div
+            style={{
+              visibility: visible ? 'visible' : 'hidden',
+              display: 'inline-block',
+            }}
+            {...draginfo.dragHandleProps}
+            className="drag handle wrapper"
+          >
+            <Icon name={dragSVG} size="18px" />
+          </div>
           {selected && !required && editable && (
             <Button
               icon

--- a/theme/themes/default/globals/site.variables
+++ b/theme/themes/default/globals/site.variables
@@ -799,6 +799,7 @@
 @secondaryColorFocus      : saturate(lighten(@secondaryColor, 8), 20, relative);
 @lightPrimaryColorFocus   : saturate(darken(@lightPrimaryColor, 8), 20, relative);
 @lightSecondaryColorFocus : saturate(lighten(@lightSecondaryColor, 8), 20, relative);
+@invertedFocus            : @whiteFocus;
 
 @redFocus                 : saturate(darken(@red, 8), 20, relative);
 @orangeFocus              : saturate(darken(@orange, 8), 20, relative);

--- a/theme/themes/pastanaga/extras/blocks.less
+++ b/theme/themes/pastanaga/extras/blocks.less
@@ -551,7 +551,7 @@ body.has-toolbar.has-sidebar-collapsed .ui.wrapper > .ui.inner.block.full {
 .drag.handle.wrapper {
   position: absolute;
   z-index: 10;
-  // top: 1px;
+  top: 0px;
   left: 0;
   color: #b8c6c8;
 

--- a/theme/themes/pastanaga/extras/main.less
+++ b/theme/themes/pastanaga/extras/main.less
@@ -115,6 +115,20 @@ button .close {
   color: @darkHotPink;
 }
 
+//focus-visible
+:focus-visible,
+a:focus-visible,
+button:focus-visible {
+  outline: 1px auto @primaryColorFocus !important;
+}
+.ui.inverted {
+  :focus-visible,
+  a:focus-visible,
+  button:focus-visible {
+    outline: 1px solid @invertedFocus !important;
+  }
+}
+
 // Override default behavior for forms and segments
 .ui.form,
 .ui.segments,

--- a/theme/themes/pastanaga/extras/toolbar.less
+++ b/theme/themes/pastanaga/extras/toolbar.less
@@ -173,7 +173,7 @@ body:not(.has-sidebar):not(.has-sidebar-collapsed) {
       a,
       button {
         margin-left: 20px;
-        color: @brown;
+        color: @black;
         cursor: pointer;
       }
 


### PR DESCRIPTION
- Now it is possible to leave a block using the Tab key.
- Slate text containers re-arranged to give the tab a proper path (text input → drag & drop button → delete button)
- Added a general ":focus-visible" to standardize the focus within the application.
- a11y -  general fixes

