### PR TITLE
Support for configurable `public` directory outside Volto using `volto.config.js`

### DIFF
--- a/packages/volto/package.json
+++ b/packages/volto/package.json
@@ -281,6 +281,7 @@
     "@babel/plugin-syntax-export-namespace-from": "7.8.3",
     "@babel/runtime": "7.20.6",
     "@babel/types": "7.20.5",
+    "@fiverr/afterbuild-webpack-plugin": "^1.0.0",
     "@jest/globals": "^29.7.0",
     "@loadable/babel-plugin": "5.13.2",
     "@loadable/webpack-plugin": "5.15.2",

--- a/packages/volto/src/express-middleware/static.js
+++ b/packages/volto/src/express-middleware/static.js
@@ -1,11 +1,17 @@
 import express from 'express';
 import path from 'path';
+import AddonConfigurationRegistry from '@plone/registry/src/addon-registry';
 import config from '@plone/volto/registry';
 
+const projectRootPath = path.resolve('.');
+const registry = new AddonConfigurationRegistry(projectRootPath);
+
 const staticMiddlewareFn = express.static(
+  // Looks if voltoConfigJS has a publicPath, if not, uses RAZZLE_PUBLIC_DIR (which
+  // the default is `./public` from RAZZLE itself
   process.env.BUILD_DIR
     ? path.join(process.env.BUILD_DIR, 'public')
-    : process.env.RAZZLE_PUBLIC_DIR,
+    : registry.voltoConfigJS.publicPath || process.env.RAZZLE_PUBLIC_DIR,
   {
     setHeaders: function (res, path) {
       const pathLib = require('path');


### PR DESCRIPTION
This feature was missing from the new setup.