### PR TITLE
fix: BodyClass depending on sections

### DIFF
--- a/packages/volto/news/6487.bugfix
+++ b/packages/volto/news/6487.bugfix
@@ -1,0 +1,1 @@
+Fixed Body class depending on sections @giuliaghisini

--- a/packages/volto/news/6487.bugfix
+++ b/packages/volto/news/6487.bugfix
@@ -1,1 +1,1 @@
-Fixed Body class depending on sections @giuliaghisini
+Replace _all_ spaces with `-` in `BodyClass` classes, instead of with `-` or `` depending on the content type or section. @giuliaghisini

--- a/packages/volto/src/components/theme/App/App.jsx
+++ b/packages/volto/src/components/theme/App/App.jsx
@@ -141,7 +141,7 @@ export class App extends Component {
         {this.props.content && this.props.content['@type'] && (
           <BodyClass
             className={`contenttype-${this.props.content['@type']
-              .replace(' ', '-')
+              .replaceAll(' ', '-')
               .toLowerCase()}`}
           />
         )}
@@ -155,7 +155,7 @@ export class App extends Component {
             [`is-adding-contenttype-${decodeURIComponent(
               this.props.location?.search?.replace('?type=', ''),
             )
-              .replace(' ', '')
+              .replaceAll(' ', '-')
               .toLowerCase()}`]: this.props.location?.search,
             'is-authenticated': !!this.props.token,
             'is-anonymous': !this.props.token,


### PR DESCRIPTION
When you search for a string with spaces in search site, page brokes because section body class  is wrong calculated

 
- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't other open [pull requests](https://github.com/plone/volto/pulls) for the same change.
- [x] I followed the guidelines in [Contributing to Volto](https://6.docs.plone.org/volto/contributing/index.html).
- [x] I succesfully ran [code linting checks](https://6.docs.plone.org/volto/contributing/linting.html) on my changes locally.
- [x] I succesfully ran [unit tests](https://6.docs.plone.org/volto/contributing/testing.html) on my changes locally.
- [x] I succesfully ran [acceptance tests](https://6.docs.plone.org/volto/contributing/acceptance-tests.html) on my changes locally.
- [x] If needed, I added new tests for my changes.
- [x] If needed, I added [documentation](https://6.docs.plone.org/volto/contributing/documentation.html#narrative-documentation) for my changes, either in the Storybook or narrative documentation.
- [x] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

If your pull request closes an open issue, include the exact text below, immediately followed by the issue number. When your pull request gets merged, then that issue will close automatically.

Closes #
