### PR TITLE
Empty GridBlocks will not be rendered in 'View'

### DIFF
--- a/packages/volto/news/6279.bugfix
+++ b/packages/volto/news/6279.bugfix
@@ -1,0 +1,1 @@
+Empty GridBlocks will not be rendered in 'View' @MAX-786

--- a/packages/volto/news/6279.bugfix
+++ b/packages/volto/news/6279.bugfix
@@ -1,1 +1,1 @@
-Empty GridBlocks will not be rendered in 'View' @MAX-786
+Fix error rendering empty grid blocks. @MAX-786

--- a/packages/volto/src/components/manage/Blocks/Grid/View.jsx
+++ b/packages/volto/src/components/manage/Blocks/Grid/View.jsx
@@ -7,6 +7,9 @@ import config from '@plone/volto/registry';
 const GridBlockView = (props) => {
   const { data, path, className, style } = props;
   const metadata = props.metadata || props.properties;
+  if (data.blocks_layout === undefined) {
+    return null;
+  }
   const columns = data.blocks_layout.items;
   const blocksConfig =
     config.blocks.blocksConfig[data['@type']].blocksConfig ||


### PR DESCRIPTION
Fixes #6279 

This can be a single line fix:
 https://github.com/plone/volto/blob/7690677589ad881d794a9484d9a8ee1aa005fbcf/packages/volto/src/components/manage/Blocks/Grid/View.jsx#L10

adding this check just before the above mentioned line will fix this
```js
  if (data.blocks_layout === undefined) {
    return null;
  }
  ```
  
then this won't render any Grid block since its empty so it makes sense too, but yeah it remains in the formData so going into edit again will open up the TemplateChooser again.