### PR TITLE
Remove "Generate tabs for items other than folders" field from navigation control panel

### DIFF
--- a/packages/volto/news/6278.bugfix
+++ b/packages/volto/news/6278.bugfix
@@ -1,0 +1,1 @@
+Remove `Generate tabs for items other than folders` field from navigation control panel. @wesleybl

--- a/packages/volto/src/config/ControlPanels.js
+++ b/packages/volto/src/config/ControlPanels.js
@@ -90,6 +90,7 @@ export const unwantedControlPanelsFields = {
   navigation: [
     'generate_tabs',
     'navigation_depth',
+    'nonfolderish_tabs',
     'sort_tabs_on',
     'sort_tabs_reversed',
     'sitemap_depth',

--- a/packages/volto/src/config/config.test.js
+++ b/packages/volto/src/config/config.test.js
@@ -221,6 +221,7 @@ test('test navigation controlpanel fields', () => {
   const not_in_navigation = [
     'generate_tabs',
     'navigation_depth',
+    'nonfolderish_tabs',
     'sort_tabs_on',
     'sort_tabs_reversed',
     'sitemap_depth',


### PR DESCRIPTION
The help for this field says:

`By default, any content item in the root of the portal will appear as a tab. If you turn this option off, only folders will be shown. This only has an effect if 'automatically generate tabs' is enabled.`

This doesn't make sense in Volto. Volto doesn't display item as tab.