### PR TITLE
fix(SideBarPopup): close sidebarPopup on ESC keypress

### DIFF
--- a/packages/volto/news/6315.bugfix
+++ b/packages/volto/news/6315.bugfix
@@ -1,0 +1,1 @@
+fix: SidebarPopup close on ESC keypress @nileshgulia1

--- a/packages/volto/src/components/manage/Sidebar/SidebarPopup.jsx
+++ b/packages/volto/src/components/manage/Sidebar/SidebarPopup.jsx
@@ -16,6 +16,13 @@ const SidebarPopup = (props) => {
     onClose();
   };
 
+  const handleEscapeKey = (e) => {
+    if (open && e.key === 'Escape') {
+      onClose();
+      e.stopPropagation();
+    }
+  };
+
   const [isClient, setIsClient] = React.useState(false);
   React.useEffect(() => {
     setIsClient(true);
@@ -23,19 +30,12 @@ const SidebarPopup = (props) => {
 
   React.useEffect(() => {
     document.addEventListener('mousedown', handleClickOutside, false);
+    document.addEventListener('keyup', handleEscapeKey, false);
     return () => {
       document.removeEventListener('mousedown', handleClickOutside, false);
+      document.removeEventListener('keyup', handleEscapeKey, false);
     };
   });
-
-  React.useEffect(() => {
-    if (open) {
-      if (asideElement && asideElement.current) {
-        asideElement.current.focus();
-      }
-    }
-  }, [open, asideElement]);
-
   return (
     <>
       {overlay && (
@@ -68,9 +68,7 @@ const SidebarPopup = (props) => {
                 onClick={(e) => {
                   e.stopPropagation();
                 }}
-                tabIndex={-1}
-                onKeyUp={(e) => {
-                  if (e.key === 'Escape') onClose();
+                onKeyDown={(e) => {
                   e.stopPropagation();
                 }}
                 ref={asideElement}

--- a/packages/volto/src/components/manage/Sidebar/SidebarPopup.jsx
+++ b/packages/volto/src/components/manage/Sidebar/SidebarPopup.jsx
@@ -28,6 +28,14 @@ const SidebarPopup = (props) => {
     };
   });
 
+  React.useEffect(() => {
+    if (open) {
+      if (asideElement && asideElement.current) {
+        asideElement.current.focus();
+      }
+    }
+  }, [open, asideElement]);
+
   return (
     <>
       {overlay && (
@@ -60,7 +68,9 @@ const SidebarPopup = (props) => {
                 onClick={(e) => {
                   e.stopPropagation();
                 }}
-                onKeyDown={(e) => {
+                tabIndex={-1}
+                onKeyUp={(e) => {
+                  if (e.key === 'Escape') onClose();
                   e.stopPropagation();
                 }}
                 ref={asideElement}


### PR DESCRIPTION
As an extension of https://github.com/plone/volto/pull/2509#issuecomment-1016368522
The problem with block losing focus on ESC was originating from https://github.com/plone/volto/blob/355bbad4e61420c4ede481a1bcae21a3ed82148e/packages/volto/src/components/manage/Blocks/Block/BlocksForm.jsx#L77
The solution was to intercept the event by making `<aside>` focusable. Since non-interactive elements should not be made focusable, therefore added tabIndex={-1}.