### PR TITLE
Add note in release notes for Volto 17 final

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@
 
 ### Feature
 
-- Add control panel for relations @ksuess
+- Added a control panel for relations. @ksuess [#3382](https://github.com/plone/volto/pull/3382)
 - Add directive to cache stable resources in browser or intermediate server for 365 days by default directly in the SSR Express server, static resource that could change after a new deployment for 1 minute. @mamico [#2216](https://github.com/plone/volto/issues/2216)
 - Use popperjs in BlockChooser, move the markup to the bottom of the body tag. @sneridagh [#4141](https://github.com/plone/volto/issues/4141)
 - Improvements to the dev API proxy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
 
 ## 17.0.0 (2023-09-30)
 
+**This is a Release Notes summary of all the changes happened during the alpha stage of Volto 17.**
+
 ### Breaking
 
 - Volto 17 drops support for NodeJS 14, and adds support for Node.js 18.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 
 ### Feature
 
+- Add control panel for relations @ksuess
 - Add directive to cache stable resources in browser or intermediate server for 365 days by default directly in the SSR Express server, static resource that could change after a new deployment for 1 minute. @mamico [#2216](https://github.com/plone/volto/issues/2216)
 - Use popperjs in BlockChooser, move the markup to the bottom of the body tag. @sneridagh [#4141](https://github.com/plone/volto/issues/4141)
 - Improvements to the dev API proxy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 
 ## 17.0.0 (2023-09-30)
 
-**This is a Release Notes summary of all the changes happened during the alpha stage of Volto 17.**
+**These Release Notes summarize all the changes during the alpha stage of Volto 17.**
 
 ### Breaking
 

--- a/news/5281.documentation
+++ b/news/5281.documentation
@@ -1,2 +1,2 @@
-Add notice in release notes for Volto 17 final to clarify that it's a summary for all the alpha stage @sneridagh
-Add missing feature for the Relations Control Panel @sneridagh
+Added notice in release notes for Volto 17 final to clarify that it's a summary for all changes during the alpha stage. @sneridagh
+Added an omitted change log entry for the Relations Control Panel. @sneridagh

--- a/news/5281.documentation
+++ b/news/5281.documentation
@@ -1,0 +1,2 @@
+Add notice in release notes for Volto 17 final to clarify that it's a summary for all the alpha stage @sneridagh
+Add missing feature for the Relations Control Panel @sneridagh


### PR DESCRIPTION
@ksuess I've figured out what happened: The PR started just before we did the transition to Towncrier, then the change log info was in  `CHANGELOG.md` so it did made to the wrong place, then towncrier didn't pick it up.

Sorry about it!