### PR TITLE
Fix edge case in ContentsPropertiesModal

### DIFF
--- a/packages/volto/news/6258.bugfix
+++ b/packages/volto/news/6258.bugfix
@@ -1,0 +1,1 @@
+Fix `TypeError: values[0] is undefined` in Contents properties modal. @davisagli

--- a/packages/volto/src/components/manage/Contents/Contents.jsx
+++ b/packages/volto/src/components/manage/Contents/Contents.jsx
@@ -1534,7 +1534,7 @@ class Contents extends Component {
                     items={this.state.selected}
                     values={map(this.state.selected, (id) =>
                       find(this.state.items, { '@id': id }),
-                    )}
+                    ).filter((item) => item)}
                   />
                   {this.state.showWorkflow && (
                     <ContentsWorkflowModal


### PR DESCRIPTION
The item can be undefined if it's in this.state.selected but not this.state.items. This can happen after navigating to a different folder.