### PR TITLE
Allow aliases that redirect to an external URL

### DIFF
--- a/packages/volto/locales/ca/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ca/LC_MESSAGES/volto.po
@@ -1293,9 +1293,9 @@ msgstr "Introduïu el nom complet, per exemple John Smith."
 msgid "Enter map Embed Code"
 msgstr "Introduïu el codi d'inserció del mapa"
 
-#. Default: "Enter the absolute path of the target. The path must start with '/'. Target must exist or be an existing alternative url path to the target."
+#. Default: "Enter the absolute path of the target. Target must exist or be an existing alternative url path to the target."
 #: components/manage/Controlpanels/Aliases
-msgid "Enter the absolute path of the target. The path must start with '/'. Target must exist or be an existing alternative url path to the target."
+msgid "Enter the absolute path of the target. Target must exist or be an existing alternative url path to the target."
 msgstr ""
 
 #. Default: "Enter the absolute path where the alternative url should exist. The path must start with '/'. Only urls that result in a 404 not found page will result in a redirect occurring."
@@ -3606,11 +3606,6 @@ msgstr "Mida de memòria objectiu per memòria cau en bytes"
 #: components/manage/Controlpanels/DatabaseInformation
 msgid "Target number of objects in memory per cache"
 msgstr "Nombre objectiu d'objectes a la memòria per memòria cau"
-
-#. Default: "Target url path must start with a slash."
-#: components/manage/Controlpanels/Aliases
-msgid "Target url path must start with a slash."
-msgstr ""
 
 #. Default: "Teaser"
 #: components/manage/Blocks/Teaser/schema

--- a/packages/volto/locales/de/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/de/LC_MESSAGES/volto.po
@@ -1292,10 +1292,10 @@ msgstr "Tragen Sie bitte Ihren vollen Namen ein."
 msgid "Enter map Embed Code"
 msgstr "Karten-Einbettungscode eingeben"
 
-#. Default: "Enter the absolute path of the target. The path must start with '/'. Target must exist or be an existing alternative url path to the target."
+#. Default: "Enter the absolute path of the target. Target must exist or be an existing alternative url path to the target."
 #: components/manage/Controlpanels/Aliases
-msgid "Enter the absolute path of the target. The path must start with '/'. Target must exist or be an existing alternative url path to the target."
-msgstr "Geben Sie den absoluten Pfad des Ziels ein. Der Pfad muss mit '/' beginnen. Das Ziel muss existieren oder ein existierender, alternativer Pfad zum Ziel sein."
+msgid "Enter the absolute path of the target. Target must exist or be an existing alternative url path to the target."
+msgstr "Geben Sie den absoluten Pfad des Ziels ein. Das Ziel muss existieren oder ein existierender, alternativer Pfad zum Ziel sein."
 
 #. Default: "Enter the absolute path where the alternative url should exist. The path must start with '/'. Only urls that result in a 404 not found page will result in a redirect occurring."
 #: components/manage/Aliases/Aliases
@@ -3605,11 +3605,6 @@ msgstr "Ziel-Speichergröße pro Cache in Bytes"
 #: components/manage/Controlpanels/DatabaseInformation
 msgid "Target number of objects in memory per cache"
 msgstr "Ziel-Anzahl von Objekten im Speicher pro Cache"
-
-#. Default: "Target url path must start with a slash."
-#: components/manage/Controlpanels/Aliases
-msgid "Target url path must start with a slash."
-msgstr "Der Zielpfad muss mit einem Schrägstrich beginnen."
 
 #. Default: "Teaser"
 #: components/manage/Blocks/Teaser/schema

--- a/packages/volto/locales/en/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/en/LC_MESSAGES/volto.po
@@ -1287,9 +1287,9 @@ msgstr ""
 msgid "Enter map Embed Code"
 msgstr ""
 
-#. Default: "Enter the absolute path of the target. The path must start with '/'. Target must exist or be an existing alternative url path to the target."
+#. Default: "Enter the absolute path of the target. Target must exist or be an existing alternative url path to the target."
 #: components/manage/Controlpanels/Aliases
