### PR TITLE
Fix link to renamed `src/constants/Languages.cjs`

### DIFF
--- a/docs/source/development/i18n.md
+++ b/docs/source/development/i18n.md
@@ -25,7 +25,7 @@ The workflow for creating *new* translatable text strings is as follows:
 1.  Extract all i18n strings from your code with a script and create artifacts, like `.po` and `.pot` files.
 1.  Use your favorite editor to translate all i18n strings by editing the `.po` files.
 1.  Re-run the script, which then moves the translations from the `.po` files into `.json` files for Volto to use.
-1.  Edit [`packages/volto/src/constants/Languages.js`](https://github.com/plone/volto/blob/main/packages/volto/src/constants/Languages.js), adding your new language's locale code, as defined in {ref}`i18n-l10n-locale-and-language-tag-conventions-label`.
+1.  Edit [`packages/volto/src/constants/Languages.cjs`](https://github.com/plone/volto/blob/main/packages/volto/src/constants/Languages.cjs), adding your new language's locale code, as defined in {ref}`i18n-l10n-locale-and-language-tag-conventions-label`.
 1.  Run the unit tests as described in {ref}`run-jest-tests-on-volto-core-label`, following the prompt to update the snapshot when the test fails.
 
 This way of organizing translations relies on [gettext](https://en.wikipedia.org/wiki/Gettext), a proven and established system with great tool support.

--- a/packages/volto/news/6135.documentation
+++ b/packages/volto/news/6135.documentation
@@ -1,0 +1,1 @@
+Fix link to renamed `src/constants/Languages.cjs`. @stevepiercy


### PR DESCRIPTION
We missed this in https://github.com/plone/volto/pull/6130.

<!-- readthedocs-preview volto start -->
----
📚 Documentation preview 📚: https://volto--6135.org.readthedocs.build/

<!-- readthedocs-preview volto end -->