### PR TITLE
Fix linkcheck

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -90,11 +90,8 @@ linkcheck_ignore = [
     # Ignore github.com pages with anchors
     r"https://github.com/.*#.*",
     # Ignore other specific anchors
-    # r"https://chromewebstore.google.com/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi",  # TODO retest with latest Sphinx when upgrading theme. chromewebstore recently changed its URL and has "too many redirects".
-    # r"https://chromewebstore.google.com/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd",  # TODO retest with latest Sphinx when upgrading theme. chromewebstore recently changed its URL and has "too many redirects".
     r"https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS/Errors#Identifying_the_issue",
     r"https://docs.cypress.io/guides/references/migration-guide#Migrating-to-Cypress-version-10-0",
-    # r"https://stackoverflow.com",  # volto and documentation  # TODO retest with latest Sphinx.
 ]
 linkcheck_anchors = True
 linkcheck_timeout = 5
@@ -180,7 +177,7 @@ html_theme_options = {
     "path_to_docs": "docs",
     "repository_branch": "main",
     "repository_url": "https://github.com/plone/volto",
-    "search_bar_text": "Search",  # TODO: Confirm usage of search_bar_text in plone-sphinx-theme
+    "search_bar_text": "Search",
     "use_edit_page_button": True,
     "use_issues_button": True,
     "use_repository_button": True,
@@ -188,7 +185,7 @@ html_theme_options = {
 
 # Announce that we have an opensearch plugin
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_use_opensearch
-html_use_opensearch = "https://6.docs.plone.org"  # TODO: Confirm usage of opensearch in theme
+html_use_opensearch = "https://6.docs.plone.org"
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".

--- a/packages/registry/docs/conf.py
+++ b/packages/registry/docs/conf.py
@@ -177,7 +177,7 @@ html_theme_options = {
 
 # Announce that we have an opensearch plugin
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_use_opensearch
-html_use_opensearch = "https://plone-registry.readthedocs.io/"  # TODO: Confirm usage of opensearch in theme
+html_use_opensearch = "https://plone-registry.readthedocs.io"
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".

--- a/packages/registry/news/6502.documentation
+++ b/packages/registry/news/6502.documentation
@@ -1,0 +1,1 @@
+`html_use_opensearch` value must not have a trailing slash. Clean up comments. @stevepiercy

--- a/packages/volto/news/6502.documentation
+++ b/packages/volto/news/6502.documentation
@@ -1,0 +1,1 @@
+`html_use_opensearch` value must not have a trailing slash. Clean up comments. @stevepiercy


### PR DESCRIPTION
- html_use_opensearch value must not have a trailing slash
- Clean up comments

<!-- readthedocs-preview volto start -->
----
📚 Documentation preview 📚: https://volto--6502.org.readthedocs.build/

<!-- readthedocs-preview volto end -->