-msgid "Enter the absolute path of the target. The path must start with '/'. Target must exist or be an existing alternative url path to the target."
+msgid "Enter the absolute path of the target. Target must exist or be an existing alternative url path to the target."
 msgstr ""
 
 #. Default: "Enter the absolute path where the alternative url should exist. The path must start with '/'. Only urls that result in a 404 not found page will result in a redirect occurring."
@@ -3599,11 +3599,6 @@ msgstr ""
 #. Default: "Target number of objects in memory per cache"
 #: components/manage/Controlpanels/DatabaseInformation
 msgid "Target number of objects in memory per cache"
-msgstr ""
-
-#. Default: "Target url path must start with a slash."
-#: components/manage/Controlpanels/Aliases
-msgid "Target url path must start with a slash."
 msgstr ""
 
 #. Default: "Teaser"

--- a/packages/volto/locales/es/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/es/LC_MESSAGES/volto.po
@@ -1294,10 +1294,10 @@ msgstr "Introduzca el nombre completo, por ejemplo Leonardo Caballero."
 msgid "Enter map Embed Code"
 msgstr "Introduzca el código embebido de un mapa"
 
-#. Default: "Enter the absolute path of the target. The path must start with '/'. Target must exist or be an existing alternative url path to the target."
+#. Default: "Enter the absolute path of the target. Target must exist or be an existing alternative url path to the target."
 #: components/manage/Controlpanels/Aliases
-msgid "Enter the absolute path of the target. The path must start with '/'. Target must exist or be an existing alternative url path to the target."
-msgstr "Introduzca la ruta absoluta del destino. La ruta debe comenzar por '/'. El destino debe existir o ser una url alternativa de otro destino."
+msgid "Enter the absolute path of the target. Target must exist or be an existing alternative url path to the target."
+msgstr "Introduzca la ruta absoluta del destino. El destino debe existir o ser una url alternativa de otro destino."
 
 #. Default: "Enter the absolute path where the alternative url should exist. The path must start with '/'. Only urls that result in a 404 not found page will result in a redirect occurring."
 #: components/manage/Aliases/Aliases
@@ -3607,11 +3607,6 @@ msgstr "Número objetivo del tamaño de la memoria por caché en bytes"
 #: components/manage/Controlpanels/DatabaseInformation
 msgid "Target number of objects in memory per cache"
 msgstr "Número objetivo de elementos en la memoria por caché"
-
-#. Default: "Target url path must start with a slash."
-#: components/manage/Controlpanels/Aliases
-msgid "Target url path must start with a slash."
-msgstr "El camino de destino debe comenzar con /."
 
 #. Default: "Teaser"
 #: components/manage/Blocks/Teaser/schema

--- a/packages/volto/locales/eu/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/eu/LC_MESSAGES/volto.po
@@ -1294,10 +1294,10 @@ msgstr "Idatzi izen osoa, adb. Jon Garmendia."
 msgid "Enter map Embed Code"
 msgstr "Sartu itsasteko kodea"
 
-#. Default: "Enter the absolute path of the target. The path must start with '/'. Target must exist or be an existing alternative url path to the target."
+#. Default: "Enter the absolute path of the target. Target must exist or be an existing alternative url path to the target."
 #: components/manage/Controlpanels/Aliases
-msgid "Enter the absolute path of the target. The path must start with '/'. Target must exist or be an existing alternative url path to the target."
-msgstr "Idatzi helburuaren bide absolutua. Bidea '/' karakterearekin hasi behar da. Helburua existitu egin behar da edo ordezko helbide bat izan behar da."
+msgid "Enter the absolute path of the target. Target must exist or be an existing alternative url path to the target."
+msgstr "Idatzi helburuaren bide absolutua. Helburua existitu egin behar da edo ordezko helbide bat izan behar da."
 
 #. Default: "Enter the absolute path where the alternative url should exist. The path must start with '/'. Only urls that result in a 404 not found page will result in a redirect occurring."
 #: components/manage/Aliases/Aliases
