### PR TITLE
Check for existence of news symlink

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ DOCS_DIR        = ./docs/source/
 BUILDDIR        = ../_build/
 ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(SPHINXOPTS) .
 VALEFILES       := $(shell find $(DOCS_DIR) -type f -name "*.md" -print)
+VOLTO_NEWS_SYMLINK = ./docs/source/news
 
 # Recipe snippets for reuse
 
@@ -107,8 +108,7 @@ bin/python:
 	@echo "Python environment created."
 	bin/pip install -r requirements-docs.txt
 	@echo "Requirements installed."
-	ln -s ../../news ./docs/source/news
-	@echo "Symlink created."
+	if [ ! -L $(VOLTO_NEWS_SYMLINK) ] && [ ! -e $(VOLTO_NEWS_SYMLINK) ]; then ln -s ../../news $(VOLTO_NEWS_SYMLINK) && echo "Symlink to Volto news created."; else echo "Symlink to Volto news exists."; fi
 
 .PHONY: clean
 clean:

--- a/news/5375.documentation
+++ b/news/5375.documentation
@@ -1,0 +1,1 @@
+Improved the Makefil to check for the existence of a symlink from docs to news, and create one only if it exists, else do nothing. @stevepiercy


### PR DESCRIPTION
When running `make docs-html`, the build will fail because a symlink exists. This pull request checks for the existence of a good symlink and creates one if it does not exist. Whether it exists or not, an appropriate statement is echoed.