### PR TITLE
Fix spelling of prerequisites

### DIFF
--- a/docs/source/contributing/developing-core.md
+++ b/docs/source/contributing/developing-core.md
@@ -71,9 +71,9 @@ Volto has the following folder structure.
 ```
 
 
-## Development pre-requisites
+## Development prerequisites
 
-To set up a Volto core development environment, your system must satisfy the following pre-requisites.
+To set up a Volto core development environment, your system must satisfy the following prerequisites.
 
 ```{include} ./install-operating-system.md
 ```

--- a/packages/volto/news/6362.documentation
+++ b/packages/volto/news/6362.documentation
@@ -1,0 +1,1 @@
+Fixed spelling of prerequisites. @stevepiercy

--- a/styles/Vocab/Plone/reject.txt
+++ b/styles/Vocab/Plone/reject.txt
@@ -1,2 +1,3 @@
 [^.]js
 NodeJS
+[Pp]re-requisite


### PR DESCRIPTION
See https://github.com/plone/documentation/issues/1720

<!-- readthedocs-preview volto start -->
----
📚 Documentation preview 📚: https://volto--6362.org.readthedocs.build/

<!-- readthedocs-preview volto end -->