### PR TITLE
bug issue5452 relating to markdown  shortcut fixed

### DIFF
--- a/packages/volto-slate/src/constants.js
+++ b/packages/volto-slate/src/constants.js
@@ -23,6 +23,9 @@ export const LI = 'li';
 export const UL = 'ul';
 export const OL = 'ol';
 
+export const H2 = 'h2'
+export const H3 = 'h3'
+
 // dom parsing node information
 export const TEXT_NODE = 3;
 export const ELEMENT_NODE = 1;

--- a/packages/volto-slate/src/editor/plugins/Markdown/constants.js
+++ b/packages/volto-slate/src/editor/plugins/Markdown/constants.js
@@ -1,6 +1,6 @@
 import { toggleList, unwrapList } from './utils';
 import { isBlockActive } from '@plone/volto-slate/utils';
-import { UL, OL, LI } from '@plone/volto-slate/constants';
+import { UL, OL, LI, H2, H3 } from '@plone/volto-slate/constants';
 
 /**
  * Uses the old toggleList function to toggle lists on or off or from a type to another.
@@ -18,15 +18,14 @@ export const localToggleList = (editor, format) => {
 /**
  * The autoformat rules created by this plugin for the Markdown language.
  *
- * @todo Use constants instead of the remaining hard-coded types (h2, h3 etc.).
  */
 export const autoformatRules = [
   {
-    type: 'h2',
+    type: H2,
     markup: '#',
   },
   {
-    type: 'h3',
+    type: H3,
     markup: '##',
   },
   {

--- a/packages/volto-slate/src/editor/plugins/Markdown/extensions.js
+++ b/packages/volto-slate/src/editor/plugins/Markdown/extensions.js
@@ -199,8 +199,7 @@ export const autoformatBlock = (editor, type, at, { preFormat, format }) => {
   if (!format) {
     Transforms.setNodes(
       editor,
-      { type },
-      { match: (n) => Editor.isBlock(editor, n) },
+      { type }
     );
   } else {
     format(editor);


### PR DESCRIPTION
Issue #5452 
bug fix: Broken markdown shortcuts like ('#', '##', '>') fixed