### PR TITLE
Do not break toolbar if layout id is not registerd in layoutViewsNamesMapping

### DIFF
--- a/packages/volto/news/6485.bugfix
+++ b/packages/volto/news/6485.bugfix
@@ -1,0 +1,1 @@
+Do not break toolbar if layout id is not registerd in layoutViewsNamesMapping. @cekk

--- a/packages/volto/news/6485.bugfix
+++ b/packages/volto/news/6485.bugfix
@@ -1,1 +1,1 @@
-Do not break toolbar if layout id is not registerd in layoutViewsNamesMapping. @cekk
+Do not break toolbar if layout id is not registered in layoutViewsNamesMapping. @cekk

--- a/packages/volto/src/components/manage/Display/Display.jsx
+++ b/packages/volto/src/components/manage/Display/Display.jsx
@@ -123,13 +123,15 @@ const DisplaySelect = (props) => {
       ? state.content.data[getLayoutFieldname(state.content.data)]
       : '',
   );
+  const layoutMappingId = config.views.layoutViewsNamesMapping?.[layout];
   const [selectedOption, setselectedOption] = useState({
     value: layout,
-    label:
-      intl.formatMessage({
-        id: config.views.layoutViewsNamesMapping?.[layout],
-        defaultMessage: config.views.layoutViewsNamesMapping?.[layout],
-      }) || layout,
+    label: layoutMappingId
+      ? intl.formatMessage({
+          id: layoutMappingId,
+          defaultMessage: layoutMappingId,
+        })
+      : layout,
   });
 
   const type = useSelector((state) =>


### PR DESCRIPTION

- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't other open [pull requests](https://github.com/plone/volto/pulls) for the same change.
- [x] I followed the guidelines in [Contributing to Volto](https://6.docs.plone.org/volto/contributing/index.html).
- [x] I succesfully ran [code linting checks](https://6.docs.plone.org/volto/contributing/linting.html) on my changes locally.
- [x] I succesfully ran [unit tests](https://6.docs.plone.org/volto/contributing/testing.html) on my changes locally.
- [x] I succesfully ran [acceptance tests](https://6.docs.plone.org/volto/contributing/acceptance-tests.html) on my changes locally.
documentation) for my changes, either in the Storybook or narrative documentation.
- [x] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

