### PR TITLE
fix: onFocus handle to focus tabbed blocks - file cleaned

### DIFF
--- a/packages/volto/src/components/manage/Blocks/Block/Edit.jsx
+++ b/packages/volto/src/components/manage/Blocks/Block/Edit.jsx
@@ -152,13 +152,8 @@ export class Edit extends Component {
               }
             }}
             onFocus={(e) => {
-              // TODO: This `onFocus` steals somehow the focus from the slate block
-              // we have to investigate why this is happening
-              // Apparently, I can't see any difference in the behavior
-              // If any, we can fix it in successive iterations
-              // if (this.props.hovered !== this.props.id) {
-              //   this.props.setUIState({ hovered: this.props.id });
-              // }
+              !this.props.selected &&
+                this.props.onSelectBlock(this.props.id, this.props.selected, e);
             }}
             onMouseLeave={(e) => {
               e.preventDefault();

--- a/packages/volto/src/components/manage/Blocks/Block/EditBlockWrapper.jsx
+++ b/packages/volto/src/components/manage/Blocks/Block/EditBlockWrapper.jsx
@@ -4,7 +4,6 @@ import {
   applyBlockInitialValue,
   getBlocksFieldname,
   blockHasValue,
-  buildStyleClassNamesFromData,
   buildStyleObjectFromData,
 } from '@plone/volto/helpers';
 import dragSVG from '@plone/volto/icons/drag.svg';
@@ -12,7 +11,6 @@ import { Button } from 'semantic-ui-react';
 import includes from 'lodash/includes';
 import isBoolean from 'lodash/isBoolean';
 import { defineMessages, injectIntl } from 'react-intl';
-import cx from 'classnames';
 import config from '@plone/volto/registry';
 import { BlockChooserButton } from '@plone/volto/components';
 
@@ -61,7 +59,6 @@ const EditBlockWrapper = (props) => {
     ? data.required
     : includes(config.blocks.requiredBlocks, type);
 
-  const classNames = buildStyleClassNamesFromData(data.styles);
   const style = buildStyleObjectFromData(data.styles);
 
   // We need to merge the StyleWrapper styles with the draggable props from b-D&D
@@ -77,23 +74,19 @@ const EditBlockWrapper = (props) => {
       // Right now, we can have the alignment information in the styles property or in the
       // block data root, we inject the classname here for having control over the whole
       // Block Edit wrapper
-      className={cx(`block-editor-${data['@type']}`, classNames, {
-        [data.align]: data.align,
-      })}
     >
       <div style={{ position: 'relative' }}>
-        <div
-          style={{
-            visibility: visible ? 'visible' : 'hidden',
-            display: 'inline-block',
-          }}
-          {...draginfo.dragHandleProps}
-          className="drag handle wrapper"
-        >
-          <Icon name={dragSVG} size="18px" />
-        </div>
         <div className={`ui drag block inner ${type}`}>
-          {children}
+          <div
+            style={{
+              visibility: visible ? 'visible' : 'hidden',
+              display: 'inline-block',
+            }}
+            className="drag handle wrapper"
+            aria-controls="block-1"
+          >
+            <Icon name={dragSVG} size="18px" />
+          </div>
           {selected && !required && editable && (
             <Button
               icon
@@ -140,6 +133,7 @@ const EditBlockWrapper = (props) => {
               contentType={contentType}
             />
           )}
+          {children}
         </div>
       </div>
     </div>


### PR DESCRIPTION
The focus issue when entering a block using the Tab key has been fixed. Now, the onFocus function works similarly to the onClick function, giving focus to the block and activating the visible border and functional buttons (drag, delete, and add block).

**To reproduce this issue:**
1-Enter edit mode
2-Press Tab to move from the title to the first block
3-Go back to the title by pressing the Up Arrow key
4-Press Tab again

-Without this fix, the focus would not appear on the block.

P.S.: At this point, those buttons are not accessible yet, but this will be fixed soon (I hope).