@@ -3607,11 +3607,6 @@ msgstr "Katxe bakoitzaren tamaina "
 #: components/manage/Controlpanels/DatabaseInformation
 msgid "Target number of objects in memory per cache"
 msgstr "Katxe bakoitzaren elementu-kopurua"
-
-#. Default: "Target url path must start with a slash."
-#: components/manage/Controlpanels/Aliases
-msgid "Target url path must start with a slash."
-msgstr "Helburuaren bidea / karakterearekin hasi behar da"
 
 #. Default: "Teaser"
 #: components/manage/Blocks/Teaser/schema

--- a/packages/volto/locales/fi/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/fi/LC_MESSAGES/volto.po
@@ -1292,10 +1292,10 @@ msgstr "Syötä koko nimi, esimerkiksi Lumi Vuorinen."
 msgid "Enter map Embed Code"
 msgstr "Syötä Google Maps -upotuskoodi"
 
-#. Default: "Enter the absolute path of the target. The path must start with '/'. Target must exist or be an existing alternative url path to the target."
+#. Default: "Enter the absolute path of the target. Target must exist or be an existing alternative url path to the target."
 #: components/manage/Controlpanels/Aliases
-msgid "Enter the absolute path of the target. The path must start with '/'. Target must exist or be an existing alternative url path to the target."
-msgstr "Syötä kohteen osoite. Osoitteen tulee alkaa merkillä '/'. Kohteen tulee olla olemassa tai sen tulee olla olemassaoleva vaihtoehtoinen URL-polku kohteelle."
+msgid "Enter the absolute path of the target. Target must exist or be an existing alternative url path to the target."
+msgstr "Syötä kohteen osoite. Kohteen tulee olla olemassa tai sen tulee olla olemassaoleva vaihtoehtoinen URL-polku kohteelle."
 
 #. Default: "Enter the absolute path where the alternative url should exist. The path must start with '/'. Only urls that result in a 404 not found page will result in a redirect occurring."
 #: components/manage/Aliases/Aliases
@@ -3605,11 +3605,6 @@ msgstr "Välimuistin tavoitekoko tavuina"
 #: components/manage/Controlpanels/DatabaseInformation
 msgid "Target number of objects in memory per cache"
 msgstr "Välimuistin tavoitekoko olioiden määrässä"
-
-#. Default: "Target url path must start with a slash."
-#: components/manage/Controlpanels/Aliases
-msgid "Target url path must start with a slash."
-msgstr "Kohdeosoitteen tulee alkaa kauttaviivalla."
 
 #. Default: "Teaser"
 #: components/manage/Blocks/Teaser/schema

--- a/packages/volto/locales/fr/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/fr/LC_MESSAGES/volto.po
@@ -1294,10 +1294,10 @@ msgstr "Saisissez votre nom complet (par exemple : John Smith)"
 msgid "Enter map Embed Code"
 msgstr "Saisissez le code intégré de la carte"
 
-#. Default: "Enter the absolute path of the target. The path must start with '/'. Target must exist or be an existing alternative url path to the target."
+#. Default: "Enter the absolute path of the target. Target must exist or be an existing alternative url path to the target."
 #: components/manage/Controlpanels/Aliases
-msgid "Enter the absolute path of the target. The path must start with '/'. Target must exist or be an existing alternative url path to the target."
-msgstr "Saisissez le chemin absolu de la cible. Le chemin doit commencer par '/'. La cible doit exister ou être un chemin d'URL alternatif existant vers la cible."
+msgid "Enter the absolute path of the target. Target must exist or be an existing alternative url path to the target."
+msgstr "Saisissez le chemin absolu de la cible. La cible doit exister ou être un chemin d'URL alternatif existant vers la cible."
 
 #. Default: "Enter the absolute path where the alternative url should exist. The path must start with '/'. Only urls that result in a 404 not found page will result in a redirect occurring."
 #: components/manage/Aliases/Aliases
