### PR TITLE
Update volto.blocks behavior name

### DIFF
--- a/docs/source/blocks/introduction.md
+++ b/docs/source/blocks/introduction.md
@@ -82,7 +82,7 @@ You can also add the behavior programmatically via GenericSetup:
 <object name="LRF" meta_type="Dexterity FTI" i18n:domain="plone"
    xmlns:i18n="http://xml.zope.org/namespaces/i18n">
  <property name="behaviors" purge="false">
-  <element value="plone.restapi.behaviors.IBlocks" />
+  <element value="volto.blocks" />
  </property>
 </object>
 ```


### PR DESCRIPTION
the full Interface dotted name is the old 'native' python dotted path, but volto.blocks is the official behavior name and should be used.

<!-- readthedocs-preview volto start -->
----
📚 Documentation preview 📚: https://volto--6222.org.readthedocs.build/

<!-- readthedocs-preview volto end -->