### PR TITLE
Solving issue [API requests that don't return a 2XX HTTP Status result in an exception being raised ] #6260

### DIFF
--- a/packages/client/src/API.ts
+++ b/packages/client/src/API.ts
@@ -44,6 +44,13 @@ const _handleResponse = ({ data }: AxiosResponse) => data;
 
 const _handleError = (error: any) => {
   debug(error);
+  if (axios.isAxiosError(error) && error.response){
+    return Promise.resolve({
+      status: error.response.status,
+      data: error.response.data,
+      headers: error.response.headers,
+    });
+  }
   return Promise.reject(error);
 };
 


### PR DESCRIPTION
This is a Commit to solve [issue #6260](https://github.com/plone/volto/issues/6260#issue-2474138317)

Handle non-2XX status codes in apiRequest function

This PR addresses the issue of uncaught exceptions for non-2XX status codes in the apiRequest function. The changes include:

1. Modified the _handleError function to return error response data for AxiosErrors instead of rejecting the promise.
2. Updated documentation to explain the new behavior for non-2XX status codes.
3. Added an example in the documentation demonstrating how to handle different status codes.

These changes allow users to handle different status codes without uncaught exceptions while maintaining the existing API structure.


