### PR TITLE
fixed a11y Logo Issue and added Translations

### DIFF
--- a/packages/volto/locales/ca/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ca/LC_MESSAGES/volto.po
@@ -462,6 +462,11 @@ msgstr ""
 msgid "Back"
 msgstr "Enrere"
 
+#. Default: "Back to homepage"
+#: components/theme/Logo/Logo
+msgid "Back to homepage"
+msgstr "Torna a la pàgina d'inici"
+
 #. Default: "Base"
 #: components/manage/Diff/Diff
 msgid "Base"

--- a/packages/volto/locales/de/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/de/LC_MESSAGES/volto.po
@@ -461,6 +461,11 @@ msgstr "Verfügbare Inhaltsregeln:"
 msgid "Back"
 msgstr "Zurück"
 
+#. Default: "Back to homepage"
+#: components/theme/Logo/Logo
+msgid "Back to homepage"
+msgstr "Zurück zur Startseite"
+
 #. Default: "Base"
 #: components/manage/Diff/Diff
 msgid "Base"

--- a/packages/volto/locales/en/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/en/LC_MESSAGES/volto.po
@@ -456,6 +456,11 @@ msgstr ""
 msgid "Back"
 msgstr ""
 
+#. Default: "Back to homepage"
+#: components/theme/Logo/Logo
+msgid "Back to homepage"
+msgstr ""
+
 #. Default: "Base"
 #: components/manage/Diff/Diff
 msgid "Base"

--- a/packages/volto/locales/es/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/es/LC_MESSAGES/volto.po
@@ -463,6 +463,11 @@ msgstr "Reglas de contenido disponibles:"
 msgid "Back"
 msgstr "Volver"
 
+#. Default: "Back to homepage"
+#: components/theme/Logo/Logo
+msgid "Back to homepage"
+msgstr "Volver a la página de inicio"
+
 #. Default: "Base"
 #: components/manage/Diff/Diff
 msgid "Base"

--- a/packages/volto/locales/eu/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/eu/LC_MESSAGES/volto.po
@@ -463,6 +463,11 @@ msgstr "Erabilgarri dauden eduki-erregelak:"
 msgid "Back"
 msgstr "Atzera"
 
+#. Default: "Back to homepage"
+#: components/theme/Logo/Logo
+msgid "Back to homepage"
+msgstr "Itzuli hasierako orrialdera"
+
 #. Default: "Base"
 #: components/manage/Diff/Diff
 msgid "Base"

--- a/packages/volto/locales/fi/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/fi/LC_MESSAGES/volto.po
@@ -461,6 +461,11 @@ msgstr "Saatavilla olevat sisältösäännöt:"
 msgid "Back"
 msgstr "Takaisin"
 
+#. Default: "Back to homepage"
+#: components/theme/Logo/Logo
+msgid "Back to homepage"
+msgstr "Takaisin kotisivulle"
+
 #. Default: "Base"
 #: components/manage/Diff/Diff
 msgid "Base"

--- a/packages/volto/locales/fr/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/fr/LC_MESSAGES/volto.po
@@ -463,6 +463,11 @@ msgstr "Règles de contenu disponibles :"
 msgid "Back"
 msgstr "Retour"
 
+#. Default: "Back to homepage"
+#: components/theme/Logo/Logo
+msgid "Back to homepage"
+msgstr "Retour à la page d'accueil"
+
 #. Default: "Base"
 #: components/manage/Diff/Diff
 msgid "Base"

--- a/packages/volto/locales/it/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/it/LC_MESSAGES/volto.po
@@ -456,6 +456,11 @@ msgstr "Regole di contenuto disponibili:"
 msgid "Back"
 msgstr "Indietro"
 
+#. Default: "Back to homepage"
+#: components/theme/Logo/Logo
+msgid "Back to homepage"
+msgstr "Torna alla home page"
+
 #. Default: "Base"
 #: components/manage/Diff/Diff
 msgid "Base"

--- a/packages/volto/locales/ja/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ja/LC_MESSAGES/volto.po
@@ -461,6 +461,11 @@ msgstr ""
 msgid "Back"
 msgstr "戻る"
 
