### PR TITLE
 fixes issue #6283

### DIFF
--- a/packages/volto/src/express-middleware/devproxy.js
+++ b/packages/volto/src/express-middleware/devproxy.js
@@ -47,6 +47,8 @@ export default function devProxyMiddleware() {
       },
     ),
     onProxyReq: (proxyReq, req, res) => {
+      //Fixes https://github.com/plone/volto/issues/6283
+      proxyReq.setHeader('Host', new URL(config.settings.apiPath).host);
       // Fixes https://github.com/chimurai/http-proxy-middleware/issues/320
       if (!req.body || !Object.keys(req.body).length) {
         return;


### PR DESCRIPTION
Hey, I fixed the issue with the Host header! The problem was that the proxy was sending requests with the wrong Host, so I updated the onProxyReq function to set it correctly to the API backend (api.myapp). Now, requests are going to the right place, and the “connection refused” error should be gone.

Let me know if it works for you!