### PR TITLE
Fix the syntax for the label `upgrade-18-cookieplone-label`

### DIFF
--- a/docs/source/upgrade-guide/index.md
+++ b/docs/source/upgrade-guide/index.md
@@ -451,7 +451,7 @@ The `Tags` component has been moved to the `belowContent` slot.
 It now receives the `content` property instead of the `tags` property.
 
 
-{upgrade-18-cookieplone-label}=
+(upgrade-18-cookieplone-label)=
 
 ### Cookieplone is now the recommended project and add-on generator for Volto 18
 

--- a/packages/volto/news/6360.documentation
+++ b/packages/volto/news/6360.documentation
@@ -1,0 +1,1 @@
+- Fix the MyST syntax for the label `upgrade-18-cookieplone-label`. @stevepiercy


### PR DESCRIPTION


<!-- readthedocs-preview volto start -->
----
📚 Documentation preview 📚: https://volto--6360.org.readthedocs.build/

<!-- readthedocs-preview volto end -->