### PR TITLE
Fixed positioning of Popup

### DIFF
--- a/packages/volto/src/components/manage/Contents/ContentsItem.jsx
+++ b/packages/volto/src/components/manage/Contents/ContentsItem.jsx
@@ -248,7 +248,7 @@ export const ContentsItemComponent = ({
                 <Icon name={showSVG} color="#007eb1" size="24px" />{' '}
                 <FormattedMessage id="View" defaultMessage="View" />
               </Link>
-              <Divider />
+              <Divider fitted />
               <Menu.Item
                 onClick={onCut}
                 value={item['@id']}
@@ -273,7 +273,7 @@ export const ContentsItemComponent = ({
                 <Icon name={deleteSVG} color="#e40166" size="24px" />{' '}
                 <FormattedMessage id="Delete" defaultMessage="Delete" />
               </Menu.Item>
-              <Divider />
+              <Divider fitted />
               <Menu.Item
                 onClick={onMoveToTop}
                 value={order}


### PR DESCRIPTION
fixes #5566 
just added a prop named fitted in divider
By using that divider can be fitted without any space above or below it .


https://github.com/plone/volto/assets/92856810/d6710eb3-e3de-4635-944d-aa4efc1168fc

