### PR TITLE
Add headers to avoid redirects being cached

### DIFF
--- a/news/5974.bugfix
+++ b/news/5974.bugfix
@@ -1,0 +1,1 @@
+Add headers to avoid redirects being cached, eg. the ones coming from the `MultilingualRedirector` @sneridagh

--- a/src/server.jsx
+++ b/src/server.jsx
@@ -273,6 +273,10 @@ server.get('/*', (req, res) => {
       }
 
       if (context.url) {
+        // If there's a redirection, do not cache it
+        res.set({
+          'Cache-Control': 'no-cache',
+        });
         res.redirect(flattenToAppURL(context.url));
       } else if (context.error_code) {
         res.set({


### PR DESCRIPTION
(eg. the one coming from the MultilingualRedirector).