### PR TITLE
PR regarding issue #5516

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "build": "pnpm build:registry && pnpm --filter @plone/volto build",
     "start": "pnpm build:registry && pnpm --filter @plone/volto start",
     "start:project": "turbo run start --filter plone",
-    "lint": "eslint --max-warnings=0 'packages/**/*.{js,jsx,ts,tsx}'",
+    "lint": "./node_modules/eslint/bin/eslint.js --max-warnings=0 'src/**/*.{js,jsx,ts,tsx,json}'",
+    "lint:fix": "./node_modules/eslint/bin/eslint.js --fix 'src/**/*.{js,jsx,ts,tsx,json}'",
+    "lint:ci": "./node_modules/eslint/bin/eslint.js --max-warnings=0 -f checkstyle 'src/**/*.{js,jsx,ts,tsx,json}' > eslint.xml",
     "lint:volto": "turbo run lint --filter @plone/volto",
     "test": "turbo run test:ci --filter @plone/volto",
     "i18n": "turbo run i18n --filter @plone/volto",
@@ -22,8 +24,12 @@
     "husky:uninstall": "husky uninstall"
   },
   "devDependencies": {
+    "@plone/scripts": "^3.0.0",
     "@typescript-eslint/eslint-plugin": "6.7.0",
     "@typescript-eslint/parser": "6.7.0",
+    "stylelint-prettier": "1.1.2",
+    "ts-jest": "^26.4.2",
+    "ts-loader": "9.4.4",
     "eslint": "^8.48.0",
     "eslint-config-prettier": "9.0.0",
     "eslint-import-resolver-typescript": "^3.6.1",
@@ -39,5 +45,13 @@
     "vitest": "^0.34.6",
     "yarnhook": "0.6.1"
   },
-  "packageManager": "pnpm@8.9.0"
+  "packageManager": "pnpm@8.9.0",
+  "dependencies": {
+    "react": "^18.2.0"
+  },
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
+  }  
 }

--- a/packages/volto/locales/ca/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ca/LC_MESSAGES/volto.po
@@ -4345,6 +4345,11 @@ msgstr ""
 msgid "addUserFormUsernameDescription"
 msgstr ""
 
+#: config/Blocks
+# defaultMessage: PloneAnnouncement
+msgid "announce"
+msgstr ""
+
 #: components/manage/Blocks/Search/schema
 # defaultMessage: Available views
 msgid "availableViews"

--- a/packages/volto/locales/de/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/de/LC_MESSAGES/volto.po
@@ -4342,6 +4342,11 @@ msgstr "Geben Sie Ihr neues Passwort ein. Das Passwort muss aus mindestens 8 Zei
 msgid "addUserFormUsernameDescription"
 msgstr "Geben Sie einen Nutzernamen ein, beispielsweise etwas wie "m.muster". Benutzen Sie keine Leer- oder Sonderzeichen. Bitte beachten Sie Groß- und Kleinschreibung und stellen Sie sicher, dass die Feststelltaste nicht aktiviert ist. Dieser Name wird zum Anmelden genutzt."
 
+#: config/Blocks
+# defaultMessage: PloneAnnouncement
+msgid "announce"
+msgstr ""
+
 #: components/manage/Blocks/Search/schema
 # defaultMessage: Available views
 msgid "availableViews"

--- a/packages/volto/locales/en/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/en/LC_MESSAGES/volto.po
@@ -4336,6 +4336,11 @@ msgstr ""
 msgid "addUserFormUsernameDescription"
 msgstr ""
 
+#: config/Blocks
+# defaultMessage: PloneAnnouncement
+msgid "announce"
+msgstr ""
+
 #: components/manage/Blocks/Search/schema
 # defaultMessage: Available views
 msgid "availableViews"

