### PR TITLE
fix- #5537

### DIFF
--- a/docs/source/contributing/developing-core.md
+++ b/docs/source/contributing/developing-core.md
@@ -161,7 +161,7 @@ pnpm --filter @plone/volto start
 ```
 
 ```shell
-pnp --filter @plone/registry build
+pnpm --filter @plone/registry build
 ```
 
 

--- a/packages/volto/news/5537.bugfix
+++ b/packages/volto/news/5537.bugfix
@@ -1,0 +1,1 @@
+changed typo of pnp to pnpm. @ujjwaleee26


### PR DESCRIPTION
Fixed typo `pnp` to `pnpm` in developing-core.md file