+#. Default: "Back to homepage"
+#: components/theme/Logo/Logo
+msgid "Back to homepage"
+msgstr "ホームページに戻ります"
+
 #. Default: "Base"
 #: components/manage/Diff/Diff
 msgid "Base"

--- a/packages/volto/locales/nl/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/nl/LC_MESSAGES/volto.po
@@ -460,6 +460,11 @@ msgstr ""
 msgid "Back"
 msgstr ""
 
+#. Default: "Back to homepage"
+#: components/theme/Logo/Logo
+msgid "Back to homepage"
+msgstr "Terug naar de startpagina"
+
 #. Default: "Base"
 #: components/manage/Diff/Diff
 msgid "Base"

--- a/packages/volto/locales/pt/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/pt/LC_MESSAGES/volto.po
@@ -461,6 +461,11 @@ msgstr ""
 msgid "Back"
 msgstr "Voltar"
 
+#. Default: "Back to homepage"
+#: components/theme/Logo/Logo
+msgid "Back to homepage"
+msgstr "Voltar à página inicial"
+
 #. Default: "Base"
 #: components/manage/Diff/Diff
 msgid "Base"

--- a/packages/volto/locales/pt_BR/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/pt_BR/LC_MESSAGES/volto.po
@@ -462,6 +462,11 @@ msgstr "Regras de conteúdo disponíveis:"
 msgid "Back"
 msgstr "Voltar"
 
+#. Default: "Back to homepage"
+#: components/theme/Logo/Logo
+msgid "Back to homepage"
+msgstr "Voltar à página inicial"
+
 #. Default: "Base"
 #: components/manage/Diff/Diff
 msgid "Base"

--- a/packages/volto/locales/ro/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ro/LC_MESSAGES/volto.po
@@ -456,6 +456,11 @@ msgstr ""
 msgid "Back"
 msgstr "Înapoi"
 
+#. Default: "Back to homepage"
+#: components/theme/Logo/Logo
+msgid "Back to homepage"
+msgstr "Înapoi la pagina de start"
+
 #. Default: "Base"
 #: components/manage/Diff/Diff
 msgid "Base"

--- a/packages/volto/locales/volto.pot
+++ b/packages/volto/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2024-01-12T09:21:12.378Z\n"
+"POT-Creation-Date: 2024-01-31T14:54:12.513Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Content-Type: text/plain; charset=utf-8\n"
@@ -456,6 +456,11 @@ msgstr ""
 #: components/theme/ContactForm/ContactForm
 #: helpers/MessageLabels/MessageLabels
 msgid "Back"
+msgstr ""
+
+#. Default: "Back to homepage"
+#: components/theme/Logo/Logo
+msgid "Back to homepage"
 msgstr ""
 
 #. Default: "Base"

--- a/packages/volto/locales/zh_CN/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/zh_CN/LC_MESSAGES/volto.po
@@ -462,6 +462,11 @@ msgstr "可用的内容规则"
 msgid "Back"
 msgstr "返回"
 
+#. Default: "Back to homepage"
+#: components/theme/Logo/Logo
+msgid "Back to homepage"
+msgstr "返回首页"
+
 #. Default: "Base"
 #: components/manage/Diff/Diff
 msgid "Base"

--- a/packages/volto/news/5722.bugfix
+++ b/packages/volto/news/5722.bugfix
@@ -1,0 +1,1 @@
+Fixed the Alt-Title of the Logo to say "Back to Homepage" in various Languages for a11y and Screenreader conformity @Molochem

--- a/packages/volto/src/components/theme/Logo/Logo.jsx
+++ b/packages/volto/src/components/theme/Logo/Logo.jsx
@@ -2,6 +2,7 @@
  * Logo component.
  * @module components/theme/Logo/Logo
  */
+import { defineMessages, useIntl } from 'react-intl';
 import { useEffect } from 'react';
 import { Image } from 'semantic-ui-react';
 import { ConditionalLink } from '@plone/volto/components';
