### PR TITLE
fix: getQuerystringSearchQuery doesn't accept path as an input

### DIFF
--- a/packages/client/src/restapi/querystring-search/get.test.tsx
+++ b/packages/client/src/restapi/querystring-search/get.test.tsx
@@ -2,8 +2,7 @@ import { renderHook, waitFor } from '@testing-library/react';
 import { createWrapper } from '../../testUtils';
 import { useQuery } from '@tanstack/react-query';
 import { setup, teardown } from '../../resetFixture';
-import { beforeEach } from 'vitest';
-import { expect, test } from 'vitest';
+import { beforeEach, afterEach, describe, test, expect } from 'vitest';
 import PloneClient from '../../client';
 import { v4 as uuid } from 'uuid';
 import { createContent } from '../content/add';
@@ -11,12 +10,11 @@ import { createContent } from '../content/add';
 const cli = PloneClient.initialize({
   apiPath: 'http://localhost:55001/plone',
 });
-
 const { login, getQuerystringSearchQuery } = cli;
-await login({ username: 'admin', password: 'secret' });
 
 beforeEach(async () => {
   await setup();
+  await login({ username: 'admin', password: 'secret' });
 });
 
 afterEach(async () => {
@@ -30,7 +28,6 @@ describe('[GET] QuerystringSearch', () => {
       '@type': 'Document',
       title: `get-search${randomId}`,
     };
-
     await createContent({ path: '/', data: contentData, config: cli.config });
 
     const querystringSearchData = {
@@ -54,7 +51,41 @@ describe('[GET] QuerystringSearch', () => {
     );
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-
     expect(result.current.data?.items_total).toBeGreaterThan(0);
+  });
+
+  test('Hook - Successful - with path', async () => {
+    const randomId = uuid();
+    const contentData = {
+      '@type': 'Document',
+      title: `get-search${randomId}`,
+    };
+    const path = '/test-folder';
+    await createContent({ path: '/', data: { '@type': 'Folder', id: 'test-folder' }, config: cli.config });
+    await createContent({ path, data: contentData, config: cli.config });
+
+    const querystringSearchData = {
+      query: [
+        {
+          i: 'portal_type',
+          o: 'plone.app.querystring.operation.selection.any',
+          v: ['Document'],
+        },
+      ],
+    };
+
+    const { result } = renderHook(
+      () =>
+        useQuery(
+          getQuerystringSearchQuery({ query: querystringSearchData.query, path }),
+        ),
+      {
+        wrapper: createWrapper(),
+      },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.items_total).toBe(1);
+    expect(result.current.data?.items[0]['@id']).toContain(path);
   });
 });

--- a/packages/client/src/restapi/querystring-search/get.ts
+++ b/packages/client/src/restapi/querystring-search/get.ts
@@ -8,34 +8,38 @@ export type QuerystringSearchArgs = z.infer<
   typeof getQuerystringSearchSchema
 > & {
   config: PloneClientConfig;
+  path?: string;
 };
 
 export const getQuerystringSearch = async ({
   query,
   config,
+  path, // Add path parameter
 }: QuerystringSearchArgs): Promise<GetQuerystringSearchResponse> => {
   const validatedArgs = getQuerystringSearchSchema.parse({
     query,
+    path, // Include path in validation
   });
-
-  const queryObject = { query: validatedArgs.query };
+  const queryObject = { 
+    query: validatedArgs.query,
+    path: validatedArgs.path, // Include path in queryObject if it exists
+  };
   const querystring = JSON.stringify(queryObject);
   const encodedQuery = encodeURIComponent(querystring);
-
   const options: ApiRequestParams = {
     config,
     params: {
       ...(encodedQuery && { query: encodedQuery }),
     },
   };
-
   return apiRequest('get', '/@querystring-search', options);
 };
 
 export const getQuerystringSearchQuery = ({
   query,
   config,
+  path,
 }: QuerystringSearchArgs) => ({
-  queryKey: ['get', 'querystringSearch'],
-  queryFn: () => getQuerystringSearch({ query, config }),
+  queryKey: ['get', 'querystringSearch', path],
+  queryFn: () => getQuerystringSearch({ query, config, path }),
 });

--- a/packages/client/src/validation/querystring-search.ts
+++ b/packages/client/src/validation/querystring-search.ts
@@ -14,4 +14,5 @@ export const querystringSearchDataSchema = z.object({
   sort_order: z.string().optional(),
   fullobjects: z.boolean().optional(),
   query: z.array(query),
+  path: z.string().optional(),
 });

--- a/packages/types/news/6254.feature
+++ b/packages/types/news/6254.feature
@@ -1,0 +1,3 @@
+Added optional 'path' parameter to querystringSearch functionality. This enables scoped searches, 
+allowing for more efficient and context-specific queries. Updated tests and schema to support 
+this new feature. @your-github-username


### PR DESCRIPTION
This Pull Request fixes #6254 , which is "Without being able to pass in a path to the querystring-search, all searches are performed from the root, breaking relative queries (e.g. ../::1)"
I've added all the important tests which are required, also made it optional so it does not break for the existing users. 
This is a cool project btw, will look forward to contribute more <3