### PR TITLE
(fix): export getFieldURL from Url.js in helpers

### DIFF
--- a/packages/volto/news/6100.bugfix
+++ b/packages/volto/news/6100.bugfix
@@ -1,0 +1,1 @@
+export getFieldURL from Url.js in helpers  @dobri1408

--- a/packages/volto/src/helpers/index.js
+++ b/packages/volto/src/helpers/index.js
@@ -30,6 +30,7 @@ export {
   removeProtocol,
   URLUtils,
   flattenScales,
+  getFieldURL,
 } from '@plone/volto/helpers/Url/Url';
 export { generateRobots } from '@plone/volto/helpers/Robots/Robots';
 export {


### PR DESCRIPTION
In this pr: https://github.com/plone/volto/pull/4731/files, the authors forgot to export the getFieldURL, so you can't import it like this:
`import { getFieldURL } from '@plone/volto/helpers';`