### PR TITLE
Fixed edge case error in Unauthorised page and Login route behavior.

### DIFF
--- a/packages/volto/news/5536.bugfix
+++ b/packages/volto/news/5536.bugfix
@@ -1,0 +1,1 @@
+Fixed edge case error in Unauthorised page and Login route behavior @sneridagh

--- a/packages/volto/src/components/theme/Login/Login.jsx
+++ b/packages/volto/src/components/theme/Login/Login.jsx
@@ -77,8 +77,9 @@ const Login = (props) => {
     qs.parse(props.location?.search ?? location.search).return_url ||
     location.pathname.replace(/\/login\/?$/, '').replace(/\/logout\/?$/, '') ||
     '/';
+
   useEffect(() => {
-    if (token && !props.isLogout) {
+    if (token && !(props.isLogout || location.state.isLogout)) {
       history.push(returnUrl || '/');
       if (toast.isActive('loggedOut')) {
         toast.dismiss('loggedOut');
@@ -108,7 +109,16 @@ const Login = (props) => {
         dispatch(resetLoginRequest());
       }
     };
-  }, [dispatch, token, error, intl, history, returnUrl, props.isLogout]);
+  }, [
+    dispatch,
+    token,
+    error,
+    intl,
+    history,
+    returnUrl,
+    props.isLogout,
+    location.state.isLogout,
+  ]);
 
   const onLogin = (event) => {
     dispatch(

--- a/packages/volto/src/components/theme/Login/Login.jsx
+++ b/packages/volto/src/components/theme/Login/Login.jsx
@@ -79,7 +79,7 @@ const Login = (props) => {
     '/';
 
   useEffect(() => {
-    if (token && !(props.isLogout || location.state.isLogout)) {
+    if (token && !(props.isLogout || location?.state?.isLogout)) {
       history.push(returnUrl || '/');
       if (toast.isActive('loggedOut')) {
         toast.dismiss('loggedOut');

--- a/packages/volto/src/components/theme/Login/Login.jsx
+++ b/packages/volto/src/components/theme/Login/Login.jsx
@@ -117,7 +117,7 @@ const Login = (props) => {
     history,
     returnUrl,
     props.isLogout,
-    location.state.isLogout,
+    location?.state?.isLogout,
   ]);
 
   const onLogin = (event) => {

--- a/packages/volto/src/components/theme/Unauthorized/Unauthorized.jsx
+++ b/packages/volto/src/components/theme/Unauthorized/Unauthorized.jsx
@@ -1,8 +1,3 @@
-/**
- * @module components/theme/Unauthorized/Unauthorized
- */
-
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import { Link } from 'react-router-dom';
 import { Container } from 'semantic-ui-react';
@@ -11,11 +6,6 @@ import { useLocation } from 'react-router-dom';
 import { withServerErrorCode } from '@plone/volto/helpers/Utils/Utils';
 import { getBaseUrl } from '@plone/volto/helpers';
 
-/**
- * unauthorized function.
- * @function Unauthorized
- * @returns {string} Markup of the unauthorized page.
- */
 const Unauthorized = () => {
   const error_message = useSelector((state) => state.apierror?.message);
   let location = useLocation();
@@ -32,7 +22,18 @@ const Unauthorized = () => {
           defaultMessage="You are trying to access a protected resource, please {login} first."
           values={{
             login: (
-              <Link to={`${getBaseUrl(location.pathname)}/login`}>
+              <Link
+                to={{
+                  pathname: `${getBaseUrl(location.pathname)}/login`,
+                  state: {
+                    // This is needed to cover the use case of being logged in in
+                    // another backend (eg. in development), having a token for
+                    // localhost and try to use it, the login route has to know that
+                    // it's the same as it comes from a logout
+                    isLogout: true,
+                  },
+                }}
+              >
                 <FormattedMessage id="log in" defaultMessage="log in" />
               </Link>
             ),


### PR DESCRIPTION
While developing, could be that you are switching projects, then one token you had from the previous version is tried to be used in the new one. In that case, the unauthorised page pops, then the login route sees that you have a token and not coming from the logout form, then sends you to the root, then the unauthorised pops again, getting into an endless loop.