### PR TITLE
Moved `applyBlockDefaults` one component up so the style is computed correctly

### DIFF
--- a/packages/volto/news/6451.bugfix
+++ b/packages/volto/news/6451.bugfix
@@ -1,0 +1,1 @@
+Moved `applyBlockDefaults` one component up so the style is computed correctly. @sneridagh

--- a/packages/volto/src/components/manage/Blocks/Block/Edit.jsx
+++ b/packages/volto/src/components/manage/Blocks/Block/Edit.jsx
@@ -12,7 +12,6 @@ import cx from 'classnames';
 import { setSidebarTab, setUIState } from '@plone/volto/actions';
 import config from '@plone/volto/registry';
 import withObjectBrowser from '@plone/volto/components/manage/Sidebar/ObjectBrowser';
-import { applyBlockDefaults } from '@plone/volto/helpers';
 import { ViewDefaultBlock, EditDefaultBlock } from '@plone/volto/components';
 
 import {
@@ -199,7 +198,7 @@ export class Edit extends Component {
             <Block
               {...this.props}
               blockNode={this.blockNode}
-              data={applyBlockDefaults(this.props)}
+              data={this.props.data}
             />
             {this.props.manage && (
               <SidebarPortal

--- a/packages/volto/src/components/manage/Blocks/Block/EditBlockWrapper.jsx
+++ b/packages/volto/src/components/manage/Blocks/Block/EditBlockWrapper.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Icon } from '@plone/volto/components';
 import {
+  applyBlockDefaults,
   applyBlockInitialValue,
   getBlocksFieldname,
   blockHasValue,
@@ -48,13 +49,15 @@ const EditBlockWrapper = (props) => {
     onInsertBlock,
     onSelectBlock,
     onMutateBlock,
-    data,
+    data: originalData,
     editable,
     properties,
     showBlockChooser,
     navRoot,
     contentType,
   } = blockProps;
+
+  const data = applyBlockDefaults({ data: originalData, ...blockProps, intl });
 
   const visible = selected && !hideHandler(data);
 


### PR DESCRIPTION
The defaults were applied later in the Edit component tree, we need them too in the top of the editWrapper to calculate the styles too.