### PR TITLE
Fix array widget sort

### DIFF
--- a/news/5804.bugfix
+++ b/news/5804.bugfix
@@ -1,0 +1,1 @@
+Fixed ArrayWidget sorting items. @giuliaghisini

--- a/src/components/manage/Widgets/ArrayWidget.jsx
+++ b/src/components/manage/Widgets/ArrayWidget.jsx
@@ -299,14 +299,15 @@ class ArrayWidget extends Component {
       !this.props.creatable
         ? SortableContainer(Select)
         : SortableContainer(CreatableSelect);
-
     return (
       <FormFieldWrapper {...this.props}>
         <SortableSelect
           useDragHandle
           // react-sortable-hoc props:
           axis="xy"
-          onSortEnd={this.onSortEnd}
+          onSortEnd={(sortProp) => {
+            this.onSortEnd(selectedOption, sortProp);
+          }}
           menuShouldScrollIntoView={false}
           distance={4}
           // small fix for https://github.com/clauderic/react-sortable-hoc/pull/352:


### PR DESCRIPTION
there was a problems sorting items in ArrayWidget, it doesn't work 
Now it's fixed:

https://github.com/plone/volto/assets/51911425/08534b7b-feed-43ad-a940-7306083984a5

