### PR TITLE
Allow to bail off the nested name build in the custom CSS properties style name generator

### DIFF
--- a/docs/source/blocks/block-style-wrapper.md
+++ b/docs/source/blocks/block-style-wrapper.md
@@ -236,6 +236,83 @@ You need to manually add the above code in your view component block code to ben
 The styles in the block edit component are injected automatically into the blocks engine editor wrappers, so you don't have to take any action.
 ```
 
+## Nested custom CSS properties
+
+Given this block enhancer:
+
+```js
+  schema.properties.styles.schema.fieldsets[0].fields = [
+    ...schema.properties.styles.schema.fieldsets[0].fields,
+    'theme',
+  ];
+
+  schema.properties.styles.schema.properties['theme'] = {
+    widget: 'color_picker',
+    title: "Theme",
+    colors,
+    default: defaultBGColor,
+  };
+```
+
+It will generate this values for the StyleWrapper to use:
+
+```js
+{
+  "styles": {
+    "theme": {
+      "--background-color": "#222",
+      "--font-color": "white"
+    }
+  }
+}
+```
+
+The resultant injected custom CSS properties will have prefixed the name of the key.
+
+```html
+<div class="block teaser" style="--theme--background-color: #222, --theme--font-color: white">
+ ...
+</div>
+```
+
+There are use cases that you want this not to happen since you want to use exactly the names defined in your custom CSS properties.
+If you want the StyleWrapper not to build the injected name using the key as prefix, you can bail off the feature by appending the suffix `:noprefix`.
+
+```js
+  schema.properties.styles.schema.fieldsets[0].fields = [
+    ...schema.properties.styles.schema.fieldsets[0].fields,
+    'theme:noprefix',
+  ];
+
+  schema.properties.styles.schema.properties['theme:noprefix'] = {
+    widget: 'color_picker',
+    title: "Theme",
+    colors,
+    default: defaultBGColor,
+  };
+```
+
+It will generate this values for the StyleWrapper to use:
+
+```js
+{
+  "styles": {
+    "theme:noprefix": {
+      "--background-color": "#222",
+      "--font-color": "white"
+    }
+  }
+}
+```
+
+Then the resultant injection:
+
+```html
+<div class="block teaser" style="--background-color: #222, --font-color: white">
+ ...
+</div>
+```
+
 ## Align class injection
 
 There is an automatic class name injection happening at the same time the style wrapper class names injection.

--- a/docs/source/blocks/block-style-wrapper.md
+++ b/docs/source/blocks/block-style-wrapper.md
@@ -238,6 +238,15 @@ The styles in the block edit component are injected automatically into the block
 
 ## Nested custom CSS properties
 
+This section describes how to work with nested custom CSS properties.
+You can inject custom CSS properties in a nested manner.
+You can also avoid some nesting, where useful.
+
+
+(inject-nested-custom-css-properties)=
+
+### Inject nested custom CSS properties
+
 Given this block enhancer:
 
 ```js
@@ -248,13 +257,13 @@ Given this block enhancer:
 
   schema.properties.styles.schema.properties['theme'] = {
     widget: 'color_picker',
-    title: "Theme",
+    title: 'Theme',
     colors,
     default: defaultBGColor,
   };
 ```
 
-It will generate this values for the StyleWrapper to use:
+It will generate these values for the `StyleWrapper` to use:
 
 ```js
 {
@@ -267,7 +276,7 @@ It will generate this values for the StyleWrapper to use:
 }
 ```
 
-The resultant injected custom CSS properties will have prefixed the name of the key.
+The resultant injected custom CSS properties will be prefixed with two dashes plus the name of the key, `--theme` in this example.
 
 ```html
 <div class="block teaser" style="--theme--background-color: #222, --theme--font-color: white">
@@ -275,8 +284,11 @@ The resultant injected custom CSS properties will have prefixed the name of the 
 </div>
 ```
 
-There are use cases that you want this not to happen since you want to use exactly the names defined in your custom CSS properties.
-If you want the StyleWrapper not to build the injected name using the key as prefix, you can bail off the feature by appending the suffix `:noprefix`.
+
+### Avoid injecting nested custom CSS properties
+
+Sometimes you might not want to build the custom CSS property name with a prefix in a nested structure, as described in {ref}`inject-nested-custom-css-properties`, because you want to use the exact names defined in your custom CSS properties.
+To avoid building a prefix, you can append the suffix `:noprefix` in your block enhancer.
 
 ```js
   schema.properties.styles.schema.fieldsets[0].fields = [
@@ -292,7 +304,7 @@ If you want the StyleWrapper not to build the injected name using the key as pre
   };
 ```
 
-It will generate this values for the StyleWrapper to use:
+It will generate these values for the `StyleWrapper` to use:
 
 ```js
 {
@@ -305,7 +317,7 @@ It will generate this values for the StyleWrapper to use:
 }
 ```
 
-Then the resultant injection:
+This will yield the resultant markup without a prefix.
 
 ```html
 <div class="block teaser" style="--background-color: #222, --font-color: white">

