### PR TITLE
Fixes #6046 pass proper defaults to align and size fields of Image block

### DIFF
--- a/packages/volto/news/6046.bugfix
+++ b/packages/volto/news/6046.bugfix
@@ -1,0 +1,2 @@
+Add default 'l' and 'center' values to size and align fields of `Image` block.
+This fixes data not having any value adding proper options to the `Image` block. @ichim-david

--- a/packages/volto/src/components/manage/Blocks/Image/__snapshots__/ImageSidebar.test.jsx.snap
+++ b/packages/volto/src/components/manage/Blocks/Image/__snapshots__/ImageSidebar.test.jsx.snap
@@ -84,11 +84,13 @@ Array [
     },
     \\"align\\": {
       \\"title\\": \\"Alignment\\",
-      \\"widget\\": \\"align\\"
+      \\"widget\\": \\"align\\",
+      \\"default\\": \\"center\\"
     },
     \\"size\\": {
       \\"title\\": \\"Image size\\",
-      \\"widget\\": \\"image_size\\"
+      \\"widget\\": \\"image_size\\",
+      \\"default\\": \\"l\\"
     },
     \\"href\\": {
       \\"title\\": \\"Link to\\",

--- a/packages/volto/src/components/manage/Blocks/Image/schema.js
+++ b/packages/volto/src/components/manage/Blocks/Image/schema.js
@@ -77,10 +77,12 @@ export function ImageSchema({ formData, intl }) {
       align: {
         title: intl.formatMessage(messages.Align),
         widget: 'align',
+        default: 'center',
       },
       size: {
         title: intl.formatMessage(messages.size),
         widget: 'image_size',
+        default: 'l',
       },
       href: {
         title: intl.formatMessage(messages.LinkTo),


### PR DESCRIPTION
Fixes #6046 pass proper defaults to align and size fields of Image block
<!-- readthedocs-preview volto start -->
----
📚 Documentation preview 📚: https://volto--6093.org.readthedocs.build/

<!-- readthedocs-preview volto end -->