### PR TITLE
Fix Uncaught RangeError: date value is not finite in DateTimeFormat.format

### DIFF
--- a/packages/volto/news/6087.bugfix
+++ b/packages/volto/news/6087.bugfix
@@ -1,0 +1,1 @@
+Fix Uncaught RangeError: date value is not finite in DateTimeFormat.format.  @mauritsvanrees

--- a/packages/volto/src/components/theme/FormattedDate/FormattedDate.jsx
+++ b/packages/volto/src/components/theme/FormattedDate/FormattedDate.jsx
@@ -18,13 +18,25 @@ const FormattedDate = ({
   const language = useSelector((state) => locale || state.intl.locale);
   const toDate = (d) => (typeof d === 'string' ? new Date(d) : d);
   const args = { date, long, includeTime, format, locale: language };
+  const new_date = new Date(toDate(date));
+  // Dat check taken from https://stackoverflow.com/questions/1353684/detecting-an-invalid-date-date-instance-in-javascript#1353711
+  if (Object.prototype.toString.call(new_date) === '[object Date]') {
+    // it is a date
+    if (isNaN(new_date)) {
+      // date object is not valid
+      return <span>bad date</span>;
+    }
+  } else {
+    // not a date object
+    return <span>not a date</span>;
+  }
 
   return (
     <time
       className={className}
       dateTime={date}
       title={new Intl.DateTimeFormat(language, long_date_format)
-        .format(new Date(toDate(date)))
+        .format(new_date)
         .replace('\u202F', ' ')}
     >
       {children


### PR DESCRIPTION
Fixes https://github.com/plone/volto/issues/6087

This shows a basic error message, instead of completely crashing the page.
We could also leave this empty.

<!-- readthedocs-preview volto start -->
----
📚 Documentation preview 📚: https://volto--6088.org.readthedocs.build/

<!-- readthedocs-preview volto end -->