@@ -3607,11 +3607,6 @@ msgstr "Taille de la mémoire par cache en octets"
 #: components/manage/Controlpanels/DatabaseInformation
 msgid "Target number of objects in memory per cache"
 msgstr "Nombre d'objets en mémoire par cache"
-
-#. Default: "Target url path must start with a slash."
-#: components/manage/Controlpanels/Aliases
-msgid "Target url path must start with a slash."
-msgstr "Le chemin de destination d'URL doit commencer par une barre oblique."
 
 #. Default: "Teaser"
 #: components/manage/Blocks/Teaser/schema

--- a/packages/volto/locales/hi/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/hi/LC_MESSAGES/volto.po
@@ -1287,10 +1287,10 @@ msgstr "पूरा नाम दर्ज करें, उदाहरण क
 msgid "Enter map Embed Code"
 msgstr "नक्शे का एम्बेड कोड दर्ज करें"
 
-#. Default: "Enter the absolute path of the target. The path must start with '/'. Target must exist or be an existing alternative url path to the target."
+#. Default: "Enter the absolute path of the target. Target must exist or be an existing alternative url path to the target."
 #: components/manage/Controlpanels/Aliases
-msgid "Enter the absolute path of the target. The path must start with '/'. Target must exist or be an existing alternative url path to the target."
-msgstr "लक्ष्य का पूर्ण रास्ता दर्ज करें। पथ '/ ' से प्रारंभ होना चाहिए। लक्ष्य मौजूद होना चाहिए या लक्ष्य के लिए मौजूदा वैकल्पिक URL पथ होना चाहिए।"
+msgid "Enter the absolute path of the target. Target must exist or be an existing alternative url path to the target."
+msgstr "लक्ष्य का पूर्ण रास्ता दर्ज करें। लक्ष्य मौजूद होना चाहिए या लक्ष्य के लिए मौजूदा वैकल्पिक URL पथ होना चाहिए।"
 
 #. Default: "Enter the absolute path where the alternative url should exist. The path must start with '/'. Only urls that result in a 404 not found page will result in a redirect occurring."
 #: components/manage/Aliases/Aliases
@@ -3600,11 +3600,6 @@ msgstr "प्रति कैश के लिए लक्षित मेम�
 #: components/manage/Controlpanels/DatabaseInformation
 msgid "Target number of objects in memory per cache"
 msgstr "प्रति कैश में मेमोरी में ऑब्जेक्ट की लक्षित संख्या"
-
-#. Default: "Target url path must start with a slash."
-#: components/manage/Controlpanels/Aliases
-msgid "Target url path must start with a slash."
-msgstr "लक्षित URL पथ को स्लैश के साथ शुरू होना चाहिए।"
 
 #. Default: "Teaser"
 #: components/manage/Blocks/Teaser/schema

--- a/packages/volto/locales/it/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/it/LC_MESSAGES/volto.po
@@ -1287,10 +1287,10 @@ msgstr "Inserisci il tuo nome completo, ad esempio Mario Rossi."
 msgid "Enter map Embed Code"
 msgstr "Inserisci il codice di incorporamento della mappa"
 
-#. Default: "Enter the absolute path of the target. The path must start with '/'. Target must exist or be an existing alternative url path to the target."
+#. Default: "Enter the absolute path of the target. Target must exist or be an existing alternative url path to the target."
 #: components/manage/Controlpanels/Aliases
-msgid "Enter the absolute path of the target. The path must start with '/'. Target must exist or be an existing alternative url path to the target."
-msgstr "Inserisci il path assoluto per la destinazione. Il path deve iniziare con '/'. La destinazione deve già esistere o essere un url alternativo per la destinazione."
+msgid "Enter the absolute path of the target. Target must exist or be an existing alternative url path to the target."
+msgstr "Inserisci il path assoluto per la destinazione. La destinazione deve già esistere o essere un url alternativo per la destinazione."
 
 #. Default: "Enter the absolute path where the alternative url should exist. The path must start with '/'. Only urls that result in a 404 not found page will result in a redirect occurring."
 #: components/manage/Aliases/Aliases
