### PR TITLE
Fix flaky test 'As editor I can add links' by using getSlateEditorAndType

### DIFF
--- a/packages/volto/cypress/tests/core/volto-slate/06-block-slate-format-link.js
+++ b/packages/volto/cypress/tests/core/volto-slate/06-block-slate-format-link.js
@@ -4,8 +4,7 @@ describe('Block Tests: Links', () => {
   beforeEach(slateBeforeEach);
 
   it('As editor I can add links', function () {
-    cy.get('#toolbar').click();
-    cy.getSlate().type('Colorless green ideas sleep furiously.');
+    cy.getSlateEditorAndType('Colorless green ideas sleep furiously.');
 
     cy.log('Create a Link');
 

--- a/packages/volto/news/5965.bugfix
+++ b/packages/volto/news/5965.bugfix
@@ -1,0 +1,1 @@
+Fix flaky test 'As editor I can add links' by using getSlateEditorAndType. @ksuess


### PR DESCRIPTION
This should fix the failing test in https://github.com/plone/volto/actions/runs/8726201362/job/23941446900?pr=5295
Locally I could reproduce the failure with Electron and fix it like this by using cy.getSlateEditorAndType.
