### PR TITLE
Fix compare translations view

### DIFF
--- a/news/5327.bugfix
+++ b/news/5327.bugfix
@@ -1,0 +1,1 @@
+Fix compare translations view @sneridagh

--- a/src/components/manage/Edit/Edit.jsx
+++ b/src/components/manage/Edit/Edit.jsx
@@ -35,7 +35,11 @@ import {
   getSchema,
   listActions,
 } from '@plone/volto/actions';
-import { getBaseUrl, hasBlocksData } from '@plone/volto/helpers';
+import {
+  flattenToAppURL,
+  getBaseUrl,
+  hasBlocksData,
+} from '@plone/volto/helpers';
 import { preloadLazyLibs } from '@plone/volto/helpers/Loadable';
 
 import saveSVG from '@plone/volto/icons/save.svg';
@@ -260,7 +264,12 @@ class Edit extends Component {
 
   setComparingLanguage(lang, content_id) {
     this.setState({ comparingLanguage: lang });
-    this.props.getContent(content_id, null, 'compare_to', null);
+    this.props.getContent(
+      flattenToAppURL(content_id),
+      null,
+      'compare_to',
+      null,
+    );
   }
 
   form = React.createRef();


### PR DESCRIPTION
It seems it was a while since it was not working... I guess we will need some tests around it. A simple `flattenToAppURL` missing :( 