@@ -3600,11 +3600,6 @@ msgstr "Dimensionei target della memoria per cache in byte"
 #: components/manage/Controlpanels/DatabaseInformation
 msgid "Target number of objects in memory per cache"
 msgstr "Numero target di oggetti in memoria per cache"
-
-#. Default: "Target url path must start with a slash."
-#: components/manage/Controlpanels/Aliases
-msgid "Target url path must start with a slash."
-msgstr "Il percorso url di destinazione deve cominciare con uno slash."
 
 #. Default: "Teaser"
 #: components/manage/Blocks/Teaser/schema

--- a/packages/volto/locales/ja/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ja/LC_MESSAGES/volto.po
@@ -1292,9 +1292,9 @@ msgstr "氏名（フルネーム）を入力。例： Hanako Suzuki や 山田�
 msgid "Enter map Embed Code"
 msgstr "地図のEmbedコードを入力"
 
-#. Default: "Enter the absolute path of the target. The path must start with '/'. Target must exist or be an existing alternative url path to the target."
+#. Default: "Enter the absolute path of the target. Target must exist or be an existing alternative url path to the target."
 #: components/manage/Controlpanels/Aliases
-msgid "Enter the absolute path of the target. The path must start with '/'. Target must exist or be an existing alternative url path to the target."
+msgid "Enter the absolute path of the target. Target must exist or be an existing alternative url path to the target."
 msgstr ""
 
 #. Default: "Enter the absolute path where the alternative url should exist. The path must start with '/'. Only urls that result in a 404 not found page will result in a redirect occurring."
@@ -3605,11 +3605,6 @@ msgstr "キャッシュごとの最大容量(byte単位)"
 #: components/manage/Controlpanels/DatabaseInformation
 msgid "Target number of objects in memory per cache"
 msgstr "キャッシュごとのメモリー上の最大オブジェクト数"
-
-#. Default: "Target url path must start with a slash."
-#: components/manage/Controlpanels/Aliases
-msgid "Target url path must start with a slash."
-msgstr ""
 
 #. Default: "Teaser"
 #: components/manage/Blocks/Teaser/schema

--- a/packages/volto/locales/nl/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/nl/LC_MESSAGES/volto.po
@@ -1291,9 +1291,9 @@ msgstr "Vul de volledige naam in, bijvoorbeeld Jan Smit."
 msgid "Enter map Embed Code"
 msgstr ""
 
-#. Default: "Enter the absolute path of the target. The path must start with '/'. Target must exist or be an existing alternative url path to the target."
+#. Default: "Enter the absolute path of the target. Target must exist or be an existing alternative url path to the target."
 #: components/manage/Controlpanels/Aliases
-msgid "Enter the absolute path of the target. The path must start with '/'. Target must exist or be an existing alternative url path to the target."
+msgid "Enter the absolute path of the target. Target must exist or be an existing alternative url path to the target."
 msgstr ""
 
 #. Default: "Enter the absolute path where the alternative url should exist. The path must start with '/'. Only urls that result in a 404 not found page will result in a redirect occurring."
@@ -3603,11 +3603,6 @@ msgstr ""
 #. Default: "Target number of objects in memory per cache"
 #: components/manage/Controlpanels/DatabaseInformation
 msgid "Target number of objects in memory per cache"
-msgstr ""
-
-#. Default: "Target url path must start with a slash."
-#: components/manage/Controlpanels/Aliases
-msgid "Target url path must start with a slash."
 msgstr ""
 
 #. Default: "Teaser"

--- a/packages/volto/locales/pt/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/pt/LC_MESSAGES/volto.po
@@ -1292,9 +1292,9 @@ msgstr "Escreva o nome completo. Por exemplo, José Silva."
 msgid "Enter map Embed Code"
 msgstr ""
 
