### PR TITLE
Add new multilingual acceptance tests with Seamless mode enabled

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -745,3 +745,57 @@ jobs:
         with:
           name: cypress-videos
           path: cypress/videos
+
+  multilingualseamless:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+    name: Multilingual in Seamless Mode
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [18.x]
+    steps:
+      - uses: actions/checkout@v3
+
+      # node setup
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
+
+      # node install
+      - run: yarn --immutable
+
+      - name: Cypress acceptance tests
+        uses: cypress-io/github-action@v6
+        env:
+          BABEL_ENV: production
+          CYPRESS_RETRIES: 2
+          # Recommended: pass the GitHub token lets this action correctly
+          # determine the unique run id necessary to re-run the checks
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          install: false
+          browser: chrome
+          spec: cypress/tests/multilingual/**/*.js
+          config: baseUrl=http://localhost
+          start: |
+            make start-test-acceptance-server-seamless-multilingual
+            make start-test-acceptance-frontend-seamless-multilingual
+            make start-test-acceptance-webserver-seamless
+          wait-on: 'npx wait-on --httpTimeout 20000 http-get://127.0.0.1:55001/plone http://127.0.0.1:3000 http://localhost'
+
+      # Upload Cypress screenshots
+      - uses: actions/upload-artifact@v1
+        if: failure()
+        with:
+          name: cypress-screenshots
+          path: cypress/screenshots
+      # Upload Cypress videos
+      - uses: actions/upload-artifact@v1
+        if: failure()
+        with:
+          name: cypress-videos
+          path: cypress/videos

--- a/Makefile
+++ b/Makefile
@@ -319,6 +319,28 @@ test-acceptance-multilingual-headless: ## Start Multilingual Cypress Acceptance 
 full-test-acceptance-multilingual: ## Runs Multilingual Full Acceptance Testing in headless mode
 	$(NODEBIN)/start-test "make start-test-acceptance-server-multilingual" http-get://127.0.0.1:55001/plone "make start-test-acceptance-frontend-multilingual" http://127.0.0.1:3000 "make test-acceptance-multilingual-headless"
 
+######### Seamless Multilingual Acceptance tests
+
+.PHONY: start-test-acceptance-server-seamless-multilingual test-acceptance-server-seamless-multilingual
+start-test-acceptance-server-seamless-multilingual test-acceptance-server-seamless-multilingual: ## Start Seamless Multilingual Acceptance Server Multilingual Fixture (docker container)
+	docker run -i --rm -p 55001:55001 -e APPLY_PROFILES=plone.app.contenttypes:plone-content,plone.restapi:default,plone.volto:multilingual $(DOCKER_IMAGE_ACCEPTANCE)
+
+.PHONY: start-test-acceptance-frontend-seamless-multilingual
+start-test-acceptance-frontend-seamless-multilingual: ## Start the Seamless Multilingual Acceptance Frontend Fixture
+	ADDONS=coresandbox:multilingualFixture yarn build && yarn start:prod
+
+.PHONY: test-acceptance-seamless-multilingual
+test-acceptance-seamless-multilingual: ## Start Seamless Multilingual Cypress Acceptance Tests
+	NODE_ENV=production CYPRESS_API=plone $(NODEBIN)/cypress open --config baseUrl='http://localhost',specPattern='cypress/tests/multilingual/**/*.{js,jsx,ts,tsx}'
+
+.PHONY: test-acceptance-seamless-multilingual-headless
+test-acceptance-seamless-multilingual-headless: ## Start Seamless Multilingual Cypress Acceptance Tests in headless mode
+	NODE_ENV=production CYPRESS_API=plone $(NODEBIN)/cypress run --config specPattern='cypress/tests/multilingual/**/*.{js,jsx,ts,tsx}'
+
+.PHONY: full-test-acceptance-seamless-multilingual
+full-test-acceptance-seamless-multilingual: ## Runs Seamless Multilingual Full Acceptance Testing in headless mode
+	$(NODEBIN)/start-test "make start-test-acceptance-server-seamless-multilingual" http-get://127.0.0.1:55001/plone "make start-test-acceptance-frontend-seamless-multilingual" http://127.0.0.1:3000 "make test-acceptance-multilingual-headless"
+
 ######### WorkingCopy Acceptance tests
 
 .PHONY: start-test-acceptance-server-workingcopy test-acceptance-server-workingcopy

--- a/news/5332.internal
+++ b/news/5332.internal
@@ -1,0 +1,1 @@
+Add a new set of acceptance tests with the multilingual fixture using seamless mode. @sneridagh


### PR DESCRIPTION
After #5327 I was wondering how it didn't break cypress, since there was a test in place testing the feature already.

It seems that didn't break in non-seamless mode. So I've enabled a set of acceptance tests that uses the fixture for multilingual using seamless mode. The tests did break using a checkout prior to the test, and they were fixed after applying the fix.

