### PR TITLE
Aligned the Edit Recurrence button in Recurrence widget

### DIFF
--- a/theme/themes/pastanaga/collections/grid.overrides
+++ b/theme/themes/pastanaga/collections/grid.overrides
@@ -9,3 +9,8 @@
 .ui.form .ui.grid > .row {
   padding: 0;
 }
+
+.ui.grid > .stretched.row > .column > *{
+  display: flex;
+  align-items: center;
+}


### PR DESCRIPTION
Added the following override in 

> theme/themes/pastanaga/collections/grid.overrides

```
.ui.grid > .stretched.row > .column > *{
  display: flex;
  align-items: center;
}
```
now the button looks symmetrical

![image](https://github.com/plone/volto/assets/92005669/31b87e32-41d6-445e-a509-30aff0a9d8a1)