### PR TITLE
Update Semantic UI React to version 2.1.5

### DIFF
--- a/packages/volto/news/5632.internal
+++ b/packages/volto/news/5632.internal
@@ -1,0 +1,1 @@
+Upgade `semantic-ui-react` to latest version (2.1.5) @sneridagh

--- a/packages/volto/package.json
+++ b/packages/volto/package.json
@@ -319,7 +319,7 @@
     "redux-thunk": "2.3.0",
     "rrule": "2.7.1",
     "semantic-ui-less": "2.4.1",
-    "semantic-ui-react": "2.0.3",
+    "semantic-ui-react": "2.1.5",
     "serialize-javascript": "3.1.0",
     "slate": "0.100.0",
     "slate-hyperscript": "0.100.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1626,8 +1626,8 @@ importers:
         specifier: 2.4.1
         version: 2.4.1
       semantic-ui-react:
-        specifier: 2.0.3
-        version: 2.0.3(react-dom@17.0.2)(react@17.0.2)
+        specifier: 2.1.5
+        version: 2.1.5(react-dom@17.0.2)(react@17.0.2)
       serialize-javascript:
         specifier: 3.1.0
         version: 3.1.0
@@ -4445,11 +4445,34 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
+  /@fluentui/react-component-event-listener@0.63.1(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-gSMdOh6tI3IJKZFqxfQwbTpskpME0CvxdxGM2tdglmf6ZPVDi0L4+KKIm+2dN8nzb8Ya1A8ZT+Ddq0KmZtwVQg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18
+      react-dom: ^16.8.0 || ^17 || ^18
+    dependencies:
+      '@babel/runtime': 7.20.6
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
   /@fluentui/react-component-ref@0.51.7(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-CX27jVJYaFoBCWpuWAizQZ2se137ku1dmDyn8sw+ySNJa+kkQf7LnMydiPW5K7cRdUSqUJW3eS4EjKRvVAx8xA==}
     peerDependencies:
       react: ^16.8.0 || ^17
       react-dom: ^16.8.0 || ^17
+    dependencies:
+      '@babel/runtime': 7.20.6
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+      react-is: 16.13.1
+    dev: false
+
+  /@fluentui/react-component-ref@0.63.1(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-8MkXX4+R3i80msdbD4rFpEB4WWq2UDvGwG386g3ckIWbekdvN9z2kWAd9OXhRGqB7QeOsoAGWocp6gAMCivRlw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18
+      react-dom: ^16.8.0 || ^17 || ^18
     dependencies:
       '@babel/runtime': 7.20.6
       react: 17.0.2
@@ -32204,6 +32227,29 @@ packages:
       '@babel/runtime': 7.20.6
       '@fluentui/react-component-event-listener': 0.51.7(react-dom@17.0.2)(react@17.0.2)
       '@fluentui/react-component-ref': 0.51.7(react-dom@17.0.2)(react@17.0.2)
+      '@popperjs/core': 2.11.8
+      '@semantic-ui-react/event-stack': 3.1.3(react-dom@17.0.2)(react@17.0.2)
+      clsx: 1.2.1
+      keyboard-key: 1.1.0
+      lodash: 4.17.21
+      lodash-es: 4.17.21
+      prop-types: 15.7.2
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+      react-is: 16.13.1
+      react-popper: 2.3.0(@popperjs/core@2.11.8)(react-dom@17.0.2)(react@17.0.2)
+      shallowequal: 1.1.0
+    dev: false
+
+  /semantic-ui-react@2.1.5(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-nIqmmUNpFHfovEb+RI2w3E2/maZQutd8UIWyRjf1SLse+XF51hI559xbz/sLN3O6RpLjr/echLOOXwKCirPy3Q==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.6
+      '@fluentui/react-component-event-listener': 0.63.1(react-dom@17.0.2)(react@17.0.2)
+      '@fluentui/react-component-ref': 0.63.1(react-dom@17.0.2)(react@17.0.2)
       '@popperjs/core': 2.11.8
       '@semantic-ui-react/event-stack': 3.1.3(react-dom@17.0.2)(react@17.0.2)
       clsx: 1.2.1


### PR DESCRIPTION
@ichim-david @pnicolli @tiberiuichim @davisagli I checked the changelog and seems safe. Even for 17, I'd say. What do you think?

The version we are using is broken when used with TS.