### PR TITLE
Displays validation error messages on control panel forms

### DIFF
--- a/packages/volto/locales/ca/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ca/LC_MESSAGES/volto.po
@@ -1334,6 +1334,7 @@ msgstr ""
 #: components/manage/Add/Add
 #: components/manage/Controlpanels/AddonsControlpanel
 #: components/manage/Controlpanels/ContentTypeSchema
+#: components/manage/Controlpanels/Controlpanel
 #: components/manage/Controlpanels/UndoControlpanel
 #: components/manage/Edit/Edit
 #: components/manage/Form/InlineForm

--- a/packages/volto/locales/de/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/de/LC_MESSAGES/volto.po
@@ -1333,6 +1333,7 @@ msgstr ""
 #: components/manage/Add/Add
 #: components/manage/Controlpanels/AddonsControlpanel
 #: components/manage/Controlpanels/ContentTypeSchema
+#: components/manage/Controlpanels/Controlpanel
 #: components/manage/Controlpanels/UndoControlpanel
 #: components/manage/Edit/Edit
 #: components/manage/Form/InlineForm

--- a/packages/volto/locales/en/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/en/LC_MESSAGES/volto.po
@@ -1328,6 +1328,7 @@ msgstr ""
 #: components/manage/Add/Add
 #: components/manage/Controlpanels/AddonsControlpanel
 #: components/manage/Controlpanels/ContentTypeSchema
+#: components/manage/Controlpanels/Controlpanel
 #: components/manage/Controlpanels/UndoControlpanel
 #: components/manage/Edit/Edit
 #: components/manage/Form/InlineForm

--- a/packages/volto/locales/es/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/es/LC_MESSAGES/volto.po
@@ -1335,6 +1335,7 @@ msgstr "Entradas"
 #: components/manage/Add/Add
 #: components/manage/Controlpanels/AddonsControlpanel
 #: components/manage/Controlpanels/ContentTypeSchema
+#: components/manage/Controlpanels/Controlpanel
 #: components/manage/Controlpanels/UndoControlpanel
 #: components/manage/Edit/Edit
 #: components/manage/Form/InlineForm

--- a/packages/volto/locales/eu/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/eu/LC_MESSAGES/volto.po
@@ -1335,6 +1335,7 @@ msgstr ""
 #: components/manage/Add/Add
 #: components/manage/Controlpanels/AddonsControlpanel
 #: components/manage/Controlpanels/ContentTypeSchema
+#: components/manage/Controlpanels/Controlpanel
 #: components/manage/Controlpanels/UndoControlpanel
 #: components/manage/Edit/Edit
 #: components/manage/Form/InlineForm

--- a/packages/volto/locales/fi/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/fi/LC_MESSAGES/volto.po
@@ -1333,6 +1333,7 @@ msgstr ""
 #: components/manage/Add/Add
 #: components/manage/Controlpanels/AddonsControlpanel
 #: components/manage/Controlpanels/ContentTypeSchema
+#: components/manage/Controlpanels/Controlpanel
 #: components/manage/Controlpanels/UndoControlpanel
 #: components/manage/Edit/Edit
 #: components/manage/Form/InlineForm

--- a/packages/volto/locales/fr/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/fr/LC_MESSAGES/volto.po
@@ -1335,6 +1335,7 @@ msgstr ""
 #: components/manage/Add/Add
 #: components/manage/Controlpanels/AddonsControlpanel
 #: components/manage/Controlpanels/ContentTypeSchema
+#: components/manage/Controlpanels/Controlpanel
 #: components/manage/Controlpanels/UndoControlpanel
 #: components/manage/Edit/Edit
 #: components/manage/Form/InlineForm

--- a/packages/volto/locales/hi/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/hi/LC_MESSAGES/volto.po
@@ -1328,6 +1328,7 @@ msgstr "एन्ट्रीज़"
 #: components/manage/Add/Add
 #: components/manage/Controlpanels/AddonsControlpanel
 #: components/manage/Controlpanels/ContentTypeSchema
+#: components/manage/Controlpanels/Controlpanel
 #: components/manage/Controlpanels/UndoControlpanel
 #: components/manage/Edit/Edit
 #: components/manage/Form/InlineForm