--- a/packages/volto/locales/es/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/es/LC_MESSAGES/volto.po
@@ -4347,6 +4347,11 @@ msgstr "Introduzca su nueva contraseña. Mínimo 8 caracteres."
 msgid "addUserFormUsernameDescription"
 msgstr "Introduzca el nombre de usuario que desee utilizar. Generalmente algo como "jperez" o "jose_perez". No están permitidos caracteres especiales o espacios en el nombre de usuario. Los nombres de usuario y las contraseñas son sensibles a mayúsculas y minúsculas, asegúrese que la tecla de bloqueo de mayúsculas no está activada ('caps lock'). Este es el nombre que utilizará para identificarse."
 
+#: config/Blocks
+# defaultMessage: PloneAnnouncement
+msgid "announce"
+msgstr ""
+
 #: components/manage/Blocks/Search/schema
 # defaultMessage: Available views
 msgid "availableViews"

--- a/packages/volto/locales/eu/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/eu/LC_MESSAGES/volto.po
@@ -4343,6 +4343,11 @@ msgstr "Idatzi zure pasahitz berria. Gutxienez 8 karaktere."
 msgid "addUserFormUsernameDescription"
 msgstr "Idatzi zure erabiltzaile izena, "jgarmendia" moduko zerbait. Ez da onartzen espaziorik edo karaktere berezirik. Erabiltzaile izenak eta pasahitzak letra larri eta xeheak bereizten dituzte. Hau da webgunera sartzeko erabiliko den izena."
 
+#: config/Blocks
+# defaultMessage: PloneAnnouncement
+msgid "announce"
+msgstr ""
+
 #: components/manage/Blocks/Search/schema
 # defaultMessage: Available views
 msgid "availableViews"

--- a/packages/volto/locales/fi/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/fi/LC_MESSAGES/volto.po
@@ -4347,6 +4347,11 @@ msgstr "Lisää salasana. Minimissään 8 merkkiä."
 msgid "addUserFormUsernameDescription"
 msgstr "Lisää käyttäjätunnus, esim. mameikal. Älä käytä erikoismerkkejä."
 
+#: config/Blocks
+# defaultMessage: PloneAnnouncement
+msgid "announce"
+msgstr ""
+
 #: components/manage/Blocks/Search/schema
 # defaultMessage: Available views
 msgid "availableViews"

--- a/packages/volto/locales/fr/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/fr/LC_MESSAGES/volto.po
@@ -4353,6 +4353,11 @@ msgstr "Saisissez votre nouveau mot de passe, minimum 8 caractères."
 msgid "addUserFormUsernameDescription"
 msgstr "Saisissez un nom d'utilisateur, haituellement quelque chose comme "jdupont". Pas d'espace ou de caractères spéciaux. Les noms d'utilisateurs et mots de passes sont sensible à la casse, vérifiez que la touche verrouillage majuscule n'est pas activée. C'est le nom utilisé pour se connecté."
 
+#: config/Blocks
+# defaultMessage: PloneAnnouncement
+msgid "announce"
+msgstr ""
+
 #: components/manage/Blocks/Search/schema
 # defaultMessage: Available views
 msgid "availableViews"

--- a/packages/volto/locales/it/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/it/LC_MESSAGES/volto.po
@@ -4336,6 +4336,11 @@ msgstr "Inserisci la nuova password. Minimo 8 caratteri."
 msgid "addUserFormUsernameDescription"
 msgstr "Inserisci uno username, ad esempio 'jsmith'. Non sono consentiti spazi o caratteri speciali. Username e password sono case sensitive, assicurati che il caps lock non sia abilitato. Questo sarà il nome che userai per fare il login."
 
+#: config/Blocks
+# defaultMessage: PloneAnnouncement
+msgid "announce"
+msgstr ""
+
 #: components/manage/Blocks/Search/schema
 # defaultMessage: Available views
 msgid "availableViews"

--- a/packages/volto/locales/ja/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ja/LC_MESSAGES/volto.po
@@ -4344,6 +4344,11 @@ msgstr ""
 msgid "addUserFormUsernameDescription"
 msgstr ""
 
