### PR TITLE
fix: ineffectiveness of the "Whole Day" and "Open End" checkbox in Event forms (#3243)

### DIFF
--- a/packages/volto/news/3243.bugfix
+++ b/packages/volto/news/3243.bugfix
@@ -1,0 +1,1 @@
+Enabled the "Open End" checkbox to hide the "Event Ends" field on event forms and "Whole Day" checkbox to hide the time information on the Event forms for improving usability and interface clarity. @cihanandac

--- a/packages/volto/src/components/manage/Form/Form.jsx
+++ b/packages/volto/src/components/manage/Form/Form.jsx
@@ -334,6 +334,8 @@ class Form extends Component {
     ) {
       this.setState(() => ({ sidebarMetadataIsAvailable: true }));
     }
+
+    this.updateEventEndVisibility();
   }
 
   /**
@@ -379,6 +381,23 @@ class Form extends Component {
   }
 
   /**
+   * If user selects "Open End" checkbox on the Event forms, "Event Ends" field will disappear
+   */
+  updateEventEndVisibility() {
+    if (this.state.formData?.open_end === undefined) {
+      return;
+    }
+
+    const endFieldWrapper = document.querySelector('.field-wrapper-end');
+
+    if (endFieldWrapper) {
+      endFieldWrapper.style.display = this.state.formData.open_end
+        ? 'none'
+        : '';
+    }
+  }
+
+  /**
    * Component did mount
    * @method componentDidMount
    * @returns {undefined}
@@ -407,6 +426,7 @@ class Form extends Component {
       if (this.props.global) {
         this.props.setFormData(newFormData);
       }
+      this.updateEventEndVisibility();
       return {
         errors,
         formData: newFormData,

--- a/packages/volto/src/components/manage/Widgets/DatetimeWidget.jsx
+++ b/packages/volto/src/components/manage/Widgets/DatetimeWidget.jsx
@@ -123,7 +123,7 @@ export class DatetimeWidgetComponent extends Component {
     return (
       this.props.dateOnly ||
       this.props.widget === 'date' ||
-      this.props.formData.whole_day
+      this.props.formData?.whole_day
     );
   }
 

--- a/packages/volto/src/components/manage/Widgets/DatetimeWidget.jsx
+++ b/packages/volto/src/components/manage/Widgets/DatetimeWidget.jsx
@@ -120,7 +120,11 @@ export class DatetimeWidgetComponent extends Component {
   }
 
   getDateOnly() {
-    return this.props.dateOnly || this.props.widget === 'date';
+    return (
+      this.props.dateOnly ||
+      this.props.widget === 'date' ||
+      this.props.formData.whole_day
+    );
   }
 
   /**


### PR DESCRIPTION
This changes fix the ineffectiveness of "Whole Day" and "Open End" checkboxes over the visibility of the "Event Starts" and "Event Ends" fields. 
- When "Open End" is enabled,  the "Event Ends" field disappears from the form.
- When "Whole Day" is enabled, the time values of the "Event Starts" and "Event Ends" disappear.

Fixes #3243