-#. Default: "Enter the absolute path of the target. The path must start with '/'. Target must exist or be an existing alternative url path to the target."
+#. Default: "Enter the absolute path of the target. Target must exist or be an existing alternative url path to the target."
 #: components/manage/Controlpanels/Aliases
-msgid "Enter the absolute path of the target. The path must start with '/'. Target must exist or be an existing alternative url path to the target."
+msgid "Enter the absolute path of the target. Target must exist or be an existing alternative url path to the target."
 msgstr ""
 
 #. Default: "Enter the absolute path where the alternative url should exist. The path must start with '/'. Only urls that result in a 404 not found page will result in a redirect occurring."
@@ -3604,11 +3604,6 @@ msgstr ""
 #. Default: "Target number of objects in memory per cache"
 #: components/manage/Controlpanels/DatabaseInformation
 msgid "Target number of objects in memory per cache"
-msgstr ""
-
-#. Default: "Target url path must start with a slash."
-#: components/manage/Controlpanels/Aliases
-msgid "Target url path must start with a slash."
 msgstr ""
 
 #. Default: "Teaser"

--- a/packages/volto/locales/pt_BR/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/pt_BR/LC_MESSAGES/volto.po
@@ -1293,10 +1293,10 @@ msgstr "Digite o nome completo. Por exemplo, José da Silva."
 msgid "Enter map Embed Code"
 msgstr "Informe o código Embed do mapa"
 
-#. Default: "Enter the absolute path of the target. The path must start with '/'. Target must exist or be an existing alternative url path to the target."
+#. Default: "Enter the absolute path of the target. Target must exist or be an existing alternative url path to the target."
 #: components/manage/Controlpanels/Aliases
-msgid "Enter the absolute path of the target. The path must start with '/'. Target must exist or be an existing alternative url path to the target."
-msgstr "Informe o caminho absoluto do destino. O caminho deve começar com '/'. O destino deve existir ou ser um caminho da URL alternativa existente para o destino."
+msgid "Enter the absolute path of the target. Target must exist or be an existing alternative url path to the target."
+msgstr "Informe o caminho absoluto do destino. O destino deve existir ou ser um caminho da URL alternativa existente para o destino."
 
 #. Default: "Enter the absolute path where the alternative url should exist. The path must start with '/'. Only urls that result in a 404 not found page will result in a redirect occurring."
 #: components/manage/Aliases/Aliases
@@ -3606,11 +3606,6 @@ msgstr "Tamanho de memória por cache em bytes"
 #: components/manage/Controlpanels/DatabaseInformation
 msgid "Target number of objects in memory per cache"
 msgstr "Número de objetos na memória por cache"
-
-#. Default: "Target url path must start with a slash."
-#: components/manage/Controlpanels/Aliases
-msgid "Target url path must start with a slash."
-msgstr "O caminho da URL de destino deve começar com uma barra."
 
 #. Default: "Teaser"
 #: components/manage/Blocks/Teaser/schema

--- a/packages/volto/locales/ro/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ro/LC_MESSAGES/volto.po
@@ -1287,9 +1287,9 @@ msgstr "Introduceți numele complet, de exemplu, Valentin Popescu."
 msgid "Enter map Embed Code"
 msgstr "Introduceți codul de integrare a hărții"
 
-#. Default: "Enter the absolute path of the target. The path must start with '/'. Target must exist or be an existing alternative url path to the target."
+#. Default: "Enter the absolute path of the target. Target must exist or be an existing alternative url path to the target."
 #: components/manage/Controlpanels/Aliases
-msgid "Enter the absolute path of the target. The path must start with '/'. Target must exist or be an existing alternative url path to the target."
+msgid "Enter the absolute path of the target. Target must exist or be an existing alternative url path to the target."
 msgstr ""
 
 #. Default: "Enter the absolute path where the alternative url should exist. The path must start with '/'. Only urls that result in a 404 not found page will result in a redirect occurring."
