### PR TITLE
Fix self-registration

### DIFF
--- a/packages/volto/news/5935.bugfix
+++ b/packages/volto/news/5935.bugfix
@@ -1,0 +1,1 @@
+Fix self-registration form. @davisagli

--- a/packages/volto/src/components/theme/Register/Register.jsx
+++ b/packages/volto/src/components/theme/Register/Register.jsx
@@ -132,7 +132,7 @@ class Register extends Component {
     this.props.createUser({
       fullname: data.fullname,
       email: data.email,
-      password: data.password,
+      sendPasswordReset: true,
     });
     this.setState({
       error: null,


### PR DESCRIPTION
Fixes #941

Requires:
- working SMTP configuration
- `showSelfRegistration: true` in volto settings
- In security control panel:
  - "Enable self-registration" checked
  - "Use email address as login name" checked

More work would be needed to be support use cases where the user can choose their own username or set a password without email confirmation.