### PR TITLE
In slate, render span nodes as spans rather than paragraphs.

### DIFF
--- a/packages/volto-slate/src/editor/config.jsx
+++ b/packages/volto-slate/src/editor/config.jsx
@@ -248,6 +248,7 @@ export const elements = {
 
   div: ({ attributes, children }) => <div {...attributes}>{children}</div>,
   p: ({ attributes, children, element }) => <p {...attributes}>{children}</p>,
+  span: ({ children }) => <span>{children}</span>,
 
   // While usual slate editor consider these to be Leafs, we treat them as
   // inline elements because they can sometimes contain elements (ex:


### PR DESCRIPTION
@tiberiuichim Curious for your thoughts on this. Currently https://github.com/plone/blocks-conversion-tool produces span nodes for text inside a table cell, but perhaps it should not do that.