### PR TITLE
Backport #6309 to Volto 17

### DIFF
--- a/news/6384.feature
+++ b/news/6384.feature
@@ -1,0 +1,1 @@
+improve DiffField.jsx with better support for displaying HTML elements such as images @dobri1408

--- a/src/components/manage/Diff/DiffField.jsx
+++ b/src/components/manage/Diff/DiffField.jsx
@@ -4,7 +4,6 @@
  */
 
 import React from 'react';
-// import { diffWords as dWords } from 'diff';
 import { join, map } from 'lodash';
 import PropTypes from 'prop-types';
 import { Grid } from 'semantic-ui-react';
@@ -13,20 +12,128 @@ import { Provider } from 'react-intl-redux';
 import { createBrowserHistory } from 'history';
 import { ConnectedRouter } from 'connected-react-router';
 import { useSelector } from 'react-redux';
-
+import config from '@plone/volto/registry';
 import { Api } from '@plone/volto/helpers';
 import configureStore from '@plone/volto/store';
-import { DefaultView } from '@plone/volto/components/';
+import { RenderBlocks } from '@plone/volto/components';
 import { serializeNodes } from '@plone/volto-slate/editor/render';
-
 import { injectLazyLibs } from '@plone/volto/helpers/Loadable/Loadable';
 
-/**
- * Enhanced diff words utility
- * @function diffWords
- * @param oneStr Field one
- * @param twoStr Field two
- */
+const isHtmlTag = (str) => {
+  // Match complete HTML tags, including:
+  // 1. Opening tags like <div>, <img src="example" />, <svg>...</svg>
+  // 2. Self-closing tags like <img />, <br />
+  // 3. Closing tags like </div>
+  return /^<([a-zA-Z]+[0-9]*)\b[^>]*>|^<\/([a-zA-Z]+[0-9]*)\b[^>]*>$|^<([a-zA-Z]+[0-9]*)\b[^>]*\/>$/.test(
+    str,
+  );
+};
+
+const splitWords = (str) => {
+  if (typeof str !== 'string') return str;
+  if (!str) return [];
+
+  const result = [];
+  let currentWord = '';
+  let insideTag = false;
+  let insideSpecialTag = false;
+  let tagBuffer = '';
+
+  // Special tags that should not be split (e.g., <img />, <svg> ... </svg>)
+  const specialTags = ['img', 'svg'];
+
+  for (let i = 0; i < str.length; i++) {
+    const char = str[i];
+
+    // Start of an HTML tag
+    if (char === '<') {
+      if (currentWord) {
+        result.push(currentWord); // Push text before the tag
+        currentWord = '';
+      }
+      insideTag = true;
+      tagBuffer += char;
+    }
+    // End of an HTML tag
+    else if (char === '>') {
+      tagBuffer += char;
+      insideTag = false;
+
+      // Check if the tagBuffer contains a special tag
+      const tagNameMatch = tagBuffer.match(/^<\/?([a-zA-Z]+[0-9]*)\b/);
+      if (tagNameMatch && specialTags.includes(tagNameMatch[1])) {
+        insideSpecialTag =
+          tagNameMatch[0].startsWith('<') && !tagNameMatch[0].startsWith('</');
+        result.push(tagBuffer); // Push the complete special tag as one unit
+        tagBuffer = '';
+        continue;
+      }
+
+      result.push(tagBuffer); // Push the complete tag
+      tagBuffer = '';
+    }
+    // Inside the tag or special tag
+    else if (insideTag || insideSpecialTag) {
+      tagBuffer += char;
+    }
+    // Space outside of tags - push current word
+    else if (char === ' ' && !insideTag && !insideSpecialTag) {
+      if (currentWord) {
+        result.push(currentWord);
+        currentWord = '';
+      }
+      result.push(' ');
+    } else if (
+      char === ',' &&
+      i < str.length - 1 &&
+      str[i + 1] !== ' ' &&
+      !insideTag &&
+      !insideSpecialTag
+    ) {
+      if (currentWord) {
+        result.push(currentWord + char);
+        currentWord = '';
+      }
+      result.push(' ');
+    }
+    // Accumulate characters outside of tags
+    else {
+      currentWord += char;
+    }
+  }
+
+  // Push any remaining text
+  if (currentWord) {
+    result.push(currentWord);
+  }
+  if (tagBuffer) {
+    result.push(tagBuffer); // Push remaining tagBuffer
+  }
+
+  return result;
+};
+
+const formatDiffPart = (part, value, side) => {
+  if (!isHtmlTag(value)) {
+    if (part.removed && (side === 'left' || side === 'unified')) {
+      return `<span class="deletion">${value}</span>`;
+    } else if (part.removed) return '';
+    else if (part.added && (side === 'right' || side === 'unified')) {
+      return `<span class="addition">${value}</span>`;
+    } else if (part.added) return '';
+    return value;
+  } else {
+    if (side === 'unified' && part.added) return value;
+    else if (side === 'unified' && part.removed) return '';
+    if (part.removed && side === 'left') {
+      return value;
+    } else if (part.removed) return '';
+    else if (part.added && side === 'right') {
+      return value;
+    } else if (part.added) return '';
+    return value;
+  }
+};
 
 /**
  * Diff field component.
@@ -36,6 +143,7 @@ import { injectLazyLibs } from '@plone/volto/helpers/Loadable/Loadable';
  * @param {Object} schema Field schema
  * @returns {string} Markup of the component.
  */
