### PR TITLE
Solved issue Number-6143

### DIFF
--- a/event_scheduler/index.html
+++ b/event_scheduler/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Event Scheduler</title>
+    <script defer src="script.js"></script>
+</head>
+<body>
+    <form id="event-form">
+        <label for="start-datetime">Start Datetime:</label>
+        <input type="datetime-local" id="start-datetime" name="start-datetime" required>
+
+        <label for="end-datetime">End Datetime:</label>
+        <input type="datetime-local" id="end-datetime" name="end-datetime">
+
+        <label for="all-day-checkbox">All-Day Event:</label>
+        <input type="checkbox" id="all-day-checkbox">
+
+        <label for="is-recurring">Recurring Event:</label>
+        <input type="checkbox" id="is-recurring">
+
+        <button type="submit">Save Event</button>
+    </form>
+</body>
+</html>

--- a/event_scheduler/script.js
+++ b/event_scheduler/script.js
@@ -1,0 +1,46 @@
+document.getElementById("event-form").addEventListener("submit", function (event) {
+    event.preventDefault();
+
+    const startField = document.getElementById("start-datetime");
+    const endField = document.getElementById("end-datetime");
+    const allDayCheckbox = document.getElementById("all-day-checkbox");
+
+    const start = new Date(startField.value);
+    const end = new Date(endField.value);
+
+    // Validate start and end times
+    if (!allDayCheckbox.checked && end <= start) {
+        alert("End datetime must be after start datetime.");
+        return;
+    }
+
+    // Handle all-day event logic
+    if (allDayCheckbox.checked) {
+        const startDate = start.toISOString().slice(0, 10);
+        startField.value = `${startDate}T00:00`;
+        endField.value = `${startDate}T23:59`;
+    }
+
+    // Send data to the backend
+    const eventData = {
+        startDatetime: startField.value,
+        endDatetime: endField.value,
+        isAllDay: allDayCheckbox.checked,
+        isRecurring: document.getElementById("is-recurring").checked,
+    };
+
+    fetch("/create-event", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(eventData),
+    })
+        .then((response) => response.json())
+        .then((data) => {
+            if (data.error) {
+                alert(data.error);
+            } else {
+                alert("Event saved successfully!");
+            }
+        })
+        .catch((error) => console.error("Error:", error));
+});


### PR DESCRIPTION
When selecting a start datetime, the end datetime should be after the start datetime. #6143.

github - Harshit-7373.

- [ ] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [ ] I verified there aren't other open [pull requests](https://github.com/plone/volto/pulls) for the same change.
- [ ] I followed the guidelines in [Contributing to Volto](https://6.docs.plone.org/volto/contributing/index.html).
- [ ] I succesfully ran [code linting checks](https://6.docs.plone.org/volto/contributing/linting.html) on my changes locally.
- [ ] I succesfully ran [unit tests](https://6.docs.plone.org/volto/contributing/testing.html) on my changes locally.
- [ ] I succesfully ran [acceptance tests](https://6.docs.plone.org/volto/contributing/acceptance-tests.html) on my changes locally.
- [ ] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/volto/contributing/documentation.html#narrative-documentation) for my changes, either in the Storybook or narrative documentation.
- [ ] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

If your pull request closes an open issue, include the exact text below, immediately followed by the issue number. When your pull request gets merged, then that issue will close automatically.

Closes #
