### PR TITLE
edit recurrence button is aligned properly

### DIFF
--- a/packages/volto/news/5359.bugfix
+++ b/packages/volto/news/5359.bugfix
@@ -1,1 +1,1 @@
-"Edit Recurrence" button in Recurrence widget is aligned properly. @Ravi-kumar9347
+In the recurrence widget, set the vertical alignment of the `edit` button to `middle`. @Ravi-kumar9347

--- a/packages/volto/news/5359.bugfix
+++ b/packages/volto/news/5359.bugfix
@@ -1,0 +1,1 @@
+"Edit Recurrence" button in Recurrence widget is aligned properly. @Ravi-kumar9347

--- a/packages/volto/src/components/manage/Widgets/RecurrenceWidget/RecurrenceWidget.jsx
+++ b/packages/volto/src/components/manage/Widgets/RecurrenceWidget/RecurrenceWidget.jsx
@@ -746,7 +746,7 @@ class RecurrenceWidget extends Component {
         id={`${fieldSet || 'field'}-${id}`}
       >
         <Grid>
-          <Grid.Row stretched>
+          <Grid.Row stretched verticalAlign="middle">
             <Grid.Column width="4">
               <div className="wrapper">
                 <label htmlFor={`field-${id}`}>{title}</label>

--- a/packages/volto/src/components/manage/Widgets/RecurrenceWidget/RecurrenceWidget.test.jsx
+++ b/packages/volto/src/components/manage/Widgets/RecurrenceWidget/RecurrenceWidget.test.jsx
@@ -14,7 +14,7 @@ beforeAll(
 
 const mockStore = configureStore();
 
-test('renders a recurrence widget component', async () => {
+test('renders a recurrence widget component with aligned columns', async () => {
   const store = mockStore({
     intl: {
       locale: 'en',

--- a/packages/volto/src/components/manage/Widgets/RecurrenceWidget/__snapshots__/RecurrenceWidget.test.jsx.snap
+++ b/packages/volto/src/components/manage/Widgets/RecurrenceWidget/__snapshots__/RecurrenceWidget.test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders a recurrence widget component 1`] = `
+exports[`renders a recurrence widget component with aligned columns 1`] = `
 <div
   className="inline field recurrence-widget"
   id="field-my-field"
@@ -9,7 +9,7 @@ exports[`renders a recurrence widget component 1`] = `
     className="ui grid"
   >
     <div
-      className="stretched row"
+      className="stretched middle aligned row"
     >
       <div
         className="four wide column"


### PR DESCRIPTION
Fixes #5359, In the recurrence widget, set the vertical alignment of the `edit` button to `middle`.