+#: config/Blocks
+# defaultMessage: PloneAnnouncement
+msgid "announce"
+msgstr ""
+
 #: components/manage/Blocks/Search/schema
 # defaultMessage: Available views
 msgid "availableViews"

--- a/packages/volto/locales/nl/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/nl/LC_MESSAGES/volto.po
@@ -4355,6 +4355,11 @@ msgstr ""
 msgid "addUserFormUsernameDescription"
 msgstr ""
 
+#: config/Blocks
+# defaultMessage: PloneAnnouncement
+msgid "announce"
+msgstr ""
+
 #: components/manage/Blocks/Search/schema
 # defaultMessage: Available views
 msgid "availableViews"

--- a/packages/volto/locales/pt/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/pt/LC_MESSAGES/volto.po
@@ -4344,6 +4344,11 @@ msgstr ""
 msgid "addUserFormUsernameDescription"
 msgstr ""
 
+#: config/Blocks
+# defaultMessage: PloneAnnouncement
+msgid "announce"
+msgstr ""
+
 #: components/manage/Blocks/Search/schema
 # defaultMessage: Available views
 msgid "availableViews"

--- a/packages/volto/locales/pt_BR/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/pt_BR/LC_MESSAGES/volto.po
@@ -4346,6 +4346,11 @@ msgstr "Informe a sua nova senha. Mínimo de 8 caracteres."
 msgid "addUserFormUsernameDescription"
 msgstr "Informe o nome do usuário que você deseja, geralmente algo como 'jsilva'. Não use espaços ou caracteres especiais. Nomes de usuários e senhas são sensíveis a letras maiúsculas e minúsculas, certifique-se que a tecla Caps Lock não esteja ativada. Esse é o nome que você usará para acessar."
 
+#: config/Blocks
+# defaultMessage: PloneAnnouncement
+msgid "announce"
+msgstr ""
+
 #: components/manage/Blocks/Search/schema
 # defaultMessage: Available views
 msgid "availableViews"

--- a/packages/volto/locales/ro/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ro/LC_MESSAGES/volto.po
@@ -4336,6 +4336,11 @@ msgstr ""
 msgid "addUserFormUsernameDescription"
 msgstr ""
 
+#: config/Blocks
+# defaultMessage: PloneAnnouncement
+msgid "announce"
+msgstr ""
+
 #: components/manage/Blocks/Search/schema
 # defaultMessage: Available views
 msgid "availableViews"

--- a/packages/volto/locales/volto.pot
+++ b/packages/volto/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2023-11-27T07:34:40.957Z\n"
+"POT-Creation-Date: 2023-12-13T10:51:17.710Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -4340,6 +4340,11 @@ msgstr ""
 #: helpers/MessageLabels/MessageLabels
 # defaultMessage: Enter a user name, usually something like "jsmith". No spaces or special characters. Usernames and passwords are case sensitive, make sure the caps lock key is not enabled. This is the name used to log in.
 msgid "addUserFormUsernameDescription"
+msgstr ""
+
+#: config/Blocks
+# defaultMessage: PloneAnnouncement
+msgid "announce"
 msgstr ""
 
 #: components/manage/Blocks/Search/schema

--- a/packages/volto/locales/zh_CN/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/zh_CN/LC_MESSAGES/volto.po
@@ -4342,6 +4342,11 @@ msgstr ""
 msgid "addUserFormUsernameDescription"
 msgstr ""
 
+#: config/Blocks
+# defaultMessage: PloneAnnouncement
+msgid "announce"
+msgstr ""
+
 #: components/manage/Blocks/Search/schema
 # defaultMessage: Available views
 msgid "availableViews"

