### PR TITLE
Fix image paths in development mode

### DIFF
--- a/news/5429.bugfix
+++ b/news/5429.bugfix
@@ -1,0 +1,1 @@
+Fix image paths in development mode. @robgietema

--- a/src/helpers/Api/APIResourceWithAuth.js
+++ b/src/helpers/Api/APIResourceWithAuth.js
@@ -27,7 +27,7 @@ export const getAPIResourceWithAuth = (req) =>
       apiPath = settings.apiPath;
     }
     const request = superagent
-      .get(`${apiPath}${APISUFIX}${req.path}`)
+      .get(`${apiPath}${__DEVELOPMENT__ ? '' : APISUFIX}${req.path}`)
       .maxResponseSize(settings.maxResponseSize)
       .responseType('blob');
     const authToken = req.universalCookies.get('auth_token');


### PR DESCRIPTION
This fix changes how images are fetched from the backend. By default in development mode the images are fetched using the backend url throught the middleware, then ++api++ is added. This url suffix should only be used in either the frontend or in production. When using a different backend which doesn't use the ++api++ suffix this will break otherwise.