### PR TITLE
fix: disable save button upon submitting

### DIFF
--- a/cypress/tests/core/blocks/listing/blocks-listing-templates.js
+++ b/cypress/tests/core/blocks/listing/blocks-listing-templates.js
@@ -37,7 +37,7 @@ describe('Folder Contents Tests', () => {
     cy.getSlate().click();
     cy.get('button.block-add-button').click();
     cy.get(
-      '[style="transition: opacity 0.1s 0.2s;"] > :nth-child(2) > .ui',
+      '[style="transition: opacity 500ms ease 0ms;"] > :nth-child(2) > .ui',
     ).click();
     cy.get('#field-variation').click().type('summary{enter}');
     cy.get('#toolbar-save').click();
@@ -77,7 +77,7 @@ describe('Folder Contents Tests', () => {
     cy.getSlate().click();
     cy.get('button.block-add-button').click();
     cy.get(
-      '[style="transition: opacity 0.1s 0.2s;"] > :nth-child(2) > .ui',
+      '[style="transition: opacity 500ms ease 0ms;"] > :nth-child(2) > .ui',
     ).click();
     cy.get('#field-variation').click().type('summary{enter}');
     cy.get('#toolbar-save').click();
@@ -119,7 +119,7 @@ describe('Folder Contents Tests', () => {
     cy.getSlate().click();
     cy.get('button.block-add-button').click();
     cy.get(
-      '[style="transition: opacity 0.1s 0.2s;"] > :nth-child(2) > .ui',
+      '[style="transition: opacity 500ms ease 0ms;"] > :nth-child(2) > .ui',
     ).click();
     cy.get('#field-variation').click().type('imageGallery{enter}');
     cy.get('#toolbar-save').click();

--- a/cypress/tests/core/blocks/listing/blocks-listing-templates.js
+++ b/cypress/tests/core/blocks/listing/blocks-listing-templates.js
@@ -37,7 +37,7 @@ describe('Folder Contents Tests', () => {
     cy.getSlate().click();
     cy.get('button.block-add-button').click();
     cy.get(
-      '[style="transition: opacity 500ms ease 0ms;"] > :nth-child(2) > .ui',
+      '[style="transition: opacity 0.1s 0.2s;"] > :nth-child(2) > .ui',
     ).click();
     cy.get('#field-variation').click().type('summary{enter}');
     cy.get('#toolbar-save').click();
@@ -77,7 +77,7 @@ describe('Folder Contents Tests', () => {
     cy.getSlate().click();
     cy.get('button.block-add-button').click();
     cy.get(
-      '[style="transition: opacity 500ms ease 0ms;"] > :nth-child(2) > .ui',
+      '[style="transition: opacity 0.1s 0.2s;"] > :nth-child(2) > .ui',
     ).click();
     cy.get('#field-variation').click().type('summary{enter}');
     cy.get('#toolbar-save').click();
@@ -119,7 +119,7 @@ describe('Folder Contents Tests', () => {
     cy.getSlate().click();
     cy.get('button.block-add-button').click();
     cy.get(
-      '[style="transition: opacity 500ms ease 0ms;"] > :nth-child(2) > .ui',
+      '[style="transition: opacity 0.1s 0.2s;"] > :nth-child(2) > .ui',
     ).click();
     cy.get('#field-variation').click().type('imageGallery{enter}');
     cy.get('#toolbar-save').click();

--- a/news/6250.bugfix
+++ b/news/6250.bugfix
@@ -1,0 +1,1 @@
+Disable save button when loading POST query @sabrina-bongiovanni

--- a/src/components/manage/Add/Add.jsx
+++ b/src/components/manage/Add/Add.jsx
@@ -408,6 +408,7 @@ class Add extends Component {
                       aria-label={this.props.intl.formatMessage(messages.save)}
                       onClick={() => this.form.current.onSubmit()}
                       loading={this.props.createRequest.loading}
+                      disabled={this.props.createRequest.loading}
                     >
                       <Icon
                         name={saveSVG}


### PR DESCRIPTION
When submitting the Add form upon creating a new Content Type, if the connection is too slow, the button will start loading and the spinner will appear, but it will remain clickable, thus allowing to submit the form and trigger the query multiple times, which in turn results in creating more instances of the same CT.

Adding the disabled prop to the button when the query is still loading prevents this issue from happening.