--- a/packages/volto/locales/it/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/it/LC_MESSAGES/volto.po
@@ -1328,6 +1328,7 @@ msgstr ""
 #: components/manage/Add/Add
 #: components/manage/Controlpanels/AddonsControlpanel
 #: components/manage/Controlpanels/ContentTypeSchema
+#: components/manage/Controlpanels/Controlpanel
 #: components/manage/Controlpanels/UndoControlpanel
 #: components/manage/Edit/Edit
 #: components/manage/Form/InlineForm

--- a/packages/volto/locales/ja/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ja/LC_MESSAGES/volto.po
@@ -1333,6 +1333,7 @@ msgstr ""
 #: components/manage/Add/Add
 #: components/manage/Controlpanels/AddonsControlpanel
 #: components/manage/Controlpanels/ContentTypeSchema
+#: components/manage/Controlpanels/Controlpanel
 #: components/manage/Controlpanels/UndoControlpanel
 #: components/manage/Edit/Edit
 #: components/manage/Form/InlineForm

--- a/packages/volto/locales/nl/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/nl/LC_MESSAGES/volto.po
@@ -1332,6 +1332,7 @@ msgstr ""
 #: components/manage/Add/Add
 #: components/manage/Controlpanels/AddonsControlpanel
 #: components/manage/Controlpanels/ContentTypeSchema
+#: components/manage/Controlpanels/Controlpanel
 #: components/manage/Controlpanels/UndoControlpanel
 #: components/manage/Edit/Edit
 #: components/manage/Form/InlineForm

--- a/packages/volto/locales/pt/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/pt/LC_MESSAGES/volto.po
@@ -1333,6 +1333,7 @@ msgstr ""
 #: components/manage/Add/Add
 #: components/manage/Controlpanels/AddonsControlpanel
 #: components/manage/Controlpanels/ContentTypeSchema
+#: components/manage/Controlpanels/Controlpanel
 #: components/manage/Controlpanels/UndoControlpanel
 #: components/manage/Edit/Edit
 #: components/manage/Form/InlineForm

--- a/packages/volto/locales/pt_BR/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/pt_BR/LC_MESSAGES/volto.po
@@ -1334,6 +1334,7 @@ msgstr ""
 #: components/manage/Add/Add
 #: components/manage/Controlpanels/AddonsControlpanel
 #: components/manage/Controlpanels/ContentTypeSchema
+#: components/manage/Controlpanels/Controlpanel
 #: components/manage/Controlpanels/UndoControlpanel
 #: components/manage/Edit/Edit
 #: components/manage/Form/InlineForm

--- a/packages/volto/locales/ro/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ro/LC_MESSAGES/volto.po
@@ -1328,6 +1328,7 @@ msgstr ""
 #: components/manage/Add/Add
 #: components/manage/Controlpanels/AddonsControlpanel
 #: components/manage/Controlpanels/ContentTypeSchema
+#: components/manage/Controlpanels/Controlpanel
 #: components/manage/Controlpanels/UndoControlpanel
 #: components/manage/Edit/Edit
 #: components/manage/Form/InlineForm

--- a/packages/volto/locales/volto.pot
+++ b/packages/volto/locales/volto.pot
@@ -1330,6 +1330,7 @@ msgstr ""
 #: components/manage/Add/Add
 #: components/manage/Controlpanels/AddonsControlpanel
 #: components/manage/Controlpanels/ContentTypeSchema
+#: components/manage/Controlpanels/Controlpanel
 #: components/manage/Controlpanels/UndoControlpanel
 #: components/manage/Edit/Edit
 #: components/manage/Form/InlineForm

--- a/packages/volto/locales/zh_CN/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/zh_CN/LC_MESSAGES/volto.po
@@ -1334,6 +1334,7 @@ msgstr ""
 #: components/manage/Add/Add
 #: components/manage/Controlpanels/AddonsControlpanel
 #: components/manage/Controlpanels/ContentTypeSchema
