### PR TITLE
Fix dropdown popup positioning.

### DIFF
--- a/packages/volto/src/components/manage/Contents/ContentsItem.jsx
+++ b/packages/volto/src/components/manage/Contents/ContentsItem.jsx
@@ -241,11 +241,11 @@ export const ContentsItemComponent = ({
           >
             <Menu vertical borderless fluid>
               <Link className="item icon-align" to={`${item['@id']}/edit`}>
-                <Icon name={editingSVG} color="#007eb1" size="24px" />{' '}
+                <Icon name={editingSVG} color="#007eb1" size="20px" />{' '}
                 <FormattedMessage id="Edit" defaultMessage="Edit" />
               </Link>
               <Link className="item right-dropdown icon-align" to={item['@id']}>
-                <Icon name={showSVG} color="#007eb1" size="24px" />{' '}
+                <Icon name={showSVG} color="#007eb1" size="20px" />{' '}
                 <FormattedMessage id="View" defaultMessage="View" />
               </Link>
               <Divider />
@@ -254,7 +254,7 @@ export const ContentsItemComponent = ({
                 value={item['@id']}
                 className="right-dropdown icon-align"
               >
-                <Icon name={cutSVG} color="#007eb1" size="24px" />{' '}
+                <Icon name={cutSVG} color="#007eb1" size="20px" />{' '}
                 <FormattedMessage id="Cut" defaultMessage="Cut" />
               </Menu.Item>
               <Menu.Item
@@ -262,7 +262,7 @@ export const ContentsItemComponent = ({
                 value={item['@id']}
                 className="right-dropdown icon-align"
               >
-                <Icon name={copySVG} color="#007eb1" size="24px" />{' '}
+                <Icon name={copySVG} color="#007eb1" size="20px" />{' '}
                 <FormattedMessage id="Copy" defaultMessage="Copy" />
               </Menu.Item>
               <Menu.Item
@@ -270,7 +270,7 @@ export const ContentsItemComponent = ({
                 value={item['@id']}
                 className="right-dropdown icon-align"
               >
-                <Icon name={deleteSVG} color="#e40166" size="24px" />{' '}
+                <Icon name={deleteSVG} color="#e40166" size="20px" />{' '}
                 <FormattedMessage id="Delete" defaultMessage="Delete" />
               </Menu.Item>
               <Divider />
@@ -279,7 +279,7 @@ export const ContentsItemComponent = ({
                 value={order}
                 className="right-dropdown icon-align"
               >
-                <Icon name={moveUpSVG} color="#007eb1" size="24px" />{' '}
+                <Icon name={moveUpSVG} color="#007eb1" size="20px" />{' '}
                 <FormattedMessage
                   id="Move to top of folder"
                   defaultMessage="Move to top of folder"
@@ -290,7 +290,7 @@ export const ContentsItemComponent = ({
                 value={order}
                 className="right-dropdown icon-align"
               >
-                <Icon name={moveDownSVG} color="#007eb1" size="24px" />{' '}
+                <Icon name={moveDownSVG} color="#007eb1" size="20px" />{' '}
                 <FormattedMessage
                   id="Move to bottom of folder"
                   defaultMessage="Move to bottom of folder"


### PR DESCRIPTION
As highlighted by user @Mandy767 in [issue#5566](https://github.com/plone/volto/issues/5566), there was an issue with the dropdown menu on the contents page, causing an undesired extra space below the footer due to its positioning. I fixed this issue by simply adjusting the icon size from 24px to 20px, as it's the most straightforward and efficient solution.
| Before | After | 
|--------|-------|
| ![image](https://github.com/plone/volto/assets/91622060/b171f58d-0bb2-4089-8bed-62adea8f063d) |  ![image](https://github.com/plone/volto/assets/91622060/d037e32e-9c9e-49c9-b902-a604cab76615)  |