### PR TITLE
feat: added custom condition to the aria-label user button

### DIFF
--- a/packages/volto/src/components/manage/Toolbar/Toolbar.jsx
+++ b/packages/volto/src/components/manage/Toolbar/Toolbar.jsx
@@ -27,6 +27,7 @@ import {
   listActions,
   setExpandedToolbar,
   unlockContent,
+  getUser,
 } from '@plone/volto/actions';
 import { Icon } from '@plone/volto/components';
 import {
@@ -34,6 +35,7 @@ import {
   getBaseUrl,
   getCookieOptions,
   hasApiExpander,
+  userHasRoles,
 } from '@plone/volto/helpers';
 import { Pluggable } from '@plone/volto/components/manage/Pluggable';
 
@@ -195,6 +197,7 @@ class Toolbar extends Component {
       menuComponents: [],
       loadedComponents: [],
       hideToolbarBody: false,
+      user: null,
     };
   }
 
@@ -220,6 +223,9 @@ class Toolbar extends Component {
     };
     this.props.setExpandedToolbar(this.state.expanded);
     document.addEventListener('mousedown', this.handleClickOutside, false);
+
+    const { userId, getUser } = this.props;
+    getUser(userId);
   }
 
   /**
@@ -600,9 +606,14 @@ class Toolbar extends Component {
                 {!this.props.hideDefaultViewButtons && (
                   <button
                     className="user"
-                    aria-label={this.props.intl.formatMessage(
-                      messages.personalTools,
-                    )}
+                    aria-label={
+                      userHasRoles(this.props.user, [
+                        'Site Administrator',
+                        'Manager',
+                      ])
+                        ? this.props.intl.formatMessage(messages.personalTools)
+                        : 'test'
+                    }
                     onClick={(e) => this.toggleMenu(e, 'personalTools')}
                     tabIndex={0}
                     id="toolbar-personal"
@@ -652,7 +663,8 @@ export default compose(
       pathname: props.pathname,
       types: filter(state.types.types, 'addable'),
       unlockRequest: state.content.unlock,
+      user: state.users.user,
     }),
-    { getTypes, listActions, setExpandedToolbar, unlockContent },
+    { getTypes, listActions, setExpandedToolbar, unlockContent, getUser },
   ),
 )(Toolbar);


### PR DESCRIPTION
Added a condition to set the aria-label to differentiate the "regular users" from the admin users.

The condition is the same one used inside the 'PersonalTools' component, which opens after the user button is clicked.

Issue with discussion:
https://github.com/plone/volto/issues/5119