### PR TITLE
Updated #2573 to Volto 18: Change text color to black for input:focus

### DIFF
--- a/packages/volto/cypress/tests/core/basic/a11y.js
+++ b/packages/volto/cypress/tests/core/basic/a11y.js
@@ -10,6 +10,10 @@ describe('Accessibility Tests', () => {
 
   it('Contact form has not a11y violations', () => {
     cy.navigate('/contact-form');
+    cy.get('#field-name').click().type('input');
+    cy.get('#field-from').click().type('something@domain.com');
+    cy.get('#field-subject').click().type('input');
+    cy.get('#field-message').click().type('input');
     cy.checkA11y();
   });
 

--- a/packages/volto/news/2570.bugfix
+++ b/packages/volto/news/2570.bugfix
@@ -1,0 +1,1 @@
+Change Form input:focus text color to black for a11y. @ThomasKindermann

--- a/packages/volto/news/2570.bugfix
+++ b/packages/volto/news/2570.bugfix
@@ -1,1 +1,2 @@
-Change Form input:focus text color to black for a11y. @ThomasKindermann
+Change Form input:focus text color to the `textColor` value for a11y. 
+Add Cypress test for contact form inputs. @ThomasKindermann @tedw87

--- a/packages/volto/theme/themes/pastanaga/collections/form.overrides
+++ b/packages/volto/theme/themes/pastanaga/collections/form.overrides
@@ -50,6 +50,7 @@
 
   &:focus {
     border-radius: 0;
+    color: @textColor;
   }
 }
 


### PR DESCRIPTION
The PR #2573 is quite old, and since then, the structure of Volto 18 has changed. This PR aims to bring it up to date.
It was approved 3 years ago.