### PR TITLE
Bundle optimization

### DIFF
--- a/news/5282.feature
+++ b/news/5282.feature
@@ -1,0 +1,1 @@
+Upgrade to @plone/scripts 3.0.1 @sneridagh

--- a/package.json
+++ b/package.json
@@ -241,7 +241,7 @@
     "@loadable/component": "5.14.1",
     "@loadable/server": "5.14.0",
     "@loadable/webpack-plugin": "5.15.2",
-    "@plone/scripts": "3.0.0",
+    "@plone/scripts": "3.0.1",
     "@testing-library/cypress": "9.0.0",
     "@testing-library/jest-dom": "5.16.4",
     "@testing-library/react": "12.1.5",

--- a/package.json
+++ b/package.json
@@ -412,6 +412,7 @@
     "@storybook/builder-webpack5": "^6.5.15",
     "@storybook/manager-webpack5": "^6.5.15",
     "@storybook/react": "^6.5.15",
+    "@types/loadable__component": "5.13.5",
     "@types/react-test-renderer": "18.0.1",
     "@typescript-eslint/eslint-plugin": "6.7.0",
     "@typescript-eslint/parser": "6.7.0",

--- a/packages/coresandbox/src/components/Blocks/TestBlock/Data.jsx
+++ b/packages/coresandbox/src/components/Blocks/TestBlock/Data.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useIntl } from 'react-intl';
-import { BlockDataForm } from '@plone/volto/components';
+import { BlockDataForm } from '@plone/volto/components/manage/Form';
 
 const TestBlockData = (props) => {
   const { block, blocksConfig, data, onChangeBlock } = props;

--- a/packages/volto-slate/src/blocks/Table/TableBlockEdit.jsx
+++ b/packages/volto-slate/src/blocks/Table/TableBlockEdit.jsx
@@ -11,7 +11,8 @@ import cx from 'classnames';
 import { defineMessages, injectIntl } from 'react-intl';
 
 import Cell from './Cell';
-import { BlockDataForm, Icon, SidebarPortal } from '@plone/volto/components';
+import { Icon, SidebarPortal } from '@plone/volto/components';
+import { BlockDataForm } from '@plone/volto/components/manage/Form';
 import TableSchema from './schema';
 
 import rowBeforeSVG from '@plone/volto/icons/row-before.svg';

--- a/packages/volto-slate/src/blocks/Text/DefaultTextBlockEditor.jsx
+++ b/packages/volto-slate/src/blocks/Text/DefaultTextBlockEditor.jsx
@@ -12,11 +12,7 @@ import {
   validateFileUploadSize,
 } from '@plone/volto/helpers';
 import config from '@plone/volto/registry';
-import {
-  BlockDataForm,
-  SidebarPortal,
-  BlockChooserButton,
-} from '@plone/volto/components';
+import { SidebarPortal, BlockChooserButton } from '@plone/volto/components';
 
 import { SlateEditor } from '@plone/volto-slate/editor';
 import { serializeNodesToText } from '@plone/volto-slate/editor/render';
@@ -34,7 +30,7 @@ import { handleKey } from './keyboard';
 import TextBlockSchema from './schema';
 
 import imageBlockSVG from '@plone/volto/components/manage/Blocks/Image/block-image.svg';
-
+import { BlockDataForm } from '@plone/volto/components/manage/Form';
 import './css/editor.css';
 
 // TODO: refactor dropzone to separate component wrapper

--- a/packages/volto-slate/src/elementEditor/PluginEditor.jsx
+++ b/packages/volto-slate/src/elementEditor/PluginEditor.jsx
@@ -3,9 +3,10 @@ import { isEqual } from 'lodash';
 import React from 'react';
 import { useDispatch } from 'react-redux';
 import { ReactEditor } from 'slate-react';
-import { Icon as VoltoIcon, BlockDataForm } from '@plone/volto/components';
+import { Icon as VoltoIcon } from '@plone/volto/components';
 import { setPluginOptions } from '@plone/volto-slate/actions';
 import BaseSchemaProvider from './SchemaProvider';
+import { BlockDataForm } from '@plone/volto/components/manage/Form';
 
 import briefcaseSVG from '@plone/volto/icons/briefcase.svg';
 import checkSVG from '@plone/volto/icons/check.svg';

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -77,7 +77,6 @@ export { default as Actions } from '@plone/volto/components/manage/Actions/Actio
 export { default as Add } from '@plone/volto/components/manage/Add/Add';
 export { default as AddonsControlpanel } from '@plone/volto/components/manage/Controlpanels/AddonsControlpanel';
 export { default as UndoControlpanel } from '@plone/volto/components/manage/Controlpanels/UndoControlpanel';
-export { default as Contents } from '@plone/volto/components/manage/Contents/Contents';
 export { default as Circle } from '@plone/volto/components/manage/Contents/circle';
 export { default as DatabaseInformation } from '@plone/volto/components/manage/Controlpanels/DatabaseInformation';
 export { default as Controlpanel } from '@plone/volto/components/manage/Controlpanels/Controlpanel';
@@ -88,14 +87,7 @@ export { default as ContentType } from '@plone/volto/components/manage/Controlpa
 export { default as ContentTypeLayout } from '@plone/volto/components/manage/Controlpanels/ContentTypeLayout';
 export { default as ContentTypeSchema } from '@plone/volto/components/manage/Controlpanels/ContentTypeSchema';
 export { default as ContentTypesActions } from '@plone/volto/components/manage/Controlpanels/ContentTypesActions';
-export { default as UsersControlpanel } from '@plone/volto/components/manage/Controlpanels/Users/UsersControlpanel';
-export { default as UserGroupMembershipControlPanel } from '@plone/volto/components/manage/Controlpanels/Users/UserGroupMembershipControlPanel';
-export { default as Relations } from '@plone/volto/components/manage/Controlpanels/Relations/Relations';
 export { default as GroupsControlpanel } from '@plone/volto/components/manage/Controlpanels/Groups/GroupsControlpanel';
-export { default as RulesControlpanel } from '@plone/volto/components/manage/Controlpanels/Rules/Rules';
-export { default as AddRuleControlpanel } from '@plone/volto/components/manage/Controlpanels/Rules/AddRule';
-export { default as EditRuleControlpanel } from '@plone/volto/components/manage/Controlpanels/Rules/EditRule';
-export { default as ConfigureRuleControlpanel } from '@plone/volto/components/manage/Controlpanels/Rules/ConfigureRule';
 export { default as UpgradeControlPanel } from '@plone/volto/components/manage/Controlpanels/UpgradeControlPanel';
 
 export { default as ModerateComments } from '@plone/volto/components/manage/Controlpanels/ModerateComments';
@@ -108,7 +100,6 @@ export { default as Display } from '@plone/volto/components/manage/Display/Displ
 export { default as Edit } from '@plone/volto/components/manage/Edit/Edit';
 export { default as History } from '@plone/volto/components/manage/History/History';
 export { default as Sharing } from '@plone/volto/components/manage/Sharing/Sharing';
-export { default as Rules } from '@plone/volto/components/manage/Rules/Rules';
 export { default as Aliases } from '@plone/volto/components/manage/Aliases/Aliases';
 export { default as LinksToItem } from '@plone/volto/components/manage/LinksToItem/LinksToItem';
 export { default as Workflow } from '@plone/volto/components/manage/Workflow/Workflow';
@@ -130,15 +121,6 @@ export { default as ManageTranslations } from '@plone/volto/components/manage/Mu
 export Form from '@plone/volto/components/manage/Form/Form';
 export { default as SearchTags } from '@plone/volto/components/theme/Search/SearchTags';
 export { default as CommentEditModal } from '@plone/volto/components/theme/Comments/CommentEditModal';
-export { default as ContentsBreadcrumbs } from '@plone/volto/components/manage/Contents/ContentsBreadcrumbs';
-export { default as ContentsIndexHeader } from '@plone/volto/components/manage/Contents/ContentsIndexHeader';
-export { default as ContentsItem } from '@plone/volto/components/manage/Contents/ContentsItem';
-export { default as ContentsUploadModal } from '@plone/volto/components/manage/Contents/ContentsUploadModal';
-export { default as ContentsPropertiesModal } from '@plone/volto/components/manage/Contents/ContentsPropertiesModal';
-export { default as ContentsRenameModal } from '@plone/volto/components/manage/Contents/ContentsRenameModal';
-export { default as ContentsWorkflowModal } from '@plone/volto/components/manage/Contents/ContentsWorkflowModal';
-export { default as ContentsTagsModal } from '@plone/volto/components/manage/Contents/ContentsTagsModal';
-export { default as RenderUsers } from '@plone/volto/components/manage/Controlpanels/Users/RenderUsers';
 export { default as RenderGroups } from '@plone/volto/components/manage/Controlpanels/Groups/RenderGroups';
 export { default as DragDropList } from '@plone/volto/components/manage/DragDropList/DragDropList';
 

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -127,10 +127,7 @@ export { default as ManageTranslations } from '@plone/volto/components/manage/Mu
 
 // Potentially could ve removed from index, since they are internal components and
 // we don't want them to end up in the main chunk
-export const Form = loadable(() =>
-  import('@plone/volto/components/manage/Form/Form'),
-);
-
+export Form from '@plone/volto/components/manage/Form/Form';
 export { default as SearchTags } from '@plone/volto/components/theme/Search/SearchTags';
 export { default as CommentEditModal } from '@plone/volto/components/theme/Comments/CommentEditModal';
 export { default as ContentsBreadcrumbs } from '@plone/volto/components/manage/Contents/ContentsBreadcrumbs';

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -101,10 +101,11 @@ export { default as UpgradeControlPanel } from '@plone/volto/components/manage/C
 export { default as ModerateComments } from '@plone/volto/components/manage/Controlpanels/ModerateComments';
 export { default as VersionOverview } from '@plone/volto/components/manage/Controlpanels/VersionOverview';
 export { default as Delete } from '@plone/volto/components/manage/Delete/Delete';
-export { default as Diff } from '@plone/volto/components/manage/Diff/Diff';
+export const Diff = loadable(() =>
+  import('@plone/volto/components/manage/Diff/Diff'),
+);
 export { default as Display } from '@plone/volto/components/manage/Display/Display';
 export { default as Edit } from '@plone/volto/components/manage/Edit/Edit';
-export { default as ModalForm } from '@plone/volto/components/manage/Form/ModalForm';
 export { default as History } from '@plone/volto/components/manage/History/History';
 export { default as Sharing } from '@plone/volto/components/manage/Sharing/Sharing';
 export { default as Rules } from '@plone/volto/components/manage/Rules/Rules';
@@ -126,10 +127,10 @@ export { default as ManageTranslations } from '@plone/volto/components/manage/Mu
 
 // Potentially could ve removed from index, since they are internal components and
 // we don't want them to end up in the main chunk
-export { default as Form } from '@plone/volto/components/manage/Form/Form';
-export { default as BlocksToolbar } from '@plone/volto/components/manage/Form/BlocksToolbar';
-export { default as UndoToolbar } from '@plone/volto/components/manage/Form/UndoToolbar';
-export { default as Field } from '@plone/volto/components/manage/Form/Field';
+export const Form = loadable(() =>
+  import('@plone/volto/components/manage/Form/Form'),
+);
+
 export { default as SearchTags } from '@plone/volto/components/theme/Search/SearchTags';
 export { default as CommentEditModal } from '@plone/volto/components/theme/Comments/CommentEditModal';
 export { default as ContentsBreadcrumbs } from '@plone/volto/components/manage/Contents/ContentsBreadcrumbs';
@@ -142,11 +143,7 @@ export { default as ContentsWorkflowModal } from '@plone/volto/components/manage
 export { default as ContentsTagsModal } from '@plone/volto/components/manage/Contents/ContentsTagsModal';
 export { default as RenderUsers } from '@plone/volto/components/manage/Controlpanels/Users/RenderUsers';
 export { default as RenderGroups } from '@plone/volto/components/manage/Controlpanels/Groups/RenderGroups';
-export { default as DiffField } from '@plone/volto/components/manage/Diff/DiffField';
 export { default as DragDropList } from '@plone/volto/components/manage/DragDropList/DragDropList';
-export { default as InlineForm } from '@plone/volto/components/manage/Form/InlineForm';
-export { default as BlocksForm } from '@plone/volto/components/manage/Blocks/Block/BlocksForm';
-export { default as BlockDataForm } from '@plone/volto/components/manage/Form/BlockDataForm';
 
 export { default as FormFieldWrapper } from '@plone/volto/components/manage/Widgets/FormFieldWrapper';
 export { default as ArrayWidget } from '@plone/volto/components/manage/Widgets/ArrayWidget';

--- a/src/components/manage/Actions/Actions.jsx
+++ b/src/components/manage/Actions/Actions.jsx
@@ -8,7 +8,8 @@ import { FormattedMessage, defineMessages, useIntl } from 'react-intl';
 
 import { cut, copy, copyContent, moveContent } from '@plone/volto/actions';
 import { getBaseUrl } from '@plone/volto/helpers';
-import { ContentsRenameModal, Toast } from '@plone/volto/components';
+import { Toast } from '@plone/volto/components';
+import { ContentsRenameModal } from '@plone/volto/components/manage/Contents';
 
 const messages = defineMessages({
   cut: {

--- a/src/components/manage/Actions/Actions.test.jsx
+++ b/src/components/manage/Actions/Actions.test.jsx
@@ -8,9 +8,9 @@ import Actions from './Actions';
 
 const mockStore = configureStore();
 
-jest.mock('../Contents/ContentsRenameModal', () =>
-  jest.fn(() => <div className="RenameModal" />),
-);
+jest.mock('@plone/volto/components/manage/Contents', () => ({
+  ContentsRenameModal: jest.fn(() => <div className="RenameModal" />),
+}));
 
 describe('Actions', () => {
   it('renders an actions component', () => {

--- a/src/components/manage/Blocks/Block/DefaultEdit.jsx
+++ b/src/components/manage/Blocks/Block/DefaultEdit.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 import config from '@plone/volto/registry';
 import { useIntl } from 'react-intl';
 import { SidebarPortal } from '@plone/volto/components';
-import { BlockDataForm } from '@plone/volto/components';
 import DefaultBlockView from './DefaultView';
+import { BlockDataForm } from '@plone/volto/components/manage/Form';
 
 const DefaultBlockEdit = (props) => {
   const { blocksConfig = config.blocks.blocksConfig } = props;

--- a/src/components/manage/Blocks/Block/Settings.jsx
+++ b/src/components/manage/Blocks/Block/Settings.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
-import BlockDataForm from '@plone/volto/components/manage/Form/BlockDataForm';
+import { BlockDataForm } from '@plone/volto/components/manage/Form';
 
 const Settings = ({ data, block, onChangeBlock, schema }) => {
   return (

--- a/src/components/manage/Blocks/Container/Data.jsx
+++ b/src/components/manage/Blocks/Container/Data.jsx
@@ -1,5 +1,5 @@
 import { useIntl } from 'react-intl';
-import { BlockDataForm } from '@plone/volto/components';
+import { BlockDataForm } from '@plone/volto/components/manage/Form';
 
 const ContainerData = (props) => {
   const { block, blocksConfig, data, onChangeBlock } = props;

--- a/src/components/manage/Blocks/Container/Edit.jsx
+++ b/src/components/manage/Blocks/Container/Edit.jsx
@@ -1,14 +1,14 @@
 import { useState } from 'react';
 import { useIntl } from 'react-intl';
 import { pickBy } from 'lodash';
-import { BlocksForm, SidebarPortal } from '@plone/volto/components';
+import { SidebarPortal } from '@plone/volto/components';
 import PropTypes from 'prop-types';
 import ContainerData from './Data';
 import DefaultEditBlockWrapper from './EditBlockWrapper';
 import SimpleContainerToolbar from './SimpleContainerToolbar';
 import { v4 as uuid } from 'uuid';
 import { blocksFormGenerator } from '@plone/volto/helpers';
-
+import { BlocksForm } from '@plone/volto/components/manage/Form';
 import DefaultTemplateChooser from '@plone/volto/components/manage/TemplateChooser/TemplateChooser';
 
 import config from '@plone/volto/registry';

--- a/src/components/manage/Blocks/HeroImageLeft/Data.jsx
+++ b/src/components/manage/Blocks/HeroImageLeft/Data.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useIntl } from 'react-intl';
 import schemaHero from './schema.js';
-import { BlockDataForm } from '@plone/volto/components';
+import { BlockDataForm } from '@plone/volto/components/manage/Form';
 
 const HeroImageLeftBlockData = (props) => {
   const { block, data, onChangeBlock } = props;

--- a/src/components/manage/Blocks/Image/ImageSidebar.jsx
+++ b/src/components/manage/Blocks/Image/ImageSidebar.jsx
@@ -3,8 +3,9 @@ import PropTypes from 'prop-types';
 import { Segment, Button } from 'semantic-ui-react';
 import { useIntl, FormattedMessage, defineMessages } from 'react-intl';
 import { flattenToAppURL, isInternalURL } from '@plone/volto/helpers';
-import { BlockDataForm, Icon, Image } from '@plone/volto/components';
+import { Icon, Image } from '@plone/volto/components';
 import { ImageSchema } from './schema';
+import { BlockDataForm } from '@plone/volto/components/manage/Form';
 import imageSVG from '@plone/volto/icons/image.svg';
 import trashSVG from '@plone/volto/icons/delete.svg';
 

--- a/src/components/manage/Blocks/Listing/ListingData.jsx
+++ b/src/components/manage/Blocks/Listing/ListingData.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
-import { BlockDataForm } from '@plone/volto/components';
+import { BlockDataForm } from '@plone/volto/components/manage/Form';
+
 import config from '@plone/volto/registry';
 
 const ListingData = (props) => {

--- a/src/components/manage/Blocks/Maps/MapsSidebar.jsx
+++ b/src/components/manage/Blocks/Maps/MapsSidebar.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { MapsSchema } from './schema';
-import { BlockDataForm } from '@plone/volto/components';
 import { useIntl, defineMessages } from 'react-intl';
 import globeSVG from '@plone/volto/icons/globe.svg';
 import { Icon } from '@plone/volto/components';
 import { Segment } from 'semantic-ui-react';
+import { BlockDataForm } from '@plone/volto/components/manage/Form';
 
 const messages = defineMessages({
   Maps: {

--- a/src/components/manage/Blocks/Search/SearchBlockEdit.jsx
+++ b/src/components/manage/Blocks/Search/SearchBlockEdit.jsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import { defineMessages } from 'react-intl';
 import { compose } from 'redux';
 
-import { SidebarPortal, BlockDataForm } from '@plone/volto/components';
+import { SidebarPortal } from '@plone/volto/components';
 import { addExtensionFieldToSchema } from '@plone/volto/helpers/Extensions/withBlockSchemaEnhancer';
 import { getBaseUrl } from '@plone/volto/helpers';
 import config from '@plone/volto/registry';
@@ -11,6 +11,7 @@ import { SearchBlockViewComponent } from './SearchBlockView';
 import Schema from './schema';
 import { withSearch, withQueryString } from './hocs';
 import { cloneDeep } from 'lodash';
+import { BlockDataForm } from '@plone/volto/components/manage/Form';
 
 const messages = defineMessages({
   template: {

--- a/src/components/manage/Blocks/Table/Edit.jsx
+++ b/src/components/manage/Blocks/Table/Edit.jsx
@@ -13,7 +13,7 @@ import cx from 'classnames';
 import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
 
 import Cell from '@plone/volto/components/manage/Blocks/Table/Cell';
-import { Field, Icon } from '@plone/volto/components';
+import { Icon } from '@plone/volto/components';
 import { injectLazyLibs } from '@plone/volto/helpers/Loadable/Loadable';
 
 import rowBeforeSVG from '@plone/volto/icons/row-before.svg';
@@ -22,6 +22,7 @@ import colBeforeSVG from '@plone/volto/icons/column-before.svg';
 import colAfterSVG from '@plone/volto/icons/column-after.svg';
 import rowDeleteSVG from '@plone/volto/icons/row-delete.svg';
 import colDeleteSVG from '@plone/volto/icons/column-delete.svg';
+import { Field } from '@plone/volto/components/manage/Form';
 
 const getId = () => Math.floor(Math.random() * Math.pow(2, 24)).toString(32);
 

--- a/src/components/manage/Blocks/Teaser/Data.jsx
+++ b/src/components/manage/Blocks/Teaser/Data.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import { Button } from 'semantic-ui-react';
-import { BlockDataForm, Icon } from '@plone/volto/components';
+import { Icon } from '@plone/volto/components';
 import { isEmpty } from 'lodash';
+import { BlockDataForm } from '@plone/volto/components/manage/Form';
 
 import trashSVG from '@plone/volto/icons/delete.svg';
 

--- a/src/components/manage/Blocks/ToC/Edit.jsx
+++ b/src/components/manage/Blocks/ToC/Edit.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 
 import { SidebarPortal } from '@plone/volto/components';
-import BlockDataForm from '@plone/volto/components/manage/Form/BlockDataForm';
+import { BlockDataForm } from '@plone/volto/components/manage/Form';
 
 import TableOfContentsSchema from './Schema';
 import View from './View';

--- a/src/components/manage/Blocks/Video/VideoSidebar.jsx
+++ b/src/components/manage/Blocks/Video/VideoSidebar.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { VideoBlockSchema } from './schema';
-import { BlockDataForm } from '@plone/volto/components';
 import { Segment } from 'semantic-ui-react';
 import { defineMessages, useIntl } from 'react-intl';
 import { Icon } from '@plone/volto/components';
 import videoSVG from '@plone/volto/icons/videocamera.svg';
+import { BlockDataForm } from '@plone/volto/components/manage/Form';
 
 const messages = defineMessages({
   Video: {

--- a/src/components/manage/Contents/Contents.jsx
+++ b/src/components/manage/Contents/Contents.jsx
@@ -53,14 +53,6 @@ import {
 } from '@plone/volto/actions';
 import Indexes, { defaultIndexes } from '@plone/volto/constants/Indexes';
 import {
-  ContentsBreadcrumbs,
-  ContentsIndexHeader,
-  ContentsItem,
-  ContentsRenameModal,
-  ContentsUploadModal,
-  ContentsWorkflowModal,
-  ContentsTagsModal,
-  ContentsPropertiesModal,
   Pagination,
   Popup,
   Toolbar,
@@ -68,6 +60,14 @@ import {
   Icon,
   Unauthorized,
 } from '@plone/volto/components';
+import ContentsBreadcrumbs from '@plone/volto/components/manage/Contents/ContentsBreadcrumbs';
+import ContentsIndexHeader from '@plone/volto/components/manage/Contents/ContentsIndexHeader';
+import ContentsItem from '@plone/volto/components/manage/Contents/ContentsItem';
+import { ContentsRenameModal } from '@plone/volto/components/manage/Contents';
+import ContentsUploadModal from '@plone/volto/components/manage/Contents/ContentsUploadModal';
+import ContentsWorkflowModal from '@plone/volto/components/manage/Contents/ContentsWorkflowModal';
+import ContentsTagsModal from '@plone/volto/components/manage/Contents/ContentsTagsModal';
+import ContentsPropertiesModal from '@plone/volto/components/manage/Contents/ContentsPropertiesModal';
 
 import { Helmet, getBaseUrl } from '@plone/volto/helpers';
 import { injectLazyLibs } from '@plone/volto/helpers/Loadable/Loadable';

--- a/src/components/manage/Contents/ContentsIndexHeader.test.jsx
+++ b/src/components/manage/Contents/ContentsIndexHeader.test.jsx
@@ -4,7 +4,7 @@ import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { Provider } from 'react-intl-redux';
 
-import { ContentsIndexHeader } from '@plone/volto/components';
+import ContentsIndexHeader from './ContentsIndexHeader';
 
 const mockStore = configureStore([thunk]);
 

--- a/src/components/manage/Contents/ContentsPropertiesModal.jsx
+++ b/src/components/manage/Contents/ContentsPropertiesModal.jsx
@@ -6,7 +6,7 @@ import { defineMessages, useIntl } from 'react-intl';
 
 import { usePrevious } from '@plone/volto/helpers';
 import { updateContent } from '@plone/volto/actions';
-import { ModalForm } from '@plone/volto/components';
+import { ModalForm } from '@plone/volto/components/manage/Form';
 
 const messages = defineMessages({
   properties: {

--- a/src/components/manage/Contents/ContentsRenameModal.jsx
+++ b/src/components/manage/Contents/ContentsRenameModal.jsx
@@ -6,7 +6,7 @@ import { defineMessages, useIntl } from 'react-intl';
 
 import { usePrevious } from '@plone/volto/helpers';
 import { updateContent } from '@plone/volto/actions';
-import { ModalForm } from '@plone/volto/components';
+import { ModalForm } from '@plone/volto/components/manage/Form';
 
 const messages = defineMessages({
   renameItems: {

--- a/src/components/manage/Contents/ContentsTagsModal.jsx
+++ b/src/components/manage/Contents/ContentsTagsModal.jsx
@@ -6,7 +6,7 @@ import { defineMessages, useIntl } from 'react-intl';
 
 import { usePrevious } from '@plone/volto/helpers';
 import { updateContent } from '@plone/volto/actions';
-import { ModalForm } from '@plone/volto/components';
+import { ModalForm } from '@plone/volto/components/manage/Form';
 
 const messages = defineMessages({
   default: {

--- a/src/components/manage/Contents/ContentsWorkflowModal.jsx
+++ b/src/components/manage/Contents/ContentsWorkflowModal.jsx
@@ -6,7 +6,7 @@ import { defineMessages, useIntl } from 'react-intl';
 
 import { usePrevious } from '@plone/volto/helpers';
 import { getWorkflow, transitionWorkflow } from '@plone/volto/actions';
-import { ModalForm } from '@plone/volto/components';
+import { ModalForm } from '@plone/volto/components/manage/Form';
 
 const messages = defineMessages({
   default: {

--- a/src/components/manage/Contents/index.tsx
+++ b/src/components/manage/Contents/index.tsx
@@ -1,0 +1,9 @@
+import loadable from '@loadable/component';
+
+export const Contents = loadable(
+  () => import('@plone/volto/components/manage/Contents/Contents'),
+);
+
+export const ContentsRenameModal = loadable(
+  () => import('@plone/volto/components/manage/Contents/ContentsRenameModal'),
+);

--- a/src/components/manage/Controlpanels/ContentTypes.jsx
+++ b/src/components/manage/Controlpanels/ContentTypes.jsx
@@ -17,7 +17,6 @@ import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
 import {
   Error,
   Icon,
-  ModalForm,
   Toolbar,
   Toast,
   ContentTypesActions,
@@ -31,6 +30,7 @@ import { getId } from '@plone/volto/helpers';
 
 import addSVG from '@plone/volto/icons/add-document.svg';
 import backSVG from '@plone/volto/icons/back.svg';
+import { ModalForm } from '@plone/volto/components/manage/Form';
 
 const messages = defineMessages({
   add: {

--- a/src/components/manage/Controlpanels/Groups/GroupsControlpanel.jsx
+++ b/src/components/manage/Controlpanels/Groups/GroupsControlpanel.jsx
@@ -13,7 +13,6 @@ import {
 } from '@plone/volto/actions';
 import {
   Icon,
-  ModalForm,
   Toast,
   Toolbar,
   RenderGroups,
@@ -44,6 +43,7 @@ import {
   Segment,
   Table,
 } from 'semantic-ui-react';
+import { ModalForm } from '@plone/volto/components/manage/Form';
 
 /**
  * GroupsControlpanel class.

--- a/src/components/manage/Controlpanels/Relations/RelationsListing.jsx
+++ b/src/components/manage/Controlpanels/Relations/RelationsListing.jsx
@@ -15,7 +15,7 @@ import {
   searchContent,
 } from '@plone/volto/actions';
 
-const ListingTemplate = ({
+const RelationsListing = ({
   relationtype,
   query_source,
   query_target,
@@ -477,4 +477,4 @@ const ListingTemplate = ({
     </>
   );
 };
-export default ListingTemplate;
+export default RelationsListing;

--- a/src/components/manage/Controlpanels/Relations/RelationsMatrix.jsx
+++ b/src/components/manage/Controlpanels/Relations/RelationsMatrix.jsx
@@ -22,8 +22,8 @@ import {
   queryRelations,
   rebuildRelations,
 } from '@plone/volto/actions';
-import RelationsListing from './RelationsListing';
-import BrokenRelations from './BrokenRelations';
+import RelationsListing from '@plone/volto/components/manage/Controlpanels/Relations/RelationsListing';
+import BrokenRelations from '@plone/volto/components/manage/Controlpanels/Relations/BrokenRelations';
 import helpSVG from '@plone/volto/icons/help.svg';
 import clearSVG from '@plone/volto/icons/clear.svg';
 import navTreeSVG from '@plone/volto/icons/nav.svg';

--- a/src/components/manage/Controlpanels/Rules/AddRule.jsx
+++ b/src/components/manage/Controlpanels/Rules/AddRule.jsx
@@ -19,9 +19,10 @@ import {
   Segment,
 } from 'semantic-ui-react';
 import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
-import { Icon, Toolbar, Field } from '@plone/volto/components';
+import { Icon, Toolbar } from '@plone/volto/components';
 import { toast } from 'react-toastify';
 import { Toast } from '@plone/volto/components';
+import { Field } from '@plone/volto/components/manage/Form';
 
 import { getContentRulesEvents, addNewRule } from '@plone/volto/actions';
 

--- a/src/components/manage/Controlpanels/Rules/AddRule.test.jsx
+++ b/src/components/manage/Controlpanels/Rules/AddRule.test.jsx
@@ -12,6 +12,9 @@ const mockStore = configureMockStore(middlewares);
 jest.mock('react-portal', () => ({
   Portal: jest.fn(() => <div id="Portal" />),
 }));
+jest.mock('@plone/volto/components/manage/Form', () => ({
+  Field: jest.fn(() => <div className="Field" />),
+}));
 
 describe('AddRule', () => {
   it('renders rules add interface', () => {

--- a/src/components/manage/Controlpanels/Rules/EditRule.jsx
+++ b/src/components/manage/Controlpanels/Rules/EditRule.jsx
@@ -20,7 +20,7 @@ import {
 } from 'semantic-ui-react';
 import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
 
-import { Icon, Toolbar, Field } from '@plone/volto/components';
+import { Icon, Toolbar } from '@plone/volto/components';
 import {
   getControlPanelRule,
   editRule,
@@ -28,6 +28,7 @@ import {
 } from '@plone/volto/actions';
 import { toast } from 'react-toastify';
 import { Toast } from '@plone/volto/components';
+import { Field } from '@plone/volto/components/manage/Form';
 
 import backSVG from '@plone/volto/icons/back.svg';
 

--- a/src/components/manage/Controlpanels/Rules/components/VariableModal.jsx
+++ b/src/components/manage/Controlpanels/Rules/components/VariableModal.jsx
@@ -6,7 +6,7 @@ import { getVocabulary } from '@plone/volto/actions';
 import { injectIntl } from 'react-intl';
 import { compose } from 'redux';
 
-import { ModalForm } from '@plone/volto/components';
+import { ModalForm } from '@plone/volto/components/manage/Form';
 
 const setSchema = (name, choices = '') => {
   switch (name) {

--- a/src/components/manage/Controlpanels/Users/RenderUsers.jsx
+++ b/src/components/manage/Controlpanels/Users/RenderUsers.jsx
@@ -8,13 +8,14 @@ import { FormattedMessage, injectIntl } from 'react-intl';
 import { Dropdown, Table, Checkbox } from 'semantic-ui-react';
 import trashSVG from '@plone/volto/icons/delete.svg';
 import editSVG from '@plone/volto/icons/editing.svg';
-import { Icon, ModalForm, Toast } from '@plone/volto/components';
+import { Icon, Toast } from '@plone/volto/components';
 import { updateUser } from '@plone/volto/actions';
 import ploneSVG from '@plone/volto/icons/plone.svg';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { messages } from '@plone/volto/helpers';
 import { toast } from 'react-toastify';
+import { ModalForm } from '@plone/volto/components/manage/Form';
 
 /**
  * UsersControlpanelUser class.

--- a/src/components/manage/Controlpanels/Users/UserGroupMembershipMatrix.jsx
+++ b/src/components/manage/Controlpanels/Users/UserGroupMembershipMatrix.jsx
@@ -7,7 +7,7 @@ import { isEqual } from 'lodash';
 
 import { messages } from '@plone/volto/helpers';
 import { listGroups } from '@plone/volto/actions'; // getRegistry
-import UserGroupMembershipListing from './UserGroupMembershipListing';
+import UserGroupMembershipListing from '@plone/volto/components/manage/Controlpanels/Users/UserGroupMembershipListing';
 
 const UserGroupMembershipMatrix = ({ many_users, many_groups }) => {
   const intl = useIntl();

--- a/src/components/manage/Controlpanels/Users/UsersControlpanel.jsx
+++ b/src/components/manage/Controlpanels/Users/UsersControlpanel.jsx
@@ -17,7 +17,6 @@ import {
   Icon,
   Toast,
   Toolbar,
-  RenderUsers,
   Pagination,
   Error,
 } from '@plone/volto/components';
@@ -45,6 +44,7 @@ import {
   Table,
 } from 'semantic-ui-react';
 import { ModalForm } from '@plone/volto/components/manage/Form';
+import RenderUsers from '@plone/volto/components/manage/Controlpanels/Users/RenderUsers';
 
 /**
  * UsersControlpanel class.

--- a/src/components/manage/Controlpanels/Users/UsersControlpanel.jsx
+++ b/src/components/manage/Controlpanels/Users/UsersControlpanel.jsx
@@ -15,7 +15,6 @@ import {
 } from '@plone/volto/actions';
 import {
   Icon,
-  ModalForm,
   Toast,
   Toolbar,
   RenderUsers,
@@ -45,6 +44,7 @@ import {
   Segment,
   Table,
 } from 'semantic-ui-react';
+import { ModalForm } from '@plone/volto/components/manage/Form';
 
 /**
  * UsersControlpanel class.

--- a/src/components/manage/Controlpanels/index.tsx
+++ b/src/components/manage/Controlpanels/index.tsx
@@ -1,0 +1,54 @@
+import loadable from '@loadable/component';
+
+// RULES CONTROLPANELS
+
+export const RulesControlpanel = loadable(
+  () =>
+    import(
+      /* webpackChunkName: "RulesControlpanel" */ '@plone/volto/components/manage/Controlpanels/Rules/Rules'
+    ),
+);
+
+export const AddRuleControlpanel = loadable(
+  () =>
+    import(
+      /* webpackChunkName: "RulesControlpanel" */ '@plone/volto/components/manage/Controlpanels/Rules/AddRule'
+    ),
+);
+
+export const EditRuleControlpanel = loadable(
+  () =>
+    import(
+      /* webpackChunkName: "RulesControlpanel" */ '@plone/volto/components/manage/Controlpanels/Rules/EditRule'
+    ),
+);
+
+export const ConfigureRuleControlpanel = loadable(
+  () =>
+    import(
+      /* webpackChunkName: "RulesControlpanel" */ '@plone/volto/components/manage/Controlpanels/Rules/ConfigureRule'
+    ),
+);
+
+// USERS CONTROLPANELS
+
+export const UsersControlpanel = loadable(
+  () =>
+    import(
+      '@plone/volto/components/manage/Controlpanels/Users/UsersControlpanel'
+    ),
+);
+
+export const UserGroupMembershipControlPanel = loadable(
+  () =>
+    import(
+      '@plone/volto/components/manage/Controlpanels/Users/UserGroupMembershipControlPanel'
+    ),
+);
+
+// RELATIONS CONTROLPANEL
+
+export const RelationsControlpanel = loadable(
+  () =>
+    import('@plone/volto/components/manage/Controlpanels/Relations/Relations'),
+);

--- a/src/components/manage/Diff/Diff.jsx
+++ b/src/components/manage/Diff/Diff.jsx
@@ -23,12 +23,12 @@ import {
   hasBlocksData,
 } from '@plone/volto/helpers';
 import {
-  DiffField,
   FormattedDate,
   Icon,
   Toolbar,
   Unauthorized,
 } from '@plone/volto/components';
+import DiffField from '@plone/volto/components/manage/Diff/DiffField';
 
 import backSVG from '@plone/volto/icons/back.svg';
 

--- a/src/components/manage/Form/BlockDataForm.jsx
+++ b/src/components/manage/Form/BlockDataForm.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { InlineForm } from '@plone/volto/components';
 import { withVariationSchemaEnhancer } from '@plone/volto/helpers';
+import { InlineForm } from '@plone/volto/components/manage/Form';
 
 const EnhancedBlockDataForm = withVariationSchemaEnhancer(InlineForm);
 

--- a/src/components/manage/Form/Form.jsx
+++ b/src/components/manage/Form/Form.jsx
@@ -3,7 +3,7 @@
  * @module components/manage/Form/Form
  */
 
-import { BlocksForm, Field, Icon, Toast } from '@plone/volto/components';
+import { Icon, Toast } from '@plone/volto/components';
 import {
   difference,
   FormValidation,
@@ -39,9 +39,11 @@ import {
 } from 'semantic-ui-react';
 import { v4 as uuid } from 'uuid';
 import { toast } from 'react-toastify';
-import { BlocksToolbar, UndoToolbar } from '@plone/volto/components';
+import BlocksToolbar from '@plone/volto/components/manage/Form/BlocksToolbar';
+import UndoToolbar from '@plone/volto/components/manage/Form/UndoToolbar';
 import { setSidebarTab } from '@plone/volto/actions';
 import { compose } from 'redux';
+import { Field, BlocksForm } from '@plone/volto/components/manage/Form';
 import config from '@plone/volto/registry';
 
 /**

--- a/src/components/manage/Form/Form.test.jsx
+++ b/src/components/manage/Form/Form.test.jsx
@@ -2,14 +2,15 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 import configureStore from 'redux-mock-store';
 import { Provider } from 'react-intl-redux';
-
 import Form from './Form';
 
 const mockStore = configureStore();
 const errorMessage =
   "[{'message': 'The specified email is not valid.', 'field': 'contact_email', 'error': 'ValidationError'}";
 
-jest.mock('./Field', () => jest.fn(() => <div className="Field" />));
+jest.mock('@plone/volto/components/manage/Form', () => ({
+  Field: jest.fn(() => <div className="Field" />),
+}));
 
 describe('Form', () => {
   it('renders a form component', () => {

--- a/src/components/manage/Form/InlineForm.jsx
+++ b/src/components/manage/Form/InlineForm.jsx
@@ -11,8 +11,9 @@ import {
   removeFromArray,
   arrayRange,
 } from '@plone/volto/helpers/Utils/Utils';
-import { Field, Icon } from '@plone/volto/components';
+import { Icon } from '@plone/volto/components';
 import { applySchemaDefaults } from '@plone/volto/helpers';
+import { Field } from '@plone/volto/components/manage/Form';
 
 import upSVG from '@plone/volto/icons/up-key.svg';
 import downSVG from '@plone/volto/icons/down-key.svg';

--- a/src/components/manage/Form/ModalForm.jsx
+++ b/src/components/manage/Form/ModalForm.jsx
@@ -18,7 +18,8 @@ import {
 } from 'semantic-ui-react';
 import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
 import { FormValidation } from '@plone/volto/helpers';
-import { Field, Icon } from '@plone/volto/components';
+import { Icon } from '@plone/volto/components';
+import { Field } from '@plone/volto/components/manage/Form';
 import aheadSVG from '@plone/volto/icons/ahead.svg';
 import clearSVG from '@plone/volto/icons/clear.svg';
 

--- a/src/components/manage/Form/index.tsx
+++ b/src/components/manage/Form/index.tsx
@@ -1,23 +1,50 @@
 import loadable from '@loadable/component';
 
 export const Field = loadable(
-  () => import('@plone/volto/components/manage/Form/Field'),
+  () =>
+    import(
+      /* webpackChunkName: "Form" */ '@plone/volto/components/manage/Form/Field'
+    ),
 );
 export const InlineForm = loadable(
-  () => import('@plone/volto/components/manage/Form/InlineForm'),
+  () =>
+    import(
+      /* webpackChunkName: "Form" */ '@plone/volto/components/manage/Form/InlineForm'
+    ),
 );
 export const ModalForm = loadable(
-  () => import('@plone/volto/components/manage/Form/ModalForm'),
+  () =>
+    import(
+      /* webpackChunkName: "Form" */ '@plone/volto/components/manage/Form/ModalForm'
+    ),
 );
 export const UndoToolbar = loadable(
-  () => import('@plone/volto/components/manage/Form/UndoToolbar'),
+  () =>
+    import(
+      /* webpackChunkName: "Form" */ '@plone/volto/components/manage/Form/UndoToolbar'
+    ),
 );
 export const BlocksToolbar = loadable(
-  () => import('@plone/volto/components/manage/Form/BlocksToolbar'),
+  () =>
+    import(
+      /* webpackChunkName: "Form" */ '@plone/volto/components/manage/Form/BlocksToolbar'
+    ),
 );
 export const BlockDataForm = loadable(
-  () => import('@plone/volto/components/manage/Form/BlockDataForm'),
+  () =>
+    import(
+      /* webpackChunkName: "Form" */ '@plone/volto/components/manage/Form/BlockDataForm'
+    ),
 );
 export const BlocksForm = loadable(
-  () => import('@plone/volto/components/manage/Blocks/Block/BlocksForm'),
+  () =>
+    import(
+      /* webpackChunkName: "Form" */ '@plone/volto/components/manage/Blocks/Block/BlocksForm'
+    ),
+);
+export const Form = loadable(
+  () =>
+    import(
+      /* webpackChunkName: "Form" */ '@plone/volto/components/manage/Form/Form'
+    ),
 );

--- a/src/components/manage/Form/index.tsx
+++ b/src/components/manage/Form/index.tsx
@@ -1,0 +1,23 @@
+import loadable from '@loadable/component';
+
+export const Field = loadable(
+  () => import('@plone/volto/components/manage/Form/Field'),
+);
+export const InlineForm = loadable(
+  () => import('@plone/volto/components/manage/Form/InlineForm'),
+);
+export const ModalForm = loadable(
+  () => import('@plone/volto/components/manage/Form/ModalForm'),
+);
+export const UndoToolbar = loadable(
+  () => import('@plone/volto/components/manage/Form/UndoToolbar'),
+);
+export const BlocksToolbar = loadable(
+  () => import('@plone/volto/components/manage/Form/BlocksToolbar'),
+);
+export const BlockDataForm = loadable(
+  () => import('@plone/volto/components/manage/Form/BlockDataForm'),
+);
+export const BlocksForm = loadable(
+  () => import('@plone/volto/components/manage/Blocks/Block/BlocksForm'),
+);

--- a/src/components/manage/Multilingual/TranslationObject.jsx
+++ b/src/components/manage/Multilingual/TranslationObject.jsx
@@ -8,7 +8,7 @@ import { map } from 'lodash';
 import { defineMessages, useIntl } from 'react-intl';
 import { Form as UiForm, Menu, Segment } from 'semantic-ui-react';
 import { Provider } from 'react-intl-redux';
-import { Form, Field } from '@plone/volto/components';
+import { Form } from '@plone/volto/components';
 import config from '@plone/volto/registry';
 import configureStore from '@plone/volto/store';
 import {
@@ -19,6 +19,8 @@ import {
   toReactIntlLang,
 } from '@plone/volto/helpers';
 import { createBrowserHistory } from 'history';
+import { Field } from '@plone/volto/components/manage/Form';
+
 const messages = defineMessages({
   document: {
     id: 'Document',

--- a/src/components/manage/Rules/index.tsx
+++ b/src/components/manage/Rules/index.tsx
@@ -1,0 +1,5 @@
+import loadable from '@loadable/component';
+
+export const Rules = loadable(
+  () => import('@plone/volto/components/manage/Rules/Rules'),
+);

--- a/src/components/manage/Widgets/ObjectWidget.jsx
+++ b/src/components/manage/Widgets/ObjectWidget.jsx
@@ -6,8 +6,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Tab } from 'semantic-ui-react';
-
-import Field from '@plone/volto/components/manage/Form/Field';
+import { Field } from '@plone/volto/components/manage/Form';
 
 /**
  * Renders a field set. Passes some of the values in the schema to the Field

--- a/src/components/manage/Widgets/SchemaWidget.jsx
+++ b/src/components/manage/Widgets/SchemaWidget.jsx
@@ -14,11 +14,8 @@ import { defineMessages, injectIntl } from 'react-intl';
 import { injectLazyLibs } from '@plone/volto/helpers/Loadable/Loadable';
 import { slugify } from '@plone/volto/helpers/Utils/Utils';
 
-import {
-  Field,
-  ModalForm,
-  SchemaWidgetFieldset,
-} from '@plone/volto/components';
+import { SchemaWidgetFieldset } from '@plone/volto/components';
+import { Field, ModalForm } from '@plone/volto/components/manage/Form';
 
 const messages = defineMessages({
   add: {

--- a/src/components/theme/Comments/CommentEditModal.jsx
+++ b/src/components/theme/Comments/CommentEditModal.jsx
@@ -5,7 +5,7 @@ import { defineMessages, useIntl } from 'react-intl';
 
 import { usePrevious } from '@plone/volto/helpers';
 import { updateComment } from '@plone/volto/actions';
-import { ModalForm } from '@plone/volto/components';
+import { ModalForm } from '@plone/volto/components/manage/Form';
 
 const messages = defineMessages({
   editComment: {

--- a/src/routes.js
+++ b/src/routes.js
@@ -10,7 +10,6 @@ import {
   Aliases,
   ChangePassword,
   ContactForm,
-  Contents,
   ContentType,
   ContentTypeLayout,
   ContentTypeSchema,
@@ -30,25 +29,28 @@ import {
   ModerateComments,
   NotFound,
   PasswordReset,
-  Relations,
   Register,
-  Rules,
   RequestPasswordReset,
   Search,
   Sharing,
   Sitemap,
   AliasesControlpanel,
   UndoControlpanel,
-  UsersControlpanel,
-  UserGroupMembershipControlPanel,
   GroupsControlpanel,
+  UpgradeControlPanel,
+  PersonalInformation,
+} from '@plone/volto/components';
+import { Contents } from '@plone/volto/components/manage/Contents';
+import { Rules } from '@plone/volto/components/manage/Rules';
+import {
   RulesControlpanel,
   AddRuleControlpanel,
   EditRuleControlpanel,
   ConfigureRuleControlpanel,
-  UpgradeControlPanel,
-  PersonalInformation,
-} from '@plone/volto/components';
+  UsersControlpanel,
+  UserGroupMembershipControlPanel,
+  RelationsControlpanel,
+} from '@plone/volto/components/manage/Controlpanels';
 
 // Deliberatelly use of absolute path of these components, since we do not want them
 // in the components/index.js file.
@@ -228,7 +230,7 @@ export const defaultRoutes = [
   },
   {
     path: '/controlpanel/relations',
-    component: Relations,
+    component: RelationsControlpanel,
   },
   {
     path: '/controlpanel/:id',

--- a/yarn.lock
+++ b/yarn.lock
@@ -3307,6 +3307,7 @@ __metadata:
     "@testing-library/jest-dom": 5.16.4
     "@testing-library/react": 12.1.5
     "@testing-library/react-hooks": 8.0.1
+    "@types/loadable__component": 5.13.5
     "@types/react-test-renderer": 18.0.1
     "@typescript-eslint/eslint-plugin": 6.7.0
     "@typescript-eslint/parser": 6.7.0
@@ -5316,6 +5317,15 @@ __metadata:
   version: 0.0.29
   resolution: "@types/json5@npm:0.0.29"
   checksum: e60b153664572116dfea673c5bda7778dbff150498f44f998e34b5886d8afc47f16799280e4b6e241c0472aef1bc36add771c569c68fc5125fc2ae519a3eb9ac
+  languageName: node
+  linkType: hard
+
+"@types/loadable__component@npm:5.13.5":
+  version: 5.13.5
+  resolution: "@types/loadable__component@npm:5.13.5"
+  dependencies:
+    "@types/react": "*"
+  checksum: 9ff5c96931bbc1eeb7ba776890ca576a3a96c8f236538ce29380d6d4b28643d14a50bac5524be0859ade3620e47ec41a68af1d9e17c2cec6d3271424b144ac21
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3257,23 +3257,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@plone/scripts@npm:3.0.0":
-  version: 3.0.0
-  resolution: "@plone/scripts@npm:3.0.0"
+"@plone/scripts@npm:3.0.1":
+  version: 3.0.1
+  resolution: "@plone/scripts@npm:3.0.1"
   dependencies:
     babel-plugin-react-intl: 5.1.17
     babel-preset-razzle: 4.2.17
     chalk: 4
     commander: 8.2.0
     fs-extra: 10.1.0
-    git-url-parse: ^11.6.0
+    git-url-parse: ^13.1.0
     mrs-developer: "*"
     pofile: 1.0.10
   bin:
     addon: addon/index.js
     changelogupdater: changelogupdater.cjs
     i18n: i18n.cjs
-  checksum: c5a03a68fd16f731fd40bbf94e3bc6addb4395a04049eb98fbb95f1e1ebcc2468e003149b829261a1b577d50cce032d80dc99c8e812a126621f730f6e431cb97
+  checksum: 06a7c63f975268c97c5a70d1f104de5089adb36bbe1b15a860ad108f72c2109f90ab246b80f74238f9fb1f406866202260ea5a8ee1953fe919ddf5947a201d86
   languageName: node
   linkType: hard
 
@@ -3295,7 +3295,7 @@ __metadata:
     "@loadable/component": 5.14.1
     "@loadable/server": 5.14.0
     "@loadable/webpack-plugin": 5.15.2
-    "@plone/scripts": 3.0.0
+    "@plone/scripts": 3.0.1
     "@storybook/addon-actions": ^6.5.15
     "@storybook/addon-controls": 6.5.15
     "@storybook/addon-essentials": ^6.5.15
@@ -13264,16 +13264,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"git-up@npm:^4.0.0":
-  version: 4.0.5
-  resolution: "git-up@npm:4.0.5"
-  dependencies:
-    is-ssh: ^1.3.0
-    parse-url: ^6.0.0
-  checksum: dd8f39a115ec0523b7da369cd4c6dc94a9b11fcc652e6fc9d011a93c287e27cc34e1d1c89cff8864f9ab11a1b2bea49786951d8eb3f1e5babd351afcc63f6135
-  languageName: node
-  linkType: hard
-
 "git-up@npm:^7.0.0":
   version: 7.0.0
   resolution: "git-up@npm:7.0.0"
@@ -13284,21 +13274,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"git-url-parse@npm:13.1.0":
+"git-url-parse@npm:13.1.0, git-url-parse@npm:^13.1.0":
   version: 13.1.0
   resolution: "git-url-parse@npm:13.1.0"
   dependencies:
     git-up: ^7.0.0
   checksum: 212a9b0343e9199998b6a532efe2014476a7a1283af393663ca49ac28d4768929aad16d3322e2685236065ee394dbc93e7aa63a48956531e984c56d8b5edb54d
-  languageName: node
-  linkType: hard
-
-"git-url-parse@npm:^11.6.0":
-  version: 11.6.0
-  resolution: "git-url-parse@npm:11.6.0"
-  dependencies:
-    git-up: ^4.0.0
-  checksum: 18a7d0bbac76c55fe8a501d4bd4c6b5f5528883a4dadcfce1152b4902e3e5831df8e97f36ea3f564de633e9ab44d9ab09bb2f319e41af1b6e4f627af139d35d5
   languageName: node
   linkType: hard
 
@@ -15394,7 +15375,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-ssh@npm:^1.3.0, is-ssh@npm:^1.4.0":
+"is-ssh@npm:^1.4.0":
   version: 1.4.0
   resolution: "is-ssh@npm:1.4.0"
   dependencies:
@@ -18359,13 +18340,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"normalize-url@npm:^6.1.0":
-  version: 6.1.0
-  resolution: "normalize-url@npm:6.1.0"
-  checksum: 4a4944631173e7d521d6b80e4c85ccaeceb2870f315584fa30121f505a6dfd86439c5e3fdd8cd9e0e291290c41d0c3599f0cb12ab356722ed242584c30348e50
-  languageName: node
-  linkType: hard
-
 "normalize-url@npm:^8.0.0":
   version: 8.0.0
   resolution: "normalize-url@npm:8.0.0"
@@ -19126,36 +19100,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"parse-path@npm:^4.0.0":
-  version: 4.0.4
-  resolution: "parse-path@npm:4.0.4"
-  dependencies:
-    is-ssh: ^1.3.0
-    protocols: ^1.4.0
-    qs: ^6.9.4
-    query-string: ^6.13.8
-  checksum: 909e628c35baebeb3bdcaa376e2c5a21632a9094079ac55e04b3311db28219b15e517e10987dd49a13a904f2605b747b6368b0092130e0f2ff9bc5ffc40ceb63
-  languageName: node
-  linkType: hard
-
 "parse-path@npm:^7.0.0":
   version: 7.0.0
   resolution: "parse-path@npm:7.0.0"
   dependencies:
     protocols: ^2.0.0
   checksum: 244b46523a58181d251dda9b888efde35d8afb957436598d948852f416d8c76ddb4f2010f9fc94218b4be3e5c0f716aa0d2026194a781e3b8981924142009302
-  languageName: node
-  linkType: hard
-
-"parse-url@npm:^6.0.0":
-  version: 6.0.5
-  resolution: "parse-url@npm:6.0.5"
-  dependencies:
-    is-ssh: ^1.3.0
-    normalize-url: ^6.1.0
-    parse-path: ^4.0.0
-    protocols: ^1.4.0
-  checksum: b583800f63a8a293c5d53ee6b28b99293c742791fba4f14c1b829547a78bad93500fe0d448f8d8e2087a3c4d39deab236ed3837830ea522272e8c5852f21d223
   languageName: node
   linkType: hard
 
@@ -20394,13 +20344,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"protocols@npm:^1.4.0":
-  version: 1.4.8
-  resolution: "protocols@npm:1.4.8"
-  checksum: 2d555c013df0b05402970f67f7207c9955a92b1d13ffa503c814b5fe2f6dde7ac6a03320e0975c1f5832b0113327865e0b3b28bfcad023c25ddb54b53fab8684
-  languageName: node
-  linkType: hard
-
 "protocols@npm:^2.0.0, protocols@npm:^2.0.1":
   version: 2.0.1
   resolution: "protocols@npm:2.0.1"
@@ -20564,7 +20507,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qs@npm:6.11.0, qs@npm:^6.10.0, qs@npm:^6.5.1, qs@npm:^6.9.4":
+"qs@npm:6.11.0, qs@npm:^6.10.0, qs@npm:^6.5.1":
   version: 6.11.0
   resolution: "qs@npm:6.11.0"
   dependencies:
@@ -20596,18 +20539,6 @@ __metadata:
     split-on-first: ^1.0.0
     strict-uri-encode: ^2.0.0
   checksum: 4594a0a092772eb6854310feea85e34f8dcf70df494776a45b9e5be53621ffbcf930ae669974e4e171ce5e0f29a837e9821d48db843106dd94ee390f6f5ac857
-  languageName: node
-  linkType: hard
-
-"query-string@npm:^6.13.8":
-  version: 6.14.1
-  resolution: "query-string@npm:6.14.1"
-  dependencies:
-    decode-uri-component: ^0.2.0
-    filter-obj: ^1.1.0
-    split-on-first: ^1.0.0
-    strict-uri-encode: ^2.0.0
-  checksum: f2c7347578fa0f3fd4eaace506470cb4e9dc52d409a7ddbd613f614b9a594d750877e193b5d5e843c7477b3b295b857ec328903c943957adc41a3efb6c929449
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Reduce bundle size by splitting code. Work started from editor/admin interfaces.

Already split as of this writing:
- Folder Contents
- Rules Controlpanel
- Users Controlpanel
- Relations Controlpanel
- Form components
- Diff

Reduced bundle size by ~7% (gzipped), from 582.92 to 542.6.
A lot more can be done.