### PR TITLE
fix: array widget sort

### DIFF
--- a/packages/volto/news/5805.bugfix
+++ b/packages/volto/news/5805.bugfix
@@ -1,0 +1,1 @@
+Fixed ArrayWidget sorting items. @giuliaghisini

--- a/packages/volto/src/components/manage/Widgets/ArrayWidget.jsx
+++ b/packages/volto/src/components/manage/Widgets/ArrayWidget.jsx
@@ -306,7 +306,9 @@ class ArrayWidget extends Component {
           useDragHandle
           // react-sortable-hoc props:
           axis="xy"
-          onSortEnd={this.onSortEnd}
+          onSortEnd={(sortProp) => {
+            this.onSortEnd(selectedOption, sortProp);
+          }}
           menuShouldScrollIntoView={false}
           distance={4}
           // small fix for https://github.com/clauderic/react-sortable-hoc/pull/352:


### PR DESCRIPTION
there was a problems sorting items in ArrayWidget, it doesn't work
Now it's fixed:

https://github.com/plone/volto/assets/51911425/65f1f2c7-8801-439d-a7e1-6faa3451a843

