### PR TITLE
Fix the introduction of a mutable (referenced) object when assigning …

### DIFF
--- a/packages/volto/news/5850.bugfix
+++ b/packages/volto/news/5850.bugfix
@@ -1,0 +1,1 @@
+Fix the introduction of a mutable (referenced) object when assigning the default inner `blocksConfig` object for the `grid` block, pass by value instead. sneridagh

--- a/packages/volto/src/config/Blocks.jsx
+++ b/packages/volto/src/config/Blocks.jsx
@@ -1,4 +1,5 @@
 import { defineMessages } from 'react-intl';
+import { cloneDeep } from 'lodash';
 
 import ViewTitleBlock from '@plone/volto/components/manage/Blocks/Title/View';
 import ViewDescriptionBlock from '@plone/volto/components/manage/Blocks/Description/View';
@@ -518,7 +519,7 @@ const blocksConfig = {
 // for the grid block, since we need to modify how the inner teaser
 // block behave in it (= no schemaEnhancer fields for teasers inside a grid)
 // Afterwards, it can be further customized in add-ons using the same technique.
-blocksConfig.gridBlock.blocksConfig = { ...blocksConfig };
+blocksConfig.gridBlock.blocksConfig = cloneDeep(blocksConfig);
 blocksConfig.gridBlock.blocksConfig.teaser = {
   ...blocksConfig.teaser,
   schemaEnhancer: gridTeaserDisableStylingSchema,


### PR DESCRIPTION
…the default inner `blocksConfig` object for the `grid` block, pass by value instead.