### PR TITLE
First focus edit page

### DIFF
--- a/locales/ca/LC_MESSAGES/volto.po
+++ b/locales/ca/LC_MESSAGES/volto.po
@@ -776,6 +776,11 @@ msgstr ""
 msgid "Content that links to or references {title}"
 msgstr ""
 
+#: components/manage/Blocks/Title/Edit
+# defaultMessage: Content title
+msgid "Content title"
+msgstr ""
+
 #: components/manage/Controlpanels/ContentTypes
 # defaultMessage: Content type created
 msgid "Content type created"

--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -773,6 +773,11 @@ msgstr "Inhaltsregeln von übergeordneten Seiten"
 msgid "Content that links to or references {title}"
 msgstr "Zu {title} verlinkende oder referenzierende Inhalte"
 
+#: components/manage/Blocks/Title/Edit
+# defaultMessage: Content title
+msgid "Content title"
+msgstr ""
+
 #: components/manage/Controlpanels/ContentTypes
 # defaultMessage: Content type created
 msgid "Content type created"

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -767,6 +767,11 @@ msgstr ""
 msgid "Content that links to or references {title}"
 msgstr ""
 
+#: components/manage/Blocks/Title/Edit
+# defaultMessage: Content title
+msgid "Content title"
+msgstr ""
+
 #: components/manage/Controlpanels/ContentTypes
 # defaultMessage: Content type created
 msgid "Content type created"

--- a/locales/es/LC_MESSAGES/volto.po
+++ b/locales/es/LC_MESSAGES/volto.po
@@ -778,6 +778,11 @@ msgstr "Reglas de contenido de las carpetas principales"
 msgid "Content that links to or references {title}"
 msgstr "Contenido que enlaza o hace referencia a {title}"
 
+#: components/manage/Blocks/Title/Edit
+# defaultMessage: Content title
+msgid "Content title"
+msgstr "Título del contenido"
+
 #: components/manage/Controlpanels/ContentTypes
 # defaultMessage: Content type created
 msgid "Content type created"

--- a/locales/eu/LC_MESSAGES/volto.po
+++ b/locales/eu/LC_MESSAGES/volto.po
@@ -774,6 +774,11 @@ msgstr "Gurasoetan dauden eduki erregelak"
 msgid "Content that links to or references {title}"
 msgstr ""
 
+#: components/manage/Blocks/Title/Edit
+# defaultMessage: Content title
+msgid "Content title"
+msgstr ""
+
 #: components/manage/Controlpanels/ContentTypes
 # defaultMessage: Content type created
 msgid "Content type created"

--- a/locales/fi/LC_MESSAGES/volto.po
+++ b/locales/fi/LC_MESSAGES/volto.po
@@ -778,6 +778,11 @@ msgstr "Sisältösäännöt ylemmistä kansioista"
 msgid "Content that links to or references {title}"
 msgstr ""
 
+#: components/manage/Blocks/Title/Edit
+# defaultMessage: Content title
+msgid "Content title"
+msgstr ""
+
 #: components/manage/Controlpanels/ContentTypes
 # defaultMessage: Content type created
 msgid "Content type created"

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -784,6 +784,11 @@ msgstr "Règles de contenu des dossiers parents"
 msgid "Content that links to or references {title}"
 msgstr ""
 
+#: components/manage/Blocks/Title/Edit
+# defaultMessage: Content title
+msgid "Content title"
+msgstr ""
+
 #: components/manage/Controlpanels/ContentTypes
 # defaultMessage: Content type created
 msgid "Content type created"

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -767,6 +767,11 @@ msgstr "Regole di contenuto da cartelle padre"
 msgid "Content that links to or references {title}"
 msgstr "Contenuto collegato a {title}"
 
+#: components/manage/Blocks/Title/Edit
+# defaultMessage: Content title
+msgid "Content title"
+msgstr "Titolo del contenuto"
+
 #: components/manage/Controlpanels/ContentTypes
 # defaultMessage: Content type created
 msgid "Content type created"

--- a/locales/ja/LC_MESSAGES/volto.po
+++ b/locales/ja/LC_MESSAGES/volto.po
@@ -775,6 +775,11 @@ msgstr ""
 msgid "Content that links to or references {title}"
 msgstr ""
 
+#: components/manage/Blocks/Title/Edit
+# defaultMessage: Content title
+msgid "Content title"
+msgstr ""
+
 #: components/manage/Controlpanels/ContentTypes
 # defaultMessage: Content type created
 msgid "Content type created"

--- a/locales/nl/LC_MESSAGES/volto.po
+++ b/locales/nl/LC_MESSAGES/volto.po
@@ -786,6 +786,11 @@ msgstr ""
 msgid "Content that links to or references {title}"
 msgstr ""
 
+#: components/manage/Blocks/Title/Edit
+# defaultMessage: Content title
+msgid "Content title"
+msgstr ""
+
 #: components/manage/Controlpanels/ContentTypes
 # defaultMessage: Content type created
 msgid "Content type created"

--- a/locales/pt/LC_MESSAGES/volto.po
+++ b/locales/pt/LC_MESSAGES/volto.po
@@ -775,6 +775,11 @@ msgstr ""
 msgid "Content that links to or references {title}"
 msgstr ""
 
+#: components/manage/Blocks/Title/Edit
+# defaultMessage: Content title
+msgid "Content title"
+msgstr ""
+
 #: components/manage/Controlpanels/ContentTypes
 # defaultMessage: Content type created
 msgid "Content type created"

