### PR TITLE
Use consistent text colour for accordion titles to improve contrast and CMS consistency

### DIFF
--- a/packages/volto/news/6330.bugfix
+++ b/packages/volto/news/6330.bugfix
@@ -1,0 +1,1 @@
+Changed sidebar accordion text colour from @teal to @textColor. @JeffersonBledsoe

--- a/packages/volto/theme/themes/pastanaga/modules/accordion.variables
+++ b/packages/volto/theme/themes/pastanaga/modules/accordion.variables
@@ -34,14 +34,14 @@
 
 /* Styled Title */
 @styledTitleFontWeight: @normal;
-@styledTitleColor: @teal;
+@styledTitleColor: @textColor;
 @styledTitleBorder: none;
 
 /* Styled Title States */
 @styledTitleHoverBackground: @darkWhite;
-@styledTitleHoverColor: @teal;
+@styledTitleHoverColor: @textColor;
 @styledActiveTitleBackground: @darkWhite;
-@styledActiveTitleColor: @teal;
+@styledActiveTitleColor: @textColor;
 
 /* Styled Child Title States */
 


### PR DESCRIPTION
Fixes #6319 

<img width="386" alt="Screenshot 2024-09-25 at 1 27 36 PM" src="https://github.com/user-attachments/assets/aa0aef48-c4f4-457c-914c-56e4cf2b4485">
