### PR TITLE
Updated build-deps command to check if registry is newer than dist to force rebuild

### DIFF
--- a/packages/volto/Makefile
+++ b/packages/volto/Makefile
@@ -67,7 +67,10 @@ cypress-install:
 
 .PHONY: build-deps
 build-deps:
-	if [ ! -d $$(pwd)/../registry/dist ]; then (cd ../../ && pnpm build:deps); fi
+	@if [ ! -d $$(pwd)/../registry/dist ] || [ $$(find $$(pwd)/../registry -newer $$(pwd)/../registry/dist -print -quit) ]; then \
+		(cd ../../ && pnpm build:deps); \
+	fi
+
 
 ##### Release (it runs the one inside)
 

--- a/packages/volto/news/5825.bugfix
+++ b/packages/volto/news/5825.bugfix
@@ -1,0 +1,1 @@
+Modified build-deps make command to check if registry files are newer than dist to force rebuild. @ichim-david


### PR DESCRIPTION
After the slots merge when I wanted to bring pull request https://github.com/plone/volto/pull/4252 up to date
Volto crashed with config.getSlots isn't a function.
This change to build-deps checks if there are newer files within the registry folder as opposed to the dist in
which case it should run the registry compile again.
That compile then adds the getSlots config and the instance can properly run again.