### PR TITLE
Remove devserver settings for HMR of volto

### DIFF
--- a/packages/volto/news/6511.bugfix
+++ b/packages/volto/news/6511.bugfix
@@ -1,1 +1,1 @@
-Fix warnings related to snapshot.managedPaths on startup. @davisagli
+Fix warnings related to `snapshot.managedPaths` on startup. @davisagli

--- a/packages/volto/news/6511.bugfix
+++ b/packages/volto/news/6511.bugfix
@@ -1,0 +1,1 @@
+Fix warnings related to snapshot.managedPaths on startup. @davisagli

--- a/packages/volto/razzle.config.js
+++ b/packages/volto/razzle.config.js
@@ -414,15 +414,6 @@ const defaultModify = ({
         ]
       : [];
 
-  if (config.devServer) {
-    config.devServer.static.watch.ignored = /node_modules\/(?!@plone\/volto)/;
-    config.snapshot = {
-      managedPaths: [
-        /^(.+?[\\/]node_modules[\\/](?!(@plone[\\/]volto))(@.+?[\\/])?.+?)[\\/]/,
-      ],
-    };
-  }
-
   return config;
 };
 


### PR DESCRIPTION
It still seems to work without this, and it was showing some warnings on startup. (Reported in https://community.plone.org/t/warnings-durung-volto-start-using-2024-training/20205)