### PR TITLE
Improve container detection, `config.settings.containerBlockTypes` is no longer needed

### DIFF
--- a/docs/source/upgrade-guide/index.md
+++ b/docs/source/upgrade-guide/index.md
@@ -237,6 +237,10 @@ If your tests rely on the old fieldset's generated value for selecting fields, y
 Now `config.getSlots` in the configuration registry takes the argument `location` instead of `pathname`.
 This allows more expressive conditions to fulfill the use case of the `Add` form.
 
+### Improve container detection
+
+The mechanism to detect if a block is a container or not has been improved and the config setting `config.settings.containerBlockTypes` is no longer needed, and core won't check for it anymore.
+
 (volto-upgrade-guide-17.x.x)=
 
 ## Upgrading to Volto 17.x.x

--- a/packages/types/news/6099.breaking
+++ b/packages/types/news/6099.breaking
@@ -1,0 +1,1 @@
+Remove unused `config.settings.containerBlockTypes` @sneridagh

--- a/packages/types/src/config/Settings.d.ts
+++ b/packages/types/src/config/Settings.d.ts
@@ -97,7 +97,6 @@ export interface SettingsConfig {
   querystringSearchGet: boolean;
   blockSettingsTabFieldsetsInitialStateOpen: boolean;
   excludeLinksAndReferencesMenuItem: boolean;
-  containerBlockTypes: string[];
   siteTitleFormat: {
     includeSiteTitle: boolean;
     titleAndSiteTitleSeparator: string;

--- a/packages/volto/news/6099.breaking
+++ b/packages/volto/news/6099.breaking
@@ -1,0 +1,1 @@
+Improve container detection, `config.settings.containerBlockTypes` is no longer needed @sneridagh

--- a/packages/volto/src/config/index.js
+++ b/packages/volto/src/config/index.js
@@ -178,7 +178,6 @@ let config = {
     querystringSearchGet: false,
     blockSettingsTabFieldsetsInitialStateOpen: true,
     excludeLinksAndReferencesMenuItem: false,
-    containerBlockTypes: ['gridBlock'],
     siteTitleFormat: {
       includeSiteTitle: false,
       titleAndSiteTitleSeparator: '-',

--- a/packages/volto/src/helpers/Blocks/Blocks.js
+++ b/packages/volto/src/helpers/Blocks/Blocks.js
@@ -694,6 +694,18 @@ export const getPreviousNextBlock = ({ content, block }) => {
 };
 
 /**
+ * Check if a block is a container block
+ * check blocks from data as well since some add-ons use that
+ * such as @eeacms/volto-tabs-block
+ */
+export function isBlockContainer(block) {
+  return (
+    hasBlocksData(block) ||
+    (block.hasOwnProperty('data') && hasBlocksData(block.data))
+  );
+}
+
+/**
  * Given a `block` object and a list of block types, return a list of block ids matching the types
  *
  * @function findBlocks
@@ -701,8 +713,6 @@ export const getPreviousNextBlock = ({ content, block }) => {
  * @return {Array} An array of block ids
  */
 export function findBlocks(blocks, types, result = []) {
-  const containerBlockTypes = config.settings.containerBlockTypes;
-
   Object.keys(blocks).forEach((blockId) => {
     const block = blocks[blockId];
     // check blocks from data as well since some add-ons use that
@@ -710,7 +720,7 @@ export function findBlocks(blocks, types, result = []) {
     const child_blocks = block.blocks || block.data?.blocks;
     if (types.includes(block['@type'])) {
       result.push(blockId);
-    } else if (containerBlockTypes.includes(block['@type']) || child_blocks) {
+    } else if (isBlockContainer(block)) {
       findBlocks(child_blocks, types, result);
     }
   });
@@ -718,6 +728,9 @@ export function findBlocks(blocks, types, result = []) {
   return result;
 }
 
+/**
+ * Build a block's hierarchy that the order tab can understand and uses
+ */
 export const getBlocksHierarchy = (properties) => {
   const blocksFieldName = getBlocksFieldname(properties);
   const blocksLayoutFieldname = getBlocksLayoutFieldname(properties);
@@ -725,10 +738,9 @@ export const getBlocksHierarchy = (properties) => {
     id: n,
     title: properties[blocksFieldName][n]?.['@type'],
     data: properties[blocksFieldName][n],
-    children:
-      properties[blocksFieldName][n]?.['@type'] === 'gridBlock'
-        ? getBlocksHierarchy(properties[blocksFieldName][n])
-        : [],
+    children: isBlockContainer(properties[blocksFieldName][n])
+      ? getBlocksHierarchy(properties[blocksFieldName][n])
+      : [],
   }));
 };
 

--- a/packages/volto/src/helpers/Blocks/Blocks.js
+++ b/packages/volto/src/helpers/Blocks/Blocks.js
@@ -700,8 +700,9 @@ export const getPreviousNextBlock = ({ content, block }) => {
  */
 export function isBlockContainer(block) {
   return (
-    hasBlocksData(block) ||
-    (block.hasOwnProperty('data') && hasBlocksData(block.data))
+    block &&
+    (hasBlocksData(block) ||
+      (block.hasOwnProperty('data') && hasBlocksData(block.data)))
   );
 }
 

--- a/packages/volto/src/helpers/Blocks/Blocks.test.js
+++ b/packages/volto/src/helpers/Blocks/Blocks.test.js
@@ -23,6 +23,7 @@ import {
   blocksFormGenerator,
   findBlocks,
   findContainer,
+  isBlockContainer,
 } from './Blocks';
 
 import config from '@plone/volto/registry';
@@ -1640,6 +1641,60 @@ describe('findContainer', () => {
         '@type': 'container',
         ...blocksData,
       });
+    });
+  });
+
+  describe('isBlockContainer', () => {
+    const blocksData = { blocks: {}, blocks_layout: { items: [] } };
+
+    it('basic test', () => {
+      const formData = {
+        title: 'Example',
+        blocks: {
+          1: { title: 'title', '@type': 'title' },
+          2: { title: 'an image', '@type': 'image' },
+          3: { title: 'description', '@type': 'description' },
+          4: { title: 'a container', '@type': 'container', ...blocksData },
+        },
+        blocks_layout: {
+          items: ['1', '2', '3', '4'],
+        },
+      };
+
+      const container = isBlockContainer(formData);
+      expect(container).toBeTruthy();
+    });
+
+    it('in data key (EEA add-ons)', () => {
+      const formData = {
+        title: 'Example',
+        data: {
+          blocks: {
+            1: { title: 'title', '@type': 'title' },
+            2: { title: 'an image', '@type': 'image' },
+            3: { title: 'description', '@type': 'description' },
+            4: { title: 'a container', '@type': 'container', ...blocksData },
+          },
+          blocks_layout: {
+            items: ['1', '2', '3', '4'],
+          },
+        },
+      };
+
+      const container = isBlockContainer(formData);
+      expect(container).toBeTruthy();
+    });
+
+    it('not a container', () => {
+      const formData = {
+        title: 'Example',
+        styles: {
+          color: 'red',
+        },
+      };
+
+      const container = isBlockContainer(formData);
+      expect(container).toBeFalsy();
     });
   });
 });


### PR DESCRIPTION

This fixes the order tab to detect all containers, including EEA's nested ones in `data` keys.

@ichim-david I updated also the pagination `findBlocks` helper too, with the new code, please take a look.

<!-- readthedocs-preview volto start -->
----
📚 Documentation preview 📚: https://volto--6099.org.readthedocs.build/

<!-- readthedocs-preview volto end -->