### PR TITLE
Add support for reading the add-ons `tsconfig.json` paths

### DIFF
--- a/packages/registry/news/6096.feature
+++ b/packages/registry/news/6096.feature
@@ -1,0 +1,1 @@
+Add support for reading the add-ons `tsconfig.json` paths and add them to the build resolve aliases @sneridagh

--- a/packages/volto/__tests__/addon-registry-project.test.js
+++ b/packages/volto/__tests__/addon-registry-project.test.js
@@ -46,15 +46,20 @@ describe('AddonConfigurationRegistry - Project', () => {
         version: '0.0.0',
       },
       'test-released-addon': {
+        basePath:
+          '/Users/sneridagh/Development/plone/volto/packages/volto/__tests__/fixtures/test-volto-project/node_modules/test-released-addon',
         isPublishedPackage: true,
         modulePath: `${base}/node_modules/test-released-addon`,
         name: 'test-released-addon',
         packageJson: `${base}/node_modules/test-released-addon/package.json`,
         addons: ['test-released-unmentioned:extra1,extra2'],
         isRegisteredAddon: true,
+        tsConfigPaths: null,
         version: '0.0.0',
       },
       'test-released-source-addon': {
+        basePath:
+          '/Users/sneridagh/Development/plone/volto/packages/volto/__tests__/fixtures/test-volto-project/node_modules/test-released-source-addon',
         isPublishedPackage: true,
         modulePath: `${base}/node_modules/test-released-source-addon/src`,
         name: 'test-released-source-addon',
@@ -62,15 +67,19 @@ describe('AddonConfigurationRegistry - Project', () => {
         razzleExtender: `${base}/node_modules/test-released-source-addon/razzle.extend.js`,
         addons: [],
         isRegisteredAddon: true,
+        tsConfigPaths: null,
         version: '0.0.0',
       },
       'test-released-unmentioned': {
         addons: [],
+        basePath:
+          '/Users/sneridagh/Development/plone/volto/packages/volto/__tests__/fixtures/test-volto-project/node_modules/test-released-unmentioned',
         isPublishedPackage: true,
         modulePath: `${base}/node_modules/test-released-unmentioned`,
         name: 'test-released-unmentioned',
         packageJson: `${base}/node_modules/test-released-unmentioned/package.json`,
         isRegisteredAddon: true,
+        tsConfigPaths: null,
         version: '0.0.0',
       },
       'my-volto-config-addon': {

--- a/packages/volto/__tests__/addon-registry-project.test.js
+++ b/packages/volto/__tests__/addon-registry-project.test.js
@@ -46,8 +46,7 @@ describe('AddonConfigurationRegistry - Project', () => {
         version: '0.0.0',
       },
       'test-released-addon': {
-        basePath:
-          '/Users/sneridagh/Development/plone/volto/packages/volto/__tests__/fixtures/test-volto-project/node_modules/test-released-addon',
+        basePath: `${base}/node_modules/test-released-addon`,
         isPublishedPackage: true,
         modulePath: `${base}/node_modules/test-released-addon`,
         name: 'test-released-addon',
@@ -58,8 +57,7 @@ describe('AddonConfigurationRegistry - Project', () => {
         version: '0.0.0',
       },
       'test-released-source-addon': {
-        basePath:
-          '/Users/sneridagh/Development/plone/volto/packages/volto/__tests__/fixtures/test-volto-project/node_modules/test-released-source-addon',
+        basePath: `${base}/node_modules/test-released-source-addon`,
         isPublishedPackage: true,
         modulePath: `${base}/node_modules/test-released-source-addon/src`,
         name: 'test-released-source-addon',
@@ -72,8 +70,7 @@ describe('AddonConfigurationRegistry - Project', () => {
       },
       'test-released-unmentioned': {
         addons: [],
-        basePath:
-          '/Users/sneridagh/Development/plone/volto/packages/volto/__tests__/fixtures/test-volto-project/node_modules/test-released-unmentioned',
+        basePath: `${base}/node_modules/test-released-unmentioned`,
         isPublishedPackage: true,
         modulePath: `${base}/node_modules/test-released-unmentioned`,
         name: 'test-released-unmentioned',

--- a/packages/volto/news/6096.feature
+++ b/packages/volto/news/6096.feature
@@ -1,0 +1,1 @@
+Add support for reading the add-ons `tsconfig.json` paths and add them to the build resolve aliases @sneridagh


### PR DESCRIPTION
... and add them to the build resolve aliases

This was missing in the new setup, so now the roundtrip is supported, since the add-ons will declare their resolve paths in `tsconfig.json`, so IDEs JS and TS will be happy, and then the build will recognize them.

In the future this will be also important since we want this to be passed to other builds. Until now, Razzle was who was reading this (only in the main project root) and adding them lately to the Webpack aliases. Now we have it per add-on, independent of the build, `@plone/registry` powered.