### PR TITLE
Backport #5725 16.x.x

### DIFF
--- a/docs/source/robots.txt
+++ b/docs/source/robots.txt
@@ -1,7 +1,2 @@
-# Disallow all user agents from the following directories and files
-User-agent: *
-Disallow: /_sources/
-Disallow: /.doctrees/
-Disallow: /*.txt$
-Disallow: /.buildinfo$
-Disallow: /objects.inv$
+# Disallow all user agents from indexing pages and links in the site on Netlify only.
+Disallow: /

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,3 +3,7 @@
   NODE_VERSION = "16.17.1"
 [build]
   ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF ./docs/"
+[[headers]]
+  for = "/*"
+  [[headers.values]]
+    X-Robots-Tag = "none"

--- a/news/5916.documentation
+++ b/news/5916.documentation
@@ -1,0 +1,1 @@
+Block search engines from indexing content on Netlify preview builds. @stevepiercy


### PR DESCRIPTION
Block search engines from indexing content on Netlify preview builds.

See #5725