### PR TITLE
Revert rename of .gitkeep for consistency

### DIFF
--- a/packages/volto/news/6232.internal
+++ b/packages/volto/news/6232.internal
@@ -1,0 +1,1 @@
+Revert rename of `.gitkeep`. @stevepiercy


### PR DESCRIPTION
Merge after the inclusion of the merged PR https://github.com/twisted/towncrier/pull/647, which closed https://github.com/twisted/towncrier/issues/643, in the next release of towncrier. 

Closes #6225.