@@ -3600,11 +3600,6 @@ msgstr "Dimensiunea țintă a memoriei raportat la cache în octeți"
 #: components/manage/Controlpanels/DatabaseInformation
 msgid "Target number of objects in memory per cache"
 msgstr "Numărul țintă de obiecte din memorie raportat la cache"
-
-#. Default: "Target url path must start with a slash."
-#: components/manage/Controlpanels/Aliases
-msgid "Target url path must start with a slash."
-msgstr ""
 
 #. Default: "Teaser"
 #: components/manage/Blocks/Teaser/schema

--- a/packages/volto/locales/volto.pot
+++ b/packages/volto/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2024-08-02T16:48:19.008Z\n"
+"POT-Creation-Date: 2024-08-09T15:47:03.838Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Content-Type: text/plain; charset=utf-8\n"
@@ -1289,9 +1289,9 @@ msgstr ""
 msgid "Enter map Embed Code"
 msgstr ""
 
-#. Default: "Enter the absolute path of the target. The path must start with '/'. Target must exist or be an existing alternative url path to the target."
+#. Default: "Enter the absolute path of the target. Target must exist or be an existing alternative url path to the target."
 #: components/manage/Controlpanels/Aliases
-msgid "Enter the absolute path of the target. The path must start with '/'. Target must exist or be an existing alternative url path to the target."
+msgid "Enter the absolute path of the target. Target must exist or be an existing alternative url path to the target."
 msgstr ""
 
 #. Default: "Enter the absolute path where the alternative url should exist. The path must start with '/'. Only urls that result in a 404 not found page will result in a redirect occurring."
@@ -3601,11 +3601,6 @@ msgstr ""
 #. Default: "Target number of objects in memory per cache"
 #: components/manage/Controlpanels/DatabaseInformation
 msgid "Target number of objects in memory per cache"
-msgstr ""
-
-#. Default: "Target url path must start with a slash."
-#: components/manage/Controlpanels/Aliases
-msgid "Target url path must start with a slash."
 msgstr ""
 
 #. Default: "Teaser"

--- a/packages/volto/locales/zh_CN/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/zh_CN/LC_MESSAGES/volto.po
@@ -1293,10 +1293,10 @@ msgstr "输入您的姓名，如：张三"
 msgid "Enter map Embed Code"
 msgstr "输入 map 嵌入代码"
 
-#. Default: "Enter the absolute path of the target. The path must start with '/'. Target must exist or be an existing alternative url path to the target."
+#. Default: "Enter the absolute path of the target. Target must exist or be an existing alternative url path to the target."
 #: components/manage/Controlpanels/Aliases
-msgid "Enter the absolute path of the target. The path must start with '/'. Target must exist or be an existing alternative url path to the target."
-msgstr "输入目标的绝对路径。路径必须以‘/’开头。目标必须存在，或者是指向目标的现有可选的url路径。"
+msgid "Enter the absolute path of the target. Target must exist or be an existing alternative url path to the target."
+msgstr "输入目标的绝对路径。目标必须存在，或者是指向目标的现有可选的url路径。"
 
 #. Default: "Enter the absolute path where the alternative url should exist. The path must start with '/'. Only urls that result in a 404 not found page will result in a redirect occurring."
 #: components/manage/Aliases/Aliases
@@ -3606,11 +3606,6 @@ msgstr "每个缓存目标以字节为单位的内存大小"
 #: components/manage/Controlpanels/DatabaseInformation
 msgid "Target number of objects in memory per cache"
 msgstr ""
-
-#. Default: "Target url path must start with a slash."
-#: components/manage/Controlpanels/Aliases
-msgid "Target url path must start with a slash."
-msgstr "目标url路径必须以斜杠开头。"
 
 #. Default: "Teaser"
 #: components/manage/Blocks/Teaser/schema

--- a/packages/volto/news/6247.bugfix
+++ b/packages/volto/news/6247.bugfix
@@ -1,0 +1,1 @@
+In the URL Management control panel, allow external URLs as targets. @davisagli

