### PR TITLE
Add a reference label

### DIFF
--- a/docs/source/addons/best-practices.md
+++ b/docs/source/addons/best-practices.md
@@ -62,6 +62,9 @@ a screenshot.
 Ideally, the Readme should also include install instructions and details on any
 possible settings.
 
+
+(testing-the-add-on-label)=
+
 ## Testing the add-on
 
 It is not easy, right now, to ship an add-on with a self-bootstraping and


### PR DESCRIPTION
This merely adds a reference label so it can be reached from the main documentation. Consider it a typo fix.