--- a/packages/volto/src/components/index.js
+++ b/packages/volto/src/components/index.js
@@ -189,6 +189,7 @@ export { default as EditHeroImageLeftBlock } from '@plone/volto/components/manag
 export { default as ViewHeroImageLeftBlock } from '@plone/volto/components/manage/Blocks/HeroImageLeft/View';
 export { default as EditMapBlock } from '@plone/volto/components/manage/Blocks/Maps/Edit';
 export { default as EditHTMLBlock } from '@plone/volto/components/manage/Blocks/HTML/Edit';
+export { default as EditAnnounceBlock } from '@plone/volto/components/manage/Blocks/Announce/edit';
 
 export { default as ViewDefaultBlock } from '@plone/volto/components/manage/Blocks/Block/DefaultView';
 export { default as ViewDescriptionBlock } from '@plone/volto/components/manage/Blocks/Description/View';
@@ -200,6 +201,7 @@ export { default as ViewListingBlock } from '@plone/volto/components/manage/Bloc
 export { default as ViewVideoBlock } from '@plone/volto/components/manage/Blocks/Video/View';
 export { default as ViewMapBlock } from '@plone/volto/components/manage/Blocks/Maps/View';
 export { default as ViewHTMLBlock } from '@plone/volto/components/manage/Blocks/HTML/View';
+export { default as ViewAnnounceBlock } from '@plone/volto/components/manage/Blocks/Announce/view';
 
 export { default as ListingBlockBody } from '@plone/volto/components/manage/Blocks/Listing/ListingBody';
 export { default as ListingBlockData } from '@plone/volto/components/manage/Blocks/Listing/ListingData';

--- a/packages/volto/src/components/manage/Blocks/Announce/Schema.js
+++ b/packages/volto/src/components/manage/Blocks/Announce/Schema.js
@@ -1,0 +1,47 @@
+const AnnounceBlockSchema = (props) => {
+  return {
+    required: [],
+    fieldsets: [
+      {
+        id: 'default',
+        title: 'Default',
+        fields: ['title', 'description', 'image', 'imageAlt'],
+      },
+      {
+        id: 'button',
+        title: 'Button',
+        fields: ['buttonTitle', 'buttonLink'],
+      },
+    ],
+    properties: {
+      title: {
+        title: 'Title',
+        widget: 'text',
+      },
+      description: {
+        title: 'Description',
+        widget: 'text',
+      },
+      buttonTitle: {
+        title: 'Button Title',
+        widget: 'text',
+      },
+      buttonLink: {
+        title: 'Button link',
+        widget: 'object_browser',
+        mode: 'link',
+        allowExternals: true,
+      },
+      image: {
+        title: 'Image',
+        widget: 'object_browser',
+        mode: 'image',
+      },
+      imageAlt: {
+        title: 'Image alt text',
+        widget: 'text',
+      },
+    },
+  };
+};
+export { AnnounceBlockSchema };

--- a/packages/volto/src/components/manage/Blocks/Announce/data.jsx
+++ b/packages/volto/src/components/manage/Blocks/Announce/data.jsx
@@ -1,0 +1,25 @@
+import { BlockDataForm } from '@plone/volto/components';
+import { AnnounceBlockSchema } from './Schema';
+
+const AnnounceData = (props) => {
+  const { data, block, onChangeBlock, blocksConfig } = props;
+  const schema = AnnounceBlockSchema({ ...props });
+  return (
+    <BlockDataForm
+      schema={schema}
+      title={schema.title}
+      onChangeField={(id, value) => {
+        onChangeBlock(block, {
+          ...data,
+          [id]: value,
+        });
+      }}
+      onChangeBlock={onChangeBlock}
+      formData={data}
+      block={block}
+      blocksConfig={blocksConfig}
+    />
+  );
+};
+
+export default AnnounceData;

