### PR TITLE
Backport #5448 -- fix restapi version check in group membership control panel

### DIFF
--- a/news/5448.bugfix
+++ b/news/5448.bugfix
@@ -1,0 +1,1 @@
+Fixed group membership control panel's check for the `plone.restapi` version. @shibbu264

--- a/src/components/manage/Controlpanels/Users/UserGroupMembershipControlPanel.jsx
+++ b/src/components/manage/Controlpanels/Users/UserGroupMembershipControlPanel.jsx
@@ -3,7 +3,7 @@
  * TODO Enrich with features of user control panel. Then replace user control panel.
  */
 import React, { useEffect } from 'react';
-import { find, toNumber } from 'lodash';
+import { find } from 'lodash';
 import { Portal } from 'react-portal';
 import { useHistory } from 'react-router';
 import { Link, useLocation } from 'react-router-dom';
@@ -38,7 +38,7 @@ const UserGroupMembershipPanel = () => {
     (state) => state.controlpanels.systeminformation,
   );
   const can_use_group_membership_panel = systeminformation
-    ? toNumber(systeminformation?.plone_restapi_version.slice(0, 4)) >= 8.24
+    ? parseFloat(systeminformation?.plone_restapi_version.slice(0, 4)) >= 8.24
     : false;
   const actions = useSelector((state) => state.actions?.actions ?? {});
   const ploneSetupAction = find(actions.user, {


### PR DESCRIPTION
This fix is needed for the control panel to work with plone.restapi 9.