### PR TITLE
Fix the boilerplate for old generator and add a missing upgrade guide…

### DIFF
--- a/docs/source/upgrade-guide/index.md
+++ b/docs/source/upgrade-guide/index.md
@@ -474,6 +474,35 @@ The recommended way of generating a project boilerplate is [Cookieplone](https:/
 Please update your code to use the `pnpm` based setup.
 ```
 
+### Update needed to project boilerplate generated with `@plone/generator-volto`
+
+```{versionadded} Volto 18.0.0-alpha.42
+From this version, a new feature introduced a breaking change in the boilerplates created using `@plone/generator-volto` previous to version 9.0.0-alpha.17.
+```
+
+This is the change that you need to introduce in your `razzle.config.js` file in the root of your boilerplate.
+
+```diff
+razzle.config.js
+@@ -27,12 +27,14 @@ const customModifyWebpackConfig = ({
+   webpackConfig,
+   webpackObject,
+   options,
++  path,
+ }) => {
+   const config = modifyWebpackConfig({
+     env: { target, dev },
+     webpackConfig,
+     webpackObject,
+     options,
++    path,
+   });
+   // add custom code here..
+   return config;
+```
+
+The change involves adding a new `path` argument to the `customModifyWebpackConfig` function.
+
 (volto-upgrade-guide-17.x.x)=
 
 ## Upgrading to Volto 17.x.x

--- a/docs/source/upgrade-guide/index.md
+++ b/docs/source/upgrade-guide/index.md
@@ -477,10 +477,10 @@ Please update your code to use the `pnpm` based setup.
 ### Update needed to project boilerplate generated with `@plone/generator-volto`
 
 ```{versionadded} Volto 18.0.0-alpha.42
-From this version, a new feature introduced a breaking change in the boilerplates created using `@plone/generator-volto` previous to version 9.0.0-alpha.17.
+Effective with Volto 18.0.0-alpha.42, a new feature introduced a breaking change in the boilerplates created using `@plone/generator-volto` 9.0.0-alpha.17 and earlier.
 ```
 
-This is the change that you need to introduce in your `razzle.config.js` file in the root of your boilerplate.
+You need to change your {file}`razzle.config.js` file in the root of your boilerplate.
 
 ```diff
 razzle.config.js

--- a/docs/source/upgrade-guide/index.md
+++ b/docs/source/upgrade-guide/index.md
@@ -488,20 +488,20 @@ razzle.config.js
    webpackConfig,
    webpackObject,
    options,
-+  path,
++  paths,
  }) => {
    const config = modifyWebpackConfig({
      env: { target, dev },
      webpackConfig,
      webpackObject,
      options,
-+    path,
++    paths,
    });
    // add custom code here..
    return config;
 ```
 
-The change involves adding a new `path` argument to the `customModifyWebpackConfig` function.
+The change involves adding a new `paths` argument to the `customModifyWebpackConfig` function.
 
 (volto-upgrade-guide-17.x.x)=
 

--- a/packages/generator-volto/generators/app/templates/razzle.config.js
+++ b/packages/generator-volto/generators/app/templates/razzle.config.js
@@ -27,14 +27,14 @@ const customModifyWebpackConfig = ({
   webpackConfig,
   webpackObject,
   options,
-  path,
+  paths,
 }) => {
   const config = modifyWebpackConfig({
     env: { target, dev },
     webpackConfig,
     webpackObject,
     options,
-    path,
+    paths,
   });
   // add custom code here..
   return config;

--- a/packages/generator-volto/generators/app/templates/razzle.config.js
+++ b/packages/generator-volto/generators/app/templates/razzle.config.js
@@ -27,12 +27,14 @@ const customModifyWebpackConfig = ({
   webpackConfig,
   webpackObject,
   options,
+  path,
 }) => {
   const config = modifyWebpackConfig({
     env: { target, dev },
     webpackConfig,
     webpackObject,
     options,
+    path,
   });
   // add custom code here..
   return config;

--- a/packages/generator-volto/news/6368.breaking
+++ b/packages/generator-volto/news/6368.breaking
@@ -1,1 +1,1 @@
-Update `razzle.config.js` to accommodate new argument `path` passed down to `customModifyWebpackConfig` @sneridagh
+Updated `razzle.config.js` to accommodate new argument `path` passed down to `customModifyWebpackConfig`. @sneridagh

--- a/packages/generator-volto/news/6368.breaking
+++ b/packages/generator-volto/news/6368.breaking
@@ -1,1 +1,1 @@
-Updated `razzle.config.js` to accommodate new argument `path` passed down to `customModifyWebpackConfig`. @sneridagh
+Updated `razzle.config.js` to accommodate new argument `paths` passed down to `customModifyWebpackConfig`. @sneridagh

--- a/packages/generator-volto/news/6368.breaking
+++ b/packages/generator-volto/news/6368.breaking
@@ -1,0 +1,1 @@
+Update `razzle.config.js` to accommodate new argument `path` passed down to `customModifyWebpackConfig` @sneridagh


### PR DESCRIPTION
… entry

Fixes #6335

- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't other open [pull requests](https://github.com/plone/volto/pulls) for the same change.
- [x] I followed the guidelines in [Contributing to Volto](https://6.docs.plone.org/volto/contributing/index.html).
- [x] I succesfully ran [code linting checks](https://6.docs.plone.org/volto/contributing/linting.html) on my changes locally.
- [x] I succesfully ran [unit tests](https://6.docs.plone.org/volto/contributing/testing.html) on my changes locally.
- [x] I succesfully ran [acceptance tests](https://6.docs.plone.org/volto/contributing/acceptance-tests.html) on my changes locally.
- [x] If needed, I added new tests for my changes.
- [x] If needed, I added [documentation](https://6.docs.plone.org/volto/contributing/documentation.html#narrative-documentation) for my changes, either in the Storybook or narrative documentation.
- [x] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

If your pull request closes an open issue, include the exact text below, immediately followed by the issue number. When your pull request gets merged, then that issue will close automatically.

Closes #


<!-- readthedocs-preview volto start -->
----
📚 Documentation preview 📚: https://volto--6368.org.readthedocs.build/

<!-- readthedocs-preview volto end -->