### PR TITLE
Add documentation chapter to Volto contributing

### DIFF
--- a/docs/source/contributing/documentation.md
+++ b/docs/source/contributing/documentation.md
@@ -1,0 +1,142 @@
+---
+myst:
+  html_meta:
+    "description": "Documentation in Volto"
+    "property=og:description": "Documentation in Volto"
+    "property=og:title": "Documentation in Volto"
+    "keywords": "Volto, Plone, frontend, React, Documentation, MyST, Storybook, Vale, spell, grammar, style, check, linkcheck"
+---
+
+(volto-documentation-label)=
+
+# Documentation
+
+> "If it ain't documented, it's broken."
+
+Documentation in Volto has two parts, {ref}`narrative <volto-documentation-narrative-label>` and {ref}`Storybook <volto-documentation-storybook-label>`.
+
+
+(volto-documentation-narrative-label)=
+
+## Narrative documentation
+
+Volto follows the guidance of {doc}`plone:index` and uses the same tools when writing narrative documentation.
+
+We use Sphinx to build and check documentation.
+
+We use MyST, an extended flavor of Markdown that allows the use of reStructuredText and Sphinx extensions to provide a rich experience.
+
+The {doc}`plone:index` also provides excellent references for writing high quality narrative documentation.
+
+-   {doc}`plone:contributing/documentation/authors`
+-   {doc}`plone:contributing/documentation/myst-reference`
+-   {doc}`plone:contributing/documentation/themes-and-extensions`
+
+
+### Building and checking the quality of narrative documentation
+
+We use Make commands to run Sphinx to build and check documentation.
+All build and check documentation commands use the file `Makefile`.
+In Volto, all documentation commands are prefixed with `docs-`.
+
+To see the all Make commands, use the following command.
+
+```shell
+make help
+```
+
+Else you can open `Makefile` to see other build formats.
+
+
+#### Warnings from `make docs-*` commands
+
+When running any of the documentation Make commands, you may safely ignore warnings such as the following:
+
+```console
+/system-file-to-path/volto/docs/source/news/5294.breaking: WARNING: document isn't included in any toctree
+```
+
+These warnings only check each of the changelog entries for valid MyST syntax.
+We do not want to include them in the documentation through a toctree entry, because the release process copies them into the {doc}`../release-notes/index` and deletes them.
+Thus it is safe to ignore warnings of this specific type, but you should heed all others.
+
+
+#### `docs-html`
+
+`docs-html` is the HTML version of the documentation.
+
+```shell
+make docs-html
+```
+
+Open `/docs/_build/html/index.html` in a web browser.
+
+
+#### `docs-livehtml`
+
+`docs-livehtml` rebuilds Sphinx documentation on changes, with live-reload in the browser.
+
+```shell
+make docs-livehtml
+```
+
+Open http://127.0.0.1:8000/ in a web browser.
+
+
+#### `docs-linkcheck`
+
+`docs-linkcheck` checks all links.
+See {ref}`plone:authors-linkcheck-label` for configuration.
+
+```shell
+make docs-linkcheck
+```
+
+Open `/docs/_build/linkcheck/output.txt` for a list of broken links.
+
+
+#### `docs-linkcheckbroken`
+
+`docs-linkcheckbroken` runs `docs-linkcheck`, but returns only errors and provides coloring on the console.
+
+```shell
+make docs-linkcheckbroken
+```
+
+Open `/docs/_build/linkcheck/output.txt` for a list of broken links.
+
+
+#### `docs-vale`
+
+See {ref}`plone:setup-build-installation-vale-label` for how to install Vale.
+
+`docs-vale` checks for American English spelling, grammar, syntax, and the Microsoft Developer Style Guide.
+See {ref}`plone:authors-english-label` for configuration.
+
+```shell
+make docs-vale
+```
+
+See the output on the console for suggestions.
+
+
+
+(volto-documentation-storybook-label)=
+
+## Storybook entry
+
+[Storybook](https://storybook.js.org) is a tool that demonstrates the visual elements in a system.
+Storybook provides a sandbox to build, test, and document these visual elements (components) in isolation, mock them to show different data, test edge cases.
+
+Components include widgets, blocks, and basic and structural items.
+When you develop a component, we encourage you to create or update its [Volto Storybook](https://6.docs.plone.org/storybook/) entry.
+As an example of how to do that, you can copy the existing Storybook entry for the `RichTextWidget` component.
+
+- https://github.com/plone/volto/blob/main/src/components/theme/Widgets/RichTextWidget.stories.jsx#L3
+- https://github.com/plone/volto/blob/main/src/components/theme/Widgets/RichTextWidget.jsx
+
+To build the Volto Storybook locally and test your entry, run the following command from the repository root.
+
+```shell
+make storybook-build
+```

--- a/docs/source/contributing/index.md
+++ b/docs/source/contributing/index.md
@@ -80,7 +80,7 @@ yarn
 
 ### Start Volto
 
-```
+```shell
 yarn start
 ```
 
@@ -121,7 +121,7 @@ For details see {ref}`contributing-change-log-label`.
 
 (contributing-documenting-your-changes-label)=
 
-## Document your changes
+## Document breaking changes
 
 If the feature includes a breaking change, you must include instructions for how to upgrade in the [upgrade guide](../upgrade-guide/index.md).
 
@@ -138,6 +138,7 @@ Specifically:
 -   {doc}`./linting`
 -   {doc}`./testing`
 -   {doc}`./acceptance-tests`
+-   {doc}`./documentation`
 
 
 (contributing-developer-guidelines-label)=
@@ -151,12 +152,13 @@ design-principles
 style-guide
 language-features
 linting
+testing
+acceptance-tests
+documentation
 react
 redux
 routing
 icons
-testing
-acceptance-tests
 accessibility-guidelines
 typescript
 volto-core-addons

--- a/news/5377.documentation
+++ b/news/5377.documentation
@@ -1,0 +1,1 @@
+Added documentation to contributing. @stevepiercy


### PR DESCRIPTION
The documentation policies are now documented explicitly for Volto, instead of implicitly inherited from `plone/documentation`.

This includes a new Storybook policy, so it should get reviewed and approved by the @plone/volto-team. Also closes #5369.

It also reorganizes contributing toctree so that code quality checks are grouped together.