### PR TITLE
Allow enhancing the ContentsPropertiesModal schema

### DIFF
--- a/packages/volto/news/6248.feature
+++ b/packages/volto/news/6248.feature
@@ -1,0 +1,2 @@
+The schema for the ContentsPropertiesModal can be enhanced using the `contentPropertiesSchemaEnhancer` setting.
+Also, the properties form is now prepopulated with values if all selected items share the same value. @davisagli

--- a/packages/volto/news/6248.feature
+++ b/packages/volto/news/6248.feature
@@ -1,2 +1,2 @@
-The schema for the ContentsPropertiesModal can be enhanced using the `contentPropertiesSchemaEnhancer` setting.
+The schema for the `ContentsPropertiesModal` can be enhanced using the `contentPropertiesSchemaEnhancer` setting.
 Also, the properties form is now prepopulated with values if all selected items share the same value. @davisagli

--- a/packages/volto/src/components/manage/Contents/Contents.jsx
+++ b/packages/volto/src/components/manage/Contents/Contents.jsx
@@ -1532,6 +1532,9 @@ class Contents extends Component {
                     onCancel={this.onPropertiesCancel}
                     onOk={this.onPropertiesOk}
                     items={this.state.selected}
+                    values={map(this.state.selected, (id) =>
+                      find(this.state.items, { '@id': id }),
+                    )}
                   />
                   {this.state.showWorkflow && (
                     <ContentsWorkflowModal

--- a/packages/volto/src/components/manage/Contents/ContentsPropertiesModal.jsx
+++ b/packages/volto/src/components/manage/Contents/ContentsPropertiesModal.jsx
@@ -131,6 +131,13 @@ const ContentsPropertiesModal = (props) => {
   if (values?.length) {
     for (const name of Object.keys(schema.properties)) {
       const firstValue = values[0][name];
+      // should not show floor or ceiling dates
+      if (
+        (name === 'effective' && firstValue && firstValue <= '1970') ||
+        (name === 'expires' && firstValue && firstValue >= '2499')
+      ) {
+        continue;
+      }
       if (values.every((item) => item[name] === firstValue)) {
         initialData[name] = firstValue;
       }

--- a/packages/volto/src/components/manage/Contents/ContentsPropertiesModal.jsx
+++ b/packages/volto/src/components/manage/Contents/ContentsPropertiesModal.jsx
@@ -1,12 +1,14 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
 import { isEmpty, map } from 'lodash';
 import { defineMessages, useIntl } from 'react-intl';
 
 import { usePrevious } from '@plone/volto/helpers';
+import { cloneDeepSchema } from '@plone/volto/helpers/Utils/Utils';
 import { updateContent } from '@plone/volto/actions';
 import { ModalForm } from '@plone/volto/components/manage/Form';
+import config from '@plone/volto/registry';
 
 const messages = defineMessages({
   properties: {
@@ -65,11 +67,75 @@ const messages = defineMessages({
 });
 
 const ContentsPropertiesModal = (props) => {
-  const { onCancel, onOk, open, items } = props;
+  const { onCancel, onOk, open, items, values } = props;
   const intl = useIntl();
   const dispatch = useDispatch();
   const request = useSelector((state) => state.content.update);
   const prevrequestloading = usePrevious(request.loading);
+
+  const baseSchema = {
+    fieldsets: [
+      {
+        id: 'default',
+        title: intl.formatMessage(messages.default),
+        fields: [
+          'effective',
+          'expires',
+          'rights',
+          'creators',
+          'exclude_from_nav',
+        ],
+      },
+    ],
+    properties: {
+      effective: {
+        description: intl.formatMessage(messages.effectiveDescription),
+        title: intl.formatMessage(messages.effectiveTitle),
+        type: 'string',
+        widget: 'datetime',
+      },
+      expires: {
+        description: intl.formatMessage(messages.expiresDescription),
+        title: intl.formatMessage(messages.expiresTitle),
+        type: 'string',
+        widget: 'datetime',
+      },
+      rights: {
+        description: intl.formatMessage(messages.rightsDescription),
+        title: intl.formatMessage(messages.rightsTitle),
+        type: 'string',
+        widget: 'textarea',
+      },
+      creators: {
+        description: intl.formatMessage(messages.creatorsDescription),
+        title: intl.formatMessage(messages.creatorsTitle),
+        type: 'array',
+      },
+      exclude_from_nav: {
+        description: intl.formatMessage(messages.excludeFromNavDescription),
+        title: intl.formatMessage(messages.excludeFromNavTitle),
+        type: 'boolean',
+      },
+    },
+    required: [],
+  };
+  const schemaEnhancer = config.settings.contentPropertiesSchemaEnhancer;
+  let schema = schemaEnhancer
+    ? schemaEnhancer({
+        schema: cloneDeepSchema(baseSchema),
+        intl,
+      })
+    : baseSchema;
+
+  const initialData = {};
+  if (values?.length) {
+    for (const name of Object.keys(schema.properties)) {
+      const firstValue = values[0][name];
+      if (values.every((item) => item[name] === firstValue)) {
+        initialData[name] = firstValue;
+      }
+    }
+  }
 
   useEffect(() => {
     if (prevrequestloading && request.loaded) {
@@ -78,13 +144,19 @@ const ContentsPropertiesModal = (props) => {
   }, [onOk, prevrequestloading, request.loaded]);
 
   const onSubmit = (data) => {
-    if (isEmpty(data)) {
+    let changes = {};
+    for (const name of Object.keys(data)) {
+      if (data[name] !== initialData[name]) {
+        changes[name] = data[name];
+      }
+    }
+    if (isEmpty(changes)) {
       onOk();
     } else {
       dispatch(
         updateContent(
           items,
-          map(items, () => data),
+          map(items, () => changes),
         ),
       );
     }
@@ -97,54 +169,8 @@ const ContentsPropertiesModal = (props) => {
         onSubmit={onSubmit}
         onCancel={onCancel}
         title={intl.formatMessage(messages.properties)}
-        schema={{
-          fieldsets: [
-            {
-              id: 'default',
-              title: intl.formatMessage(messages.default),
-              fields: [
-                'effective',
-                'expires',
-                'rights',
-                'creators',
-                'exclude_from_nav',
-              ],
-            },
-          ],
-          properties: {
-            effective: {
-              description: intl.formatMessage(messages.effectiveDescription),
-              title: intl.formatMessage(messages.effectiveTitle),
-              type: 'string',
-              widget: 'datetime',
-            },
-            expires: {
-              description: intl.formatMessage(messages.expiresDescription),
-              title: intl.formatMessage(messages.expiresTitle),
-              type: 'string',
-              widget: 'datetime',
-            },
-            rights: {
-              description: intl.formatMessage(messages.rightsDescription),
-              title: intl.formatMessage(messages.rightsTitle),
-              type: 'string',
-              widget: 'textarea',
-            },
-            creators: {
-              description: intl.formatMessage(messages.creatorsDescription),
-              title: intl.formatMessage(messages.creatorsTitle),
-              type: 'array',
-            },
-            exclude_from_nav: {
-              description: intl.formatMessage(
-                messages.excludeFromNavDescription,
-              ),
-              title: intl.formatMessage(messages.excludeFromNavTitle),
-              type: 'boolean',
-            },
-          },
-          required: [],
-        }}
+        schema={schema}
+        formData={initialData}
       />
     )
   );

--- a/packages/volto/src/config/index.js
+++ b/packages/volto/src/config/index.js
@@ -168,6 +168,7 @@ let config = {
     ],
     showSelfRegistration: false,
     contentMetadataTagsImageField: 'image',
+    contentPropertiesSchemaEnhancer: null,
     hasWorkingCopySupport: false,
     maxUndoLevels: 200, // undo history size for the main form
     addonsInfo: addonsInfo,


### PR DESCRIPTION
This has a couple improvements for the "properties" modal in the Contents view.

1. It makes it possible for an addon to add more properties with a schema enhancer, without needing to shadow the ContentsPropertiesModal component.
2. If all selected items have the same value for a field, the form is now prepopulated with that value.