### PR TITLE
Revert "Fix 301 and 302 redirects. (#5999)"

### DIFF
--- a/packages/volto/news/5999.bugfix
+++ b/packages/volto/news/5999.bugfix
@@ -1,1 +1,0 @@
-Fix 301 and 302 redirects. @robgietema

--- a/packages/volto/src/components/theme/View/View.jsx
+++ b/packages/volto/src/components/theme/View/View.jsx
@@ -209,11 +209,6 @@ class View extends Component {
     if (this.props.error && this.props.error.code === 301) {
       const redirect = flattenToAppURL(this.props.error.url).split('?')[0];
       return <Redirect to={`${redirect}${this.props.location.search}`} />;
-    } else if (this.props.error && this.props.error.status === 302) {
-      const redirect = flattenToAppURL(
-        this.props.error.response.header.location,
-      ).split('?')[0];
-      return <Redirect to={`${redirect}${this.props.location.search}`} />;
     } else if (this.props.error && !this.props.connectionRefused) {
       let FoundView;
       if (this.props.error.status === undefined) {

--- a/packages/volto/src/helpers/Api/Api.js
+++ b/packages/volto/src/helpers/Api/Api.js
@@ -54,7 +54,7 @@ class Api {
       ) => {
         let request;
         let promise = new Promise((resolve, reject) => {
-          request = superagent[method](formatUrl(path)).redirects(0);
+          request = superagent[method](formatUrl(path));
 
           if (params) {
             request.query(params);

--- a/packages/volto/src/helpers/Api/Api.plone.rest.test.js
+++ b/packages/volto/src/helpers/Api/Api.plone.rest.test.js
@@ -3,14 +3,12 @@ import Api from './Api';
 
 jest.mock('superagent', () => ({
   get: jest.fn((url) => ({
-    redirects: jest.fn(() => ({
-      url,
-      query: jest.fn(),
-      set: jest.fn(),
-      type: jest.fn(),
-      send: jest.fn(),
-      end: jest.fn(),
-    })),
+    url,
+    query: jest.fn(),
+    set: jest.fn(),
+    type: jest.fn(),
+    send: jest.fn(),
+    end: jest.fn(),
   })),
 }));
 

--- a/packages/volto/src/helpers/Api/Api.test.js
+++ b/packages/volto/src/helpers/Api/Api.test.js
@@ -9,14 +9,12 @@ import Api from './Api';
 
 jest.mock('superagent', () => ({
   get: jest.fn((url) => ({
-    redirects: jest.fn(() => ({
-      url,
-      query: jest.fn(),
-      set: jest.fn(),
-      type: jest.fn(),
-      send: jest.fn(),
-      end: jest.fn(),
-    })),
+    url,
+    query: jest.fn(),
+    set: jest.fn(),
+    type: jest.fn(),
+    send: jest.fn(),
+    end: jest.fn(),
   })),
 }));
 


### PR DESCRIPTION
This reverts commit 0fbeea4ec9e21dfca80a61d1c2e73055caf4a381.

It is causing redirects to API URLs when there is a plone.app.redirector alias, instead of to the correct frontend URL.