### PR TITLE
Fix loading .cjs in webpack

### DIFF
--- a/packages/volto/news/6237.bugfix
+++ b/packages/volto/news/6237.bugfix
@@ -1,0 +1,1 @@
+Fix loading of .cjs in webpack. @davisagli

--- a/packages/volto/razzle.config.js
+++ b/packages/volto/razzle.config.js
@@ -277,7 +277,7 @@ const defaultModify = ({
   // Don't load SVGs from ./src/icons with file-loader
   const fileLoader = config.module.rules.find(fileLoaderFinder);
   fileLoader.exclude = [
-    /\.(config|variables|overrides)$/,
+    /\.(config|variables|overrides|cjs)$/,
     /icons\/.*\.svg$/,
     ...fileLoader.exclude,
   ];


### PR DESCRIPTION
(Make sure it doesn't get processed by the file-loader)

Fixes #6219 