+
 const DiffField = ({
   one,
   two,
@@ -51,7 +159,10 @@ const DiffField = ({
     timeStyle: 'short',
   };
   const diffWords = (oneStr, twoStr) => {
-    return diffLib.diffWords(String(oneStr), String(twoStr));
+    return diffLib.diffArrays(
+      splitWords(String(oneStr)),
+      splitWords(String(twoStr)),
+    );
   };
 
   let parts, oneArray, twoArray;
@@ -78,14 +189,14 @@ const DiffField = ({
           ReactDOMServer.renderToStaticMarkup(
             <Provider store={store}>
               <ConnectedRouter history={history}>
-                <DefaultView content={contentOne} />
+                <RenderBlocks content={contentOne} />
               </ConnectedRouter>
             </Provider>,
           ),
           ReactDOMServer.renderToStaticMarkup(
             <Provider store={store}>
               <ConnectedRouter history={history}>
-                <DefaultView content={contentTwo} />
+                <RenderBlocks content={contentTwo} />
               </ConnectedRouter>
             </Provider>,
           ),
@@ -116,7 +227,30 @@ const DiffField = ({
       }
       case 'textarea':
       default:
-        parts = diffWords(one, two);
+        const Widget = config.widgets?.views?.widget?.[schema.widget];
+
+        if (Widget) {
+          const api = new Api();
+          const history = createBrowserHistory();
+          const store = configureStore(window.__data, history, api);
+          parts = diffWords(
+            ReactDOMServer.renderToStaticMarkup(
+              <Provider store={store}>
+                <ConnectedRouter history={history}>
+                  <Widget value={one} />
+                </ConnectedRouter>
+              </Provider>,
+            ),
+            ReactDOMServer.renderToStaticMarkup(
+              <Provider store={store}>
+                <ConnectedRouter history={history}>
+                  <Widget value={two} />
+                </ConnectedRouter>
+              </Provider>,
+            ),
+          );
+        } else parts = diffWords(one, two);
+
         break;
     }
   } else if (schema.type === 'object') {
@@ -128,6 +262,7 @@ const DiffField = ({
   } else {
     parts = diffWords(one?.title || one, two?.title || two);
   }
+
   return (
     <Grid data-testid="DiffField">
       <Grid.Row>
@@ -140,14 +275,12 @@ const DiffField = ({
             <span
               dangerouslySetInnerHTML={{
                 __html: join(
-                  map(
-                    parts,
-                    (part) =>
-                      (part.removed &&
-                        `<span class="deletion">${part.value}</span>`) ||
-                      (!part.added && `<span>${part.value}</span>`) ||
-                      '',
-                  ),
+                  map(parts, (part) => {
+                    let combined = (part.value || []).reduce((acc, value) => {
+                      return acc + formatDiffPart(part, value, 'left');
+                    }, '');
+                    return combined;
+                  }),
                   '',
                 ),
               }}
@@ -157,14 +290,12 @@ const DiffField = ({
             <span
               dangerouslySetInnerHTML={{
                 __html: join(
-                  map(
-                    parts,
-                    (part) =>
-                      (part.added &&
-                        `<span class="addition">${part.value}</span>`) ||
-                      (!part.removed && `<span>${part.value}</span>`) ||
-                      '',
-                  ),
+                  map(parts, (part) => {
+                    let combined = (part.value || []).reduce((acc, value) => {
+                      return acc + formatDiffPart(part, value, 'right');
+                    }, '');
+                    return combined;
+                  }),
                   '',
                 ),
               }}
@@ -178,15 +309,12 @@ const DiffField = ({
             <span
               dangerouslySetInnerHTML={{
                 __html: join(
-                  map(
-                    parts,
-                    (part) =>
-                      (part.removed &&
-                        `<span class="deletion">${part.value}</span>`) ||
-                      (part.added &&
-                        `<span class="addition">${part.value}</span>`) ||
-                      (!part.added && `<span>${part.value}</span>`),
-                  ),
+                  map(parts, (part) => {
+                    let combined = (part.value || []).reduce((acc, value) => {
+                      return acc + formatDiffPart(part, value, 'unified');
+                    }, '');
+                    return combined;
+                  }),
                   '',
                 ),
               }}

--- a/src/components/manage/Diff/__snapshots__/Diff.test.jsx.snap
+++ b/src/components/manage/Diff/__snapshots__/Diff.test.jsx.snap
@@ -266,9 +266,9 @@ exports[`Diff renders a diff component 1`] = `
         </div>
       </div>
     </div>
-  <div
-    id="Portal"
-  />
+    <div
+      id="Portal"
+    />
   </div>
 </div>
 `;

--- a/src/components/manage/Diff/__snapshots__/Diff.test.jsx.snap
+++ b/src/components/manage/Diff/__snapshots__/Diff.test.jsx.snap
@@ -266,13 +266,9 @@ exports[`Diff renders a diff component 1`] = `
         </div>
       </div>
     </div>
-  </div>
   <div
-    id="toolbar"
-  >
-    <div
-      id="Portal"
-    />
+    id="Portal"
+  />
   </div>
 </div>
 `;

--- a/src/components/manage/Diff/__snapshots__/Diff.test.jsx.snap
+++ b/src/components/manage/Diff/__snapshots__/Diff.test.jsx.snap
@@ -232,16 +232,17 @@ exports[`Diff renders a diff component 1`] = `
           class="top aligned six wide column"
         >
           <span>
-            <span>
-              My 
-            </span>
+            My 
             <span
               class="deletion"
             >
               old
             </span>
-            <span>
-               title
+             
+            <span
+              class="deletion"
+            >
+              title
             </span>
           </span>
         </div>
@@ -249,26 +250,26 @@ exports[`Diff renders a diff component 1`] = `
           class="top aligned six wide column"
         >
           <span>
-            <span>
-              My 
-            </span>
+            My 
             <span
               class="addition"
             >
               new
             </span>
-            <span>
-               title
-            </span>
+             
             <span
               class="addition"
             >
-              ,
+              title,
             </span>
           </span>
         </div>
       </div>
     </div>
+  </div>
+  <div
+    id="toolbar"
+  >
     <div
       id="Portal"
     />

--- a/src/components/manage/Diff/__snapshots__/DiffField.test.jsx.snap
+++ b/src/components/manage/Diff/__snapshots__/DiffField.test.jsx.snap
@@ -103,16 +103,14 @@ exports[`DiffField renders a datetime field 1`] = `
           <span
             class="deletion"
           >
-            Tuesday
+            Tuesday,
           </span>
           <span
             class="addition"
           >
-            Monday
+            Monday,
           </span>
-          <span>
-            , April 25, 
-          </span>
+           April 25, 
           <span
             class="deletion"
           >
@@ -123,9 +121,7 @@ exports[`DiffField renders a datetime field 1`] = `
           >
             2016
           </span>
-          <span>
-             at 2:14 PM
-          </span>
+           at 2:14 PM
         </span>
       </div>
     </div>
@@ -155,34 +151,26 @@ exports[`DiffField renders a diff field in split mode 1`] = `
         class="top aligned six wide column"
       >
         <span>
-          <span>
-            My 
-          </span>
+          My 
           <span
             class="deletion"
           >
             old
           </span>
-          <span>
-             string
-          </span>
+           string
         </span>
       </div>
       <div
         class="top aligned six wide column"
       >
         <span>
-          <span>
-            My 
-          </span>
+          My 
           <span
             class="addition"
           >
             new
           </span>
-          <span>
-             string
-          </span>
+           string
         </span>
       </div>
     </div>
@@ -212,9 +200,7 @@ exports[`DiffField renders a diff field in unified mode 1`] = `
         class="top aligned sixteen wide column"
       >
         <span>
-          <span>
-            My 
-          </span>
+          My 
           <span
             class="deletion"
           >
@@ -225,9 +211,7 @@ exports[`DiffField renders a diff field in unified mode 1`] = `
           >
             new
           </span>
-          <span>
-             string
-          </span>
+           string
         </span>
       </div>
     </div>
@@ -257,9 +241,7 @@ exports[`DiffField renders a richtext field 1`] = `
         class="top aligned sixteen wide column"
       >
         <span>
-          <span>
-            My 
-          </span>
+          My 
           <span
             class="deletion"
           >
@@ -270,9 +252,7 @@ exports[`DiffField renders a richtext field 1`] = `
           >
             new
           </span>
-          <span>
-             string
-          </span>
+           string
         </span>
       </div>
     </div>
@@ -302,9 +282,7 @@ exports[`DiffField renders a textarea field 1`] = `
         class="top aligned sixteen wide column"
       >
         <span>
-          <span>
-            My 
-          </span>
+          My 
           <span
             class="deletion"
           >
@@ -315,9 +293,7 @@ exports[`DiffField renders a textarea field 1`] = `
           >
             new
           </span>
-          <span>
-             string
-          </span>
+           string
         </span>
       </div>
     </div>
@@ -347,9 +323,7 @@ exports[`DiffField renders an array field 1`] = `
         class="top aligned sixteen wide column"
       >
         <span>
-          <span>
-            one,
-          </span>
+          one, 
           <span
             class="deletion"
           >
@@ -389,9 +363,7 @@ exports[`DiffField renders an array of objects field 1`] = `
         class="top aligned sixteen wide column"
       >
         <span>
-          <span>
-            one,
-          </span>
+          one, 
           <span
             class="deletion"
           >


### PR DESCRIPTION

This is a backport PR for [PR #6309](https://github.com/plone/volto/pull/6309).

**Why I believe this is not a breaking change:**

1) This can be viewed as a bug fix, as the History page appears broken when used on a complex page. This PR aims to resolve that issue.

2) Although the snapshot changes, it doesn't introduce a breaking change since there is no visual impact. The removal of the span occurs because this fix ensures that RenderBlocks, rather than DefaultView, is used to render the block changes, as it should be.