### PR TITLE
fix: pass down locale to IntlProvider

### DIFF
--- a/packages/volto/news/5976.bugfix
+++ b/packages/volto/news/5976.bugfix
@@ -1,0 +1,1 @@
+Add possibility to pass down `locale`, `messages` and `defaultLocale` properties inside the `customStore` object to `IntlProvider`. With this change we can control react-intl language provider from inside storybook and switch for example from english to german with storybook args.

--- a/packages/volto/src/storybook.jsx
+++ b/packages/volto/src/storybook.jsx
@@ -1387,14 +1387,15 @@ export default class Wrapper extends Component {
   render() {
     const mockStore = configureStore();
     const store = mockStore(this.customState());
+    const state = store.getState();
 
     return (
       <Provider store={store}>
         <PluggablesProvider>
           <IntlProvider
-            locale={store.getState().intl.locale}
-            messages={store.getState().intl.messages}
-            defaultLocale={store.getState().intl.defaultLocale ?? 'en'}
+            locale={state.intl.locale}
+            messages={state.intl.messages}
+            defaultLocale={state.intl.defaultLocale ?? 'en'}
           >
             <StaticRouter location={this.props.location}>
               <div className="volto-storybook-container">
@@ -1438,14 +1439,15 @@ export class RealStoreWrapper extends Component {
     // If thunk is not included there's a complaint about async actions
     const history = createBrowserHistory();
     const store = configureRealStore(this.customState(), history);
+    const state = store.getState();
 
     return (
       <Provider store={store}>
         <PluggablesProvider>
           <IntlProvider
-            locale={store.getState().intl.locale}
-            messages={store.getState().intl.messages}
-            defaultLocale={store.getState().intl.defaultLocale ?? 'en'}
+            locale={state.intl.locale}
+            messages={state.intl.messages}
+            defaultLocale={state.intl.defaultLocale ?? 'en'}
           >
             <StaticRouter location={this.props.location}>
               <div className="volto-storybook-container">

--- a/packages/volto/src/storybook.jsx
+++ b/packages/volto/src/storybook.jsx
@@ -1392,9 +1392,9 @@ export default class Wrapper extends Component {
       <Provider store={store}>
         <PluggablesProvider>
           <IntlProvider
-            locale={this.props.customStore.intl.locale}
-            messages={this.props.customStore.intl.messages}
-            defaultLocale={this.props.customStore.intl.defaultLocale ?? 'en'}
+            locale={store.getState().intl.locale}
+            messages={store.getState().intl.messages}
+            defaultLocale={store.getState().intl.defaultLocale ?? 'en'}
           >
             <StaticRouter location={this.props.location}>
               <div className="volto-storybook-container">

--- a/packages/volto/src/storybook.jsx
+++ b/packages/volto/src/storybook.jsx
@@ -1391,7 +1391,7 @@ export default class Wrapper extends Component {
     return (
       <Provider store={store}>
         <PluggablesProvider>
-          <IntlProvider locale="en">
+          <IntlProvider locale={this.props.customStore.intl.locale ?? 'en'}>
             <StaticRouter location={this.props.location}>
               <div className="volto-storybook-container">
                 {this.props.children}
@@ -1438,7 +1438,7 @@ export class RealStoreWrapper extends Component {
     return (
       <Provider store={store}>
         <PluggablesProvider>
-          <IntlProvider locale="en">
+          <IntlProvider locale={this.props.customStore.intl.locale ?? 'en'}>
             <StaticRouter location={this.props.location}>
               <div className="volto-storybook-container">
                 {this.props.children}

--- a/packages/volto/src/storybook.jsx
+++ b/packages/volto/src/storybook.jsx
@@ -1391,7 +1391,11 @@ export default class Wrapper extends Component {
     return (
       <Provider store={store}>
         <PluggablesProvider>
-          <IntlProvider locale={this.props.customStore.intl.locale ?? 'en'}>
+          <IntlProvider
+            locale={this.props.customStore.intl.locale}
+            messages={this.props.customStore.intl.messages}
+            defaultLocale={this.props.customStore.intl.defaultLocale ?? 'en'}
+          >
             <StaticRouter location={this.props.location}>
               <div className="volto-storybook-container">
                 {this.props.children}
@@ -1438,7 +1442,11 @@ export class RealStoreWrapper extends Component {
     return (
       <Provider store={store}>
         <PluggablesProvider>
-          <IntlProvider locale={this.props.customStore.intl.locale ?? 'en'}>
+          <IntlProvider
+            locale={this.props.customStore.intl.locale}
+            messages={this.props.customStore.intl.messages}
+            defaultLocale={this.props.customStore.intl.defaultLocale ?? 'en'}
+          >
             <StaticRouter location={this.props.location}>
               <div className="volto-storybook-container">
                 {this.props.children}

--- a/packages/volto/src/storybook.jsx
+++ b/packages/volto/src/storybook.jsx
@@ -1443,9 +1443,9 @@ export class RealStoreWrapper extends Component {
       <Provider store={store}>
         <PluggablesProvider>
           <IntlProvider
-            locale={this.props.customStore.intl.locale}
-            messages={this.props.customStore.intl.messages}
-            defaultLocale={this.props.customStore.intl.defaultLocale ?? 'en'}
+            locale={store.getState().intl.locale}
+            messages={store.getState().intl.messages}
+            defaultLocale={store.getState().intl.defaultLocale ?? 'en'}
           >
             <StaticRouter location={this.props.location}>
               <div className="volto-storybook-container">


### PR DESCRIPTION
Add possibility to pass down `locale`, `messages` and `defaultLocale` properties inside the `customStore` object to `IntlProvider`. With this change we can control react-intl language provider from inside storybook and switch for example from english to german with storybook args.