### PR TITLE
feat: handle breakList in detached TextBlockEditor

### DIFF
--- a/packages/volto-slate/news/6106.feature
+++ b/packages/volto-slate/news/6106.feature
@@ -1,0 +1,1 @@
+Handle breakList in DetachedTextBlockEditor. @giuliaghisini

--- a/packages/volto-slate/src/blocks/Text/DetachedTextBlockEditor.jsx
+++ b/packages/volto-slate/src/blocks/Text/DetachedTextBlockEditor.jsx
@@ -4,6 +4,7 @@ import { useInView } from 'react-intersection-observer';
 import { SlateEditor } from '@plone/volto-slate/editor';
 import { serializeNodesToText } from '@plone/volto-slate/editor/render';
 import { handleKeyDetached } from './keyboard';
+import config from '@plone/volto/registry';
 
 const DEBUG = false;
 
@@ -29,6 +30,7 @@ export const DetachedTextBlockEditor = (props) => {
   const { value } = data;
 
   const intl = useIntl();
+  const { textblockExtensions } = config.settings.slate;
   const placeholder =
     data.placeholder || formTitle || intl.formatMessage(messages.text);
   let instructions = data?.instructions?.data || data?.instructions;
@@ -41,13 +43,22 @@ export const DetachedTextBlockEditor = (props) => {
     rootMargin: '0px 0px 200px 0px',
   });
 
+  const withBlockProperties = React.useCallback(
+    (editor) => {
+      editor.getBlockProps = () => props;
+      return editor;
+    },
+    [props],
+  );
+
   return (
     <div className="text-slate-editor-inner detached-slate-editor" ref={ref}>
       <SlateEditor
         index={index}
         readOnly={!inView}
         properties={properties}
-        renderExtensions={[]}
+        extensions={textblockExtensions}
+        renderExtensions={[withBlockProperties]}
         value={value}
         block={block /* is this needed? */}
         debug={DEBUG}

--- a/packages/volto-slate/src/blocks/Text/extensions/insertBreak.js
+++ b/packages/volto-slate/src/blocks/Text/extensions/insertBreak.js
@@ -34,7 +34,7 @@ export const withSplitBlocksOnBreak = (editor) => {
         const { data } = blockProps;
 
         // Don't add new block if not allowed
-        if (data?.disableNewBlocks) {
+        if (data?.disableNewBlocks || blockProps.detached) {
           return insertBreak();
         }
 

--- a/packages/volto/src/components/theme/Logo/Logo.jsx
+++ b/packages/volto/src/components/theme/Logo/Logo.jsx
@@ -27,7 +27,6 @@ const Logo = () => {
   const navroot = useSelector((state) => state.navroot.data);
   const dispatch = useDispatch();
   const intl = useIntl();
-  return <></>;
 
   const messages = defineMessages({
     home: {

--- a/packages/volto/src/components/theme/Logo/Logo.jsx
+++ b/packages/volto/src/components/theme/Logo/Logo.jsx
@@ -27,6 +27,7 @@ const Logo = () => {
   const navroot = useSelector((state) => state.navroot.data);
   const dispatch = useDispatch();
   const intl = useIntl();
+  return <></>;
 
   const messages = defineMessages({
     home: {


### PR DESCRIPTION
Now you could break lists also in DetachedTextBlockEditor, like in text block inside a Grid block

https://github.com/plone/volto/assets/51911425/da08bdea-ee63-4aeb-aeb2-6e2c56f70486



<!-- readthedocs-preview volto start -->
----
📚 Documentation preview 📚: https://volto--6106.org.readthedocs.build/

<!-- readthedocs-preview volto end -->