### PR TITLE
Fix the right order of parameters in normalizeExternalData.js

### DIFF
--- a/packages/volto-slate/src/editor/extensions/normalizeExternalData.js
+++ b/packages/volto-slate/src/editor/extensions/normalizeExternalData.js
@@ -2,7 +2,7 @@ import { normalizeExternalData as normalize } from '@plone/volto-slate/utils';
 
 export function normalizeExternalData(editor) {
   editor.normalizeExternalData = (fragment) => {
-    return normalize(fragment);
+    return normalize(editor, fragment);
   };
   return editor;
 }


### PR DESCRIPTION
Because of this bug, if you try to copy the text:
This indicator is a headline indicator for monitoring progress towards
In a richtext widget, an error will come.
