### PR TITLE
Add how-to-restrict-blocks to recipes/index.md

### DIFF
--- a/docs/source/recipes/index.md
+++ b/docs/source/recipes/index.md
@@ -27,5 +27,6 @@ appextras
 contextnavigation
 pluggables
 widget
+how-to-restrict-blocks
 ie11compat
 ```

--- a/packages/volto/news/5546.documentation
+++ b/packages/volto/news/5546.documentation
@@ -1,0 +1,1 @@
+Add `how-to-restrict-blocks` to `recipes/index.md`, avoiding Sphinx warning. @stevepiercy


### PR DESCRIPTION
Unfortunately, the warning type `WARNING: document isn't included in any toctree` does not cause the build to fail, and we decided to not enforce it in Volto because we need to validate change log entries to have correct MyST syntax and links. Also we don't want to turn all warnings into errors at this time because we have a couple of other warning types that we want to allow, such as the LESS lexer in Pygments and html_meta checking.