### PR TITLE
Fix block chooser search is not focusable when clicked on add button

### DIFF
--- a/packages/volto/news/5866.bugfix
+++ b/packages/volto/news/5866.bugfix
@@ -1,0 +1,1 @@
+Fix block chooser search is not focusable when clicked on add button @iRohitSingh

--- a/packages/volto/src/components/manage/BlockChooser/BlockChooserSearch.jsx
+++ b/packages/volto/src/components/manage/BlockChooser/BlockChooserSearch.jsx
@@ -35,6 +35,7 @@ const BlockChooserSearch = ({ onChange, searchValue }) => {
           placeholder={intl.formatMessage(messages.search)}
           title={intl.formatMessage(messages.search)}
           ref={searchInput}
+          autoFocus
         />
         {searchValue && (
           <Button


### PR DESCRIPTION
Fix #5866 


https://github.com/plone/volto/assets/61353484/a27b4519-5cb0-4f3c-aebb-5b1a89699ddb

