### PR TITLE
Mention what version the 'links and references' view was added

### DIFF
--- a/docs/source/configuration/settings-reference.md
+++ b/docs/source/configuration/settings-reference.md
@@ -415,6 +415,10 @@ excludeLinksAndReferencesMenuItem
     The content menu links to the {guilabel}`Links and references` view per default.
     Exclude this menu item by setting `excludeLinksAndReferencesMenuItem` to `true`.
 
+    ```{seealso}
+    {doc}`../user-manual/links-to-item`
+    ```
+
 okRoute
     Volto provides an `/ok` URL where it responds with a `text/plain ok` response, with an `HTTP 200` status code, to signal third party health check services that the Volto process is running correctly.
 

--- a/docs/source/user-manual/links-to-item.md
+++ b/docs/source/user-manual/links-to-item.md
@@ -32,6 +32,15 @@ An item references another item by creating a hyperlink to this item, using the 
 In the toolbar on the left side, you can click on the item with the three horizontally aligned dots, called {guilabel}`More menu`.
 Click then on the item labeled {guilabel}`Links and references`.
 
+````{note}
+If you do not see {guilabel}`Links and references`, then you either have a version of Volto that does not support this feature, or this feature has not been enabled on your site.
+In either case, contact your site administrator for assistance.
+
+```{seealso}
+{term}`excludeLinksAndReferencesMenuItem`
+```
+````
+
 You can see now a table displaying all links to and references of the current item.
 
 ```{image} ../_static/user-manual/manage/link-to-items.png

--- a/docs/source/user-manual/links-to-item.md
+++ b/docs/source/user-manual/links-to-item.md
@@ -11,6 +11,14 @@ myst:
 
 # Finding links and references to the current page
 
+```{versionadded} Volto 16.28.0
+This feature was added in Volto 16.28.0, but it was disabled by default.
+```
+
+```{versionchanged} Volto 17.0.0-alpha.19
+This feature is now enabled by default.
+```
+
 Sometimes it can be hard to keep track from where a certain page is referenced.
 This is especially true whenever you want to reconstruct your website with a greater number of objects being moved or deleted.
 For this situation, you can visit the {guilabel}`Links and references` page, which is an overview of all content items that reference a certain content item.
@@ -20,14 +28,6 @@ An item references another item by creating a hyperlink to this item, using the 
 ```
 
 ## {guilabel}`Links and references` view
-
-```{versionadded} Volto 16.28.0
-This feature was added in Volto 16.28.0, but it was disabled by default.
-```
-
-```{versionchanged} Volto 17.0.0-alpha.19
-This feature is now enabled by default.
-```
 
 In the toolbar on the left side, you can click on the item with the three horizontally aligned dots, called {guilabel}`More menu`.
 Click then on the item labeled {guilabel}`Links and references`.

--- a/docs/source/user-manual/links-to-item.md
+++ b/docs/source/user-manual/links-to-item.md
@@ -19,6 +19,9 @@ For this situation, you can visit the {guilabel}`Links and references` page, whi
 An item references another item by creating a hyperlink to this item, using the item in a block, referencing it in the {guilabel}`Related Items` field, or referencing it in a relation field.
 ```
 
+```{versionadded} Volto 17.0.0-alpha.19
+```
+
 ## {guilabel}`Links and references` view
 
 In the toolbar on the left side, you can click on the item with the three horizontally aligned dots, called {guilabel}`More menu`.

--- a/docs/source/user-manual/links-to-item.md
+++ b/docs/source/user-manual/links-to-item.md
@@ -1,10 +1,10 @@
 ---
 myst:
   html_meta:
-    'description': 'User manual on how to find all links and relations to the current item.'
-    'property=og:description': 'User manual on how to find all links and relations to the current item.'
-    'property=og:title': 'Finding links and relations to the current item.'
-    'keywords': 'Volto, Plone, frontend, React, User manual, links, relations, references, related content'
+    "description": "User manual on how to find all links and relations to the current item."
+    "property=og:description": "User manual on how to find all links and relations to the current item."
+    "property=og:title": "Finding links and relations to the current item."
+    "keywords": "Volto, Plone, frontend, React, User manual, links, relations, references, related content"
 ---
 
 (links-to-item-label)=

--- a/docs/source/user-manual/links-to-item.md
+++ b/docs/source/user-manual/links-to-item.md
@@ -1,10 +1,10 @@
 ---
 myst:
   html_meta:
-    "description": "User manual on how to find all links and relations to the current item."
-    "property=og:description": "User manual on how to find all links and relations to the current item."
-    "property=og:title": "Finding links and relations to the current item."
-    "keywords": "Volto, Plone, frontend, React, User manual, links, relations, references, related content"
+    'description': 'User manual on how to find all links and relations to the current item.'
+    'property=og:description': 'User manual on how to find all links and relations to the current item.'
+    'property=og:title': 'Finding links and relations to the current item.'
+    'keywords': 'Volto, Plone, frontend, React, User manual, links, relations, references, related content'
 ---
 
 (links-to-item-label)=
@@ -19,10 +19,15 @@ For this situation, you can visit the {guilabel}`Links and references` page, whi
 An item references another item by creating a hyperlink to this item, using the item in a block, referencing it in the {guilabel}`Related Items` field, or referencing it in a relation field.
 ```
 
-```{versionadded} Volto 17.0.0-alpha.19
+## {guilabel}`Links and references` view
+
+```{versionadded} Volto 16.28.0
+This feature was added in Volto 16.28.0, but it was disabled by default.
 ```
 
-## {guilabel}`Links and references` view
+```{versionchanged} Volto 17.0.0-alpha.19
+This feature is now enabled by default.
+```
 
 In the toolbar on the left side, you can click on the item with the three horizontally aligned dots, called {guilabel}`More menu`.
 Click then on the item labeled {guilabel}`Links and references`.

--- a/packages/volto/news/5756.documentation
+++ b/packages/volto/news/5756.documentation
@@ -1,0 +1,1 @@
+Document when the 'links and references' view was added. @davisagli


### PR DESCRIPTION
~~@stevepiercy It's a bit more complicated than this... the feature was also backported to Volto 16, but there it is disabled by default. Should we mention this here?~~

The setting which controls it is documented here: https://6.docs.plone.org/volto/configuration/settings-reference.html#term-excludeLinksAndReferencesMenuItem ...should it also be mentioned on this page, or not since this is more for an editor audience?