+#: components/manage/Controlpanels/Controlpanel
 #: components/manage/Controlpanels/UndoControlpanel
 #: components/manage/Edit/Edit
 #: components/manage/Form/InlineForm

--- a/packages/volto/news/5274.bugfix
+++ b/packages/volto/news/5274.bugfix
@@ -1,0 +1,1 @@
+Displays validation error messages on control panel forms. @wesleybl

--- a/packages/volto/src/components/manage/Add/Add.jsx
+++ b/packages/volto/src/components/manage/Add/Add.jsx
@@ -5,7 +5,11 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { BodyClass, Helmet } from '@plone/volto/helpers';
+import {
+  BodyClass,
+  Helmet,
+  extractInvariantErrors,
+} from '@plone/volto/helpers';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 import { keys, isEmpty } from 'lodash';
@@ -182,9 +186,7 @@ class Add extends Component {
       const errorsList = tryParseJSON(error);
       let erroMessage;
       if (Array.isArray(errorsList)) {
-        const invariantErrors = errorsList
-          .filter((errorItem) => !('field' in errorItem))
-          .map((errorItem) => errorItem['message']);
+        const invariantErrors = extractInvariantErrors(errorsList);
         if (invariantErrors.length > 0) {
           // Plone invariant validation message.
           erroMessage = invariantErrors.join(' - ');

--- a/packages/volto/src/components/manage/Controlpanels/Controlpanel.jsx
+++ b/packages/volto/src/components/manage/Controlpanels/Controlpanel.jsx
@@ -8,7 +8,11 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 import { withRouter } from 'react-router-dom';
-import { Helmet, tryParseJSON } from '@plone/volto/helpers';
+import {
+  Helmet,
+  tryParseJSON,
+  extractInvariantErrors,
+} from '@plone/volto/helpers';
 import { createPortal } from 'react-dom';
 import { Button, Container } from 'semantic-ui-react';
 import { defineMessages, injectIntl } from 'react-intl';
@@ -131,9 +135,7 @@ class Controlpanel extends Component {
       const errorsList = tryParseJSON(error);
       let invariantErrors = [];
       if (Array.isArray(errorsList)) {
-        invariantErrors = errorsList
-          .filter((errorItem) => !('field' in errorItem))
-          .map((errorItem) => errorItem['message']);
+        invariantErrors = extractInvariantErrors(errorsList);
       }
 
       this.setState({ error: error });

--- a/packages/volto/src/components/manage/Controlpanels/Controlpanel.jsx
+++ b/packages/volto/src/components/manage/Controlpanels/Controlpanel.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 import { withRouter } from 'react-router-dom';
-import { Helmet } from '@plone/volto/helpers';
+import { Helmet, tryParseJSON } from '@plone/volto/helpers';
 import { createPortal } from 'react-dom';
 import { Button, Container } from 'semantic-ui-react';
 import { defineMessages, injectIntl } from 'react-intl';
@@ -43,6 +43,10 @@ const messages = defineMessages({
   info: {
     id: 'Info',
     defaultMessage: 'Info',
+  },
+  error: {
+    id: 'Error',
+    defaultMessage: 'Error',
   },
 });
 
@@ -93,7 +97,7 @@ class Controlpanel extends Component {
     super(props);
     this.onCancel = this.onCancel.bind(this);
     this.onSubmit = this.onSubmit.bind(this);
-    this.state = { isClient: false };
+    this.state = { isClient: false, error: null };
   }
 
   /**
@@ -113,6 +117,38 @@ class Controlpanel extends Component {
    * @returns {undefined}
    */
   UNSAFE_componentWillReceiveProps(nextProps) {
+    if (this.props.updateRequest.loading && nextProps.updateRequest.error) {
+      const message =
+        nextProps.updateRequest.error?.response?.body?.error?.message ||
+        nextProps.updateRequest.error?.response?.body?.message ||
+        nextProps.updateRequest.error?.response?.text ||
+        '';
+
+      const error =
+        new DOMParser().parseFromString(message, 'text/html')?.all?.[0]
+          ?.textContent || message;
+
+      const errorsList = tryParseJSON(error);
+      let invariantErrors = [];
+      if (Array.isArray(errorsList)) {
+        invariantErrors = errorsList
+          .filter((errorItem) => !('field' in errorItem))
+          .map((errorItem) => errorItem['message']);
+      }
+
+      this.setState({ error: error });
+
+      if (invariantErrors.length > 0) {
+        toast.error(
+          <Toast
+            error
+            title={this.props.intl.formatMessage(messages.error)}
+            content={invariantErrors.join(' - ')}
+          />,
+        );
+      }
+    }
+
     if (this.props.updateRequest.loading && nextProps.updateRequest.loaded) {
       toast.info(
         <Toast
@@ -162,6 +198,7 @@ class Controlpanel extends Component {
               title={this.props.controlpanel.title}
               schema={filterControlPanelsSchema(this.props.controlpanel)}
               formData={this.props.controlpanel.data}
+              requestError={this.state.error}
               onSubmit={this.onSubmit}
               onCancel={this.onCancel}
               hideActions

--- a/packages/volto/src/components/manage/Controlpanels/Controlpanel.test.jsx
+++ b/packages/volto/src/components/manage/Controlpanels/Controlpanel.test.jsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import { render } from '@testing-library/react';
+import { render, waitFor, screen } from '@testing-library/react';
 import configureStore from 'redux-mock-store';
 import { Provider } from 'react-intl-redux';
 import { MemoryRouter, Route } from 'react-router-dom';
@@ -8,32 +7,40 @@ import Controlpanel from './Controlpanel';
 
 const mockStore = configureStore();
 
-jest.mock('@plone/volto/components/manage/Form');
+jest.mock('../Form/Form', () =>
+  jest.fn(({ requestError }) => (
+    <div id="form">
+      {requestError ? `requestError : ${requestError}` : null}
+    </div>
+  )),
+);
 jest.mock('../Toolbar/Toolbar', () => jest.fn(() => <div id="Portal" />));
+
+const store = mockStore({
+  controlpanels: {
+    controlpanel: {
+      '@id': 'http://localhost:8080/Plone/@controlpanels/date-and-time',
+      title: 'Date and Time',
+      schema: {
+        fieldsets: [],
+        properties: [],
+      },
+      data: {},
+    },
+    update: {
+      loading: false,
+      loaded: true,
+      error: { response: { body: { message: null } } },
+    },
+  },
+  intl: {
+    locale: 'en',
+    messages: {},
+  },
+});
 
 describe('Controlpanel', () => {
   it('renders a controlpanel component', () => {
-    const store = mockStore({
-      controlpanels: {
-        controlpanel: {
-          '@id': 'http://localhost:8080/Plone/@controlpanels/date-and-time',
-          title: 'Date and Time',
-          schema: {
-            fieldsets: [],
-            properties: [],
-          },
-          data: {},
-        },
-        update: {
-          loading: false,
-          loaded: true,
-        },
-      },
-      intl: {
-        locale: 'en',
-        messages: {},
-      },
-    });
     const { container } = render(
       <Provider store={store}>
         <MemoryRouter initialEntries={['/controlpanel/date-and-time']}>
@@ -43,6 +50,30 @@ describe('Controlpanel', () => {
       </Provider>,
     );
 
+    expect(container).toMatchSnapshot();
+  });
+  it('renders a controlpanel component with error', async () => {
+    const { container, rerender } = render(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={['/controlpanel/date-and-time']}>
+          <Route path={'/controlpanel/:id'} component={Controlpanel} />
+          <div id="toolbar"></div>
+        </MemoryRouter>
+      </Provider>,
+    );
+    store.getState().controlpanels.update.loading = true;
+    store.getState().controlpanels.update.error.response.body.message =
+      "[{'message': 'Twitter username should not include the \"@\" prefix character.', 'field': 'twitter_username', 'error': 'ValidationError'}]";
+
+    rerender(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={['/controlpanel/date-and-time']}>
+          <Route path={'/controlpanel/:id'} component={Controlpanel} />
+          <div id="toolbar"></div>
+        </MemoryRouter>
+      </Provider>,
+    );
+    await waitFor(() => screen.findByText(/Twitter/i));
     expect(container).toMatchSnapshot();
   });
 });

--- a/packages/volto/src/components/manage/Controlpanels/__snapshots__/Controlpanel.test.jsx.snap
+++ b/packages/volto/src/components/manage/Controlpanels/__snapshots__/Controlpanel.test.jsx.snap
@@ -7,14 +7,31 @@ exports[`Controlpanel renders a controlpanel component 1`] = `
   >
     <div
       class="ui container"
+    />
+  </div>
+  <div
+    id="toolbar"
+  >
+    <div
+      id="Portal"
+    />
+  </div>
+</div>
+`;
+
+exports[`Controlpanel renders a controlpanel component with error 1`] = `
+<div>
+  <div
+    id="page-controlpanel"
+  >
+    <div
+      class="ui container"
     >
       <div
-        data-schema="{
-  \\"fieldsets\\": [],
-  \\"properties\\": {}
-}"
-        id="Form"
-      />
+        id="form"
+      >
+        requestError : [{'message': 'Twitter username should not include the "@" prefix character.', 'field': 'twitter_username', 'error': 'ValidationError'}]
+      </div>
     </div>
   </div>
   <div

--- a/packages/volto/src/components/manage/Edit/Edit.jsx
+++ b/packages/volto/src/components/manage/Edit/Edit.jsx
@@ -5,7 +5,7 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Helmet } from '@plone/volto/helpers';
+import { Helmet, extractInvariantErrors } from '@plone/volto/helpers';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 import { asyncConnect, hasApiExpander } from '@plone/volto/helpers';
@@ -208,9 +208,7 @@ class Edit extends Component {
       const errorsList = tryParseJSON(error);
       let erroMessage;
       if (Array.isArray(errorsList)) {
-        const invariantErrors = errorsList
-          .filter((errorItem) => !('field' in errorItem))
-          .map((errorItem) => errorItem['message']);
+        const invariantErrors = extractInvariantErrors(errorsList);
         if (invariantErrors.length > 0) {
           // Plone invariant validation message.
           erroMessage = invariantErrors.join(' - ');

--- a/packages/volto/src/helpers/FormValidation/FormValidation.jsx
+++ b/packages/volto/src/helpers/FormValidation/FormValidation.jsx
@@ -165,7 +165,14 @@ export const tryParseJSON = (requestItem) => {
     try {
       resultObj = JSON.parse(requestItem.replace(/'/g, '"'));
     } catch (e) {
-      resultObj = null;
+      try {
+        // Treats strings like: `'String "double quotes"'`
+        resultObj = JSON.parse(
+          requestItem.replace(/"/g, '\\"').replace(/'/g, '"'),
+        );
+      } catch (e) {
+        resultObj = null;
+      }
     }
   }
   return resultObj;

--- a/packages/volto/src/helpers/FormValidation/FormValidation.jsx
+++ b/packages/volto/src/helpers/FormValidation/FormValidation.jsx
@@ -406,3 +406,13 @@ export const validateFileUploadSize = (file, intlFunc) => {
   }
   return isValid;
 };
+
+/**
+ * Extract invariant errors given an array of errors.
+ * @param {Array} erros
+ */
+export const extractInvariantErrors = (erros) => {
+  return erros
+    .filter((errorItem) => !('field' in errorItem))
+    .map((errorItem) => errorItem['message']);
+};

--- a/packages/volto/src/helpers/index.js
+++ b/packages/volto/src/helpers/index.js
@@ -85,6 +85,7 @@ export { default as Helmet } from './Helmet/Helmet';
 export { default as FormValidation } from './FormValidation/FormValidation';
 export { validateFileUploadSize } from './FormValidation/FormValidation';
 export { tryParseJSON } from './FormValidation/FormValidation';
+export { extractInvariantErrors } from './FormValidation/FormValidation';
 export {
   difference,
   getColor,


### PR DESCRIPTION
Fixes: #5274

Now the error is displayed:

![download (13)](https://github.com/plone/volto/assets/3297795/91ff00b6-09a5-4a69-b27a-d353e2b4a98b)

To works properly, it needs: https://github.com/plone/plone.restapi/pull/1771

But it can be merged separately without any problems.