### PR TITLE
Fix Content title ("Contents"->"Contents - Welcome to Plone 6!"

### DIFF
--- a/src/components/manage/Contents/Contents.jsx
+++ b/src/components/manage/Contents/Contents.jsx
@@ -100,8 +100,8 @@ const messages = defineMessages({
     defaultMessage: 'Back',
   },
   contents: {
-    id: 'Contents',
-    defaultMessage: 'Contents',
+    id: 'Contents - Welcome to Plone 6!',
+    defaultMessage: 'Contents - Welcome to Plone 6!',
   },
   copy: {
     id: 'Copy',


### PR DESCRIPTION
Fixes #5321 

Changed the title of "Contents" to "Contents - Welcome to Plone 6!". 
<img width="1440" alt="280375298-ba235648-f3fa-4832-9faf-247b045533b0" src="https://github.com/plone/volto/assets/121725696/03a7a335-9483-41e6-b9b6-04375348a286">
