### PR TITLE
Image full alignment size issue on edit#5936

### DIFF
--- a/packages/volto/news/5936.bugfix
+++ b/packages/volto/news/5936.bugfix
@@ -1,2 +1,1 @@
-Fixed full aligned image size issue on the edit screen by changing padding-left and width
-values depending on the position of the sidebar and toolbar. @cihanandac
+When adding an image to a block, and selecting the `full` alignment option, keep the image inside the block instead of overflowing. @cihanandac

--- a/packages/volto/news/5936.bugfix
+++ b/packages/volto/news/5936.bugfix
@@ -1,0 +1,2 @@
+Fixed full aligned image size issue on the edit screen by changing padding-left and width
+values depending on the position of the sidebar and toolbar. @cihanandac

--- a/packages/volto/theme/themes/pastanaga/extras/blocks.less
+++ b/packages/volto/theme/themes/pastanaga/extras/blocks.less
@@ -275,6 +275,58 @@ body.has-toolbar.has-sidebar-collapsed .ui.wrapper > .ui.inner.block.full {
   }
 }
 
+// Hacks for keeping the full-width image in the edit screen
+.view-editview {
+  &.has-sidebar {
+    .block.align.full img {
+      width: calc(100vw - 375px) !important;
+    }
+  }
+
+  &.has-sidebar-collapsed {
+    .block.align.full img {
+      width: calc(100vw - 20px) !important;
+    }
+  }
+  @media (min-width: 766px) {
+    &.has-toolbar {
+      &.has-sidebar {
+        .block.align.full img {
+          width: calc(100vw - 228px) !important;
+          padding-left: 228px;
+          transition: padding-left 0.3s cubic-bezier(0.6, -0.28, 0.735, 0.045);
+        }
+      }
+
+      &.has-sidebar-collapsed {
+        .block.align.full img {
+          width: calc(100vw - 50px) !important;
+          padding-left: 51px;
+          transition: width 0.3s cubic-bezier(0.6, -0.28, 0.735, 0.045);
+        }
+      }
+    }
+
+    &.has-toolbar-collapsed {
+      &.has-sidebar {
+        .block.align.full img {
+          width: calc(100vw - 198px) !important;
+          padding-left: 198px;
+          transition: padding-left 0.3s cubic-bezier(0.6, -0.28, 0.735, 0.045);
+        }
+      }
+
+      &.has-sidebar-collapsed {
+        .block.align.full img {
+          width: calc(100vw - 20px) !important;
+          padding-left: 20px;
+          transition: width 0.3s cubic-bezier(0.6, -0.28, 0.735, 0.045);
+        }
+      }
+    }
+  }
+}
+
 .block.align:not(.right):not(.left) {
   clear: both;
 }

--- a/packages/volto/theme/themes/pastanaga/extras/blocks.less
+++ b/packages/volto/theme/themes/pastanaga/extras/blocks.less
@@ -280,12 +280,14 @@ body.has-toolbar.has-sidebar-collapsed .ui.wrapper > .ui.inner.block.full {
   &.has-sidebar {
     .block.align.full img {
       width: calc(100vw - 375px) !important;
+      transition: width 0.3s cubic-bezier(0.6, -0.28, 0.735, 0.045);
     }
   }
 
   &.has-sidebar-collapsed {
     .block.align.full img {
       width: calc(100vw - 20px) !important;
+      transition: width 0.3s cubic-bezier(0.6, -0.28, 0.735, 0.045);
     }
   }
   @media (min-width: 766px) {
@@ -302,7 +304,6 @@ body.has-toolbar.has-sidebar-collapsed .ui.wrapper > .ui.inner.block.full {
         .block.align.full img {
           width: calc(100vw - 50px) !important;
           padding-left: 51px;
-          transition: width 0.3s cubic-bezier(0.6, -0.28, 0.735, 0.045);
         }
       }
     }
@@ -320,7 +321,6 @@ body.has-toolbar.has-sidebar-collapsed .ui.wrapper > .ui.inner.block.full {
         .block.align.full img {
           width: calc(100vw - 20px) !important;
           padding-left: 20px;
-          transition: width 0.3s cubic-bezier(0.6, -0.28, 0.735, 0.045);
         }
       }
     }

--- a/packages/volto/theme/themes/pastanaga/extras/blocks.less
+++ b/packages/volto/theme/themes/pastanaga/extras/blocks.less
@@ -303,7 +303,7 @@ body.has-toolbar.has-sidebar-collapsed .ui.wrapper > .ui.inner.block.full {
       &.has-sidebar-collapsed {
         .block.align.full img {
           width: calc(100vw - 50px) !important;
-          padding-left: 51px;
+          padding-left: 50px;
         }
       }
     }


### PR DESCRIPTION
Fix for issue #5936

This change fixes the full aligned images size problem on the edit screen by changing the padding-left and width values. Transitions are set so that opening/closing of sidebar and toolbar would look seamless.