### PR TITLE
Add wait commands to flaky block-listing tests

### DIFF
--- a/packages/volto/cypress/tests/core/blocks/listing/blocks-listing.js
+++ b/packages/volto/cypress/tests/core/blocks/listing/blocks-listing.js
@@ -1100,10 +1100,11 @@ describe('Listing Block Tests', () => {
     cy.url().should('not.include', '=3');
     //test back button
     cy.navigate('/my-page');
-    cy.wait('@content');
+    cy.wait(1000);
     cy.get('.ui.pagination.menu a[value="2"]').first().click({ force: true });
     cy.get('.ui.pagination.menu a[value="3"]').first().click({ force: true });
     cy.go(-1);
+    cy.wait(1000);
     cy.isInHTML({ parent: '.listing-item', content: 'My Folder 3' });
     cy.url().should('not.include', '=3');
     cy.go(-1);

--- a/packages/volto/news/5753.bugfix
+++ b/packages/volto/news/5753.bugfix
@@ -1,0 +1,1 @@
+Add extra wait calls to listing block tests to avoid sporadic failures. @ichim-david


### PR DESCRIPTION
- Using only wait('@content') mean that every x times the assert command failed due to running too quick before proper page load