### PR TITLE
fix: default language for content if not set

### DIFF
--- a/packages/volto/src/middleware/api.js
+++ b/packages/volto/src/middleware/api.js
@@ -230,7 +230,7 @@ const apiMiddlewareFactory =
             });
           }
           if (type === GET_CONTENT) {
-            const lang = result?.language?.token;
+            const lang = result?.language?.token ?? config.settings.defaultLanguage;
             if (
               lang &&
               state.intl.locale !== toReactIntlLang(lang) &&


### PR DESCRIPTION
if language from retrived content is not set for some reasons, set default language from settings

