### PR TITLE
Fix `error is null` in `FormFieldWrapper.jsx`.

### DIFF
--- a/packages/volto/news/5919.bugfix
+++ b/packages/volto/news/5919.bugfix
@@ -1,0 +1,1 @@
+Fix `error is null` in `FormFieldWrapper.jsx`.  @mauritsvanrees

--- a/packages/volto/src/components/manage/Widgets/FormFieldWrapper.jsx
+++ b/packages/volto/src/components/manage/Widgets/FormFieldWrapper.jsx
@@ -107,7 +107,7 @@ class FormFieldWrapper extends Component {
       <Form.Field
         inline
         required={required}
-        error={error.length > 0}
+        error={error && error.length > 0}
         className={cx(
           description ? 'help' : '',
           className,


### PR DESCRIPTION
Fixes https://github.com/plone/volto/issues/5919
This is my first Volto fix. :-)