--- a/packages/volto/news/5586.feature
+++ b/packages/volto/news/5586.feature
@@ -1,0 +1,1 @@
+Allow to opt-out the nested name build in the custom CSS properties style name generator if an object is found in the style wrapper object @sneridagh

--- a/packages/volto/news/5586.feature
+++ b/packages/volto/news/5586.feature
@@ -1,1 +1,1 @@
-Allow to opt-out the nested name build in the custom CSS properties style name generator if an object is found in the style wrapper object @sneridagh
+Allow to opt out of the nested prefixed name build in the custom CSS properties style name generator if an object is found in the style wrapper object. @sneridagh

--- a/packages/volto/src/helpers/Blocks/Blocks.js
+++ b/packages/volto/src/helpers/Blocks/Blocks.js
@@ -642,13 +642,21 @@ export const buildStyleObjectFromData = (obj = {}, prefix = '') => {
           // ...(() => {
           //   if (isObject(v)) {
           //     return Object.entries(
-          //       buildStyleObjectFromData(v, `${prefix}${k}--`),
+          //       buildStyleObjectFromData(
+          //         v,
+          //         `${k.endsWith(':noprefix') ? '' : `${prefix}${k}--`}`,
+          //       ),
           //     );
           //   }
           //   return [styleDataToStyleObject(k, v, prefix)];
           // })(),
           ...(isObject(v)
-            ? Object.entries(buildStyleObjectFromData(v, `${prefix}${k}--`))
+            ? Object.entries(
+                buildStyleObjectFromData(
+                  v,
+                  `${k.endsWith(':noprefix') ? '' : `${prefix}${k}--`}`, // We don't add a prefix if the key ends with the marker suffix
+                ),
+              )
             : [styleDataToStyleObject(k, v, prefix)]),
         ],
         [],

--- a/packages/volto/src/helpers/Blocks/Blocks.test.js
+++ b/packages/volto/src/helpers/Blocks/Blocks.test.js
@@ -1123,6 +1123,26 @@ describe('Blocks', () => {
         '--nested--level2--foo': '#fff',
       });
     });
+
+    it('Supports multiple nested levels and optional inclusion of the name of the level', () => {
+      const styles = {
+        '--color': 'red',
+        backgroundColor: '#AABBCC',
+        'nested:noprefix': {
+          l1: 'white',
+          '--foo': 'white',
+          level2: {
+            '--foo': '#fff',
+            bar: '#000',
+          },
+        },
+      };
+      expect(buildStyleObjectFromData(styles)).toEqual({
+        '--color': 'red',
+        '--foo': 'white',
+        '--level2--foo': '#fff',
+      });
+    });
   });
 
   describe('getPreviousNextBlock', () => {


### PR DESCRIPTION
Feedback from testing the new feature. Sometimes, you might not want to build the custom CSS property name from the a nested structure (eg. the ColorPickerWidget).

Now you can use the `:noprefix` suffix in the nested property.

Given this block enhancer:

```js
  schema.properties.styles.schema.fieldsets[0].fields = [
    ...schema.properties.styles.schema.fieldsets[0].fields,
    'theme',
  ];

  schema.properties.styles.schema.properties['theme'] = {
    widget: 'color_picker',
    title: "Theme",
    colors,
    default: defaultBGColor,
  };
```

It will generate this values for the StyleWrapper to use:

```js
{
  "styles": {
    "theme": {
      "--background-color": "#222",
      "--font-color": "white"
    }
  }
}
```

The resultant injected custom CSS properties will have prefixed the name of the key.

```html
<div class="block teaser" style="--theme--background-color: #222, --theme--font-color: white">
 ...
</div>
```

There are use cases that you want this not to happen since you want to use exactly the names defined in your custom CSS properties.
If you want the StyleWrapper not to build the injected name using the key as prefix, you can bail off the feature by appending the suffix `:noprefix`.

```js
  schema.properties.styles.schema.fieldsets[0].fields = [
    ...schema.properties.styles.schema.fieldsets[0].fields,
    'theme:noprefix',
  ];

  schema.properties.styles.schema.properties['theme:noprefix'] = {
    widget: 'color_picker',
    title: "Theme",
    colors,
    default: defaultBGColor,
  };
```

It will generate this values for the StyleWrapper to use:

```js
{
  "styles": {
    "theme:noprefix": {
      "--background-color": "#222",
      "--font-color": "white"
    }
  }
}
```

Then the resultant injection:

```html
<div class="block teaser" style="--background-color: #222, --font-color: white">
 ...
</div>
```