### PR TITLE
Allow Makefile to be modified by Makefile.local if present

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -401,3 +401,4 @@ stop-test-acceptance-server-detached: ## Stop Test Acceptance Server Main Fixtur
 
 # include local overrides if present
 -include Makefile.local
+-include ../../../Makefile.local

--- a/Makefile
+++ b/Makefile
@@ -398,3 +398,6 @@ start-test-acceptance-server-detached: ## Start Test Acceptance Server Main Fixt
 .PHONY: stop-test-acceptance-server-detached
 stop-test-acceptance-server-detached: ## Stop Test Acceptance Server Main Fixture (docker container) in a detached (daemon) mode
 	docker kill plone-client-acceptance-server
+
+# include local overrides if present
+-include Makefile.local

--- a/packages/volto/news/5997.internal
+++ b/packages/volto/news/5997.internal
@@ -1,0 +1,1 @@
+Allow `Makefile` options to be modified by a `Makefile.local` file if present. @ichim-david


### PR DESCRIPTION
This way we can modify any of the makefile commands or add extra without having to touch the
Volto core file.