### PR TITLE
Added support for custom CSS properties in the StyleWrapper

### DIFF
--- a/docs/source/blocks/block-style-wrapper.md
+++ b/docs/source/blocks/block-style-wrapper.md
@@ -151,6 +151,9 @@ Then it's at your discretion how you define the CSS class names in your theme.
 
 ## Customize the injected class names
 
+```{versionadded} release-version-number
+```
+
 If you need other style of classnames generated, you can use the classname
 converters defined in `config.settings.styleClassNameConverters`, by
 registering fieldnames suffixed with the converter name. For example, a style
@@ -169,10 +172,13 @@ will generate classnames `primary inverted`
 
 ## Injecting custom CSS properties
 
+```{versionadded} release-version-number
+```
+
 The style wrapper also allows to inject custom CSS properties, using the converter syntax.
 This use case is useful in some scenarios where the property that you are injecting is generic, customizable per project.
 
-```
+```css
 {
   "styles": {
     "backgroundColor:CSSProperty": "#222",
@@ -180,7 +186,7 @@ This use case is useful in some scenarios where the property that you are inject
 }
 ```
 
-will inject a style object prop in the component:
+The above style will inject a style object property in the following component:
 
 ```html
 <div class="block teaser" style="--background-color: #222">
@@ -211,7 +217,7 @@ const BlockView = (props)=> (
 ```
 
 ```{note}
-You need to manually add the above code in your view component block code in order to benefit from the style injection.
+You need to manually add the above code in your view component block code to benefit from the style injection.
 The styles in the block edit component are injected automatically into the blocks engine editor wrappers, so you don't have to take any action.
 ```
 

--- a/docs/source/blocks/block-style-wrapper.md
+++ b/docs/source/blocks/block-style-wrapper.md
@@ -182,6 +182,14 @@ Then in your customized theme, you could set CSS attributes for this property, c
 The key feature of custom CSS properties is that they can be applied also using the cascade.
 This means that they can be placed anywhere in either CSS definitions or HTML structure, and they will be applied only in the context where they are defined.
 
+As an example, first define the style of a teaser block image as follows.
+
+```css
+.block.teaser img {
+  aspect-ratio: var(--image-aspect-ratio, 16 / 9);
+}
+```
+
 Next, you can enhance a block's schema by injecting the custom CSS property as follows.
 
 ```js
@@ -208,14 +216,6 @@ Finally the markup of the block will contain the custom property as shown.
 <div class="block teaser" style="--image-aspect-ratio: 1">
 ...
 </div>
-```
-
-As an example, first define the style of a teaser block image as follows.
-
-```css
-.block.teaser img {
-  aspect-ratio: var(--image-aspect-ratio, 16 / 9);
-}
 ```
 
 The custom CSS property definition will only apply within the div that it's defined.

--- a/docs/source/blocks/block-style-wrapper.md
+++ b/docs/source/blocks/block-style-wrapper.md
@@ -175,32 +175,50 @@ will generate classnames `primary inverted`
 ```{versionadded} 17.8.0
 ```
 
-The style wrapper also allows to inject custom CSS properties, using the converter syntax.
+The style wrapper also allows to inject custom CSS properties.
 This is useful where the property that you want to inject is customizable per project.
+For example, imagine we have in place a global CSS custom property `--image-aspect-ratio` so all the images in blocks (teasers, listings too) use it. The idea was that someone in his customized theme could set it and change them all in runtime, because this is how custom CSS properties work.
+The key feature of custom CSS properties is that they can be applied also using the cascade.
+This means that they can be placed anywhere in the CSS definitions or in the HTML structure, and they will be applied only in the context they are defined.
 
-```css
-{
-  "styles": {
-    "--background-color": "#222",
-  }
-}
+When the feature in this PR is used combined with the above you can enhance a block's schema (eg. teaser) as follows:
+
+```js
+  schema.properties.styles.schema.fieldsets[0].fields = [
+    ...schema.properties.styles.schema.fieldsets[0].fields,
+    '--image-aspect-ratio',
+  ];
+
+  // We use a select widget and set a default
+  schema.properties.styles.schema.properties['--image-aspect-ratio'] = {
+    widget: 'select',
+    title: 'Aspect Ratio',
+    choices: [
+      ['1', '1:1'],
+      ['16 / 9', '16/9'],
+    ],
+    default: '1',
+  };
 ```
 
-The above style will inject a style object property in the following component:
+Then, the markup of the block will contain the custom property:
 
 ```html
-<div class="block teaser" style="--background-color: #222">
+<div class="block teaser" style="--image-aspect-ratio: 1">
+...
+</div>
 ```
 
-Then, provided that you have the following CSS in place:
+and if we have this CSS definitions in place:
 
 ```css
-.block.teaser {
-  background-color: var(--background-color);
+.block.teaser img {
+  aspect-ratio: var(--image-aspect-ratio, 16 / 9);
 }
 ```
 
-It will apply the variable value injected by the style wrapper for the teaser block.
+The custom CSS property definition will only apply within the div that it's defined.
+Then the CSS where it's used will apply that custom CSS property value for only that div.
 
 If you want to use it in your custom components, you need to apply it in the root of your block's view component as follows:
 

--- a/docs/source/blocks/block-style-wrapper.md
+++ b/docs/source/blocks/block-style-wrapper.md
@@ -177,11 +177,12 @@ will generate classnames `primary inverted`
 
 The style wrapper also allows to inject custom CSS properties.
 This is useful where the property that you want to inject is customizable per project.
-For example, imagine we have in place a global CSS custom property `--image-aspect-ratio` so all the images in blocks (teasers, listings too) use it. The idea was that someone in his customized theme could set it and change them all in runtime, because this is how custom CSS properties work.
+For example, imagine you have an existing global CSS custom property `--image-aspect-ratio` that you use for all images in all blocks.
+Then in your customized theme, you could set CSS attributes for this property, changing it in runtime.
 The key feature of custom CSS properties is that they can be applied also using the cascade.
-This means that they can be placed anywhere in the CSS definitions or in the HTML structure, and they will be applied only in the context they are defined.
+This means that they can be placed anywhere in either CSS definitions or HTML structure, and they will be applied only in the context where they are defined.
 
-When the feature in this PR is used combined with the above you can enhance a block's schema (eg. teaser) as follows:
+Next, you can enhance a block's schema by injecting the custom CSS property as follows.
 
 ```js
   schema.properties.styles.schema.fieldsets[0].fields = [
@@ -201,7 +202,7 @@ When the feature in this PR is used combined with the above you can enhance a bl
   };
 ```
 
-Then, the markup of the block will contain the custom property:
+Finally the markup of the block will contain the custom property as shown.
 
 ```html
 <div class="block teaser" style="--image-aspect-ratio: 1">
@@ -209,7 +210,7 @@ Then, the markup of the block will contain the custom property:
 </div>
 ```
 
-and if we have this CSS definitions in place:
+As an example, first define the style of a teaser block image as follows.
 
 ```css
 .block.teaser img {
@@ -218,7 +219,7 @@ and if we have this CSS definitions in place:
 ```
 
 The custom CSS property definition will only apply within the div that it's defined.
-Then the CSS where it's used will apply that custom CSS property value for only that div.
+As you can see, the custom CSS property applies only within the `div` in which it is defined.
 
 If you want to use it in your custom components, you need to apply it in the root of your block's view component as follows:
 

--- a/docs/source/blocks/block-style-wrapper.md
+++ b/docs/source/blocks/block-style-wrapper.md
@@ -151,7 +151,7 @@ Then it's at your discretion how you define the CSS class names in your theme.
 
 ## Customize the injected class names
 
-```{versionadded} release-version-number
+```{versionadded} 16.0.0
 ```
 
 If you need other style of classnames generated, you can use the classname
@@ -172,7 +172,7 @@ will generate classnames `primary inverted`
 
 ## Injecting custom CSS properties
 
-```{versionadded} release-version-number
+```{versionadded} 17.8.0
 ```
 
 The style wrapper also allows to inject custom CSS properties, using the converter syntax.
@@ -181,7 +181,7 @@ This use case is useful in some scenarios where the property that you are inject
 ```css
 {
   "styles": {
-    "backgroundColor:CSSProperty": "#222",
+    "--background-color": "#222",
   }
 }
 ```
@@ -190,10 +190,6 @@ The above style will inject a style object property in the following component:
 
 ```html
 <div class="block teaser" style="--background-color: #222">
-```
-
-```{note}
-Please notice that the resultant variable is transformed from camel case to kebab case.
 ```
 
 Then, provided that you have the following CSS in place:

--- a/docs/source/blocks/block-style-wrapper.md
+++ b/docs/source/blocks/block-style-wrapper.md
@@ -109,7 +109,7 @@ config.blocks.blocksConfig.listing.schemaEnhancer = composeSchema(
 
 The `styles` field is mapped to an `objectWidget`.
 The following is an example of a possible set of styles.
-The style wrapper will read the styles and inject them into the edit and view components as shown in the next sections.
+The style wrapper will read the styles and inject the resultant class names into the edit and view components as shown in the next sections.
 
 ```json
 {
@@ -127,7 +127,7 @@ The style wrapper will read the styles and inject them into the edit and view co
 ## Using the injected class names in your block
 
 The resultant class names are injected as a `className` prop into the wrapped block.
-Thus you can use it in the root component of your block view and edit components as follows:
+Thus you can use it in the root component of your block view component as follows:
 
 ```jsx
 const BlockView = (props)=> (
@@ -149,6 +149,8 @@ The resultant HTML would be the following:
 ```
 Then it's at your discretion how you define the CSS class names in your theme.
 
+## Customize the injected class names
+
 If you need other style of classnames generated, you can use the classname
 converters defined in `config.settings.styleClassNameConverters`, by
 registering fieldnames suffixed with the converter name. For example, a style
@@ -164,6 +166,54 @@ data like:
 ```
 
 will generate classnames `primary inverted`
+
+## Injecting custom CSS properties
+
+The style wrapper also allows to inject custom CSS properties, using the converter syntax.
+This use case is useful in some scenarios where the property that you are injecting is generic, customizable per project.
+
+```
+{
+  "styles": {
+    "backgroundColor:CSSProperty": "#222",
+  }
+}
+```
+
+will inject a style object prop in the component:
+
+```html
+<div class="block teaser" style="--background-color: #222">
+```
+
+```{note}
+Please notice that the resultant variable is transformed from camel case to kebab case.
+```
+
+Then, provided that you have the following CSS in place:
+
+```css
+.block.teaser {
+  background-color: var(--background-color);
+}
+```
+
+It will apply the variable value injected by the style wrapper for the teaser block.
+
+If you want to use it in your custom components, you need to apply it in the root of your block's view component as follows:
+
+```jsx
+const BlockView = (props)=> (
+  <div style={props.style}>
+    // Block's view component code
+  </div>
+)
+```
+
+```{note}
+You need to manually add the above code in your view component block code in order to benefit from the style injection.
+The styles in the block edit component are injected automatically into the blocks engine editor wrappers, so you don't have to take any action.
+```
 
 ## Align class injection
 

--- a/docs/source/blocks/block-style-wrapper.md
+++ b/docs/source/blocks/block-style-wrapper.md
@@ -210,7 +210,7 @@ Next, you can enhance a block's schema by injecting the custom CSS property as f
   };
 ```
 
-Finally the markup of the block will contain the custom property as shown.
+Finally, assuming that you select the default value for the {guilabel}`Aspect Ratio` for the custom CSS property, then the markup of the block will contain the custom property as shown.
 
 ```html
 <div class="block teaser" style="--image-aspect-ratio: 1">

--- a/docs/source/blocks/block-style-wrapper.md
+++ b/docs/source/blocks/block-style-wrapper.md
@@ -170,13 +170,13 @@ data like:
 
 will generate classnames `primary inverted`
 
-## Injecting custom CSS properties
+## Inject custom CSS properties
 
 ```{versionadded} 17.8.0
 ```
 
 The style wrapper also allows to inject custom CSS properties, using the converter syntax.
-This use case is useful in some scenarios where the property that you are injecting is generic, customizable per project.
+This is useful where the property that you want to inject is customizable per project.
 
 ```css
 {

--- a/docs/source/blocks/block-style-wrapper.md
+++ b/docs/source/blocks/block-style-wrapper.md
@@ -11,6 +11,9 @@ myst:
 
 # Block style wrapper
 
+```{versionadded} 16.0.0
+```
+
 The block style wrapper is part of a block anatomy.
 It allows you to inject styles from the block schema into the block wrapper in the form of class names.
 It wraps the block edit and the view components.
@@ -150,9 +153,6 @@ The resultant HTML would be the following:
 Then it's at your discretion how you define the CSS class names in your theme.
 
 ## Customize the injected class names
-
-```{versionadded} 16.0.0
-```
 
 If you need other style of classnames generated, you can use the classname
 converters defined in `config.settings.styleClassNameConverters`, by

--- a/docs/source/blocks/block-style-wrapper.md
+++ b/docs/source/blocks/block-style-wrapper.md
@@ -214,7 +214,7 @@ Finally the markup of the block will contain the custom property as shown.
 
 ```html
 <div class="block teaser" style="--image-aspect-ratio: 1">
-...
+<img src="example.png">
 </div>
 ```
 

--- a/packages/volto/news/5581.feature
+++ b/packages/volto/news/5581.feature
@@ -1,0 +1,1 @@
+Added support for custom CSS properties in the StyleWrapper @sneridagh

--- a/packages/volto/news/5581.feature
+++ b/packages/volto/news/5581.feature
@@ -1,1 +1,1 @@
-Added support for custom CSS properties in the StyleWrapper @sneridagh
+Added support for custom CSS properties in the `StyleWrapper`. @sneridagh

--- a/packages/volto/src/components/manage/Blocks/Block/EditBlockWrapper.jsx
+++ b/packages/volto/src/components/manage/Blocks/Block/EditBlockWrapper.jsx
@@ -3,6 +3,7 @@ import { Icon } from '@plone/volto/components';
 import {
   blockHasValue,
   buildStyleClassNamesFromData,
+  buildStyleObjectFromData,
 } from '@plone/volto/helpers';
 import dragSVG from '@plone/volto/icons/drag.svg';
 import { Button } from 'semantic-ui-react';
@@ -57,7 +58,8 @@ const EditBlockWrapper = (props) => {
     ? data.required
     : includes(config.blocks.requiredBlocks, type);
 
-  const styles = buildStyleClassNamesFromData(data.styles);
+  const classNames = buildStyleClassNamesFromData(data.styles);
+  const style = buildStyleObjectFromData(data.styles);
 
   return (
     <div
@@ -66,9 +68,10 @@ const EditBlockWrapper = (props) => {
       // Right now, we can have the alignment information in the styles property or in the
       // block data root, we inject the classname here for having control over the whole
       // Block Edit wrapper
-      className={cx(`block-editor-${data['@type']}`, styles, {
+      className={cx(`block-editor-${data['@type']}`, classNames, {
         [data.align]: data.align,
       })}
+      style={style}
     >
       <div style={{ position: 'relative' }}>
         <div

--- a/packages/volto/src/components/manage/Blocks/Block/StyleWrapper.jsx
+++ b/packages/volto/src/components/manage/Blocks/Block/StyleWrapper.jsx
@@ -3,10 +3,12 @@ import cx from 'classnames';
 import {
   buildStyleClassNamesFromData,
   buildStyleClassNamesExtenders,
+  buildStyleObjectFromData,
 } from '@plone/volto/helpers';
 
 const StyleWrapper = (props) => {
-  let classNames = [];
+  let classNames,
+    style = [];
   const { children, content, data = {}, block } = props;
   classNames = buildStyleClassNamesFromData(data.styles);
 
@@ -16,11 +18,15 @@ const StyleWrapper = (props) => {
     data,
     classNames,
   });
+
+  style = buildStyleObjectFromData(data.styles);
+
   const rewrittenChildren = React.Children.map(children, (child) => {
     if (React.isValidElement(child)) {
       const childProps = {
         ...props,
         className: cx([child.props.className, ...classNames]),
+        style: { ...child.props.style, ...style },
       };
       return React.cloneElement(child, childProps);
     }

--- a/packages/volto/src/components/manage/Blocks/Grid/View.jsx
+++ b/packages/volto/src/components/manage/Blocks/Grid/View.jsx
@@ -5,7 +5,7 @@ import { withBlockExtensions } from '@plone/volto/helpers';
 import config from '@plone/volto/registry';
 
 const GridBlockView = (props) => {
-  const { data, path, className } = props;
+  const { data, path, className, style } = props;
   const metadata = props.metadata || props.properties;
   const columns = data.blocks_layout.items;
   const blocksConfig =
@@ -22,6 +22,7 @@ const GridBlockView = (props) => {
         three: columns?.length === 3,
         four: columns?.length === 4,
       })}
+      style={style}
     >
       {data.headline && <h2 className="headline">{data.headline}</h2>}
 

--- a/packages/volto/src/components/manage/Blocks/Image/View.jsx
+++ b/packages/volto/src/components/manage/Blocks/Image/View.jsx
@@ -9,7 +9,7 @@ import {
 } from '@plone/volto/helpers';
 import config from '@plone/volto/registry';
 
-export const View = ({ className, data, detached, properties }) => {
+export const View = ({ className, data, detached, properties, style }) => {
   const href = data?.href?.[0]?.['@id'] || '';
 
   const Image = config.getComponent({ name: 'Image' }).component;
@@ -25,6 +25,7 @@ export const View = ({ className, data, detached, properties }) => {
         data.align,
         className,
       )}
+      style={style}
     >
       {data.url && (
         <>

--- a/packages/volto/src/components/manage/Blocks/Listing/View.jsx
+++ b/packages/volto/src/components/manage/Blocks/Listing/View.jsx
@@ -6,11 +6,12 @@ import { withBlockExtensions } from '@plone/volto/helpers';
 import { ListingBlockBody as ListingBody } from '@plone/volto/components';
 
 const View = (props) => {
-  const { data, path, pathname, className } = props;
+  const { data, path, pathname, className, style } = props;
 
   return (
     <div
       className={cx('block listing', data.variation || 'default', className)}
+      style={style}
     >
       <ListingBody {...props} path={path ?? pathname} />
     </div>

--- a/packages/volto/src/components/manage/Blocks/Teaser/DefaultBody.jsx
+++ b/packages/volto/src/components/manage/Blocks/Teaser/DefaultBody.jsx
@@ -18,7 +18,7 @@ const messages = defineMessages({
 });
 
 const TeaserDefaultTemplate = (props) => {
-  const { className, data, isEditMode } = props;
+  const { className, data, isEditMode, style } = props;
   const intl = useIntl();
   const href = data.href?.[0];
   const image = data.preview_image?.[0];
@@ -27,7 +27,7 @@ const TeaserDefaultTemplate = (props) => {
   const { openExternalLinkInNewTab } = config.settings;
 
   return (
-    <div className={cx('block teaser', className)}>
+    <div className={cx('block teaser', className)} style={style}>
       <>
         {!href && isEditMode && (
           <Message>

--- a/packages/volto/src/config/Style.jsx
+++ b/packages/volto/src/config/Style.jsx
@@ -6,6 +6,7 @@ export const styleClassNameConverters = {
   },
   noprefix: (name, value) => value,
   bool: (name, value) => (value ? name : ''),
+  CSSProperty: (name, value) => {},
 };
 
 export const styleClassNameExtenders = [];

--- a/packages/volto/src/config/Style.jsx
+++ b/packages/volto/src/config/Style.jsx
@@ -6,7 +6,6 @@ export const styleClassNameConverters = {
   },
   noprefix: (name, value) => value,
   bool: (name, value) => (value ? name : ''),
-  CSSProperty: (name, value) => {},
 };
 
 export const styleClassNameExtenders = [];

--- a/packages/volto/src/helpers/Blocks/Blocks.js
+++ b/packages/volto/src/helpers/Blocks/Blocks.js
@@ -571,6 +571,7 @@ export const buildStyleClassNamesFromData = (obj = {}, prefix = '') => {
   // Returns: ['has--color--red', 'has--backgroundColor--AABBCC']
 
   return Object.entries(obj)
+    .filter(([k, v]) => !k.startsWith('--'))
     .reduce(
       (acc, [k, v]) => [
         ...acc,
@@ -602,18 +603,16 @@ export const buildStyleClassNamesExtenders = ({
   );
 };
 
-const camelToKebabCase = (str) =>
-  str.replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`);
-
 /**
  * Converts a name+value style pair (ex: color/red) to a pair of [k, v],
  * such as ["color", "red"] so it can be converted back to an object.
  * For now, only covering the 'CSSProperty' use case.
  */
 export const styleDataToStyleObject = (key, value, prefix = '') => {
-  const [name, converterID] = key.split(':');
-  if (converterID === 'CSSProperty') {
-    return [`--${prefix}${camelToKebabCase(name)}`, value];
+  if (prefix) {
+    return [`--${prefix}${key.replace('--', '')}`, value];
+  } else {
+    return [key, value];
   }
 };
 
@@ -629,12 +628,13 @@ export const buildStyleObjectFromData = (obj = {}, prefix = '') => {
   // style wrapper object has the form:
   // const styles = {
   //   color: 'red',
-  //   'backgroundColor:style': '#AABBCC',
+  //   '--background-color': '#AABBCC',
   // }
-  // Returns: {'--backgroundColor: 'AABBCC'}
+  // Returns: {'--background-color: '#AABBCC'}
 
   return Object.fromEntries(
     Object.entries(obj)
+      .filter(([k, v]) => k.startsWith('--') || isObject(v))
       .reduce(
         (acc, [k, v]) => [
           ...acc,

--- a/packages/volto/src/helpers/Blocks/Blocks.test.js
+++ b/packages/volto/src/helpers/Blocks/Blocks.test.js
@@ -18,6 +18,7 @@ import {
   applySchemaDefaults,
   buildStyleClassNamesFromData,
   buildStyleClassNamesExtenders,
+  buildStyleObjectFromData,
   getPreviousNextBlock,
   blocksFormGenerator,
   findBlocks,
@@ -1065,6 +1066,61 @@ describe('Blocks', () => {
         },
       };
       expect(buildStyleClassNamesFromData(styles)).toEqual([]);
+    });
+
+    it('It does not output any className for style converter values', () => {
+      const styles = {
+        color: 'red',
+        'backgroundColor:CSSProperty': '#FFF',
+      };
+      expect(buildStyleClassNamesFromData(styles)).toEqual(['has--color--red']);
+    });
+
+    it.skip('It does not output any className for unknown converter values', () => {
+      const styles = {
+        color: 'red',
+        'backgroundColor:style': '#FFF',
+      };
+      expect(buildStyleClassNamesFromData(styles)).toEqual(['has--color--red']);
+    });
+  });
+
+  describe('buildStyleObjectFromData', () => {
+    it('Understands style converter for style values, no styles found', () => {
+      const styles = {
+        color: 'red',
+        backgroundColor: '#FFF',
+      };
+      expect(buildStyleObjectFromData(styles)).toEqual({});
+    });
+    it('Understands style converter for style values', () => {
+      const styles = {
+        color: 'red',
+        'backgroundColor:CSSProperty': '#FFF',
+      };
+      expect(buildStyleObjectFromData(styles)).toEqual({
+        '--background-color': '#FFF',
+      });
+    });
+
+    it('Supports multiple nested levels', () => {
+      const styles = {
+        'color:CSSProperty': 'red',
+        backgroundColor: '#AABBCC',
+        nested: {
+          l1: 'white',
+          'foo:CSSProperty': 'white',
+          level2: {
+            'foo:CSSProperty': '#fff',
+            bar: '#000',
+          },
+        },
+      };
+      expect(buildStyleObjectFromData(styles)).toEqual({
+        '--color': 'red',
+        '--nested--foo': 'white',
+        '--nested--level2--foo': '#fff',
+      });
     });
   });
 

--- a/packages/volto/src/helpers/Blocks/Blocks.test.js
+++ b/packages/volto/src/helpers/Blocks/Blocks.test.js
@@ -1071,7 +1071,7 @@ describe('Blocks', () => {
     it('It does not output any className for style converter values', () => {
       const styles = {
         color: 'red',
-        'backgroundColor:CSSProperty': '#FFF',
+        '--background-color': '#FFF',
       };
       expect(buildStyleClassNamesFromData(styles)).toEqual(['has--color--red']);
     });
@@ -1093,10 +1093,11 @@ describe('Blocks', () => {
       };
       expect(buildStyleObjectFromData(styles)).toEqual({});
     });
+
     it('Understands style converter for style values', () => {
       const styles = {
         color: 'red',
-        'backgroundColor:CSSProperty': '#FFF',
+        '--background-color': '#FFF',
       };
       expect(buildStyleObjectFromData(styles)).toEqual({
         '--background-color': '#FFF',
@@ -1105,13 +1106,13 @@ describe('Blocks', () => {
 
     it('Supports multiple nested levels', () => {
       const styles = {
-        'color:CSSProperty': 'red',
+        '--color': 'red',
         backgroundColor: '#AABBCC',
         nested: {
           l1: 'white',
-          'foo:CSSProperty': 'white',
+          '--foo': 'white',
           level2: {
-            'foo:CSSProperty': '#fff',
+            '--foo': '#fff',
             bar: '#000',
           },
         },

--- a/packages/volto/src/helpers/index.js
+++ b/packages/volto/src/helpers/index.js
@@ -58,6 +58,7 @@ export {
   blocksFormGenerator,
   buildStyleClassNamesFromData,
   buildStyleClassNamesExtenders,
+  buildStyleObjectFromData,
   getPreviousNextBlock,
   findBlocks,
 } from '@plone/volto/helpers/Blocks/Blocks';


### PR DESCRIPTION
This is a pattern I use lately, and it makes a lot of sense to me.

A couple of questions:

- Would it be useful/needed to also inject a className in order to hook to? I was about to do it, but I don't know if that would be required... maybe to know if a value is set or not... but you can always have a default fallback value.
- Naming... what not! I chose `CSSProperty` as the sufix... any other suggestions?

I'm well aware that this opens the door to fine grained style customizations, if we extend the pattern not only to use custom CSS properties but also use random CSS properties (another converter should be created, then do not append the -- and disable nested support, then) I leave it up to the community. However, the initial feeling when we came up with the style wrapper stands: I wouldn't like the wrapper to be missunderstood, and that people are able to easy create blocks that resemble WordPress Elementor...

Let's iterate over this, in the meanwhile, I will work on integrate the PoC into VLT.

**Update 01/01/2024**: Answer to questions:

- It's not really needed, since one could build a selector like this:

```css
 .block.teaser[style*='--background-color'] {
    padding: 20px 0;
}
```

if required.

- This PR is not using a suffix discriminator to differentiate from the others. Now it detects if the property starts by `--` see the documentation.