### PR TITLE
Pin Vale to 2.30.0 to allow build of documentation until we can upgrade to v3.x

### DIFF
--- a/packages/volto/news/5656.documentation
+++ b/packages/volto/news/5656.documentation
@@ -1,0 +1,1 @@
+Pin Vale to 2.30.0 to allow build of documentation until we can upgrade to v3.x. @stevepiercy

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -17,4 +17,4 @@ sphinxcontrib-htmlhelp==2.0.1  # https://github.com/plone/documentation/issues/1
 sphinxcontrib-qthelp==1.0.3  # https://github.com/plone/documentation/issues/1604
 sphinxcontrib-serializinghtml==1.1.5  # https://github.com/plone/documentation/issues/1604
 sphinxcontrib-video
-vale
+vale==2.30.0


### PR DESCRIPTION
See https://github.com/plone/documentation/issues/1602