### PR TITLE
Fix link in pop-up RelationsMatrix.jsx

### DIFF
--- a/packages/volto/news/6085.bugfix
+++ b/packages/volto/news/6085.bugfix
@@ -1,0 +1,1 @@
+Fix link in pop-up in `RelationsMatrix.jsx`. @stevepiercy

--- a/packages/volto/src/components/manage/Controlpanels/Relations/RelationsMatrix.jsx
+++ b/packages/volto/src/components/manage/Controlpanels/Relations/RelationsMatrix.jsx
@@ -414,7 +414,7 @@ const RelationsMatrix = (props) => {
                           <Popup
                             trigger={
                               <a
-                                href="https://6.docs.plone.org/volto/recipes/widget.html#restricting-potential-targets"
+                                href="https://6.docs.plone.org/volto/development/widget.html#widget-relation-field-label"
                                 target="_blank"
                                 rel="noopener noreferrer"
                               >


### PR DESCRIPTION
This link is outdated after https://github.com/plone/volto/pull/5809, and its anchor never existed. This PR corrects both issues.

<!-- readthedocs-preview volto start -->
----
📚 Documentation preview 📚: https://volto--6085.org.readthedocs.build/

<!-- readthedocs-preview volto end -->