@@ -26,6 +27,14 @@ const Logo = () => {
   const site = useSelector((state) => state.site.data);
   const navroot = useSelector((state) => state.navroot.data);
   const dispatch = useDispatch();
+  const intl = useIntl();
+
+  const messages = defineMessages({
+    homepage: {
+      id: 'Back to homepage',
+      defaultMessage: 'Back to homepage',
+    },
+  });
 
   useEffect(() => {
     if (pathname && !hasApiExpander('navroot', getBaseUrl(pathname))) {
@@ -50,8 +59,8 @@ const Logo = () => {
             ? flattenToAppURL(site['plone.site_logo'])
             : LogoImage
         }
-        alt={navroot?.navroot?.title}
-        title={navroot?.navroot?.title}
+        alt={intl.formatMessage(messages.homepage)}
+        title={intl.formatMessage(messages.homepage)}
       />
     </ConditionalLink>
   );

--- a/packages/volto/src/components/theme/Logo/__snapshots__/Logo.Multilingual.test.jsx.snap
+++ b/packages/volto/src/components/theme/Logo/__snapshots__/Logo.Multilingual.test.jsx.snap
@@ -2,10 +2,10 @@
 
 exports[`Multilingual Logo renders a logo component in a multilingual site language root 1`] = `
 <img
-  alt="English"
+  alt="Back to homepage"
   className="ui image"
   src="Logo.svg"
-  title="English"
+  title="Back to homepage"
 />
 `;
 
@@ -18,20 +18,20 @@ exports[`Multilingual Logo renders a logo component in a multilingual site root 
   title="Plone Site"
 >
   <img
-    alt="Plone Site"
+    alt="Back to homepage"
     className="ui image"
     src="Logo.svg"
-    title="Plone Site"
+    title="Back to homepage"
   />
 </a>
 `;
 
 exports[`Multilingual Logo renders a logo component with a custom logo in a non-root url 1`] = `
 <img
-  alt="English"
+  alt="Back to homepage"
   className="ui image"
   src="/@@site-logo/logo.cab945d8.svg"
-  title="English"
+  title="Back to homepage"
 />
 `;
 
@@ -44,10 +44,10 @@ exports[`Multilingual Logo renders a logo component with a custom logo in a non-
   title="English"
 >
   <img
-    alt="English"
+    alt="Back to homepage"
     className="ui image"
     src="/@@site-logo/logo.cab945d8.svg"
-    title="English"
+    title="Back to homepage"
   />
 </a>
 `;

--- a/packages/volto/src/components/theme/Logo/__snapshots__/Logo.test.jsx.snap
+++ b/packages/volto/src/components/theme/Logo/__snapshots__/Logo.test.jsx.snap
@@ -2,10 +2,10 @@
 
 exports[`Logo renders a logo component with a custom logo 1`] = `
 <img
-  alt="Plone Site"
+  alt="Back to homepage"
   className="ui image"
   src="/@@site-logo/logo.cab945d8.svg"
-  title="Plone Site"
+  title="Back to homepage"
 />
 `;
 
@@ -18,20 +18,20 @@ exports[`Logo renders a logo component with a custom logo in a non-root url 1`] 
   title="Plone Site"
 >
   <img
-    alt="Plone Site"
+    alt="Back to homepage"
     className="ui image"
     src="/@@site-logo/logo.cab945d8.svg"
-    title="Plone Site"
+    title="Back to homepage"
   />
 </a>
 `;
 
 exports[`Logo renders a logo component with default config 1`] = `
 <img
-  alt="Plone Site"
+  alt="Back to homepage"
   className="ui image"
   src="Logo.svg"
-  title="Plone Site"
+  title="Back to homepage"
 />
 `;
 
@@ -44,10 +44,10 @@ exports[`Logo renders a logo component with default config in a non-root url 1`]
   title="Plone Site"
 >
   <img
-    alt="Plone Site"
+    alt="Back to homepage"
     className="ui image"
     src="/@@site-logo/logo.cab945d8.svg"
-    title="Plone Site"
+    title="Back to homepage"
   />
 </a>
 `;


### PR DESCRIPTION
fixes #5720 

Fixed the Alt-Title of the Logo to say "Back to Homepage" in various Languages for a11y and Screenreader conformity