### PR TITLE
Merge the StyleWrapper styles with the draggable props from b-D&D

### DIFF
--- a/packages/volto/news/5652.bugfix
+++ b/packages/volto/news/5652.bugfix
@@ -1,0 +1,2 @@
+Merge the StyleWrapper styles with the draggable props from b-D&D. @sneridagh
+This fixes the D&D bug introduced in https://github.com/plone/volto/pull/5581

--- a/packages/volto/src/components/manage/Blocks/Block/EditBlockWrapper.jsx
+++ b/packages/volto/src/components/manage/Blocks/Block/EditBlockWrapper.jsx
@@ -61,17 +61,22 @@ const EditBlockWrapper = (props) => {
   const classNames = buildStyleClassNamesFromData(data.styles);
   const style = buildStyleObjectFromData(data.styles);
 
+  // We need to merge the StyleWrapper styles with the draggable props from b-D&D
+  const styleMergedWithDragProps = {
+    ...draginfo.draggableProps,
+    style: { ...style, ...draginfo.draggableProps.style },
+  };
+
   return (
     <div
       ref={draginfo.innerRef}
-      {...draginfo.draggableProps}
+      {...styleMergedWithDragProps}
       // Right now, we can have the alignment information in the styles property or in the
       // block data root, we inject the classname here for having control over the whole
       // Block Edit wrapper
       className={cx(`block-editor-${data['@type']}`, classNames, {
         [data.align]: data.align,
       })}
-      style={style}
     >
       <div style={{ position: 'relative' }}>
         <div


### PR DESCRIPTION
 This fixes the D&D bug introduced in https://github.com/plone/volto/pull/5581