### PR TITLE
Fix packaging and plone/components src export

### DIFF
--- a/packages/components/news/+packagingfix.internal
+++ b/packages/components/news/+packagingfix.internal
@@ -1,0 +1,1 @@
+Improve packaging and bring back the export for `src` folder. @sneridagh

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -29,7 +29,8 @@
       "import": "./dist/index.js",
       "default": "./dist/index.cjs"
     },
-    "./dist/*.css": "./dist/*.css"
+    "./dist/*.css": "./dist/*.css",
+    "./src/*": "./src/*"
   },
   "homepage": "https://plone.org",
   "keywords": [

--- a/packages/providers/news/+packagingfix.internal
+++ b/packages/providers/news/+packagingfix.internal
@@ -1,0 +1,1 @@
+Improve packaging. @sneridagh

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -29,6 +29,10 @@
     "access": "public"
   },
   "type": "module",
+  "files": [
+    "dist",
+    "README.md"
+  ],
   "main": "./dist/index.js",
   "exports": {
     "./package.json": "./package.json",

--- a/packages/registry/news/+packagingfix.internal
+++ b/packages/registry/news/+packagingfix.internal
@@ -1,0 +1,1 @@
+Improve packaging. @sneridagh

--- a/packages/registry/package.json
+++ b/packages/registry/package.json
@@ -31,12 +31,12 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "module",
   "files": [
     "dist",
     "README.md",
     "vite-plugin.*"
   ],
-  "type": "module",
   "main": "dist/index.js",
   "exports": {
     "./package.json": "./package.json",

--- a/packages/scripts/.npmignore
+++ b/packages/scripts/.npmignore
@@ -2,6 +2,8 @@ news
 towncrier.toml
 .changelog.draft
 node_modules/
+.release-it.json
+.eslintrc.cjs
 
 # yarn 3
 .pnp.*

--- a/packages/scripts/news/+packagingfix.internal
+++ b/packages/scripts/news/+packagingfix.internal
@@ -1,0 +1,1 @@
+Improve packaging. @sneridagh

--- a/packages/volto/news/6470.internal
+++ b/packages/volto/news/6470.internal
@@ -1,0 +1,1 @@
+Fix missing export src in @plone/components Also improve packaging in packages. @sneridagh


### PR DESCRIPTION
Fix missing export `src` in @plone/components Also improve packaging in packages.