### PR TITLE
Added data folder as volume for backend-docker-start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ cypress/screenshots
 # Local environment setup
 .env
 public/critical.css
+packages/volto/data
 
 # Sphinx and MyST
 docs/_build/

--- a/docs/source/contributing/developing-core.md
+++ b/docs/source/contributing/developing-core.md
@@ -162,6 +162,10 @@ pnpm install
 
 ## Start the backend and Volto
 
+```{versionadded} 18.0.0-alpha.42
+Persist backend data across Docker sessions.
+```
+
 Every time you want to run Volto for core development, you will need to create two terminal sessions, one for the backend and one for the frontend.
 For both sessions, change your working directory to the root of your Volto clone.
 
@@ -171,23 +175,19 @@ In the first session, start the backend.
 make backend-docker-start
 ```
 
-```{versionadded} 18.0.0-alpha.42
-Persist backend data across Docker sessions.
-```
-
 When you run this command for the first time, it will download Docker images, configure the backend, create a Docker volume to persist the data named `volto-backend-data`, and start the backend.
 
+Subsequently, when you run `make backend-docker-start`, it will only start the backend using the existing configuration and Docker image and volume.
 
-When you run `make backend-docker-start` again, it will not download the Docker images, but will start the backend using the existing Docker volume.
+````{note}
+If you would like to start the backend with a clean data volume, you can run the following command.
 
-```{note}
-If you would like to start the backend with a clean data volume, you can run the following command:
-
-    docker volume rm volto-backend-data
-
-Then, run `make backend-docker-start` again to start the backend with a clean data volume.
-
+```shell
+docker volume rm volto-backend-data
 ```
+
+Then run `make backend-docker-start` again to start the backend with a clean data volume.
+````
     
 Browse to the backend running at http://localhost:8080.
 

--- a/docs/source/contributing/developing-core.md
+++ b/docs/source/contributing/developing-core.md
@@ -171,9 +171,8 @@ In the first session, start the backend.
 make backend-docker-start
 ```
 
-```{note}
-Since `Volto 18.0.0-alpha.42`, the backend data is stored in a `Docker` volume named `volto-backend-data` added within the `Docker` volumes directory when you run `make backend-docker-start` for the first time.
-This way you can easily persist the data between sessions.
+```{versionadded} 18.0.0-alpha.42
+Persist backend data across Docker sessions.
 ```
 
 When you run this command for the first time, it will download Docker images, configure the backend, and start the backend.

--- a/docs/source/contributing/developing-core.md
+++ b/docs/source/contributing/developing-core.md
@@ -162,9 +162,18 @@ pnpm install
 
 ## Start the backend and Volto
 
-```{versionadded} 18.0.0-alpha.42
+`````{versionadded} 18.0.0-alpha.42
 Persist backend data across Docker sessions.
+
+````{warning}
+Do not use this method of persistence in a production environment.
+It is intended only for development.
+
+```{seealso}
+{doc}`../deploying/index`
 ```
+````
+`````
 
 Every time you want to run Volto for core development, you will need to create two terminal sessions, one for the backend and one for the frontend.
 For both sessions, change your working directory to the root of your Volto clone.

--- a/docs/source/contributing/developing-core.md
+++ b/docs/source/contributing/developing-core.md
@@ -175,7 +175,20 @@ make backend-docker-start
 Persist backend data across Docker sessions.
 ```
 
-When you run this command for the first time, it will download Docker images, configure the backend, and start the backend.
+When you run this command for the first time, it will download Docker images, configure the backend, create a Docker volume to persist the data named `volto-backend-data`, and start the backend.
+
+
+When you run `make backend-docker-start` again, it will not download the Docker images, but will start the backend using the existing Docker volume.
+
+```{note}
+If you would like to start the backend with a clean data volume, you can run the following command:
+
+    docker volume rm volto-backend-data
+
+Then, run `make backend-docker-start` again to start the backend with a clean data volume.
+
+```
+    
 Browse to the backend running at http://localhost:8080.
 
 In the second session, start the frontend.

