### PR TITLE
Move Vale from a manual installation to pip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,9 +151,9 @@ docs-linkcheckbroken: bin/python docs-news  ## Run linkcheck and show only broke
 	cd $(DOCS_DIR) && $(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck | GREP_COLORS='0;31' grep -wi "broken\|redirect" --color=always | GREP_COLORS='0;31' grep -vi "https://github.com/plone/volto/issues/" --color=always && if test $$? -eq 0; then exit 1; fi || test $$? -ne 0
 
 .PHONY: docs-vale
-docs-vale:  ## Run Vale style, grammar, and spell checks
-	vale sync
-	vale --no-wrap $(VALEFILES)
+docs-vale: bin/python docs-news  ## Install (once) and run Vale style, grammar, and spell checks
+	bin/vale sync
+	bin/vale --no-wrap $(VALEFILES)
 	@echo
 	@echo "Vale is finished; look for any errors in the above output."
 

--- a/docs/source/contributing/documentation.md
+++ b/docs/source/contributing/documentation.md
@@ -110,10 +110,7 @@ Open `/docs/_build/linkcheck/output.txt` for a list of broken links.
 
 #### `docs-vale`
 
-See {ref}`plone:setup-build-installation-vale-label` for how to install Vale.
-
 `docs-vale` checks for American English spelling, grammar, syntax, and the Microsoft Developer Style Guide.
-See {ref}`plone:authors-english-label` for configuration.
 
 ```shell
 make docs-vale
@@ -121,6 +118,11 @@ make docs-vale
 
 See the output on the console for suggestions.
 
+```{seealso}
+See {ref}`plone:authors-english-label` for basic usage.
+
+See {ref}`plone:authors-advanced-vale-usage-label` for Vale configuration, integration with popular IDEs, and other tips.
+```
 
 
 (volto-documentation-storybook-label)=

--- a/packages/volto/news/5508.documentation
+++ b/packages/volto/news/5508.documentation
@@ -1,0 +1,1 @@
+Changed installation of Vale from manual to automatic via `make docs-vale`. @stevepiercy

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -12,3 +12,4 @@ sphinx-togglebutton
 sphinxcontrib-spelling
 sphinxext-opengraph
 sphinxcontrib-video
+vale


### PR DESCRIPTION
~Requires https://github.com/plone/documentation/pull/1591 to be merged first, because of a main documentation reorganization of Vale installation and configuration.~ It was merged.