### PR TITLE
Refactor Logo component to improve the conditional link to the root

### DIFF
--- a/news/5280.bugfix
+++ b/news/5280.bugfix
@@ -1,0 +1,1 @@
+Refactor Logo component to improve the conditional link to the root @sneridagh

--- a/src/components/theme/Logo/Logo.Multilingual.test.jsx
+++ b/src/components/theme/Logo/Logo.Multilingual.test.jsx
@@ -24,14 +24,9 @@ describe('Multilingual Logo', () => {
         data: {
           id: 'http://localhost:3000/@navroot',
           navroot: {
-            '@id': 'http://localhost:3000',
+            '@id': 'http://localhost:3000/en',
             title: 'Plone Site',
           },
-        },
-      },
-      router: {
-        location: {
-          pathname: '/',
         },
       },
       site: {
@@ -40,7 +35,7 @@ describe('Multilingual Logo', () => {
     });
     const component = renderer.create(
       <Provider store={store}>
-        <MemoryRouter>
+        <MemoryRouter initialEntries={[{ pathname: '/' }]}>
           <Logo />
         </MemoryRouter>
       </Provider>,
@@ -64,11 +59,6 @@ describe('Multilingual Logo', () => {
           },
         },
       },
-      router: {
-        location: {
-          pathname: '/en',
-        },
-      },
       site: {
         data: {
           'plone.site_title': 'Plone Site',
@@ -77,7 +67,7 @@ describe('Multilingual Logo', () => {
     });
     const component = renderer.create(
       <Provider store={store}>
-        <MemoryRouter>
+        <MemoryRouter initialEntries={[{ pathname: '/en' }]}>
           <Logo />
         </MemoryRouter>
       </Provider>,
@@ -101,11 +91,6 @@ describe('Multilingual Logo', () => {
           },
         },
       },
-      router: {
-        location: {
-          pathname: '/en',
-        },
-      },
       site: {
         data: {
           'plone.site_logo':
@@ -115,7 +100,7 @@ describe('Multilingual Logo', () => {
     });
     const component = renderer.create(
       <Provider store={store}>
-        <MemoryRouter>
+        <MemoryRouter initialEntries={[{ pathname: '/en' }]}>
           <Logo />
         </MemoryRouter>
       </Provider>,
@@ -139,11 +124,6 @@ describe('Multilingual Logo', () => {
           },
         },
       },
-      router: {
-        location: {
-          pathname: '/en/my/path',
-        },
-      },
       site: {
         data: {
           'plone.site_logo':
@@ -153,7 +133,7 @@ describe('Multilingual Logo', () => {
     });
     const component = renderer.create(
       <Provider store={store}>
-        <MemoryRouter>
+        <MemoryRouter initialEntries={[{ pathname: '/en/my/path' }]}>
           <Logo />
         </MemoryRouter>
       </Provider>,

--- a/src/components/theme/Logo/Logo.jsx
+++ b/src/components/theme/Logo/Logo.jsx
@@ -7,12 +7,12 @@ import { Image } from 'semantic-ui-react';
 import { ConditionalLink } from '@plone/volto/components';
 import LogoImage from '@plone/volto/components/theme/Logo/Logo.svg';
 import { useSelector, useDispatch } from 'react-redux';
+import { useLocation } from 'react-router-dom';
 import { getNavroot } from '@plone/volto/actions';
 import {
   flattenToAppURL,
   hasApiExpander,
   getBaseUrl,
-  toPublicURL,
 } from '@plone/volto/helpers';
 
 /**
@@ -22,7 +22,7 @@ import {
  * @returns {string} Markup of the component.
  */
 const Logo = () => {
-  const pathname = useSelector((state) => state.router.location.pathname);
+  const pathname = useLocation().pathname;
   const site = useSelector((state) => state.site.data);
   const navroot = useSelector((state) => state.navroot.data);
   const dispatch = useDispatch();
@@ -33,17 +33,16 @@ const Logo = () => {
     }
   }, [dispatch, pathname]);
 
-  // remove trailing slash
-  const currentURL = toPublicURL(pathname).replace(/\/$/, '');
-
-  const navRoot = navroot?.navroot?.['@id'];
-  const currentURLIsNavRoot = currentURL !== navRoot;
+  const navRootPath = flattenToAppURL(navroot?.navroot?.['@id']) || '/';
+  const currentURLIsNavRoot = pathname !== navRootPath;
 
   return (
     <ConditionalLink
-      href={navRoot || '/'}
+      href={navRootPath}
       title={navroot?.navroot?.title}
-      condition={!navRoot || currentURLIsNavRoot}
+      // In case that the content returns 404, there is no information about the portal
+      // then render the link anyways to get out of the Unauthorized page
+      condition={!navroot || currentURLIsNavRoot}
     >
       <Image
         src={

--- a/src/components/theme/Logo/Logo.jsx
+++ b/src/components/theme/Logo/Logo.jsx
@@ -36,11 +36,14 @@ const Logo = () => {
   // remove trailing slash
   const currentURL = toPublicURL(pathname).replace(/\/$/, '');
 
+  const navRoot = navroot?.navroot?.['@id'];
+  const currentURLIsNavRoot = currentURL !== navRoot;
+
   return (
     <ConditionalLink
-      href={navroot?.navroot?.['@id']}
+      href={navRoot || '/'}
       title={navroot?.navroot?.title}
-      condition={currentURL !== navroot?.navroot?.['@id']}
+      condition={!navRoot || currentURLIsNavRoot}
     >
       <Image
         src={

--- a/src/components/theme/Logo/Logo.test.jsx
+++ b/src/components/theme/Logo/Logo.test.jsx
@@ -30,18 +30,13 @@ describe('Logo', () => {
           },
         },
       },
-      router: {
-        location: {
-          pathname: '/',
-        },
-      },
       site: {
         data: {},
       },
     });
     const component = renderer.create(
       <Provider store={store}>
-        <MemoryRouter>
+        <MemoryRouter initialEntries={[{ pathname: '/' }]}>
           <Logo />
         </MemoryRouter>
       </Provider>,
@@ -64,11 +59,6 @@ describe('Logo', () => {
           },
         },
       },
-      router: {
-        location: {
-          pathname: '/',
-        },
-      },
       site: {
         data: {
           'plone.site_logo':
@@ -78,7 +68,7 @@ describe('Logo', () => {
     });
     const component = renderer.create(
       <Provider store={store}>
-        <MemoryRouter>
+        <MemoryRouter initialEntries={[{ pathname: '/' }]}>
           <Logo />
         </MemoryRouter>
       </Provider>,
@@ -86,6 +76,7 @@ describe('Logo', () => {
     const json = component.toJSON();
     expect(json).toMatchSnapshot();
   });
+
   it('renders a logo component with default config in a non-root url', () => {
     const store = mockStore({
       intl: {
@@ -115,7 +106,7 @@ describe('Logo', () => {
     });
     const component = renderer.create(
       <Provider store={store}>
-        <MemoryRouter>
+        <MemoryRouter initialEntries={[{ pathname: '/some-page' }]}>
           <Logo />
         </MemoryRouter>
       </Provider>,
@@ -123,6 +114,7 @@ describe('Logo', () => {
     const json = component.toJSON();
     expect(json).toMatchSnapshot();
   });
+
   it('renders a logo component with a custom logo in a non-root url', () => {
     const store = mockStore({
       intl: {
@@ -138,11 +130,6 @@ describe('Logo', () => {
           },
         },
       },
-      router: {
-        location: {
-          pathname: '/some-page',
-        },
-      },
       site: {
         data: {
           'plone.site_logo':
@@ -152,7 +139,7 @@ describe('Logo', () => {
     });
     const component = renderer.create(
       <Provider store={store}>
-        <MemoryRouter>
+        <MemoryRouter initialEntries={[{ pathname: '/some-page' }]}>
           <Logo />
         </MemoryRouter>
       </Provider>,

--- a/src/components/theme/Logo/__snapshots__/Logo.Multilingual.test.jsx.snap
+++ b/src/components/theme/Logo/__snapshots__/Logo.Multilingual.test.jsx.snap
@@ -10,12 +10,20 @@ exports[`Multilingual Logo renders a logo component in a multilingual site langu
 `;
 
 exports[`Multilingual Logo renders a logo component in a multilingual site root 1`] = `
-<img
-  alt="Plone Site"
-  className="ui image"
-  src="Logo.svg"
+<a
+  className={null}
+  href="/en"
+  onClick={[Function]}
+  target={null}
   title="Plone Site"
-/>
+>
+  <img
+    alt="Plone Site"
+    className="ui image"
+    src="Logo.svg"
+    title="Plone Site"
+  />
+</a>
 `;
 
 exports[`Multilingual Logo renders a logo component with a custom logo in a non-root url 1`] = `


### PR DESCRIPTION
Following up what we said during the Volto Team Meeting, it's better to not rely in `toPublicURL`, and do not rely on the router sync in Redux store. I changed all to use pathnames, and fallback to `/` if an error is found and no info is in the store.