### PR TITLE
Exclude chromewebstore from linkcheck

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -93,7 +93,8 @@ linkcheck_ignore = [
     # Ignore other specific anchors
     r"https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS/Errors#Identifying_the_issue",
     r"https://docs.cypress.io/guides/references/migration-guide#Migrating-to-Cypress-version-10-0",
-    r"https://www.youtube.com/playlist",  # TODO uncomment after installing sphinxcontrib.youtube
+    r"https://chromewebstore.google.com/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi",  # TODO retest with latest Sphinx when upgrading theme. chromewebstore recently changed its URL and has "too many redirects".
+    r"https://chromewebstore.google.com/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd",  # TODO retest with latest Sphinx when upgrading theme. chromewebstore recently changed its URL and has "too many redirects".
 ]
 linkcheck_anchors = True
 linkcheck_timeout = 10

--- a/packages/volto/news/5761.documentation
+++ b/packages/volto/news/5761.documentation
@@ -1,0 +1,1 @@
+Chromewebstore recently changed its URL and has "too many redirects", so it needs to be excluded from linkcheck. @stevepiercy


### PR DESCRIPTION
chromewebstore recently changed its URL and has "too many redirects" during linkcheck, no matter what I tried. This might be fixed with a more recent version of Sphinx, so I put in a TODO to check when that happens.