### PR TITLE
Fix display of nvm version when installing it for Contributing to Volto.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -289,20 +289,19 @@ latex_logo = "_static/logo_2x.png"
 # An extension that allows replacements for code blocks that
 # are not supported in `rst_epilog` or other substitutions.
 # https://stackoverflow.com/a/56328457/2214933
-def source_replace(app, docname, source):
-    result = source[0]
-    for key in app.config.source_replacements:
-        result = result.replace(key, app.config.source_replacements[key])
-    source[0] = result
+# def source_replace(app, docname, source):
+#     result = source[0]
+#     for key in app.config.source_replacements:
+#         result = result.replace(key, app.config.source_replacements[key])
+#     source[0] = result
 
 
 # Dict of replacements.
-source_replacements = {
-    "{NVM_VERSION}": "0.39.5",
-}
+# source_replacements = {
+# }
 
 
 def setup(app):
-    app.add_config_value("source_replacements", {}, True)
-    app.connect("source-read", source_replace)
+    # app.add_config_value("source_replacements", {}, True)
+    # app.connect("source-read", source_replace)
     app.add_config_value("context", "volto", "env")

--- a/docs/source/contributing/install-nvm.md
+++ b/docs/source/contributing/install-nvm.md
@@ -15,7 +15,7 @@ For the `fish` shell, see [`nvm.fish`](https://github.com/jorgebucaran/nvm.fish)
 2.  Download and run the `nvm` install and update script, and pipe it into `bash`.
 
     ```shell
-    curl -o- https://raw.githubusercontent.com/creationix/nvm/v{NVM_VERSION}/install.sh | bash
+    curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.39.5/install.sh | bash
     ```
 
 3.  Source your profile.

--- a/packages/volto/news/6460.documentation
+++ b/packages/volto/news/6460.documentation
@@ -1,0 +1,1 @@
+Fix display of nvm version when installing it for Contributing to Volto. @stevepiercy


### PR DESCRIPTION
We previously consolidated these instructions into a single include file, so the replacement is no longer needed, and it stopped working when we moved it into a code block.

See https://github.com/plone/documentation/pull/1746/

<!-- readthedocs-preview volto start -->
----
📚 Documentation preview 📚: https://volto--6460.org.readthedocs.build/

<!-- readthedocs-preview volto end -->