--- a/docs/source/contributing/developing-core.md
+++ b/docs/source/contributing/developing-core.md
@@ -171,6 +171,11 @@ In the first session, start the backend.
 make backend-docker-start
 ```
 
+```{note}
+Since `Volto 18.0.0-alpha.42`, the backend data is stored in a `Docker` volume named `data` added within `packages/volto` directory when you run `make backend-docker-start` for the first time.
+This way you can easily persist the data between sessions.
+```
+
 When you run this command for the first time, it will download Docker images, configure the backend, and start the backend.
 Browse to the backend running at http://localhost:8080.
 

--- a/docs/source/contributing/developing-core.md
+++ b/docs/source/contributing/developing-core.md
@@ -172,7 +172,7 @@ make backend-docker-start
 ```
 
 ```{note}
-Since `Volto 18.0.0-alpha.42`, the backend data is stored in a `Docker` volume named `data` added within `packages/volto` directory when you run `make backend-docker-start` for the first time.
+Since `Volto 18.0.0-alpha.42`, the backend data is stored in a `Docker` volume named `volto-backend-data` added within the `Docker` volumes directory when you run `make backend-docker-start` for the first time.
 This way you can easily persist the data between sessions.
 ```
 

--- a/packages/volto/Makefile
+++ b/packages/volto/Makefile
@@ -98,7 +98,7 @@ release-notes-copy-to-docs: ## Copy release notes into documentation
 
 .PHONY: backend-docker-start
 backend-docker-start: ## Starts a Docker-based backend for development
-	docker run -it --rm --name=backend -p 8080:8080 -e SITE=Plone -e ADDONS='$(KGS)' $(DOCKER_IMAGE)
+	docker run -it --rm --name=backend -p 8080:8080 -v '$(shell pwd)'/data:/data -e SITE=Plone -e ADDONS='$(KGS)' $(DOCKER_IMAGE)
 
 .PHONY: frontend-docker-start
 frontend-docker-start: ## Starts a Docker-based frontend for development

--- a/packages/volto/Makefile
+++ b/packages/volto/Makefile
@@ -98,7 +98,7 @@ release-notes-copy-to-docs: ## Copy release notes into documentation
 
 .PHONY: backend-docker-start
 backend-docker-start: ## Starts a Docker-based backend for development
-	docker run -it --rm --name=backend -p 8080:8080 -v '$(shell pwd)'/data:/data -e SITE=Plone -e ADDONS='$(KGS)' $(DOCKER_IMAGE)
+	docker run -it --rm --name=backend -p 8080:8080 -v volto-backend-data:/data -e SITE=Plone -e ADDONS='$(KGS)' $(DOCKER_IMAGE)
 
 .PHONY: frontend-docker-start
 frontend-docker-start: ## Starts a Docker-based frontend for development

--- a/packages/volto/news/6157.bugfix
+++ b/packages/volto/news/6157.bugfix
@@ -1,3 +1,3 @@
-Persist data for the `backend-docker-start` docker container in the `data` folder of `package/volto`.
-This way the data is persisted between runs of the container and if new data is needed it's easy to delete the `data` folder and start again.
+Persist data for the `backend-docker-start` `Docker` container in a `Docker` volume named `volto-backend-data`.
+This way the data is persisted between runs of the container and if new data is needed it's easy to delete the `data` volume and start again.
 @ichim-david

--- a/packages/volto/news/6157.bugfix
+++ b/packages/volto/news/6157.bugfix
@@ -1,0 +1,3 @@
+Persist data for the `backend-docker-start` docker container in the `data` folder of `package/volto`.
+This way the data is persisted between runs of the container and if new data is needed it's easy to delete the `data` folder and start again.
+@ichim-david

--- a/packages/volto/news/6157.bugfix
+++ b/packages/volto/news/6157.bugfix
@@ -1,3 +1,4 @@
-Persist data for the `backend-docker-start` `Docker` container in a `Docker` volume named `volto-backend-data`.
-This way the data is persisted between runs of the container and if new data is needed it's easy to delete the `data` volume and start again.
+Persist data for the `backend-docker-start` Docker container in a Docker volume named `volto-backend-data`.
+This way the data is persisted between runs of the container.
+You can also delete the `data` volume to start fresh.
 @ichim-david


### PR DESCRIPTION
This way we make it easy for the beginners that have the docs to use backend-docker-start to run Plone backend to have their data persisted