### PR TITLE
Improved i18n docs for customizations

### DIFF
--- a/docs/source/development/i18n.md
+++ b/docs/source/development/i18n.md
@@ -162,11 +162,12 @@ As the output suggests, it will first extract all messages from the source files
 Then it will synchronize the extracted messages with the `.pot` main template and with all the `.po` files found in the project.
 This script will combine the messages located in Volto itself and the current project, and combine them into the `.json` files.
 
+(override-i18n-messages)=
 
 ## Override i18n messages
 
 If you want to override an existing translation, you should declare the original message again somewhere else in your project.
-For example in `src/config.js`:
+For example in `src/messages.js`:
 
 ```js
 import { defineMessages } from 'react-intl';
@@ -191,11 +192,11 @@ msgstr "My overridden translation"
 After you set the override, then run `yarn i18n` again to create the `de.json` translation files.
 Restart Volto to see the changes applied.
 
-```{note}
-Shadowed components do _not_ override translations.
-99% of the time you do not want them to do that.
-Thus the `customizations` folder is excluded from the i18n build.
-```
+### Translations in shadowed components
+
+The `customizations` folder is excluded from the i18n build, this means that shadowed components do _not_ override translations.
+If this was not the case, all the translations in the customized components would be collected again, forcing you to translate them all again in the local project.
+You can add or override translated messages in your customizations by following the steps described in {ref}`override-i18n-messages`.
 
 ## Contribute translations for an unsupported language
 

--- a/packages/volto/news/6188.documentation
+++ b/packages/volto/news/6188.documentation
@@ -1,1 +1,1 @@
-Improved i18n docs for customizations @pnicolli
+Improved i18n docs regarding new translated messages not being picked up by the i18n translation mechanism when added in shadowed components. @pnicolli

--- a/packages/volto/news/6188.documentation
+++ b/packages/volto/news/6188.documentation
@@ -1,0 +1,1 @@
+Improved i18n docs for customizations @pnicolli


### PR DESCRIPTION
Fixes #1846

In addition to improving the customizations docs which I think might be clearer now, I would change the suggestion regarding overriding translations. I would in fact suggest to keep overridden translations in a dedicated file. The name is actually not important, but I would advide against cluttering the `src/config.js` file with translated messages and would suggest using a dedicated file. The name of the file is not important, but `src/messages.js` sounds like a sane default suggestion imho. Any thoughts?

<!-- readthedocs-preview volto start -->
----
📚 Documentation preview 📚: https://volto--6188.org.readthedocs.build/

<!-- readthedocs-preview volto end -->