### PR TITLE
support depth in getNavigationQuery

### DIFF
--- a/packages/client/news/6400.feature
+++ b/packages/client/news/6400.feature
@@ -1,0 +1,1 @@
+Add support for the `depth` parameter on `getNavigationQuery`. @ebrehault

--- a/packages/client/src/restapi/content/add.test.tsx
+++ b/packages/client/src/restapi/content/add.test.tsx
@@ -47,7 +47,7 @@ describe('[POST] Content', () => {
     expect(result.current.data?.title).toBe('My Page');
   });
 
-  test.only('Hook - create content in path', async () => {
+  test('Hook - create content in path', async () => {
     const myPageData = {
       '@type': 'Document',
       title: 'My Page',

--- a/packages/client/src/restapi/navigation/get.test.tsx
+++ b/packages/client/src/restapi/navigation/get.test.tsx
@@ -39,4 +39,21 @@ describe('[GET] Navigation', () => {
 
     expect(result.current.error).toBeDefined();
   });
+
+  test('Depth parameter', async () => {
+    const path = '/';
+    const depth = 3;
+    const { result } = renderHook(
+      () => useQuery(getNavigationQuery({ path, depth })),
+      {
+        wrapper: createWrapper(),
+      },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.['@id']).toBe(
+      'http://localhost:55001/plone/@navigation?expand.navigation.depth=3',
+    );
+  });
 });

--- a/packages/client/src/restapi/navigation/get.test.tsx
+++ b/packages/client/src/restapi/navigation/get.test.tsx
@@ -2,12 +2,24 @@ import { renderHook, waitFor } from '@testing-library/react';
 import { createWrapper } from '../../testUtils';
 import { useQuery } from '@tanstack/react-query';
 import ploneClient from '../../client';
+import { setup, teardown } from '../../resetFixture';
+import { createContent } from '../content/add';
 
 const cli = ploneClient.initialize({
   apiPath: 'http://localhost:55001/plone',
 });
 
-const { getNavigationQuery } = cli;
+const { getNavigationQuery, login } = cli;
+
+await login({ username: 'admin', password: 'secret' });
+
+beforeEach(async () => {
+  await setup();
+});
+
+afterEach(async () => {
+  await teardown();
+});
 
 describe('[GET] Navigation', () => {
   test('Hook - Successful', async () => {
@@ -41,19 +53,55 @@ describe('[GET] Navigation', () => {
   });
 
   test('Depth parameter', async () => {
-    const path = '/';
-    const depth = 3;
-    const { result } = renderHook(
-      () => useQuery(getNavigationQuery({ path, depth })),
+    await createContent({
+      path: '/',
+      data: {
+        '@type': 'Document',
+        title: 'Level 1',
+      },
+      config: cli.config,
+    });
+    await createContent({
+      path: '/level-1',
+      data: {
+        '@type': 'Document',
+        title: 'Level 2',
+      },
+      config: cli.config,
+    });
+    await createContent({
+      path: '/level-1/level-2',
+      data: {
+        '@type': 'Document',
+        title: 'Level 3',
+      },
+      config: cli.config,
+    });
+
+    const depth2 = renderHook(
+      () => useQuery(getNavigationQuery({ path: '/', depth: 2 })),
       {
         wrapper: createWrapper(),
       },
     );
-
-    await waitFor(() => expect(result.current.isSuccess).toBe(true));
-
-    expect(result.current.data?.['@id']).toBe(
-      'http://localhost:55001/plone/@navigation',
+    await waitFor(() => expect(depth2.result.current.isSuccess).toBe(true));
+    const level1_1 = depth2.result.current.data?.items.find(
+      (item) => item.title === 'Level 1',
     );
+    expect(level1_1.items[0].title).toBe('Level 2');
+    expect(level1_1.items[0].items.length).toBe(0);
+
+    const depth3 = renderHook(
+      () => useQuery(getNavigationQuery({ path: '/', depth: 3 })),
+      {
+        wrapper: createWrapper(),
+      },
+    );
+    await waitFor(() => expect(depth3.result.current.isSuccess).toBe(true));
+    const level1_2 = depth3.result.current.data?.items.find(
+      (item) => item.title === 'Level 1',
+    );
+    expect(level1_2.items[0].items.length).toBe(1);
+    expect(level1_2.items[0].items[0].title).toBe('Level 3');
   });
 });

--- a/packages/client/src/restapi/navigation/get.test.tsx
+++ b/packages/client/src/restapi/navigation/get.test.tsx
@@ -53,7 +53,7 @@ describe('[GET] Navigation', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     expect(result.current.data?.['@id']).toBe(
-      'http://localhost:55001/plone/@navigation?expand.navigation.depth=3',
+      'http://localhost:55001/plone/@navigation',
     );
   });
 });

--- a/packages/client/src/restapi/navigation/get.ts
+++ b/packages/client/src/restapi/navigation/get.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 
 const getNavigationSchema = z.object({
   path: z.string(),
+  depth: z.number().optional(),
 });
 
 export type NavigationArgs = z.infer<typeof getNavigationSchema> & {
@@ -13,10 +14,12 @@ export type NavigationArgs = z.infer<typeof getNavigationSchema> & {
 
 export const getNavigation = async ({
   path,
+  depth,
   config,
 }: NavigationArgs): Promise<NavigationResponse> => {
   const validatedArgs = getNavigationSchema.parse({
     path,
+    depth,
   });
 
   const options: ApiRequestParams = {
@@ -24,12 +27,19 @@ export const getNavigation = async ({
     params: {},
   };
 
-  const navigationPath = `${validatedArgs.path}/@navigation`;
+  let navigationPath = `${validatedArgs.path}/@navigation`;
+  if (validatedArgs.depth) {
+    navigationPath += `?expand.navigation.depth=${validatedArgs.depth}`;
+  }
 
   return apiRequest('get', navigationPath, options);
 };
 
-export const getNavigationQuery = ({ path, config }: NavigationArgs) => ({
-  queryKey: [path, 'get', 'navigation'],
-  queryFn: () => getNavigation({ path, config }),
+export const getNavigationQuery = ({
+  path,
+  depth,
+  config,
+}: NavigationArgs) => ({
+  queryKey: [path, depth, 'get', 'navigation'],
+  queryFn: () => getNavigation({ path, depth, config }),
 });

--- a/packages/client/src/restapi/navigation/get.ts
+++ b/packages/client/src/restapi/navigation/get.ts
@@ -27,9 +27,9 @@ export const getNavigation = async ({
     params: {},
   };
 
-  let navigationPath = `${validatedArgs.path}/@navigation`;
+  const navigationPath = `${validatedArgs.path}/@navigation`;
   if (validatedArgs.depth) {
-    navigationPath += `?expand.navigation.depth=${validatedArgs.depth}`;
+    options.params['expand.navigation.depth'] = validatedArgs.depth;
   }
 
   return apiRequest('get', navigationPath, options);


### PR DESCRIPTION
- [X] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [X] I verified there aren't other open [pull requests](https://github.com/plone/volto/pulls) for the same change.
- [X] I followed the guidelines in [Contributing to Volto](https://6.docs.plone.org/volto/contributing/index.html).
- [X] I succesfully ran [code linting checks](https://6.docs.plone.org/volto/contributing/linting.html) on my changes locally.
- [X] I succesfully ran [unit tests](https://6.docs.plone.org/volto/contributing/testing.html) on my changes locally.
- [X] I succesfully ran [acceptance tests](https://6.docs.plone.org/volto/contributing/acceptance-tests.html) on my changes locally.
- [X] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/volto/contributing/documentation.html#narrative-documentation) for my changes, either in the Storybook or narrative documentation.
- [X] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

I am not fully satisfied with the unit test I have added as it only checks the new `depth` parameter is accepted but it is not checking how deep is the obtained nav tree.
The thing is I was not able to created nested contents in the unit test (I tried `createContent` with `path: '/news'` but it was failing).