--- a/packages/volto/src/components/manage/Blocks/Announce/data.test.jsx
+++ b/packages/volto/src/components/manage/Blocks/Announce/data.test.jsx
@@ -1,0 +1,64 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import AnnounceData from './data';
+import '@testing-library/jest-dom';
+
+const mockData = {
+  title: 'Test Title',
+  description: 'Test Description',
+  buttonText: 'Test Button',
+  link: '/test-link',
+};
+
+const mockBlocksConfig = {
+  blocks: {
+    blocksConfig: {
+      '@plone/volto/components/Blocks/Text': {},
+    },
+  },
+};
+
+describe('AnnounceData Component', () => {
+  it('renders the AnnounceData component with provided data', () => {
+    const onChangeBlock = jest.fn();
+
+    render(
+      <AnnounceData
+        data={mockData}
+        block="123"
+        onChangeBlock={onChangeBlock}
+        blocksConfig={mockBlocksConfig}
+      />,
+    );
+
+    // Check if the form fields are rendered with correct values
+    expect(screen.getByLabelText('Title')).toHaveValue('Test Title');
+    expect(screen.getByLabelText('Description')).toHaveValue(
+      'Test Description',
+    );
+    expect(screen.getByLabelText('Button Text')).toHaveValue('Test Button');
+    expect(screen.getByLabelText('Link')).toHaveValue('/test-link');
+  });
+
+  it('calls onChangeBlock when form fields are updated', () => {
+    const onChangeBlock = jest.fn();
+
+    render(
+      <AnnounceData
+        data={mockData}
+        block="123"
+        onChangeBlock={onChangeBlock}
+        blocksConfig={mockBlocksConfig}
+      />,
+    );
+
+    // Find and interact with an input field using fireEvent
+    const titleInput = screen.getByLabelText('Title');
+    fireEvent.change(titleInput, { target: { value: 'Updated Title' } });
+
+    // Check if onChangeBlock is called with the updated data
+    expect(onChangeBlock).toHaveBeenCalledWith('123', {
+      ...mockData,
+      title: 'Updated Title',
+    });
+  });
+});

--- a/packages/volto/src/components/manage/Blocks/Announce/edit.jsx
+++ b/packages/volto/src/components/manage/Blocks/Announce/edit.jsx
@@ -1,0 +1,24 @@
+import { SidebarPortal } from '@plone/volto/components';
+import { withBlockExtensions } from '@plone/volto/helpers';
+import AnnounceData from './data';
+import AnnounceView from './view';
+
+const AnnounceEdit = (props) => {
+  const { data, onChangeBlock, block, selected } = props;
+  return (
+    <>
+      <AnnounceView {...props} />
+      <SidebarPortal selected={selected}>
+        <AnnounceData
+          key={block}
+          {...props}
+          data={data}
+          block={block}
+          onChangeBlock={onChangeBlock}
+        />
+      </SidebarPortal>
+    </>
+  );
+};
+
+export default withBlockExtensions(AnnounceEdit);

--- a/packages/volto/src/components/manage/Blocks/Announce/edit.test.jsx
+++ b/packages/volto/src/components/manage/Blocks/Announce/edit.test.jsx
@@ -1,0 +1,59 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import AnnounceEdit from './edit';
+
+const mockData = {
+  title: 'Test Title',
+  description: 'Test Description',
+  buttonLink: [{ '@id': '/test-link' }],
+  buttonTitle: 'Test Button',
+  image: [{ '@id': '/test-image' }],
+  imageAlt: 'Test Alt Text',
+};
+
+describe('Edit Component', () => {
+  it('renders the Edit component with provided data', () => {
+    const onChangeBlock = jest.fn();
+
+    render(
+      <AnnounceEdit
+        data={mockData}
+        onChangeBlock={onChangeBlock}
+        block="123"
+        selected={false}
+      />,
+    );
+
+    // Check if ReleaseView is rendered with correct props
+    expect(screen.getByText('Test Title')).toBeInTheDocument();
+    expect(screen.getByText('Test Description')).toBeInTheDocument();
+    expect(screen.getByText('Test Button')).toBeInTheDocument();
+
+    // Check if ReleaseData is rendered with correct props
+    const announceDataComponent = screen.getByText('Release Data');
+    expect(announceDataComponent).toBeInTheDocument();
+    expect(announceDataComponent).toHaveAttribute('data-block', '123');
+  });
+
+  it('calls onChangeBlock when AnnounceData is updated', () => {
+    const onChangeBlock = jest.fn();
+
+    render(
+      <AnnounceEdit
+        data={mockData}
+        onChangeBlock={onChangeBlock}
+        block="123"
+        selected={false}
+      />,
+    );
+
+    // Find and interact with an input field in ReleaseData using fireEvent
+    const inputField = screen.getByLabelText('Title');
+    fireEvent.change(inputField, { target: { value: 'Updated Title' } });
+
+    // Check if onChangeBlock is called with the updated data
+    expect(onChangeBlock).toHaveBeenCalledWith('123', {
+      ...mockData,
+      title: 'Updated Title',
+    });
+  });
+});

