### PR TITLE
fix: state and styles for toolbar handler for hp for volto17

### DIFF
--- a/news/6294.bugfix
+++ b/news/6294.bugfix
@@ -1,1 +1,1 @@
-Fix the toolbar handler color for the homepage to match its "published" state for Volto17. @sabrina-bongiovanni
+Fix the toolbar handler color for the homepage to match its "published" state. @sabrina-bongiovanni

--- a/news/6294.bugfix
+++ b/news/6294.bugfix
@@ -1,0 +1,1 @@
+Fix the toolbar handler color for the homepage to match its "published" state for Volto17. @sabrina-bongiovanni

--- a/src/components/manage/Toolbar/Toolbar.jsx
+++ b/src/components/manage/Toolbar/Toolbar.jsx
@@ -590,7 +590,7 @@ class Toolbar extends Component {
                 aria-label={this.props.intl.formatMessage(
                   messages.shrinkToolbar,
                 )}
-                className={cx({
+                className={cx('toolbar-handler-button', {
                   [this.props.content?.review_state]:
                     this.props.content?.review_state,
                 })}

--- a/src/components/manage/Toolbar/__snapshots__/Toolbar.test.jsx.snap
+++ b/src/components/manage/Toolbar/__snapshots__/Toolbar.test.jsx.snap
@@ -183,7 +183,7 @@ Array [
     >
       <button
         aria-label="Shrink toolbar"
-        className=""
+        className="toolbar-handler-button"
         onClick={[Function]}
       />
     </div>
@@ -377,7 +377,7 @@ Array [
     >
       <button
         aria-label="Shrink toolbar"
-        className=""
+        className="toolbar-handler-button"
         onClick={[Function]}
       />
     </div>

--- a/theme/themes/pastanaga/extras/toolbar.less
+++ b/theme/themes/pastanaga/extras/toolbar.less
@@ -129,7 +129,7 @@ body:not(.has-sidebar):not(.has-sidebar-collapsed) {
     }
 
     .toolbar-handler {
-      button {
+      .toolbar-handler-button {
         opacity: 0.3;
       }
 
@@ -243,7 +243,7 @@ body:not(.has-sidebar):not(.has-sidebar-collapsed) {
       width: 100%;
       justify-content: center;
 
-      button {
+      .toolbar-handler-button {
         width: @toolbarWidth;
         height: 20px;
         padding: 0;
@@ -428,7 +428,7 @@ body:not(.has-sidebar):not(.has-sidebar-collapsed) {
         flex-direction: column;
         justify-content: center;
 
-        button {
+        .toolbar-handler-button {
           width: @toolbarWidthMin;
           height: @toolbarWidth;
 
@@ -752,3 +752,10 @@ body:not(.has-sidebar):not(.has-sidebar-collapsed) {
   }
 }
 // End Orphaned CSS
+
+// Toolbar handler color in homepage
+.contenttype-plone-site {
+  #toolbar .toolbar-handler .toolbar-handler-button:before {
+    background: @teal-blue;
+  }
+}


### PR DESCRIPTION
Porting of PR for Volto 18 to Volto 17. 
This is what the PR for Volto 18 entailed the following:

Added a new class for the toolbar handler in the homepage based on the path.

The homepage is the only page with path ''.
The homepage is always public, so it needs a style regardless of the review state of the page
Since it's always public, I used the @teal-blue color used for public pages