--- a/packages/volto/src/components/manage/Controlpanels/Aliases.jsx
+++ b/packages/volto/src/components/manage/Controlpanels/Aliases.jsx
@@ -1,9 +1,4 @@
-/**
- * Moderate comments component.
- * @module components/manage/Controlpanels/Aliases
- */
-
-import React, { Component } from 'react';
+import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
@@ -93,7 +88,6 @@ class Aliases extends Component {
       altUrlPath: '',
       isAltUrlCorrect: false,
       targetUrlPath: '',
-      isTargetUrlCorrect: false,
       aliasesToRemove: [],
       errorMessageAdd: '',
       filterQuery: '',
@@ -158,14 +152,6 @@ class Aliases extends Component {
         this.setState({ isAltUrlCorrect: true });
       } else {
         this.setState({ isAltUrlCorrect: false });
-      }
-    }
-
-    if (prevState.targetUrlPath !== this.state.targetUrlPath) {
-      if (this.state.targetUrlPath.charAt(0) === '/') {
-        this.setState({ isTargetUrlCorrect: true });
-      } else {
-        this.setState({ isTargetUrlCorrect: false });
       }
     }
   }
@@ -295,7 +281,7 @@ class Aliases extends Component {
    * @returns {undefined}
    */
   handleSubmitAlias() {
-    if (this.state.isAltUrlCorrect && this.state.isTargetUrlCorrect) {
+    if (this.state.isAltUrlCorrect) {
       this.props.addAliases('', {
         items: [
           {
@@ -423,8 +409,8 @@ class Aliases extends Component {
                   </Header>
                   <p className="help">
                     <FormattedMessage
-                      id="Enter the absolute path of the target. The path must start with '/'. Target must exist or be an existing alternative url path to the target."
-                      defaultMessage="Enter the absolute path of the target. The path must start with '/'. Target must exist or be an existing alternative url path to the target."
+                      id="Enter the absolute path of the target. Target must exist or be an existing alternative url path to the target."
+                      defaultMessage="Enter the absolute path of the target. Target must exist or be an existing alternative url path to the target."
                     />
                   </p>
                   <Form.Field>
@@ -437,15 +423,6 @@ class Aliases extends Component {
                         this.handleTargetUrlChange(e.target.value)
                       }
                     />
-                    {!this.state.isTargetUrlCorrect &&
-                      this.state.targetUrlPath !== '' && (
-                        <p style={{ color: 'red' }}>
-                          <FormattedMessage
-                            id="Target url path must start with a slash."
-                            defaultMessage="Target url path must start with a slash."
-                          />
-                        </p>
-                      )}
                   </Form.Field>
                   <Button
                     id="submit-alias"
@@ -453,7 +430,6 @@ class Aliases extends Component {
                     onClick={() => this.handleSubmitAlias()}
                     disabled={
                       !this.state.isAltUrlCorrect ||
-                      !this.state.isTargetUrlCorrect ||
                       this.state.altUrlPath === '' ||
                       this.state.targetUrlPath === ''
                     }

--- a/packages/volto/src/components/manage/Controlpanels/__snapshots__/Aliases.test.jsx.snap
+++ b/packages/volto/src/components/manage/Controlpanels/__snapshots__/Aliases.test.jsx.snap
@@ -58,7 +58,7 @@ exports[`Aliases renders an aliases control component 1`] = `
               <p
                 class="help"
               >
-                Enter the absolute path of the target. The path must start with '/'. Target must exist or be an existing alternative url path to the target.
+                Enter the absolute path of the target. Target must exist or be an existing alternative url path to the target.
               </p>
               <div
                 class="field"


### PR DESCRIPTION
The Plone redirection tool allows creating aliases that redirect to an external URL, which is occasionally useful. But currently this is blocked by validation in Volto's control panel for aliases. This PR removes that validation so that it's also possible to do this in Volto.