--- a/packages/volto/src/components/manage/Blocks/Announce/view.jsx
+++ b/packages/volto/src/components/manage/Blocks/Announce/view.jsx
@@ -1,0 +1,34 @@
+import { Container } from 'semantic-ui-react';
+import { UniversalLink } from '@plone/volto/components';
+const AnnounceView = (props) => {
+  const { data } = props;
+
+  return (
+    <div className="block release full-width">
+      <Container>
+        <h2>{data.title}</h2>
+        <div className="text-button-wrapper">
+          <p>{data.description}</p>
+          {data.buttonLink && (
+            <UniversalLink
+              className="button-link"
+              href={data.buttonLink[0]['@id']}
+              openInNewTab
+            >
+              {data.buttonTitle}
+            </UniversalLink>
+          )}
+        </div>
+
+        {data.image && Array.isArray(data.image) && data.image.length > 0 && (
+          <img
+            src={`${data.image[0]['@id']}/@@images/image`}
+            alt={data.imageAlt}
+          />
+        )}
+      </Container>
+    </div>
+  );
+};
+
+export default AnnounceView;

--- a/packages/volto/src/components/manage/Blocks/Announce/view.test.jsx
+++ b/packages/volto/src/components/manage/Blocks/Announce/view.test.jsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import AnnounceView from './view';
+
+const mockData = {
+  title: 'Test Title',
+  description: 'Test Description',
+  buttonLink: [{ '@id': '/test-link' }],
+  buttonTitle: 'Test Button',
+  image: [{ '@id': '/test-image' }],
+  imageAlt: 'Test Alt Text',
+};
+
+describe('AnnounceView Component', () => {
+  it('renders the component with provided data', () => {
+    render(<AnnounceView data={mockData} />);
+
+    // Check if title, description, and button are rendered
+    expect(screen.getByText('Test Title')).toBeInTheDocument();
+    expect(screen.getByText('Test Description')).toBeInTheDocument();
+    expect(screen.getByText('Test Button')).toBeInTheDocument();
+
+    // Check if image is rendered
+    const image = screen.getByAltText('Test Alt Text');
+    expect(image).toBeInTheDocument();
+    expect(image.src).toContain('/test-image/@@images/image');
+  });
+
+  it('renders UniversalLink with correct href and openInNewTab prop', () => {
+    render(<AnnounceView data={mockData} />);
+
+    // Check if UniversalLink is rendered with correct props
+    const link = screen.getByText('Test Button');
+    expect(link).toBeInTheDocument();
+    expect(link.tagName).toBe('A');
+    expect(link).toHaveAttribute('href', '/test-link');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveClass('button-link');
+  });
+});

--- a/packages/volto/src/config/Blocks.jsx
+++ b/packages/volto/src/config/Blocks.jsx
@@ -12,6 +12,7 @@ import ViewHeroImageLeftBlock from '@plone/volto/components/manage/Blocks/HeroIm
 import ViewMapBlock from '@plone/volto/components/manage/Blocks/Maps/View';
 import ViewHTMLBlock from '@plone/volto/components/manage/Blocks/HTML/View';
 import ViewTableBlock from '@plone/volto/components/manage/Blocks/Table/View';
