### PR TITLE
Ensure that sidebar field will not steal focus when metadata is edited 17.x.x backport

### DIFF
--- a/cypress/tests/core/basic/metadata.js
+++ b/cypress/tests/core/basic/metadata.js
@@ -40,7 +40,7 @@ describe('Add Content Tests', () => {
     cy.get('.sidebar-container .tabs-wrapper a.active.item').contains('Page');
   });
 
-   it('After removing value of widget the focus should be removed from the field', () => {
+  it('After removing value of widget the focus should be removed from the field', () => {
     cy.get('#field-creators').type('aaa');
     cy.get('#field-creators')
       .type('aaa{Enter}')

--- a/cypress/tests/core/basic/metadata.js
+++ b/cypress/tests/core/basic/metadata.js
@@ -39,4 +39,15 @@ describe('Add Content Tests', () => {
       .contains('Required input is missing');
     cy.get('.sidebar-container .tabs-wrapper a.active.item').contains('Page');
   });
+
+   it('After removing value of widget the focus should be removed from the field', () => {
+    cy.get('#field-creators').type('aaa');
+    cy.get('#field-creators')
+      .type('aaa{Enter}')
+      .get('.react-select__multi-value__remove')
+      .click();
+    cy.getSlateEditorAndType(
+      'Test if all the text will be in this slate block',
+    ).contains('Test if all the text will be in this slate block');
+  });
 });

--- a/news/5982.bugfix
+++ b/news/5982.bugfix
@@ -1,0 +1,1 @@
+Ensure that sidebar field will not steal focus when metadata is edited 17.x.x backport @dobri1408

--- a/src/components/manage/Form/Form.jsx
+++ b/src/components/manage/Form/Form.jsx
@@ -747,7 +747,14 @@ class Form extends Component {
                                 id={field}
                                 fieldSet={fieldset.title.toLowerCase()}
                                 formData={formData}
-                                focus={__CLIENT__ && document.getElementById('sidebar-metadata')?.contains(document.activeElement) ? this.state.inFocus[field] : false}
+                                focus={
+                                  __CLIENT__ &&
+                                  document
+                                    .getElementById('sidebar-metadata')
+                                    ?.contains(document.activeElement)
+                                    ? this.state.inFocus[field]
+                                    : false
+                                }
                                 value={formData?.[field]}
                                 required={schema.required.indexOf(field) !== -1}
                                 onChange={this.onChangeField}

--- a/src/components/manage/Form/Form.jsx
+++ b/src/components/manage/Form/Form.jsx
@@ -747,7 +747,7 @@ class Form extends Component {
                                 id={field}
                                 fieldSet={fieldset.title.toLowerCase()}
                                 formData={formData}
-                                focus={this.state.inFocus[field]}
+                                focus={__CLIENT__ && document.getElementById('sidebar-metadata')?.contains(document.activeElement) ? this.state.inFocus[field] : false}
                                 value={formData?.[field]}
                                 required={schema.required.indexOf(field) !== -1}
                                 onChange={this.onChangeField}


### PR DESCRIPTION
When editing metadata externally, as in the case of our EEA metadata block, the current functionality causes the sidebar to automatically gain focus. However, this behavior is unnecessary in this context and results in the sidebar capturing focus inappropriately. To address this, I propose a solution where the sidebar will only receive focus if the user is actively working within it. This can be achieved by checking the activeElement to determine if the sidebar should be focused.

[screen-capture.webm](https://github.com/plone/volto/assets/50819975/6a771fa6-dabf-49c4-82a8-2ea579f9f5bf)
