### PR TITLE
[components] Fix `align-items: start` to make autoprefixer happy

### DIFF
--- a/packages/components/news/6062.bugfix
+++ b/packages/components/news/6062.bugfix
@@ -1,0 +1,1 @@
+Fix `align-items: start` to make autoprefixer happy @sneridagh

--- a/packages/components/src/styles/basic/BlockToolbar.css
+++ b/packages/components/src/styles/basic/BlockToolbar.css
@@ -38,7 +38,7 @@
 
   &[data-orientation='vertical'] {
     flex-direction: column;
-    align-items: start;
+    align-items: flex-start;
   }
 }
 

--- a/packages/components/src/styles/basic/Form.css
+++ b/packages/components/src/styles/basic/Form.css
@@ -5,7 +5,7 @@
 .react-aria-Form {
   display: flex;
   flex-direction: column;
-  align-items: start;
+  align-items: flex-start;
   gap: 8px;
 }
 

--- a/packages/components/src/styles/basic/Toolbar.css
+++ b/packages/components/src/styles/basic/Toolbar.css
@@ -33,7 +33,7 @@
 
   &[data-orientation='vertical'] {
     flex-direction: column;
-    align-items: start;
+    align-items: flex-start;
   }
 }
 


### PR DESCRIPTION


<!-- readthedocs-preview volto start -->
----
📚 Documentation preview 📚: https://volto--6062.org.readthedocs.build/

<!-- readthedocs-preview volto end -->