### PR TITLE
Fix rendering if ConditionalLink has no children (Volto 17)

### DIFF
--- a/news/5963.bugfix
+++ b/news/5963.bugfix
@@ -1,0 +1,1 @@
+Fixed rendering if ConditionalLink has no children @pnicolli

--- a/src/components/manage/ConditionalLink/ConditionalLink.jsx
+++ b/src/components/manage/ConditionalLink/ConditionalLink.jsx
@@ -10,7 +10,7 @@ const ConditionalLink = ({ condition, to, item, ...props }) => {
       </UniversalLink>
     );
   } else {
-    return props.children;
+    return <>{props.children}</>;
   }
 };
 


### PR DESCRIPTION
Backport of #5963 for Volto 17