### PR TITLE
Fixes imports to avoid type errors in addons tests

### DIFF
--- a/packages/volto/news/6244.bugfix
+++ b/packages/volto/news/6244.bugfix
@@ -1,1 +1,1 @@
-Fixes imports to avoid type errors in addons tests. @wesleybl
+Changed imports from relative to absolute to avoid type errors in add-on tests. @wesleybl

--- a/packages/volto/news/6244.bugfix
+++ b/packages/volto/news/6244.bugfix
@@ -1,0 +1,1 @@
+Fixes imports to avoid type errors in addons tests. @wesleybl

--- a/packages/volto/src/helpers/Blocks/cloneBlocks.ts
+++ b/packages/volto/src/helpers/Blocks/cloneBlocks.ts
@@ -4,7 +4,7 @@ import {
   getBlocksFieldname,
   getBlocksLayoutFieldname,
   hasBlocksData,
-} from './Blocks';
+} from '@plone/volto/helpers/Blocks/Blocks';
 import config from '@plone/registry';
 
 export function cloneBlocks(blocksData) {

--- a/packages/volto/src/helpers/FormValidation/FormValidation.jsx
+++ b/packages/volto/src/helpers/FormValidation/FormValidation.jsx
@@ -1,5 +1,5 @@
 import { map, keys, intersection, isEmpty } from 'lodash';
-import { messages } from '../MessageLabels/MessageLabels';
+import { messages } from '@plone/volto/helpers/MessageLabels/MessageLabels';
 import config from '@plone/volto/registry';
 import { toast } from 'react-toastify';
 import Toast from '@plone/volto/components/manage/Toast/Toast';

--- a/packages/volto/src/helpers/FormValidation/validators.ts
+++ b/packages/volto/src/helpers/FormValidation/validators.ts
@@ -1,4 +1,4 @@
-import { validationMessage } from './FormValidation';
+import { validationMessage } from '@plone/volto/helpers/FormValidation/FormValidation';
 import { messages } from '@plone/volto/helpers/MessageLabels/MessageLabels';
 
 type MinMaxValidator = {


### PR DESCRIPTION
When we shadow a module in an addon and this module is imported relatively in some `.ts` file used in the addon tests, we receive the error:

```
Could not find a declaration file for module './Module'. '../Module.jsx' implicitly has an 'any' type
```

So we use absolute import in `.ts` files to avoid this problem.

Fixes #6244 