### PR TITLE
Byday and byyear-byday buttons padding in recurrence form

### DIFF
--- a/packages/volto/news/6070.bugfix
+++ b/packages/volto/news/6070.bugfix
@@ -1,1 +1,1 @@
-Byday and byyear-byday buttons padding in recurrence form for big fonts @sabrina-bongiovanni
+Remove left and right padding from _Event > Edit recurrence > Repeat on_ buttons when repeating for weekly or yearly events for big fonts, preventing overflow. @sabrina-bongiovanni

--- a/packages/volto/news/6070.bugfix
+++ b/packages/volto/news/6070.bugfix
@@ -1,0 +1,1 @@
+Byday and byyear-byday buttons padding in recurrence form for big fonts @sabrina-bongiovanni

--- a/packages/volto/theme/themes/pastanaga/extras/widgets.less
+++ b/packages/volto/theme/themes/pastanaga/extras/widgets.less
@@ -154,7 +154,7 @@ body.babel-view .field.language-independent-field {
   .word-break();
 }
 
-// makes sure recurrence form buttons don't overflow when font is big
+// makes sure event recurrence form buttons don't overflow when font is big
 .recurrence-form {
   .byday-field {
     .button {

--- a/packages/volto/theme/themes/pastanaga/extras/widgets.less
+++ b/packages/volto/theme/themes/pastanaga/extras/widgets.less
@@ -153,3 +153,14 @@ body.babel-view .field.language-independent-field {
 .react-select__option {
   .word-break();
 }
+
+// makes sure recurrence form buttons don't overflow when font is big
+.recurrence-form {
+  .byday-field {
+    .button {
+      flex-grow: 1;
+      padding-right: 0px;
+      padding-left: 0px;
+    }
+  }
+}

--- a/packages/volto/theme/themes/pastanaga/extras/widgets.less
+++ b/packages/volto/theme/themes/pastanaga/extras/widgets.less
@@ -163,4 +163,12 @@ body.babel-view .field.language-independent-field {
       padding-left: 0px;
     }
   }
+
+  .byyear-field {
+    .byyear-byday {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+    }
+  }
 }


### PR DESCRIPTION
This PR fixes

- the byday field buttons in the recurrence widget when font-size is >16px.

<img width="1005" alt="image" src="https://github.com/plone/volto/assets/116291154/ca9c9e57-5c2d-49d3-9275-317224746d91">

- the byyear-byday buttons for the yearly recurrence when font-size is >16px.

<img width="938" alt="image" src="https://github.com/plone/volto/assets/116291154/28d30c3a-1e7a-476e-8398-9c9c08027b06">



<!-- readthedocs-preview volto start -->
----
📚 Documentation preview 📚: https://volto--6070.org.readthedocs.build/

<!-- readthedocs-preview volto end -->