### PR TITLE
Fix rendering if ConditionalLink has no children

### DIFF
--- a/packages/volto/news/5963.bugfix
+++ b/packages/volto/news/5963.bugfix
@@ -1,0 +1,1 @@
+Fixed rendering if ConditionalLink has no children @pnicolli

--- a/packages/volto/src/components/manage/ConditionalLink/ConditionalLink.jsx
+++ b/packages/volto/src/components/manage/ConditionalLink/ConditionalLink.jsx
@@ -10,7 +10,7 @@ const ConditionalLink = ({ condition, to, item, ...props }) => {
       </UniversalLink>
     );
   } else {
-    return props.children;
+    return <>{props.children}</>;
   }
 };
 


### PR DESCRIPTION
If no children are given, this rendered `undefined` causing the site to break.