--- a/locales/pt_BR/LC_MESSAGES/volto.po
+++ b/locales/pt_BR/LC_MESSAGES/volto.po
@@ -777,6 +777,11 @@ msgstr "Regras de conteúdo de pastas pai"
 msgid "Content that links to or references {title}"
 msgstr ""
 
+#: components/manage/Blocks/Title/Edit
+# defaultMessage: Content title
+msgid "Content title"
+msgstr "Título do conteúdo"
+
 #: components/manage/Controlpanels/ContentTypes
 # defaultMessage: Content type created
 msgid "Content type created"

--- a/locales/ro/LC_MESSAGES/volto.po
+++ b/locales/ro/LC_MESSAGES/volto.po
@@ -767,6 +767,11 @@ msgstr ""
 msgid "Content that links to or references {title}"
 msgstr ""
 
+#: components/manage/Blocks/Title/Edit
+# defaultMessage: Content title
+msgid "Content title"
+msgstr ""
+
 #: components/manage/Controlpanels/ContentTypes
 # defaultMessage: Content type created
 msgid "Content type created"

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2023-10-09T09:36:27.737Z\n"
+"POT-Creation-Date: 2023-11-10T14:46:23.151Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -767,6 +767,11 @@ msgstr ""
 #: components/manage/LinksToItem/LinksToItem
 # defaultMessage: Content that links to or references {title}
 msgid "Content that links to or references {title}"
+msgstr ""
+
+#: components/manage/Blocks/Title/Edit
+# defaultMessage: Content title
+msgid "Content title"
 msgstr ""
 
 #: components/manage/Controlpanels/ContentTypes

--- a/locales/zh_CN/LC_MESSAGES/volto.po
+++ b/locales/zh_CN/LC_MESSAGES/volto.po
@@ -773,6 +773,11 @@ msgstr "父文件夹的内容规则"
 msgid "Content that links to or references {title}"
 msgstr ""
 
+#: components/manage/Blocks/Title/Edit
+# defaultMessage: Content title
+msgid "Content title"
+msgstr ""
+
 #: components/manage/Controlpanels/ContentTypes
 # defaultMessage: Content type created
 msgid "Content type created"

--- a/src/components/manage/Blocks/Title/Edit.jsx
+++ b/src/components/manage/Blocks/Title/Edit.jsx
@@ -139,7 +139,7 @@ export const TitleBlockEdit = (props) => {
 
   const renderElement = useCallback(({ attributes, children }) => {
     return (
-      <h1 aria-label="test3" {...attributes} className="documentFirstHeading">
+      <h1 {...attributes} className="documentFirstHeading">
         {children}
       </h1>
     );
@@ -149,12 +149,7 @@ export const TitleBlockEdit = (props) => {
     return <div />;
   }
   return (
-    <Slate
-      editor={editor}
-      onChange={handleChange}
-      initialValue={initialValue}
-      aria-label="test2"
-    >
+    <Slate editor={editor} onChange={handleChange} initialValue={initialValue}>
       <Editable
         readOnly={!editable}
         onKeyDown={handleKeyDown}

--- a/src/components/manage/Blocks/Title/Edit.jsx
+++ b/src/components/manage/Blocks/Title/Edit.jsx
@@ -17,6 +17,10 @@ const messages = defineMessages({
     id: 'Type the title…',
     defaultMessage: 'Type the title…',
   },
+  editable_title: {
+    id: 'Content title',
+    defaultMessage: 'Content title',
+  },
 });
 
 function usePrevious(value) {
@@ -135,7 +139,7 @@ export const TitleBlockEdit = (props) => {
 
   const renderElement = useCallback(({ attributes, children }) => {
     return (
-      <h1 {...attributes} className="documentFirstHeading">
+      <h1 aria-label="test3" {...attributes} className="documentFirstHeading">
         {children}
       </h1>
     );
@@ -145,7 +149,12 @@ export const TitleBlockEdit = (props) => {
     return <div />;
   }
   return (
-    <Slate editor={editor} onChange={handleChange} initialValue={initialValue}>
+    <Slate
+      editor={editor}
+      onChange={handleChange}
+      initialValue={initialValue}
+      aria-label="test2"
+    >
       <Editable
         readOnly={!editable}
         onKeyDown={handleKeyDown}
@@ -153,6 +162,7 @@ export const TitleBlockEdit = (props) => {
         renderElement={renderElement}
         onFocus={handleFocus}
         aria-multiline="false"
+        aria-label={intl.formatMessage(messages.editable_title)}
       ></Editable>
     </Slate>
   );

--- a/src/components/manage/Blocks/Title/__snapshots__/Edit.test.jsx.snap
+++ b/src/components/manage/Blocks/Title/__snapshots__/Edit.test.jsx.snap
@@ -2,6 +2,7 @@
 
 exports[`renders edit blocks renders an edit title block component 1`] = `
 <div
+  aria-label="Content title"
   aria-multiline="false"
   autoCapitalize="false"
   autoCorrect="false"


### PR DESCRIPTION
Fix part of this issue https://github.com/plone/volto/issues/5268

- Make the first focus more informative for assistive technologies.

quote:
When you click the 'edit' button, the default behavior is to focus on the first editable block, which is usually the title block. However, when using assistive technology, this behavior can be inconsistent, leaving users unsure of their location and what action to take. To improve this, the fieldset containing all blocks should be made accessible to screen readers and provide clear information about the editable content before moving to the first element.