### PR TITLE
bug: fixed

### DIFF
--- a/src/components/manage/Sidebar/SidebarPopup.jsx
+++ b/src/components/manage/Sidebar/SidebarPopup.jsx
@@ -9,7 +9,7 @@ const DEFAULT_TIMEOUT = 500;
 const SidebarPopup = (props) => {
   const { children, open, onClose, overlay } = props;
 
-  const asideElement = React.createRef();
+  const asideElement = React.useRef(null);
 
   const handleClickOutside = (e) => {
     if (asideElement && doesNodeContainClick(asideElement.current, e)) return;
@@ -21,7 +21,7 @@ const SidebarPopup = (props) => {
     return () => {
       document.removeEventListener('mousedown', handleClickOutside, false);
     };
-  });
+  },[]);
 
   return (
     <>


### PR DESCRIPTION
## Description

Fixes the issue in the `SidebarPopup` component where `createRef` was used in a function component, causing the reference to always be null. This pull request replaces `createRef` with `useRef` for proper reference handling.

## Changes Made

- Replaced `React.createRef()` with `React.useRef(null)` in `SidebarPopup` component.

## Context

The use of `createRef` in a function component results in the reference being null. This change ensures the reference is properly initialized and maintained throughout the component's lifecycle.

## Checklist

- [ ] Tested locally
- [ ] Updated documentation (if needed)
- [ ] Added tests (if needed)

