### PR TITLE
Add a new label `needs: triage` to new bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve Volto
 title: ''
-labels: '01 type: bug'
+labels: ['01 type: bug', 'needs: triage']
 assignees: ''
 ---
 

--- a/packages/volto/news/5940.internal
+++ b/packages/volto/news/5940.internal
@@ -1,0 +1,1 @@
+Add a new label `needs: triage` to new bug reports. @stevepiercy


### PR DESCRIPTION
We need to verify that a bug report is in fact a bug. Once the issue is confirmed, then this label can be replaced with `21 status: confirmed`. This label differs from `needs: confirmation` in that the latter is for old issues that have been hanging around for a long time.