+import ViewAnnounceBlock from '@plone/volto/components/manage/Blocks/Announce/view';
 
 import EditTitleBlock from '@plone/volto/components/manage/Blocks/Title/Edit';
 import EditDescriptionBlock from '@plone/volto/components/manage/Blocks/Description/Edit';
@@ -29,6 +30,7 @@ import EditHeroImageLeftBlock from '@plone/volto/components/manage/Blocks/HeroIm
 import EditMapBlock from '@plone/volto/components/manage/Blocks/Maps/Edit';
 import EditHTMLBlock from '@plone/volto/components/manage/Blocks/HTML/Edit';
 import EditTableBlock from '@plone/volto/components/manage/Blocks/Table/Edit';
+import EditAnnounceBlock from '@plone/volto/components/manage/Blocks/Announce/edit';
 
 import descriptionSVG from '@plone/volto/icons/description.svg';
 import titleSVG from '@plone/volto/icons/text.svg';
@@ -90,6 +92,7 @@ import TeaserEditBlock from '@plone/volto/components/manage/Blocks/Teaser/Edit';
 import TeaserBlockDefaultBody from '@plone/volto/components/manage/Blocks/Teaser/DefaultBody';
 import { TeaserSchema } from '@plone/volto/components/manage/Blocks/Teaser/schema';
 import { TeaserBlockDataAdapter } from '@plone/volto/components/manage/Blocks/Teaser/adapter';
+import { AnnounceBlockSchema } from '../components/manage/Blocks/Announce/Schema';
 
 defineMessages({
   title: {
@@ -139,6 +142,10 @@ defineMessages({
   listing: {
     id: 'listing',
     defaultMessage: 'Listing',
+  },
+  announce: {
+    id: 'announce',
+    defaultMessage: 'PloneAnnouncement',
   },
   // Groups
   mostUsed: {
@@ -322,6 +329,19 @@ const blocksConfig = {
     mostUsed: true,
     sidebarTab: 1,
   },
+  announce: {
+    id: 'announce',
+    title: 'announce',
+    icon: heroSVG,
+    group: 'common',
+    view: ViewAnnounceBlock,
+    edit: EditAnnounceBlock,
+    blockSchema: AnnounceBlockSchema,
+    restricted: false,
+    mostUsed: true,
+    sidebarTab: 1,
+  },
+
   toc: {
     id: 'toc',
     title: 'Table of Contents',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      react:
+        specifier: ^18.2.0
+        version: 18.2.0
     devDependencies:
       '@typescript-eslint/eslint-plugin':
         specifier: 6.7.0

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,30 @@
 {
-  "extends": "tsconfig/base.json"
+  "compilerOptions": {
+    "target": "ESNext",
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "module": "commonjs",
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "paths": {},
+    "baseUrl": "src"
+  },
+  "include": ["src"],
+  "exclude": [
+    "node_modules",
+    "build",
+    "public",
+    "coverage",
+    "src/**/*.test.{js,jsx,ts,tsx}",
+    "src/**/*.spec.{js,jsx,ts,tsx}",
+    "src/**/*.stories.{js,jsx,ts,tsx}"
+  ]
 }


### PR DESCRIPTION
Enhancement Feature  `Announcement Block`
Adds a feature for time dependency announcements which should be  created  frequently which can help Visitors in knowing about the upcoming event or release .. Can be used a reminder block too.. You can create this demo by just adding A Title, Description, Image, Buttton to redirect which you will find while development 
<img width="811" alt="Screenshot 2023-12-12 at 4 12 10 PM" src="https://github.com/plone/volto/assets/138270264/5eb58619-e3e4-4c7d-8f68-73a257c58b6e">
