### PR TITLE
Update browserslist

### DIFF
--- a/docs/source/contributing/language-features.md
+++ b/docs/source/contributing/language-features.md
@@ -41,7 +41,6 @@ You can adjust this file according to the environments you want to target.
   ">1%",
   "last 4 versions",
   "Firefox ESR",
-  "not ie 11",
   "not dead"
 ],
 ```

--- a/packages/volto/news/6501.bugfix
+++ b/packages/volto/news/6501.bugfix
@@ -1,0 +1,1 @@
+Remove `not ie 11` from browserslist configuration, because it is now included in `not dead`. @stevepiercy

--- a/packages/volto/package.json
+++ b/packages/volto/package.json
@@ -171,7 +171,6 @@
     ">1%",
     "last 4 versions",
     "Firefox ESR",
-    "not ie 11",
     "not dead"
   ],
   "engines": {


### PR DESCRIPTION
According to https://browsersl.ist/#q=%3E1%25%0Alast+4+versions%0AFirefox+ESR%0Anot+ie+11%0Anot+dead, we don't need to explicitly list `not ie 11`, because it is now included in `not dead`.

Docs preview:

https://volto--6501.org.readthedocs.build/contributing/language-features.html#browser-compatibility

See also:

- https://github.com/plone/documentation/issues/1280
- https://github.com/plone/documentation/pull/1792