### PR TITLE
`SchemaWidget` CSS and registration

### DIFF
--- a/docs/source/upgrade-guide/index.md
+++ b/docs/source/upgrade-guide/index.md
@@ -376,6 +376,21 @@ It is unlikely that your code uses it, unless you heavily customized the Jest te
 The `react-share` library and `SocialSharing` component has not been used in the core since some time ago, and it is more suitable as an add-on and not in core.
 If you still use it, you can add it to your main add-on dependency, and extract the `SocialSharing` component from Volto 17 as a custom component in your add-on code.
 
+
+### `SchemaWidget` widget registration change
+
+Previously, it was registered as a widget `id`, but this definition could leak the widget and be applied to unwanted fields.
+Now it's registered as a `widget`, so if you are using it in your project/add-ons you should update the field definition and add the `widget` property.
+
+```ts
+// more form definition above...
+schema: {
+  title: 'Schema',
+  widget: 'schema'
+}
+// rest of the form definition...
+```
+
 (volto-upgrade-guide-17.x.x)=
 
 ## Upgrading to Volto 17.x.x

--- a/docs/source/upgrade-guide/index.md
+++ b/docs/source/upgrade-guide/index.md
@@ -379,7 +379,7 @@ If you still use it, you can add it to your main add-on dependency, and extract 
 
 ### `SchemaWidget` widget registration change
 
-Previously, it was registered as a widget `id`, but this definition could leak the widget and be applied to unwanted fields.
+Previously, it was registered as a widget `id` assigned to the `schema` key. Due to this common key name, this definition could leak the widget and be applied to unwanted fields.
 Now it's registered as a `widget`, so if you are using it in your project/add-ons you should update the field definition and add the `widget` property.
 
 ```ts

--- a/packages/volto/news/6189.breaking
+++ b/packages/volto/news/6189.breaking
@@ -1,0 +1,1 @@
+Remove widget registration as `id`, move to `widget` type instead. @sneridagh

--- a/packages/volto/news/6189.breaking
+++ b/packages/volto/news/6189.breaking
@@ -1,1 +1,1 @@
-Remove widget registration as `id`, move to `widget` type instead. @sneridagh
+Removed `SchemaWidget` widget registration as `id` widget mapping assigned to the `schema` key, moved to `widget` mapping registration with the same `schema` key.  @sneridagh

--- a/packages/volto/news/6189.bugfix
+++ b/packages/volto/news/6189.bugfix
@@ -1,0 +1,1 @@
+Improve CSS for the SchemaWidget widget @robgietema @sneridagh

--- a/packages/volto/src/components/manage/Controlpanels/ContentTypeSchema.jsx
+++ b/packages/volto/src/components/manage/Controlpanels/ContentTypeSchema.jsx
@@ -213,6 +213,7 @@ class ContentTypeSchema extends Component {
           title: 'Form schema',
           type: 'schema',
           id: 'schema',
+          widget: 'schema',
         },
       },
       required: [],

--- a/packages/volto/src/config/Widgets.jsx
+++ b/packages/volto/src/config/Widgets.jsx
@@ -55,7 +55,6 @@ import ImageWidget from '@plone/volto/components/manage/Widgets/ImageWidget';
 // Widgets mapping
 export const widgetMapping = {
   id: {
-    schema: SchemaWidget,
     subjects: TokenWidget,
     query: QuerystringWidget,
     recurrence: RecurrenceWidget,
@@ -89,6 +88,7 @@ export const widgetMapping = {
     autocomplete: SelectAutoComplete,
     color_picker: ColorPickerWidget,
     select: SelectWidget,
+    schema: SchemaWidget,
   },
   vocabulary: {
     'plone.app.vocabularies.Catalog': ObjectBrowserWidget,

--- a/packages/volto/theme/themes/pastanaga/collections/form.overrides
+++ b/packages/volto/theme/themes/pastanaga/collections/form.overrides
@@ -123,13 +123,47 @@
   z-index: 1;
   top: 0;
   right: 0;
+  left: auto;
   display: flex;
   height: 60px;
   align-items: center;
   margin-right: 1rem;
+  background: transparent;
+  box-shadow: none;
+  transform: none;
 
   .item {
     cursor: pointer;
+  }
+}
+
+.block.form {
+  [data-rbd-draggable-context-id] {
+    margin-bottom: 0;
+  }
+
+  .ui.menu .item > i.icon {
+    margin-left: -2px;
+  }
+
+  .square.icon {
+    margin-top: -2px;
+  }
+
+  .ui.segments > div {
+    background: white !important;
+  }
+
+  .drag.handle {
+    cursor: grab;
+  }
+
+  .tabular.menu > .item {
+    height: 66px;
+
+    button {
+      border-bottom-width: 5px;
+    }
   }
 }
 


### PR DESCRIPTION
- Improve CSS for the `SchemaWidget` widget.
- Remove widget registration as `id`, move to `widget` type instead.

