### PR TITLE
Fix cypress test "As editor, I can unlock a locked page"

### DIFF
--- a/packages/volto/cypress/tests/core/basic/locking.js
+++ b/packages/volto/cypress/tests/core/basic/locking.js
@@ -91,6 +91,9 @@ describe('Document locking', () => {
     cy.url().should('eq', Cypress.config().baseUrl + '/document/edit');
     cy.wait('@schema');
 
+    // Wait Plone to consider the content locked.
+    cy.wait(2000);
+
     cy.visit('/logout');
     cy.wait('@logout');
 

--- a/packages/volto/news/5933.internal
+++ b/packages/volto/news/5933.internal
@@ -1,0 +1,1 @@
+Fix cyprees test "As editor, I can unlock a locked page". @wesleybl

--- a/packages/volto/news/5933.internal
+++ b/packages/volto/news/5933.internal
@@ -1,1 +1,1 @@
-Fix cyprees test "As editor, I can unlock a locked page". @wesleybl
+Fix cypress test "As editor, I can unlock a locked page". @wesleybl


### PR DESCRIPTION
Sometimes this test fails because it does not find the alert with the message that the content is locked. What may be happening is that the test runs too quickly, and Plone does not consider that the content has been locked. Then we wait a bit for Plone to consider it locked.

This fix: https://github.com/plone/volto/actions/runs/8403447599/job/23013937367#step:10:649