### PR TITLE
move the function to get the lead image sizes to the block configuration

### DIFF
--- a/src/components/manage/Blocks/LeadImage/View.jsx
+++ b/src/components/manage/Blocks/LeadImage/View.jsx
@@ -35,13 +35,7 @@ const View = ({ data, properties }) => {
                 className={cx({ 'full-width': data.align === 'full' })}
                 item={properties}
                 imageField="image"
-                sizes={(() => {
-                  if (data.align === 'full' || data.align === 'center')
-                    return '100vw';
-                  if (data.align === 'left' || data.align === 'right')
-                    return '50vw';
-                  return undefined;
-                })()}
+                sizes={config.blocks.blocksConfig.leadimage.getSizes(data)}
                 alt={properties.image_caption || ''}
                 responsive={true}
               />

--- a/src/components/manage/Blocks/LeadImage/utils.js
+++ b/src/components/manage/Blocks/LeadImage/utils.js
@@ -1,0 +1,9 @@
+export function getLeadImageBlockSizes(data) {
+  if (data.align === 'full' || data.align === 'center') {
+    return '100vw';
+  }
+  if (data.align === 'left' || data.align === 'right') {
+    return '50vw';
+  }
+  return undefined;
+}

--- a/src/config/Blocks.jsx
+++ b/src/config/Blocks.jsx
@@ -76,6 +76,7 @@ import {
 } from '@plone/volto/components/manage/Blocks/Search/components';
 import getListingBlockAsyncData from '@plone/volto/components/manage/Blocks/Listing/getAsyncData';
 import { getImageBlockSizes } from '@plone/volto/components/manage/Blocks/Image/utils';
+import { getLeadImageBlockSizes } from '@plone/volto/components/manage/Blocks/LeadImage/utils';
 
 // block sidebar schemas (not the Dexterity Layout block settings schemas)
 import HeroImageLeftBlockSchema from '@plone/volto/components/manage/Blocks/HeroImageLeft/schema';
@@ -272,6 +273,7 @@ const blocksConfig = {
     restricted: ({ properties }) => !properties.hasOwnProperty('image'),
     mostUsed: false,
     sidebarTab: 1,
+    getSizes: getLeadImageBlockSizes,
   },
   listing: {
     id: 'listing',


### PR DESCRIPTION
This way the sizes function can be overridden in a custom project like it can be for the Image block