### PR TITLE
16.x backport: Allow enhancing the ContentsPropertiesModal schema (#6248)

### DIFF
--- a/news/6248.feature
+++ b/news/6248.feature
@@ -1,0 +1,2 @@
+The schema for the `ContentsPropertiesModal` can be enhanced using the `contentPropertiesSchemaEnhancer` setting.
+Also, the properties form is now prepopulated with values if all selected items share the same value. @davisagli

--- a/src/components/manage/Contents/Contents.jsx
+++ b/src/components/manage/Contents/Contents.jsx
@@ -1524,6 +1524,9 @@ class Contents extends Component {
                     onCancel={this.onPropertiesCancel}
                     onOk={this.onPropertiesOk}
                     items={this.state.selected}
+                    values={map(this.state.selected, (id) =>
+                      find(this.state.items, { '@id': id }),
+                    )}
                   />
                   {this.state.showWorkflow && (
                     <ContentsWorkflowModal

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -174,6 +174,7 @@ let config = {
     ],
     showSelfRegistration: false,
     contentMetadataTagsImageField: 'image',
+    contentPropertiesSchemaEnhancer: null,
     hasWorkingCopySupport: false,
     maxUndoLevels: 200, // undo history size for the main form
     addonsInfo: addonsInfo,


### PR DESCRIPTION
(Note, I've taken care that the component will still function even if Contents.jsx was shadowed and does not pass `values`)