### PR TITLE
Remove useEffect from LinkView to ensure the logic runs before render

### DIFF
--- a/packages/volto/src/components/theme/View/LinkView.jsx
+++ b/packages/volto/src/components/theme/View/LinkView.jsx
@@ -1,27 +1,18 @@
-import { useEffect } from 'react';
-import PropTypes from 'prop-types';
-import { useHistory } from 'react-router-dom';
-import { isInternalURL, flattenToAppURL } from '@plone/volto/helpers';
-import { Container as SemanticContainer } from 'semantic-ui-react';
 import { UniversalLink } from '@plone/volto/components';
-import { Redirect } from 'react-router-dom';
-import { FormattedMessage } from 'react-intl';
+import { flattenToAppURL, isInternalURL } from '@plone/volto/helpers';
 import config from '@plone/volto/registry';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+import { Redirect } from 'react-router-dom';
+import { Container as SemanticContainer } from 'semantic-ui-react';
 
 const LinkView = ({ token, content }) => {
-  const history = useHistory();
-  useEffect(() => {
-    if (!token) {
-      const { remoteUrl } = content;
-      if (isInternalURL(remoteUrl)) {
-        history.replace(flattenToAppURL(remoteUrl));
-      } else if (!__SERVER__) {
-        window.location.href = flattenToAppURL(remoteUrl);
-      }
+  if (!token && content.remoteUrl) {
+    if (isInternalURL(content.remoteUrl)) {
+      return <Redirect to={flattenToAppURL(content.remoteUrl)} />;
     }
-  }, [content, history, token]);
-  if (__SERVER__ && !token && content.remoteUrl) {
-    return <Redirect to={content.remoteUrl} />;
+    window.location.href = flattenToAppURL(content.remoteUrl);
+    return null;
   }
   const { title, description, remoteUrl } = content;
   const { openExternalLinkInNewTab } = config.settings;


### PR DESCRIPTION
- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't other open [pull requests](https://github.com/plone/volto/pulls) for the same change.
- [x] I followed the guidelines in [Contributing to Volto](https://6.docs.plone.org/volto/contributing/index.html).
- [x] I succesfully ran [code linting checks](https://6.docs.plone.org/volto/contributing/linting.html) on my changes locally.
- [ ] I succesfully ran [unit tests](https://6.docs.plone.org/volto/contributing/testing.html) on my changes locally.
- [ ] I succesfully ran [acceptance tests](https://6.docs.plone.org/volto/contributing/acceptance-tests.html) on my changes locally.
- [ ] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/volto/contributing/documentation.html#narrative-documentation) for my changes, either in the Storybook or narrative documentation.
- [ ] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

If your pull request closes an open issue, include the exact text below, immediately followed by the issue number. When your pull request gets merged, then that issue will close automatically.

Closes #6463 
