### PR TITLE
Refs #3839 - Fix error where there is no query supplied

### DIFF
--- a/news/3839.bugfix
+++ b/news/3839.bugfix
@@ -1,0 +1,1 @@
+Fix error "Exception: No query supplied" in the listing block, when there is no criteria selected. @tedw87

--- a/src/components/manage/Blocks/Listing/getAsyncData.js
+++ b/src/components/manage/Blocks/Listing/getAsyncData.js
@@ -24,6 +24,14 @@ export default function getListingBlockAsyncData(props) {
   const subrequestID = content?.UID ? `${content?.UID}-${id}` : id;
   const currentPage = getCurrentPage(location, id);
 
+  if (!data.querystring) {
+    return [
+      async () => {
+        return null;
+      },
+    ];
+  }
+
   return [
     dispatch(
       getQueryStringResults(


### PR DESCRIPTION
When you add a listing block with no criteria, it will give a backend error.

Fixes #3839 