### PR TITLE
Join validation errors in one single toast and update api error resp

### DIFF
--- a/packages/volto/news/6295.bugfix
+++ b/packages/volto/news/6295.bugfix
@@ -1,0 +1,2 @@
+- Join validation errors in one single toast and update errors from response. @cekk
+- Toast content now has a <div> wrapper instead of a <p>. @cekk

--- a/packages/volto/src/components/manage/Form/Form.jsx
+++ b/packages/volto/src/components/manage/Form/Form.jsx
@@ -274,14 +274,13 @@ class Form extends Component {
         selected: null,
       });
     }
-
-    const stateHasErrors =
-      Object.keys(this.state.errors).length > 0 &&
-      this.state.errors.constructor === Object;
     if (requestError) {
-      if (prevProps.requestError !== requestError || !stateHasErrors) {
-        errors =
-          FormValidation.giveServerErrorsToCorrespondingFields(requestError);
+      errors =
+        FormValidation.giveServerErrorsToCorrespondingFields(requestError);
+      if (
+        !isEqual(prevProps.requestError, requestError) ||
+        !isEqual(this.state.errors, errors)
+      ) {
         activeIndex = FormValidation.showFirstTabWithErrors({
           errors,
           schema: this.props.schema,
@@ -588,8 +587,8 @@ class Form extends Component {
             title={this.props.intl.formatMessage(messages.error)}
             content={
               <ul>
-                {Object.keys(errors).map((err) => (
-                  <li>
+                {Object.keys(errors).map((err, index) => (
+                  <li key={index}>
                     <strong>
                       {this.props.schema.properties[err].title || err}:
                     </strong>{' '}

--- a/packages/volto/src/components/manage/Toast/Toast.jsx
+++ b/packages/volto/src/components/manage/Toast/Toast.jsx
@@ -29,7 +29,7 @@ const Toast = (props) => {
       <Icon name={getIcon(props)} size="18px" />
       <div className="toast-inner-content">
         {title && <h4>{title}</h4>}
-        <p>{content}</p>
+        <div>{content}</div>
       </div>
     </>
   );
@@ -37,7 +37,7 @@ const Toast = (props) => {
 
 Toast.propTypes = {
   title: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
-  content: PropTypes.string.isRequired,
+  content: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired,
   info: PropTypes.bool,
   success: PropTypes.bool,
   error: PropTypes.bool,

--- a/packages/volto/src/components/manage/Toast/__snapshots__/Toast.test.jsx.snap
+++ b/packages/volto/src/components/manage/Toast/__snapshots__/Toast.test.jsx.snap
@@ -26,9 +26,9 @@ Array [
     <h4>
       I'm a title
     </h4>
-    <p>
+    <div>
       This is the content, lorem ipsum
-    </p>
+    </div>
   </div>,
 ]
 `;

--- a/packages/volto/theme/themes/pastanaga/extras/main.less
+++ b/packages/volto/theme/themes/pastanaga/extras/main.less
@@ -367,9 +367,10 @@ button {
     p {
       font-weight: 300;
     }
-  }
 
-  .toast-dismiss-action {
+    ul {
+      padding: 0;
+    }
   }
 
   .Toastify__toast--info {


### PR DESCRIPTION
With this changes error messages (and labels on single fields) are updated each time a POST/PATCH return a validation error (before this, error messages in fields weren't updated).

I've also joined error messages in one single toast because i've found that raising multiple toasts, only last will be shown.
For me it's also more readable a single toast with all the informations, but this can be reverted if you don't like it (i had to change also a wrapper into Toast component to allow insert an ul tag).

This is an example of the result:

<img width="843" alt="Screenshot 2024-09-24 alle 15 20 58" src="https://github.com/user-attachments/assets/4cdf384e-6926-4434-ac88-215340379db9">
