### PR TITLE
Remove regex from sphinx-copybutton config, now that linenos are excl…

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -181,11 +181,6 @@ ogp_custom_meta_tags = [
 ]
 
 
-# -- sphinx_copybutton -----------------------
-copybutton_prompt_text = r"^ {0,2}\d{1,3}"
-copybutton_prompt_is_regexp = True
-
-
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for

--- a/news/5346.documentation
+++ b/news/5346.documentation
@@ -1,0 +1,1 @@
+Remove regular expression from `sphinx-copybutton` configuration, now that `linenos` are excluded by default. @stevepiercy


### PR DESCRIPTION
…uded by default

See https://sphinx-copybutton.readthedocs.io/en/latest/use.html#automatic-exclusion-of-prompts-from-the-copies

See also https://github.com/plone/documentation/pull/1563