### PR TITLE
Reduce the severity level of `Microsoft.Contractions` and `Microsoft.…

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -8,3 +8,5 @@ Packages = Microsoft
 
 [*.md]
 BasedOnStyles = Vale, Microsoft
+Microsoft.Contractions = suggestion
+Microsoft.Units = suggestion

--- a/news/5371.documentation
+++ b/news/5371.documentation
@@ -1,0 +1,1 @@
+Reduce the severity level of `Microsoft.Contractions` and `Microsoft.Units` from `error` to `suggestion` when running `make docs-vale` in preparation for requiring Vale passing without errors. @stevepiercy


### PR DESCRIPTION
…Units` from `error` to `suggestion` in preparation for requiring Vale passing without errors.

See https://github.com/plone/documentation/pull/1567

## Before

```
✖ 2467 errors, 800 warnings and 1861 suggestions in 93 files.
```

## After

```
✖ 2161 errors, 800 warnings and 2167 suggestions in 93 files.
```
