### PR TITLE
Add include for use in main docs and Develop Volto core

### DIFF
--- a/docs/source/contributing/developing-core.md
+++ b/docs/source/contributing/developing-core.md
@@ -78,6 +78,7 @@ To set up a Volto core development environment, your system must satisfy the fol
 -   {term}`pnpm`
 -   {term}`GNU make`
 -   {term}`Docker`
+-   {term}`Git`
 
 ```{note}
 When developing Volto core, pnpm is required.
@@ -167,6 +168,12 @@ Compare the output to the [latest pnpm release number](https://www.npmjs.com/pac
 ### Docker
 
 ```{include} ./install-docker.md
+```
+
+
+### Git
+
+```{include} ../contributing/install-git.md
 ```
 
 

--- a/docs/source/contributing/install-git.md
+++ b/docs/source/contributing/install-git.md
@@ -1,0 +1,1 @@
+Install [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) for your operating system.

--- a/packages/volto/news/5769.documentation
+++ b/packages/volto/news/5769.documentation
@@ -1,0 +1,1 @@
+Add Git as a pre-requisite. @stevepiercy


### PR DESCRIPTION
@sneridagh do we need to add Yeoman or Yarn as requirements, aligning https://6.docs.plone.org/volto/contributing/developing-core.html with https://6.docs.plone.org/install/create-project.html?

See also https://github.com/plone/documentation/pull/1628