### PR TITLE
Fix Image block field to wrap the entire image across left and right alignments.

### DIFF
--- a/packages/volto/news/5922.bugfix
+++ b/packages/volto/news/5922.bugfix
@@ -1,1 +1,1 @@
-Fix image block field to wrap the entire image across various alignments.@mostafamagdyy
+Fix image block field to wrap the entire image across various alignments.@MostafaMagdyy

--- a/packages/volto/news/5922.bugfix
+++ b/packages/volto/news/5922.bugfix
@@ -1,1 +1,1 @@
-Fix image block field to wrap the entire image across various alignments.@MostafaMagdyy
+Fix image block field to wrap the entire image across various alignments. @MostafaMagdyy

--- a/packages/volto/news/5922.bugfix
+++ b/packages/volto/news/5922.bugfix
@@ -1,0 +1,1 @@
+Fix image block field to wrap the entire image across various alignments.@mostafamagdyy

--- a/packages/volto/theme/themes/pastanaga/extras/blocks.less
+++ b/packages/volto/theme/themes/pastanaga/extras/blocks.less
@@ -140,6 +140,7 @@
 }
 
 .block.align.left {
+  display: flex;
   z-index: 2;
 
   &.video .video-inner,
@@ -174,6 +175,8 @@
 }
 
 .block.align.right {
+  display: flex;
+  flex-direction: row-reverse;
   z-index: 2;
 
   &.maps iframe,

--- a/packages/volto/theme/themes/pastanaga/extras/blocks.less
+++ b/packages/volto/theme/themes/pastanaga/extras/blocks.less
@@ -140,8 +140,8 @@
 }
 
 .block.align.left {
-  display: flex;
   z-index: 2;
+  display: flex;
 
   &.video .video-inner,
   &.maps iframe,
@@ -175,9 +175,9 @@
 }
 
 .block.align.right {
+  z-index: 2;
   display: flex;
   flex-direction: row-reverse;
-  z-index: 2;
 
   &.maps iframe,
   &.video .video-inner,


### PR DESCRIPTION
Fixes #5922 for the image field container to wrap the entire image in right and left alignment.


For full-width alignment, I think it's another issue itself. Disregard the field to wrap the entire image because the image is going outside the whole container and above the sidebar on the right if you try to drag its block. So, I do not think this PR should fix it, because it is not related to the failure of the wrapper to fill the whole image. Let me know if I should fix it in this PR, and I will do so. Also, please clarify how the full width should be, **because I do not see any difference between it and when the image is aligned center with size=large, as both take size=100vw in getImageBlockSizes function**.



