### PR TITLE
App extras exceptions

### DIFF
--- a/packages/volto/src/components/theme/AppExtras/AppExtras.jsx
+++ b/packages/volto/src/components/theme/AppExtras/AppExtras.jsx
@@ -8,6 +8,8 @@ const AppExtras = (props) => {
   const { pathname } = props;
   const active = appExtras
     .map((reg) => {
+      const excluded = matchPath(pathname, reg.exclude || "");
+      if (excluded) return null;
       const match = matchPath(pathname, reg.match);
       return match ? { reg, match } : null;
     })


### PR DESCRIPTION
In situations where we do not want the appExtras rule to apply universally to all routes matched by a certain rule, the addition of an exclude property could be beneficial. This property would provide a way to specify exceptions to the rule. For instance:
`{
   match: '*',
   exclude: '/**/diff',
   component: RemoveSchema,
}`
To address this scenario, where the goal is to apply a rule to all pages except for the "history diff" page, incorporating an exclude property into the rule configuration is an effective solution.