### PR TITLE
Added download link to filename in file widget

### DIFF
--- a/packages/volto/news/5880.feature
+++ b/packages/volto/news/5880.feature
@@ -1,0 +1,1 @@
+Added download link to filename in file widget @sabrina-bongiovanni

--- a/packages/volto/src/components/manage/Widgets/FileWidget.jsx
+++ b/packages/volto/src/components/manage/Widgets/FileWidget.jsx
@@ -9,7 +9,7 @@ import { Button, Image, Dimmer } from 'semantic-ui-react';
 import { readAsDataURL } from 'promise-file-reader';
 import { injectIntl } from 'react-intl';
 import deleteSVG from '@plone/volto/icons/delete.svg';
-import { Icon, FormFieldWrapper } from '@plone/volto/components';
+import { Icon, FormFieldWrapper, UniversalLink } from '@plone/volto/components';
 import loadable from '@loadable/component';
 import { flattenToAppURL, validateFileUploadSize } from '@plone/volto/helpers';
 import { defineMessages, useIntl } from 'react-intl';
@@ -170,7 +170,11 @@ const FileWidget = (props) => {
         )}
       </Dropzone>
       <div className="field-file-name">
-        {value && value.filename}
+        {value && (
+          <UniversalLink href={value.download} download={true}>
+            {value.filename}
+          </UniversalLink>
+        )}
         {value && (
           <Button
             icon

--- a/packages/volto/src/components/manage/Widgets/__snapshots__/FileWidget.test.jsx.snap
+++ b/packages/volto/src/components/manage/Widgets/__snapshots__/FileWidget.test.jsx.snap
@@ -55,7 +55,14 @@ exports[`FileWidget renders a file widget component with value 1`] = `
           <div
             class="field-file-name"
           >
-            myfile
+            <a
+              class="external"
+              href="http://myfile"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              myfile
+            </a>
             <button
               aria-label="delete file"
               class="ui basic icon button delete-button"
@@ -130,7 +137,13 @@ exports[`FileWidget renders a file widget component with value in raw data 1`] =
           <div
             class="field-file-name"
           >
-            myfile
+            <a
+              class="external"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              myfile
+            </a>
             <button
               aria-label="delete file"
               class="ui basic icon button delete-button"


### PR DESCRIPTION
Added a UniversalLink tag around the filename to allow users to download the file directly from the widget in other views.
It's useful if a user needs to download the file but didn't create the content and does not have the original file.