### PR TITLE
Fixed typo and version mismatch in upgrade guide Volto 17

### DIFF
--- a/docs/source/contributing/typescript.md
+++ b/docs/source/contributing/typescript.md
@@ -62,10 +62,10 @@ Edit your {file}`package.json`:
 
 ```diff
 "devDependencies": {
-+     "@plone/scripts": ^3.0.0,
++     "@plone/scripts": "^3.0.0",
 +     "@typescript-eslint/eslint-plugin": "6.7.0",
 +     "@typescript-eslint/parser": "6.7.0",
-+     "stylelint-prettier": "1.1.2",
++     "stylelint-prettier": "4.0.2",
 +     "ts-jest": "^26.4.2",
 +     "ts-loader": "9.4.4",
 +     "typescript": "5.2.2"

--- a/docs/source/upgrade-guide/index.md
+++ b/docs/source/upgrade-guide/index.md
@@ -148,10 +148,10 @@ Edit your {file}`package.json`:
 
 ```diff
 "devDependencies": {
-+     "@plone/scripts": ^3.0.0,
++     "@plone/scripts": "^3.0.0",
 +     "@typescript-eslint/eslint-plugin": "6.7.0",
 +     "@typescript-eslint/parser": "6.7.0",
-+     "stylelint-prettier": "1.1.2",
++     "stylelint-prettier": "4.0.2",
 +     "ts-jest": "^26.4.2",
 +     "ts-loader": "9.4.4",
 +     "typescript": "5.2.2"

--- a/packages/volto/news/5702.documentation
+++ b/packages/volto/news/5702.documentation
@@ -1,0 +1,1 @@
+Fixed typo and version mismatch in upgrade guide Volto 17. @ksuess


### PR DESCRIPTION
Fix #5702 