### PR TITLE
Removed word-break:break-word from contents table tbody

### DIFF
--- a/packages/volto/news/5742.bugfix
+++ b/packages/volto/news/5742.bugfix
@@ -1,0 +1,1 @@
+Removed css from `contents.less` that made the Contents table break words in tiny sections due to small table headers such as `ID` or `UID`.  @ichim.david

--- a/packages/volto/theme/themes/pastanaga/extras/contents.less
+++ b/packages/volto/theme/themes/pastanaga/extras/contents.less
@@ -152,13 +152,6 @@
     background-color: rgb(228, 1, 102);
     color: white;
   }
-
-  @media only screen and (min-width: @largeMonitorBreakpoint) {
-    .ui.table.single.line tbody {
-      white-space: normal;
-      word-break: break-word;
-    }
-  }
 }
 
 .contents-pagination {


### PR DESCRIPTION
- Due to having small table headers such as ID or UID which meant that there was no room to show those ids

This commit fixes https://github.com/plone/volto/issues/5742 by removing the change made in this pull request https://github.com/plone/volto/pull/3245/files#diff-741dc58bf11002ee21b76a53bd83a19041a2dc2e06fcd838346af8ed52c040e6R143

