### PR TITLE
5439 clarify defaultAddonName option and mention to the generator readme the creation of the theme add-on

### DIFF
--- a/packages/generator-volto/README.md
+++ b/packages/generator-volto/README.md
@@ -1,6 +1,6 @@
 # Yeoman Volto App Generator
 
-@plone/generator-volto is a Yeoman generator that helps you to set up Volto via the command line.
+@plone/generator-volto is a Yeoman generator that helps you to set up a Volto project via the command line.
 
 ## Installation
 
@@ -23,9 +23,10 @@ See [`volto-generator` compatibility with Volto](https://6.docs.plone.org/volto/
 npm init yo @plone/volto
 ```
 
-This is the shortcut for using `npm init` command. It uses Yeoman (`yo`) and `@plone/generator-volto` and `npm` executes the commands without having the need for the packages to be installed globally.
+This is the shortcut for using `npm init` command.
+It uses Yeoman (`yo`) and `@plone/generator-volto`, and `npm` executes the commands without having the need for the packages to be installed globally.
 
-Answer the prompt questions to complete the generation process.
+Answer the prompts to complete the generation process.
 
 ### Creating a new Volto project
 
@@ -33,8 +34,8 @@ Answer the prompt questions to complete the generation process.
 yo @plone/volto
 ```
 
-This will bootstrap a new Volto project inside the current folder. It will ask
-a few questions: project name, project description and a list of add-ons. 
+This will bootstrap a new Volto project inside the current folder.
+It will ask a few questions for the project name, project description, and a list of add-ons. 
 
 Run:
 
@@ -66,13 +67,12 @@ Arguments:
 to see a full list of options and arguments.
 
 > [!NOTE]  
-> Besides the Volto project the generator also generates a theme add-on inside `src/addons`
-> with the default name of `volto-[<project-name>]`.
+> In addition to the Volto project, the generator creates a theme add-on inside `src/addons` with the default name of `volto-[<project-name>]`.
 > You can provide a specific name for the theme add-on that is created on project generation like:
-> ```bash
+> ```shell
 > yo @plone/volto --defaultAddonName="volto-project-theme"
 > ```
-> If you've used the example project name `myvoltoproject` inside `src/addons` you will find the Volto theme add-on named `volto-project-theme` instead of the default generator name `volto-myvoltoproject`.
+> If you've used the example project name `myvoltoproject` inside `src/addons`, you will find the Volto theme add-on named `volto-project-theme` instead of the default generator name `volto-myvoltoproject`.
 
 You can provide a specific Volto version like:
 

--- a/packages/generator-volto/README.md
+++ b/packages/generator-volto/README.md
@@ -34,7 +34,9 @@ yo @plone/volto
 ```
 
 This will bootstrap a new Volto project inside the current folder. It will ask
-a few questions: project name, project description and a list of add-ons. Run:
+a few questions: project name, project description and a list of add-ons. 
+
+Run:
 
 ```console
 $ yo @plone/volto --help
@@ -62,6 +64,15 @@ Arguments:
 ```
 
 to see a full list of options and arguments.
+
+> [!NOTE]  
+> Besides the Volto project the generator also generates a theme add-on inside `src/addons`
+> with the default name of `volto-[<project-name>]`.
+> You can provide a specific name for the theme add-on that is created on project generation like:
+> ```bash
+> yo @plone/volto --defaultAddonName="volto-project-theme"
+> ```
+> If you've used the example project name `myvoltoproject` inside `src/addons` you will find `volto-project-theme` instead of `volto-myvoltoproject`
 
 You can provide a specific Volto version like:
 

--- a/packages/generator-volto/README.md
+++ b/packages/generator-volto/README.md
@@ -54,7 +54,7 @@ Options:
         --addon             # Add-on loader string. Example: some-volto-addon:loadExtra,loadOtherExtra
         --workspace         # Yarn workspace. Example: src/addons/some-volto-addon
         --description       # Project description
-        --defaultAddonName  # The default add-on's name to be added to the generated project.
+        --defaultAddonName  # The default add-on's name always added to the generated project.       Default: volto-[<projectName>]
 
 Arguments:
   projectName    Type: String  Required: false

--- a/packages/generator-volto/README.md
+++ b/packages/generator-volto/README.md
@@ -72,7 +72,7 @@ to see a full list of options and arguments.
 > ```bash
 > yo @plone/volto --defaultAddonName="volto-project-theme"
 > ```
-> If you've used the example project name `myvoltoproject` inside `src/addons` you will find `volto-project-theme` instead of `volto-myvoltoproject`
+> If you've used the example project name `myvoltoproject` inside `src/addons` you will find the Volto theme add-on named `volto-project-theme` instead of the default generator name `volto-myvoltoproject`.
 
 You can provide a specific Volto version like:
 

--- a/packages/generator-volto/README.md
+++ b/packages/generator-volto/README.md
@@ -56,7 +56,7 @@ Options:
         --addon             # Add-on loader string. Example: some-volto-addon:loadExtra,loadOtherExtra
         --workspace         # Yarn workspace. Example: src/addons/some-volto-addon
         --description       # Project description
-        --defaultAddonName  # The default add-on's name always added to the generated project.       Default: volto-[<projectName>]
+        --defaultAddonName  # The default add-on's name always added to the generated project       Default: volto-[<projectName>]
 
 Arguments:
   projectName    Type: String  Required: false

--- a/packages/generator-volto/README.md
+++ b/packages/generator-volto/README.md
@@ -1,6 +1,6 @@
 # Yeoman Volto App Generator
 
-@plone/generator-volto is a Yeoman generator that helps you to set up Volto via command line.
+@plone/generator-volto is a Yeoman generator that helps you to set up Volto via the command line.
 
 ## Installation
 
@@ -23,7 +23,7 @@ See [`volto-generator` compatibility with Volto](https://6.docs.plone.org/volto/
 npm init yo @plone/volto
 ```
 
-This is the shortcut for using `npm init` command. It uses Yeoman (`yo`) and `@plone/generator-volto` and execute them without having to be installed globally.
+This is the shortcut for using `npm init` command. It uses Yeoman (`yo`) and `@plone/generator-volto` and `npm` executes the commands without having the need for the packages to be installed globally.
 
 Answer the prompt questions to complete the generation process.
 
@@ -34,7 +34,7 @@ yo @plone/volto
 ```
 
 This will bootstrap a new Volto project inside the current folder. It will ask
-a few questions: project name, project description and a list of addons. Run:
+a few questions: project name, project description and a list of add-ons. Run:
 
 ```console
 $ yo @plone/volto --help
@@ -50,7 +50,7 @@ Options:
         --volto             # Desired Volto version, if not provided, the most recent will be used
         --canary            # Desired Volto version should be a canary (alpha)                      Default: false
         --interactive       # Enable/disable interactive prompt                                     Default: true
-        --skip-addons       # Don't ask for addons as part of the scaffolding
+        --skip-addons       # Don't ask for add-ons as part of the scaffolding
         --addon             # Add-on loader string. Example: some-volto-addon:loadExtra,loadOtherExtra
         --workspace         # Yarn workspace. Example: src/addons/some-volto-addon
         --description       # Project description
@@ -63,7 +63,7 @@ Arguments:
 
 to see a full list of options and arguments.
 
-You can provide an specific Volto version like:
+You can provide a specific Volto version like:
 
 ```bash
 yo @plone/volto --volto=12.0.0-alpha.0
@@ -87,13 +87,13 @@ You can use it in full non-interactive mode by passing something like:
 yo @plone/volto myvoltoproject --no-interactive
 ```
 
-Or by skipping specific configuration:
+Or by skipping specific configuration options:
 
 ```bash
 yo @plone/volto myvoltoproject --description "My Volto project" --skip-addons --skip-install --skip-workspaces
 ```
 
-You can also specify addons to load, like:
+You can also specify add-ons to load, like:
 
 ```bash
 yo @plone/volto myvoltoproject --description "My Volto project" --addon "volto-formbuilder:x,y" --addon "volto-slate:z,t"
@@ -123,7 +123,7 @@ Options:
         --outputpath     # Output path
 
 Arguments:
-  addonName  # Addon name, e.g.: @plone-collective/volto-custom-block  Type: String  Required: false
+  addonName  # Add-on name, e.g.: @plone-collective/volto-custom-block  Type: String  Required: false
 ```
 
 ### Enable an existing add-on as a theme add-on
@@ -149,7 +149,7 @@ Options:
         --outputpath     # Output path
 
 Arguments:
-  addonName  # Addon name, e.g.: @plone-collective/volto-custom-block  Type: String  Required: false
+  addonName  # Add-on name, e.g.: @plone-collective/volto-custom-block  Type: String  Required: false
 ```
 
 You can also run the command inside the add-on folder, without passing any option.

--- a/packages/generator-volto/generators/app/index.js
+++ b/packages/generator-volto/generators/app/index.js
@@ -164,7 +164,7 @@ Run "npm install -g @plone/generator-volto" to update.`,
           {
             type: 'input',
             name: 'projectName',
-            message: 'Project name (e.g. my-volto-project)',
+            message: 'Project name (e.g. myvoltoproject)',
             default: path.basename(process.cwd()),
           },
         ]);

--- a/packages/generator-volto/news/5439.bugfix
+++ b/packages/generator-volto/news/5439.bugfix
@@ -1,2 +1,3 @@
 Clarify the default value of the --defaultAddonName @ichim-david
 Clarify that the default add-on is always added when project is generated @ichim-david
+Added note about how --defaultAddonName affects the always added theme add-on on project generation @ichim-david

--- a/packages/generator-volto/news/5439.bugfix
+++ b/packages/generator-volto/news/5439.bugfix
@@ -1,0 +1,2 @@
+Clarify the default value of the --defaultAddonName @ichim-david
+Clarify that the default add-on is always added when project is generated @ichim-david

--- a/packages/generator-volto/news/5439.bugfix
+++ b/packages/generator-volto/news/5439.bugfix
@@ -1,3 +1,3 @@
-Clarify the default value of the --defaultAddonName @ichim-david
-Clarify that the default add-on is always added when project is generated @ichim-david
-Added note about how --defaultAddonName affects the always added theme add-on on project generation @ichim-david
+Clarify the default value of `--defaultAddonName`. @ichim-david
+Clarify that the default add-on is always added when a project is generated. @ichim-david
+Added note about how `--defaultAddonName` affects the always added theme add-on on project generation. @ichim-david


### PR DESCRIPTION
Honestly, I hope this triggers a bug acknowledgment that the generator shouldn't automatically create a theme add-on whenever the generator is used to generate the volto project, however in case this is still seen as a feature and not a bug then we should document this behavior and bring it into the awareness of anyone who uses the volto generator.

Added also some extra content to the readme and modified the example project name given from my-volto-project -> myvoltoproject since this is what we use in the documentation.
