### PR TITLE
Fixes lint inside monorepo packages in VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  // This is needed for VSCode to detect eslint configs not in the root
+  "eslint.workingDirectories": [{ "mode": "auto" }]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-  // This is needed for VSCode to detect eslint configs not in the root
-  "eslint.workingDirectories": [{ "mode": "auto" }]
-}

--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,11 @@ clean:
 	$(MAKE) -C "./api/" clean
 	rm -rf node_modules
 
+.PHONY: setup
+setup:
+	# Setup ESlint for VSCode
+	node packages/scripts/vscodesettings.js
+
 ##### Documentation
 
 .PHONY: docs-clean

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "scripts": {
     "preinstall": "npx only-allow pnpm",
+    "postinstall": "make setup",
     "watch": "turbo run watch",
     "build:registry": "turbo run build --filter @plone/registry",
     "build": "turbo run build --filter @plone/volto",

--- a/packages/scripts/.eslintrc.cjs
+++ b/packages/scripts/.eslintrc.cjs
@@ -1,0 +1,18 @@
+module.exports = {
+  overrides: [
+    {
+      files: ['**/*.js', '**/*.jsx'],
+      env: {
+        node: true,
+        es6: true,
+      },
+      extends: 'eslint:recommended',
+      parserOptions: {
+        ecmaVersion: 2021, // You can adjust this based on the ECMAScript version you are using
+      },
+      rules: {
+        'no-prototype-builtins': 0,
+      },
+    },
+  ],
+};

--- a/packages/scripts/addon/utils.js
+++ b/packages/scripts/addon/utils.js
@@ -1,6 +1,6 @@
 import fs from 'fs';
 
-export function amendPackageJSON(name, destination, isCanary) {
+export function amendPackageJSON(name, destination) {
   const packageJSON = JSON.parse(
     fs.readFileSync(`${destination}/package.json`, 'utf8'),
   );

--- a/packages/scripts/backportpr.js
+++ b/packages/scripts/backportpr.js
@@ -1,6 +1,6 @@
 /* eslint no-console: 0 */
 import https from 'https';
-import { execSync, exec } from 'child_process';
+import { execSync } from 'child_process';
 
 if (process.argv.length < 2) {
   console.log(process.argv.length);
@@ -10,7 +10,7 @@ if (process.argv.length < 2) {
 const pr = process.argv[2];
 const URL = `https://api.github.com/repos/plone/volto/pulls/${pr}`;
 
-function getPRInfo(pr) {
+function getPRInfo() {
   return new Promise((resolve, reject) => {
     https
       .get(
@@ -57,8 +57,8 @@ function execCommand(command) {
   });
 }
 
-async function main(params) {
-  const PRInfo = await getPRInfo(pr);
+async function main() {
+  const PRInfo = await getPRInfo();
 
   // const currentBranch = execCommand(
   //   `git rev-parse --abbrev-ref HEAD`,

--- a/packages/scripts/news/5483.feature
+++ b/packages/scripts/news/5483.feature
@@ -1,0 +1,1 @@
+Added script to add necessary VSCode `.vscode/settings.json` to detect ESlint projects inside the monorepo @sneridagh

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -66,6 +66,7 @@
     "babel-preset-razzle": "4.2.17",
     "chalk": "4",
     "commander": "8.2.0",
+    "comment-json": "^4.2.3",
     "fs-extra": "10.1.0",
     "git-url-parse": "^13.1.0",
     "glob": "7.1.6",

--- a/packages/scripts/vscodesettings.js
+++ b/packages/scripts/vscodesettings.js
@@ -1,0 +1,21 @@
+/* eslint no-console: 0 */
+import fs from 'fs';
+import { parse, stringify } from 'comment-json';
+
+let vscodeSettingsJSON;
+if (fs.existsSync('.vscode')) {
+  vscodeSettingsJSON = parse(fs.readFileSync('.vscode/settings.json', 'utf8'));
+} else {
+  fs.mkdirSync('.vscode');
+  fs.writeFileSync('.vscode/settings.json', '{}');
+  vscodeSettingsJSON = parse(fs.readFileSync('.vscode/settings.json', 'utf8'));
+}
+
+if (!vscodeSettingsJSON['eslint.workingDirectories']) {
+  vscodeSettingsJSON['eslint.workingDirectories'] = [{ mode: 'auto' }];
+
+  fs.writeFileSync(
+    '.vscode/settings.json',
+    `${stringify(vscodeSettingsJSON, null, 2)}`,
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -698,6 +698,9 @@ importers:
       commander:
         specifier: 8.2.0
         version: 8.2.0
+      comment-json:
+        specifier: ^4.2.3
+        version: 4.2.3
       fs-extra:
         specifier: 10.1.0
         version: 10.1.0
@@ -10024,6 +10027,10 @@ packages:
       get-intrinsic: 1.2.2
       is-string: 1.0.7
 
+  /array-timsort@1.0.3:
+    resolution: {integrity: sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==}
+    dev: false
+
   /array-union@1.0.2:
     resolution: {integrity: sha512-Dxr6QJj/RdU/hCaBjOfxW+q6lyuVE6JFWIrAUpuOOhoJJoQ99cUn3igRaHVB5P9WrgFVN0FfArM3x0cueOU8ng==}
     engines: {node: '>=0.10.0'}
@@ -11998,6 +12005,17 @@ packages:
   /commander@8.3.0:
     resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
     engines: {node: '>= 12'}
+
+  /comment-json@4.2.3:
+    resolution: {integrity: sha512-SsxdiOf064DWoZLH799Ata6u7iV658A11PlWtZATDlXPpKGJnbJZ5Z24ybixAi+LUUqJ/GKowAejtC5GFUG7Tw==}
+    engines: {node: '>= 6'}
+    dependencies:
+      array-timsort: 1.0.3
+      core-util-is: 1.0.3
+      esprima: 4.0.1
+      has-own-prop: 2.0.0
+      repeat-string: 1.6.1
+    dev: false
 
   /common-ancestor-path@1.0.1:
     resolution: {integrity: sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==}
@@ -16043,6 +16061,11 @@ packages:
     dependencies:
       is-glob: 3.1.0
     dev: true
+
+  /has-own-prop@2.0.0:
+    resolution: {integrity: sha512-Pq0h+hvsVm6dDEa8x82GnLSYHOzNDt7f0ddFa3FqcQlgzEiptPqL+XrOJNavjOzSYiYWIrgeVYYgGlLmnxwilQ==}
+    engines: {node: '>=8'}
+    dev: false
 
   /has-property-descriptors@1.0.1:
     resolution: {integrity: sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==}


### PR DESCRIPTION
Enable proper linting in `packages/scripts` too.