### PR TITLE
Improve link integrity popup volto17

### DIFF
--- a/locales/ca/LC_MESSAGES/volto.po
+++ b/locales/ca/LC_MESSAGES/volto.po
@@ -531,6 +531,7 @@ msgstr "No es pot editar el disseny per al tipus de contingut <strong>{type}</st
 
 #. Default: "Cancel"
 #: components/manage/Add/Add
+#: components/manage/Contents/ContentsDeleteModal
 #: components/manage/Contents/ContentsUploadModal
 #: components/manage/Controlpanels/ContentType
 #: components/manage/Controlpanels/ContentTypeLayout
@@ -1012,12 +1013,12 @@ msgid "Delete row"
 msgstr "Suprimeix la fila"
 
 #. Default: "Delete selected items?"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Delete selected items?"
 msgstr ""
 
 #. Default: "Delete this item?"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Delete this item?"
 msgstr ""
 
@@ -1027,7 +1028,7 @@ msgid "Deleted"
 msgstr ""
 
 #. Default: "Deleting this item breaks {brokenReferences} {variation}."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
@@ -2260,6 +2261,11 @@ msgstr ""
 msgid "Navigate back"
 msgstr "Navega enrere"
 
+#. Default: "Navigate to this item"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "Navigate to this item"
+msgstr ""
+
 #. Default: "Navigation"
 #: components/theme/Navigation/ContextNavigation
 msgid "Navigation"
@@ -3131,6 +3137,11 @@ msgstr "Seleccioneu les columnes per mostrar"
 msgid "Select relation"
 msgstr ""
 
+#. Default: "Select rule"
+#: components/manage/Rules/Rules
+msgid "Select rule"
+msgstr ""
+
 #. Default: "Select the transition to be used for modifying the items state."
 #: components/manage/Contents/ContentsWorkflowModal
 msgid "Select the transition to be used for modifying the items state."
@@ -3328,12 +3339,12 @@ msgid "Small"
 msgstr ""
 
 #. Default: "Some items are also a folder. By deleting them you will delete {containedItemsToDelete} {variation} inside the folders."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Some items are also a folder. By deleting them you will delete {containedItemsToDelete} {variation} inside the folders."
 msgstr ""
 
 #. Default: "Some items are referenced by other contents. By deleting them {brokenReferences} {variation} will be broken."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Some items are referenced by other contents. By deleting them {brokenReferences} {variation} will be broken."
 msgstr ""
 
@@ -3693,6 +3704,11 @@ msgstr "Hi va haver alguns errors"
 msgid "There were some errors."
 msgstr "Hi va haver alguns errors."
 
+#. Default: "These items will have broken links"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "These items will have broken links"
+msgstr ""
+
 #. Default: "Third"
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
 msgid "Third"
@@ -3714,7 +3730,7 @@ msgid "This is a working copy of {title}"
 msgstr "Aquesta és una còpia de treball de {title}"
 
 #. Default: "This item is also a folder. By deleting it you will delete {containedItemsToDelete} {variation} inside the folder."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "This item is also a folder. By deleting it you will delete {containedItemsToDelete} {variation} inside the folder."
 msgstr ""
 
@@ -4138,7 +4154,7 @@ msgid "View changes"
 msgstr "Veure els canvis"
 
 #. Default: "View links and references to this item"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "View links and references to this item"
 msgstr ""
 
@@ -4552,12 +4568,12 @@ msgid "intranet"
 msgstr "Intranet"
 
 #. Default: "item"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "item"
 msgstr ""
 
 #. Default: "items"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "items"
 msgstr ""
 
@@ -4575,6 +4591,21 @@ msgstr "El meu nom d'usuari és"
 #: config/Blocks
 msgid "leadimage"
 msgstr "Camp d'imatge principal"
+
+#. Default: "Delete"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "link-integrity: Delete"
+msgstr ""
+
+#. Default: "Delete item and break links"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "link-integrity: Delete item and break links"
+msgstr ""
+
+#. Default: "Checking references..."
+#: components/manage/Contents/ContentsDeleteModal
+msgid "link-integrity: loading references"
+msgstr ""
 
 #. Default: "Enter a URL to an image"
 #: components/manage/Widgets/ImageWidget
@@ -4701,13 +4732,18 @@ msgid "rebuild relations"
 msgstr ""
 
 #. Default: "reference"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "reference"
 msgstr ""
 
 #. Default: "references"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "references"
+msgstr ""
+
+#. Default: "refers to"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "refers to"
 msgstr ""
 
 #. Default: "results"

--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -530,6 +530,7 @@ msgstr "Layout für <strong>{type}</strong> kann nicht verändert werden, da das
 
 #. Default: "Cancel"
 #: components/manage/Add/Add
+#: components/manage/Contents/ContentsDeleteModal
 #: components/manage/Contents/ContentsUploadModal
 #: components/manage/Controlpanels/ContentType
 #: components/manage/Controlpanels/ContentTypeLayout
@@ -1011,12 +1012,12 @@ msgid "Delete row"
 msgstr "Zeile löschen"
 
 #. Default: "Delete selected items?"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Delete selected items?"
 msgstr ""
 
 #. Default: "Delete this item?"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Delete this item?"
 msgstr ""
 
@@ -1026,7 +1027,7 @@ msgid "Deleted"
 msgstr "Gelöscht"
 
 #. Default: "Deleting this item breaks {brokenReferences} {variation}."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
@@ -2259,6 +2260,11 @@ msgstr "Schmal"
 msgid "Navigate back"
 msgstr "Zurück navigieren"
 
+#. Default: "Navigate to this item"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "Navigate to this item"
+msgstr ""
+
 #. Default: "Navigation"
 #: components/theme/Navigation/ContextNavigation
 msgid "Navigation"
@@ -3130,6 +3136,11 @@ msgstr "Anzuzeigende Spalten wählen"
 msgid "Select relation"
 msgstr "Wählen Sie eine Relation"
 
+#. Default: "Select rule"
+#: components/manage/Rules/Rules
+msgid "Select rule"
+msgstr ""
+
 #. Default: "Select the transition to be used for modifying the items state."
 #: components/manage/Contents/ContentsWorkflowModal
 msgid "Select the transition to be used for modifying the items state."
@@ -3327,12 +3338,12 @@ msgid "Small"
 msgstr "Klein"
 
 #. Default: "Some items are also a folder. By deleting them you will delete {containedItemsToDelete} {variation} inside the folders."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Some items are also a folder. By deleting them you will delete {containedItemsToDelete} {variation} inside the folders."
 msgstr ""
 
 #. Default: "Some items are referenced by other contents. By deleting them {brokenReferences} {variation} will be broken."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Some items are referenced by other contents. By deleting them {brokenReferences} {variation} will be broken."
 msgstr ""
 
@@ -3692,6 +3703,11 @@ msgstr "Es gibt Fehler"
 msgid "There were some errors."
 msgstr "Es sind Fehler aufgetreten."
 
+#. Default: "These items will have broken links"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "These items will have broken links"
+msgstr ""
+
 #. Default: "Third"
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
 msgid "Third"
@@ -3713,7 +3729,7 @@ msgid "This is a working copy of {title}"
 msgstr "Das ist eine Arbeitskopie von {title}"
 
 #. Default: "This item is also a folder. By deleting it you will delete {containedItemsToDelete} {variation} inside the folder."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "This item is also a folder. By deleting it you will delete {containedItemsToDelete} {variation} inside the folder."
 msgstr ""
 
@@ -4137,7 +4153,7 @@ msgid "View changes"
 msgstr "Änderungen anzeigen"
 
 #. Default: "View links and references to this item"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "View links and references to this item"
 msgstr ""
 
@@ -4551,12 +4567,12 @@ msgid "intranet"
 msgstr "Intranet"
 
 #. Default: "item"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "item"
 msgstr ""
 
 #. Default: "items"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "items"
 msgstr ""
 
@@ -4574,6 +4590,21 @@ msgstr "Mein Nutzername lautet"
 #: config/Blocks
 msgid "leadimage"
 msgstr "Lead-Bild"
+
+#. Default: "Delete"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "link-integrity: Delete"
+msgstr ""
+
+#. Default: "Delete item and break links"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "link-integrity: Delete item and break links"
+msgstr ""
+
+#. Default: "Checking references..."
+#: components/manage/Contents/ContentsDeleteModal
+msgid "link-integrity: loading references"
+msgstr ""
 
 #. Default: "Enter a URL to an image"
 #: components/manage/Widgets/ImageWidget
@@ -4700,13 +4731,18 @@ msgid "rebuild relations"
 msgstr "Relationen neu indizieren"
 
 #. Default: "reference"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "reference"
 msgstr ""
 
 #. Default: "references"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "references"
+msgstr ""
+
+#. Default: "refers to"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "refers to"
 msgstr ""
 
 #. Default: "results"

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -525,6 +525,7 @@ msgstr ""
 
 #. Default: "Cancel"
 #: components/manage/Add/Add
+#: components/manage/Contents/ContentsDeleteModal
 #: components/manage/Contents/ContentsUploadModal
 #: components/manage/Controlpanels/ContentType
 #: components/manage/Controlpanels/ContentTypeLayout
@@ -1006,12 +1007,12 @@ msgid "Delete row"
 msgstr ""
 
 #. Default: "Delete selected items?"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Delete selected items?"
 msgstr ""
 
 #. Default: "Delete this item?"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Delete this item?"
 msgstr ""
 
@@ -1021,7 +1022,7 @@ msgid "Deleted"
 msgstr ""
 
 #. Default: "Deleting this item breaks {brokenReferences} {variation}."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
@@ -2254,6 +2255,11 @@ msgstr ""
 msgid "Navigate back"
 msgstr ""
 
+#. Default: "Navigate to this item"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "Navigate to this item"
+msgstr ""
+
 #. Default: "Navigation"
 #: components/theme/Navigation/ContextNavigation
 msgid "Navigation"
@@ -3125,6 +3131,11 @@ msgstr ""
 msgid "Select relation"
 msgstr ""
 
+#. Default: "Select rule"
+#: components/manage/Rules/Rules
+msgid "Select rule"
+msgstr ""
+
 #. Default: "Select the transition to be used for modifying the items state."
 #: components/manage/Contents/ContentsWorkflowModal
 msgid "Select the transition to be used for modifying the items state."
@@ -3322,12 +3333,12 @@ msgid "Small"
 msgstr ""
 
 #. Default: "Some items are also a folder. By deleting them you will delete {containedItemsToDelete} {variation} inside the folders."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Some items are also a folder. By deleting them you will delete {containedItemsToDelete} {variation} inside the folders."
 msgstr ""
 
 #. Default: "Some items are referenced by other contents. By deleting them {brokenReferences} {variation} will be broken."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Some items are referenced by other contents. By deleting them {brokenReferences} {variation} will be broken."
 msgstr ""
 
@@ -3687,6 +3698,11 @@ msgstr ""
 msgid "There were some errors."
 msgstr ""
 
+#. Default: "These items will have broken links"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "These items will have broken links"
+msgstr ""
+
 #. Default: "Third"
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
 msgid "Third"
@@ -3708,7 +3724,7 @@ msgid "This is a working copy of {title}"
 msgstr ""
 
 #. Default: "This item is also a folder. By deleting it you will delete {containedItemsToDelete} {variation} inside the folder."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "This item is also a folder. By deleting it you will delete {containedItemsToDelete} {variation} inside the folder."
 msgstr ""
 
@@ -4132,7 +4148,7 @@ msgid "View changes"
 msgstr ""
 
 #. Default: "View links and references to this item"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "View links and references to this item"
 msgstr ""
 
@@ -4546,12 +4562,12 @@ msgid "intranet"
 msgstr ""
 
 #. Default: "item"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "item"
 msgstr ""
 
 #. Default: "items"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "items"
 msgstr ""
 
@@ -4568,6 +4584,21 @@ msgstr ""
 #. Default: "Lead Image Field"
 #: config/Blocks
 msgid "leadimage"
+msgstr ""
+
+#. Default: "Delete"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "link-integrity: Delete"
+msgstr ""
+
+#. Default: "Delete item and break links"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "link-integrity: Delete item and break links"
+msgstr ""
+
+#. Default: "Checking references..."
+#: components/manage/Contents/ContentsDeleteModal
+msgid "link-integrity: loading references"
 msgstr ""
 
 #. Default: "Enter a URL to an image"
@@ -4695,13 +4726,18 @@ msgid "rebuild relations"
 msgstr ""
 
 #. Default: "reference"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "reference"
 msgstr ""
 
 #. Default: "references"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "references"
+msgstr ""
+
+#. Default: "refers to"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "refers to"
 msgstr ""
 
 #. Default: "results"

--- a/locales/es/LC_MESSAGES/volto.po
+++ b/locales/es/LC_MESSAGES/volto.po
@@ -532,6 +532,7 @@ msgstr "No se puede editar la plantilla de <strong>{type}</strong> porque el sop
 
 #. Default: "Cancel"
 #: components/manage/Add/Add
+#: components/manage/Contents/ContentsDeleteModal
 #: components/manage/Contents/ContentsUploadModal
 #: components/manage/Controlpanels/ContentType
 #: components/manage/Controlpanels/ContentTypeLayout
@@ -1013,12 +1014,12 @@ msgid "Delete row"
 msgstr "Eliminar fila"
 
 #. Default: "Delete selected items?"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Delete selected items?"
 msgstr "¿Eliminar elementos seleccionados?"
 
 #. Default: "Delete this item?"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Delete this item?"
 msgstr "¿Eliminar este elemento?"
 
@@ -1028,7 +1029,7 @@ msgid "Deleted"
 msgstr "Eliminado"
 
 #. Default: "Deleting this item breaks {brokenReferences} {variation}."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
@@ -2261,6 +2262,11 @@ msgstr "Filtrar"
 msgid "Navigate back"
 msgstr "Navegar hacia atrás"
 
+#. Default: "Navigate to this item"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "Navigate to this item"
+msgstr ""
+
 #. Default: "Navigation"
 #: components/theme/Navigation/ContextNavigation
 msgid "Navigation"
@@ -3132,6 +3138,11 @@ msgstr "Seleccionar columnas a mostrar"
 msgid "Select relation"
 msgstr "Seleccionar relación"
 
+#. Default: "Select rule"
+#: components/manage/Rules/Rules
+msgid "Select rule"
+msgstr ""
+
 #. Default: "Select the transition to be used for modifying the items state."
 #: components/manage/Contents/ContentsWorkflowModal
 msgid "Select the transition to be used for modifying the items state."
@@ -3329,12 +3340,12 @@ msgid "Small"
 msgstr "Pequeño"
 
 #. Default: "Some items are also a folder. By deleting them you will delete {containedItemsToDelete} {variation} inside the folders."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Some items are also a folder. By deleting them you will delete {containedItemsToDelete} {variation} inside the folders."
 msgstr ""
 
 #. Default: "Some items are referenced by other contents. By deleting them {brokenReferences} {variation} will be broken."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Some items are referenced by other contents. By deleting them {brokenReferences} {variation} will be broken."
 msgstr "Algunos elementos están referenciados por otros contenidos. Al eliminarlos, {brokenReferences} {variation} se romperá."
 
@@ -3694,6 +3705,11 @@ msgstr "Ha habido algunos errores"
 msgid "There were some errors."
 msgstr "Hay algunos errores."
 
+#. Default: "These items will have broken links"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "These items will have broken links"
+msgstr ""
+
 #. Default: "Third"
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
 msgid "Third"
@@ -3715,7 +3731,7 @@ msgid "This is a working copy of {title}"
 msgstr "Es una copia de trabajo de {title}"
 
 #. Default: "This item is also a folder. By deleting it you will delete {containedItemsToDelete} {variation} inside the folder."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "This item is also a folder. By deleting it you will delete {containedItemsToDelete} {variation} inside the folder."
 msgstr ""
 
@@ -4139,7 +4155,7 @@ msgid "View changes"
 msgstr "Mostrar los cambios"
 
 #. Default: "View links and references to this item"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "View links and references to this item"
 msgstr ""
 
@@ -4553,12 +4569,12 @@ msgid "intranet"
 msgstr "Intranet"
 
 #. Default: "item"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "item"
 msgstr "elemento"
 
 #. Default: "items"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "items"
 msgstr "elementos"
 
@@ -4576,6 +4592,21 @@ msgstr "Mi nombre de usuario es"
 #: config/Blocks
 msgid "leadimage"
 msgstr "Imagen Principal"
+
+#. Default: "Delete"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "link-integrity: Delete"
+msgstr ""
+
+#. Default: "Delete item and break links"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "link-integrity: Delete item and break links"
+msgstr ""
+
+#. Default: "Checking references..."
+#: components/manage/Contents/ContentsDeleteModal
+msgid "link-integrity: loading references"
+msgstr ""
 
 #. Default: "Enter a URL to an image"
 #: components/manage/Widgets/ImageWidget
@@ -4702,14 +4733,19 @@ msgid "rebuild relations"
 msgstr "reconstruir relaciones"
 
 #. Default: "reference"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "reference"
 msgstr "referencia"
 
 #. Default: "references"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "references"
 msgstr "referencias"
+
+#. Default: "refers to"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "refers to"
+msgstr ""
 
 #. Default: "results"
 #: components/theme/Search/Search

--- a/locales/eu/LC_MESSAGES/volto.po
+++ b/locales/eu/LC_MESSAGES/volto.po
@@ -532,6 +532,7 @@ msgstr "Ezin da <strong>{type}</strong> elementu-motaren itxura aldatu, <strong>
 
 #. Default: "Cancel"
 #: components/manage/Add/Add
+#: components/manage/Contents/ContentsDeleteModal
 #: components/manage/Contents/ContentsUploadModal
 #: components/manage/Controlpanels/ContentType
 #: components/manage/Controlpanels/ContentTypeLayout
@@ -1013,12 +1014,12 @@ msgid "Delete row"
 msgstr "Ezabatu errenkada"
 
 #. Default: "Delete selected items?"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Delete selected items?"
 msgstr ""
 
 #. Default: "Delete this item?"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Delete this item?"
 msgstr ""
 
@@ -1028,7 +1029,7 @@ msgid "Deleted"
 msgstr "Ezabatuta"
 
 #. Default: "Deleting this item breaks {brokenReferences} {variation}."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
@@ -2261,6 +2262,11 @@ msgstr "Estutu"
 msgid "Navigate back"
 msgstr "Atzera joan"
 
+#. Default: "Navigate to this item"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "Navigate to this item"
+msgstr ""
+
 #. Default: "Navigation"
 #: components/theme/Navigation/ContextNavigation
 msgid "Navigation"
@@ -3132,6 +3138,11 @@ msgstr "Aukeratu erakutsiko diren zutabeak"
 msgid "Select relation"
 msgstr ""
 
+#. Default: "Select rule"
+#: components/manage/Rules/Rules
+msgid "Select rule"
+msgstr ""
+
 #. Default: "Select the transition to be used for modifying the items state."
 #: components/manage/Contents/ContentsWorkflowModal
 msgid "Select the transition to be used for modifying the items state."
@@ -3329,12 +3340,12 @@ msgid "Small"
 msgstr "Txikia"
 
 #. Default: "Some items are also a folder. By deleting them you will delete {containedItemsToDelete} {variation} inside the folders."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Some items are also a folder. By deleting them you will delete {containedItemsToDelete} {variation} inside the folders."
 msgstr ""
 
 #. Default: "Some items are referenced by other contents. By deleting them {brokenReferences} {variation} will be broken."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Some items are referenced by other contents. By deleting them {brokenReferences} {variation} will be broken."
 msgstr ""
 
@@ -3694,6 +3705,11 @@ msgstr "Errorea gertatu da"
 msgid "There were some errors."
 msgstr "Errorea gertatu da"
 
+#. Default: "These items will have broken links"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "These items will have broken links"
+msgstr ""
+
 #. Default: "Third"
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
 msgid "Third"
@@ -3715,7 +3731,7 @@ msgid "This is a working copy of {title}"
 msgstr "Hau {title} elementuaren lan-bertsioa da"
 
 #. Default: "This item is also a folder. By deleting it you will delete {containedItemsToDelete} {variation} inside the folder."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "This item is also a folder. By deleting it you will delete {containedItemsToDelete} {variation} inside the folder."
 msgstr ""
 
@@ -4139,7 +4155,7 @@ msgid "View changes"
 msgstr "Aldaketak ikusi"
 
 #. Default: "View links and references to this item"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "View links and references to this item"
 msgstr ""
 
@@ -4553,12 +4569,12 @@ msgid "intranet"
 msgstr "Intraneta"
 
 #. Default: "item"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "item"
 msgstr ""
 
 #. Default: "items"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "items"
 msgstr ""
 
@@ -4576,6 +4592,21 @@ msgstr "Nire erabiltzaile izena da"
 #: config/Blocks
 msgid "leadimage"
 msgstr "Irudi nagusiaren eremua"
+
+#. Default: "Delete"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "link-integrity: Delete"
+msgstr ""
+
+#. Default: "Delete item and break links"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "link-integrity: Delete item and break links"
+msgstr ""
+
+#. Default: "Checking references..."
+#: components/manage/Contents/ContentsDeleteModal
+msgid "link-integrity: loading references"
+msgstr ""
 
 #. Default: "Enter a URL to an image"
 #: components/manage/Widgets/ImageWidget
@@ -4702,13 +4733,18 @@ msgid "rebuild relations"
 msgstr ""
 
 #. Default: "reference"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "reference"
 msgstr ""
 
 #. Default: "references"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "references"
+msgstr ""
+
+#. Default: "refers to"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "refers to"
 msgstr ""
 
 #. Default: "results"

--- a/locales/fi/LC_MESSAGES/volto.po
+++ b/locales/fi/LC_MESSAGES/volto.po
@@ -530,6 +530,7 @@ msgstr "Sisältötyypin <strong>{type}</strong> asettelua ei voi muokata, koska 
 
 #. Default: "Cancel"
 #: components/manage/Add/Add
+#: components/manage/Contents/ContentsDeleteModal
 #: components/manage/Contents/ContentsUploadModal
 #: components/manage/Controlpanels/ContentType
 #: components/manage/Controlpanels/ContentTypeLayout
@@ -1011,12 +1012,12 @@ msgid "Delete row"
 msgstr "Poista valittu rivi"
 
 #. Default: "Delete selected items?"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Delete selected items?"
 msgstr ""
 
 #. Default: "Delete this item?"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Delete this item?"
 msgstr ""
 
@@ -1026,7 +1027,7 @@ msgid "Deleted"
 msgstr "Poistettu"
 
 #. Default: "Deleting this item breaks {brokenReferences} {variation}."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
@@ -2259,6 +2260,11 @@ msgstr "Kavenna"
 msgid "Navigate back"
 msgstr "Takaisin"
 
+#. Default: "Navigate to this item"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "Navigate to this item"
+msgstr ""
+
 #. Default: "Navigation"
 #: components/theme/Navigation/ContextNavigation
 msgid "Navigation"
@@ -3130,6 +3136,11 @@ msgstr "Näytettävät sarakkeet"
 msgid "Select relation"
 msgstr ""
 
+#. Default: "Select rule"
+#: components/manage/Rules/Rules
+msgid "Select rule"
+msgstr ""
+
 #. Default: "Select the transition to be used for modifying the items state."
 #: components/manage/Contents/ContentsWorkflowModal
 msgid "Select the transition to be used for modifying the items state."
@@ -3327,12 +3338,12 @@ msgid "Small"
 msgstr "Pieni"
 
 #. Default: "Some items are also a folder. By deleting them you will delete {containedItemsToDelete} {variation} inside the folders."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Some items are also a folder. By deleting them you will delete {containedItemsToDelete} {variation} inside the folders."
 msgstr ""
 
 #. Default: "Some items are referenced by other contents. By deleting them {brokenReferences} {variation} will be broken."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Some items are referenced by other contents. By deleting them {brokenReferences} {variation} will be broken."
 msgstr ""
 
@@ -3692,6 +3703,11 @@ msgstr "Lomakkeesta löytyi virheitä"
 msgid "There were some errors."
 msgstr "Löytyi joitakin puutteita tai virheitä."
 
+#. Default: "These items will have broken links"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "These items will have broken links"
+msgstr ""
+
 #. Default: "Third"
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
 msgid "Third"
@@ -3713,7 +3729,7 @@ msgid "This is a working copy of {title}"
 msgstr ""
 
 #. Default: "This item is also a folder. By deleting it you will delete {containedItemsToDelete} {variation} inside the folder."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "This item is also a folder. By deleting it you will delete {containedItemsToDelete} {variation} inside the folder."
 msgstr ""
 
@@ -4137,7 +4153,7 @@ msgid "View changes"
 msgstr "Näytä muutokset"
 
 #. Default: "View links and references to this item"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "View links and references to this item"
 msgstr ""
 
@@ -4551,12 +4567,12 @@ msgid "intranet"
 msgstr "inranet"
 
 #. Default: "item"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "item"
 msgstr ""
 
 #. Default: "items"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "items"
 msgstr ""
 
@@ -4574,6 +4590,21 @@ msgstr "Käyttäjätunnukseni"
 #: config/Blocks
 msgid "leadimage"
 msgstr "nostokuva"
+
+#. Default: "Delete"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "link-integrity: Delete"
+msgstr ""
+
+#. Default: "Delete item and break links"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "link-integrity: Delete item and break links"
+msgstr ""
+
+#. Default: "Checking references..."
+#: components/manage/Contents/ContentsDeleteModal
+msgid "link-integrity: loading references"
+msgstr ""
 
 #. Default: "Enter a URL to an image"
 #: components/manage/Widgets/ImageWidget
@@ -4700,13 +4731,18 @@ msgid "rebuild relations"
 msgstr ""
 
 #. Default: "reference"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "reference"
 msgstr ""
 
 #. Default: "references"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "references"
+msgstr ""
+
+#. Default: "refers to"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "refers to"
 msgstr ""
 
 #. Default: "results"

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -532,6 +532,7 @@ msgstr "Impossible de modifier la mise en page pour le type de contenu <strong>{
 
 #. Default: "Cancel"
 #: components/manage/Add/Add
+#: components/manage/Contents/ContentsDeleteModal
 #: components/manage/Contents/ContentsUploadModal
 #: components/manage/Controlpanels/ContentType
 #: components/manage/Controlpanels/ContentTypeLayout
@@ -1013,12 +1014,12 @@ msgid "Delete row"
 msgstr "Supprimer la ligne"
 
 #. Default: "Delete selected items?"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Delete selected items?"
 msgstr ""
 
 #. Default: "Delete this item?"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Delete this item?"
 msgstr ""
 
@@ -1028,7 +1029,7 @@ msgid "Deleted"
 msgstr "Supprimé"
 
 #. Default: "Deleting this item breaks {brokenReferences} {variation}."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
@@ -2261,6 +2262,11 @@ msgstr "Étroit"
 msgid "Navigate back"
 msgstr "Retour en arrière"
 
+#. Default: "Navigate to this item"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "Navigate to this item"
+msgstr ""
+
 #. Default: "Navigation"
 #: components/theme/Navigation/ContextNavigation
 msgid "Navigation"
@@ -3132,6 +3138,11 @@ msgstr "Sélectionnez les colonnes à afficher"
 msgid "Select relation"
 msgstr ""
 
+#. Default: "Select rule"
+#: components/manage/Rules/Rules
+msgid "Select rule"
+msgstr ""
+
 #. Default: "Select the transition to be used for modifying the items state."
 #: components/manage/Contents/ContentsWorkflowModal
 msgid "Select the transition to be used for modifying the items state."
@@ -3329,12 +3340,12 @@ msgid "Small"
 msgstr "Petit"
 
 #. Default: "Some items are also a folder. By deleting them you will delete {containedItemsToDelete} {variation} inside the folders."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Some items are also a folder. By deleting them you will delete {containedItemsToDelete} {variation} inside the folders."
 msgstr ""
 
 #. Default: "Some items are referenced by other contents. By deleting them {brokenReferences} {variation} will be broken."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Some items are referenced by other contents. By deleting them {brokenReferences} {variation} will be broken."
 msgstr ""
 
@@ -3694,6 +3705,11 @@ msgstr "Il y a eu quelques erreurs"
 msgid "There were some errors."
 msgstr "Il y a eu quelques erreurs."
 
+#. Default: "These items will have broken links"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "These items will have broken links"
+msgstr ""
+
 #. Default: "Third"
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
 msgid "Third"
@@ -3715,7 +3731,7 @@ msgid "This is a working copy of {title}"
 msgstr "Il sagit d'une copie de travail de {title}"
 
 #. Default: "This item is also a folder. By deleting it you will delete {containedItemsToDelete} {variation} inside the folder."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "This item is also a folder. By deleting it you will delete {containedItemsToDelete} {variation} inside the folder."
 msgstr ""
 
@@ -4139,7 +4155,7 @@ msgid "View changes"
 msgstr "Voir les changements"
 
 #. Default: "View links and references to this item"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "View links and references to this item"
 msgstr ""
 
@@ -4553,12 +4569,12 @@ msgid "intranet"
 msgstr "Intranet"
 
 #. Default: "item"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "item"
 msgstr ""
 
 #. Default: "items"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "items"
 msgstr ""
 
@@ -4576,6 +4592,21 @@ msgstr "Mon nom d'utilisateur est"
 #: config/Blocks
 msgid "leadimage"
 msgstr "image de garde"
+
+#. Default: "Delete"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "link-integrity: Delete"
+msgstr ""
+
+#. Default: "Delete item and break links"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "link-integrity: Delete item and break links"
+msgstr ""
+
+#. Default: "Checking references..."
+#: components/manage/Contents/ContentsDeleteModal
+msgid "link-integrity: loading references"
+msgstr ""
 
 #. Default: "Enter a URL to an image"
 #: components/manage/Widgets/ImageWidget
@@ -4702,13 +4733,18 @@ msgid "rebuild relations"
 msgstr ""
 
 #. Default: "reference"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "reference"
 msgstr ""
 
 #. Default: "references"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "references"
+msgstr ""
+
+#. Default: "refers to"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "refers to"
 msgstr ""
 
 #. Default: "results"

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -1296,7 +1296,7 @@ msgstr "Inserisci il path assoluto per la destinazione. Il path deve iniziare co
 #: components/manage/Aliases/Aliases
 #: components/manage/Controlpanels/Aliases
 msgid "Enter the absolute path where the alternative url should exist. The path must start with '/'. Only urls that result in a 404 not found page will result in a redirect occurring."
-msgstr "Inserisci il path assoluto per cui esiste un url alternativo. Il path deve iniziare con '/'. Non si possono usare come alternativi path già esistenti nel sito."
+msgstr "Inserisci un path per generare un URL alternativo per questo contenuto. Il path deve iniziare con '/'. Non si possono usare come alternativi path già esistenti nel sito."
 
 #. Default: "Enter your current password."
 #: components/manage/Preferences/ChangePassword
@@ -4113,7 +4113,7 @@ msgstr "Utenti e gruppi"
 #. Default: "Using this form, you can manage alternative urls for an item. This is an easy way to make an item available under two different URLs."
 #: components/manage/Aliases/Aliases
 msgid "Using this form, you can manage alternative urls for an item. This is an easy way to make an item available under two different URLs."
-msgstr "Utilizzando questo modulo, è possibile gestire url alternativi per gli elementi per rendere un elemento disponibile sotto due diversi indirizzi in modo facile."
+msgstr "Utilizzando questo modulo, è possibile creare URL alternativi per i contenuti in modo da renderli disponibili con due diversi indirizzi URL. Digitando su browser l'URL alternativo creato per un contenuto verrà fatto un redirect all'URL originale del contenuto stesso."
 
 #. Default: "Variation"
 #: helpers/Extensions/withBlockSchemaEnhancer

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -1296,7 +1296,7 @@ msgstr "Inserisci il path assoluto per la destinazione. Il path deve iniziare co
 #: components/manage/Aliases/Aliases
 #: components/manage/Controlpanels/Aliases
 msgid "Enter the absolute path where the alternative url should exist. The path must start with '/'. Only urls that result in a 404 not found page will result in a redirect occurring."
-msgstr "Inserisci il path assoluto per cui esiste un url alternativo. Il path deve iniziare con '/'. Solo gli url che portano a una pagina '404 not found' causeranno una redirect."
+msgstr "Inserisci il path assoluto per cui esiste un url alternativo. Il path deve iniziare con '/'. Non si possono usare come alternativi path già esistenti nel sito."
 
 #. Default: "Enter your current password."
 #: components/manage/Preferences/ChangePassword

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -496,7 +496,7 @@ msgstr "Sfoglia"
 #. Default: "Browse the site, drop an image, or use a URL"
 #: components/manage/Widgets/ImageWidget
 msgid "Browse the site, drop an image, or type a URL"
-msgstr ""
+msgstr "Cerca nel sito, trascina un'immagine, o inserisci un URL"
 
 #. Default: "Browse the site, drop an image, or type an URL"
 #: components/manage/Blocks/Image/Edit
@@ -525,6 +525,7 @@ msgstr "Non è possibile modificare il Layout per il tipo <strong>{type}</strong
 
 #. Default: "Cancel"
 #: components/manage/Add/Add
+#: components/manage/Contents/ContentsDeleteModal
 #: components/manage/Contents/ContentsUploadModal
 #: components/manage/Controlpanels/ContentType
 #: components/manage/Controlpanels/ContentTypeLayout
@@ -1006,14 +1007,14 @@ msgid "Delete row"
 msgstr "Elimina riga"
 
 #. Default: "Delete selected items?"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Delete selected items?"
-msgstr ""
+msgstr "Vuoi eliminare gli elementi selezionati?"
 
 #. Default: "Delete this item?"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Delete this item?"
-msgstr ""
+msgstr "Vuoi eliminare questo elemento?"
 
 #. Default: "Deleted"
 #: components/manage/Controlpanels/Rules/Rules
@@ -1021,9 +1022,9 @@ msgid "Deleted"
 msgstr "Cancellato"
 
 #. Default: "Deleting this item breaks {brokenReferences} {variation}."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Deleting this item breaks {brokenReferences} {variation}."
-msgstr ""
+msgstr "Eliminando questo elemento si romperanno {brokenReferences} {variation}."
 
 #. Default: "Depth"
 #: components/manage/Widgets/QuerystringWidget
@@ -1588,7 +1589,7 @@ msgstr "Gruppo creato"
 #. Default: "Group deleted"
 #: helpers/MessageLabels/MessageLabels
 msgid "Group deleted"
-msgstr ""
+msgstr "Gruppo eliminato"
 
 #. Default: "Group roles updated"
 #: helpers/MessageLabels/MessageLabels
@@ -1653,7 +1654,7 @@ msgstr "Nascondi i filtri"
 #. Default: "Hide title"
 #: components/manage/Blocks/ToC/Schema
 msgid "Hide title"
-msgstr ""
+msgstr "Nascondi il titolo"
 
 #. Default: "History"
 #: components/manage/History/History
@@ -1840,7 +1841,7 @@ msgstr "Blocco non valido - Salvando, verrà rimosso"
 #. Default: "It is not allowed to define both the password and to request sending the password reset message by e-mail. You need to select one of them."
 #: helpers/MessageLabels/MessageLabels
 msgid "It is not allowed to define both the password and to request sending the password reset message by e-mail. You need to select one of them."
-msgstr ""
+msgstr "Non è permesso definire la password e richiedere il reset della password tramite e-mail contemporaneamente. Devi selezionare solo una delle due opzioni."
 
 #. Default: "Item batch size"
 #: components/manage/Widgets/QuerystringWidget
@@ -1980,7 +1981,7 @@ msgstr "Vista collegamento"
 #. Default: "Link settings"
 #: components/manage/Blocks/Image/schema
 msgid "Link settings"
-msgstr ""
+msgstr "Impostazioni link"
 
 #. Default: "Link Title"
 #: components/manage/Blocks/HeroImageLeft/schema
@@ -2254,6 +2255,11 @@ msgstr "Restringi"
 msgid "Navigate back"
 msgstr "Torna indietro"
 
+#. Default: "Navigate to this item"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "Navigate to this item"
+msgstr "Vai a questo contenuto"
+
 #. Default: "Navigation"
 #: components/theme/Navigation/ContextNavigation
 msgid "Navigation"
@@ -2455,7 +2461,7 @@ msgstr "Ok"
 #. Default: "Only 7-bit bytes characters are allowed. Cannot contain uppercase letters, special characters: <, >, &, #, /, ?, or others that are illegal in URLs. Cannot start with: _, aq_, @@, ++. Cannot end with __. Cannot be: request,contributors, ., .., "". Cannot contain new lines."
 #: components/manage/Widgets/IdWidget
 msgid "Only 7-bit bytes characters are allowed. Cannot contain uppercase letters, special characters: <, >, &, #, /, ?, or others that are illegal in URLs. Cannot start with: _, aq_, @@, ++. Cannot end with __. Cannot be: request,contributors, ., .., "". Cannot contain new lines."
-msgstr ""
+msgstr "Sono ammessi solo 7-bit bytes di caratteri. Non può contenere lettere maiuscole, caratteris speciali come: <, >, &, #, /, ?, o altri che non sono ammessi negli URLs. Non può iniziare con: _, aq_, @@, ++. Non può finire con: __. Non può essere: request,contributors, ., .., "" Non può contenere nuove righe."
 
 #. Default: "Open in a new tab"
 #: components/manage/Blocks/Image/schema
@@ -2477,7 +2483,7 @@ msgstr "Apri object browser"
 #. Default: "Ordered"
 #: components/manage/Blocks/ToC/Schema
 msgid "Ordered"
-msgstr ""
+msgstr "Ordinati"
 
 #. Default: "Origin"
 #: components/manage/Blocks/LeadImage/LeadImageSidebar
@@ -3125,6 +3131,11 @@ msgstr "Seleziona le colonne da mostrare"
 msgid "Select relation"
 msgstr "Seleziona relazione"
 
+#. Default: "Select rule"
+#: components/manage/Rules/Rules
+msgid "Select rule"
+msgstr "Seleziona una regola"
+
 #. Default: "Select the transition to be used for modifying the items state."
 #: components/manage/Contents/ContentsWorkflowModal
 msgid "Select the transition to be used for modifying the items state."
@@ -3322,14 +3333,14 @@ msgid "Small"
 msgstr "Piccolo"
 
 #. Default: "Some items are also a folder. By deleting them you will delete {containedItemsToDelete} {variation} inside the folders."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Some items are also a folder. By deleting them you will delete {containedItemsToDelete} {variation} inside the folders."
-msgstr ""
+msgstr "Alcuni elementi sono anche delle cartelle. Eliminandoli cancellerai {containedItemsToDelete} {variation} dentro le cartelle."
 
 #. Default: "Some items are referenced by other contents. By deleting them {brokenReferences} {variation} will be broken."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Some items are referenced by other contents. By deleting them {brokenReferences} {variation} will be broken."
-msgstr ""
+msgstr "Alcuni elementi sono referenziati da altri contenuti. Eliminandoli, {brokenReferences} {variation} si romperanno."
 
 #. Default: "Some relations are broken. Please fix."
 #: components/manage/Controlpanels/Relations/Relations
@@ -3376,7 +3387,7 @@ msgstr "Ordinato"
 #. Default: "Sorted on"
 #: components/manage/Blocks/Search/components/SortOn
 msgid "Sorted on"
-msgstr ""
+msgstr "Ordinato per"
 
 #. Default: "Source"
 #: components/manage/Blocks/HTML/Edit
@@ -3653,18 +3664,18 @@ msgstr "{plonecms} è {copyright} 2000-{current_year} della {plonefoundation} ed
 #. Default: "There are no groups with the searched criteria"
 #: helpers/MessageLabels/MessageLabels
 msgid "There are no groups with the searched criteria"
-msgstr ""
+msgstr "Non ci sono gruppi corrispondenti ai criteri inseriti"
 
 #. Default: "There are no users with the searched criteria"
 #: helpers/MessageLabels/MessageLabels
 msgid "There are no users with the searched criteria"
-msgstr ""
+msgstr "Non ci sono utenti corrispondenti ai criteri inseriti"
 
 #. Default: "There are some errors."
 #: components/manage/Add/Add
 #: components/manage/Edit/Edit
 msgid "There are some errors."
-msgstr ""
+msgstr "Ci sono alcuni errori."
 
 #. Default: "There is a configuration problem on the backend"
 #: components/theme/CorsError/CorsError
@@ -3687,6 +3698,11 @@ msgstr "Si sono verificati degli errori"
 msgid "There were some errors."
 msgstr "Si sono verificati degli errori."
 
+#. Default: "These items will have broken links"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "These items will have broken links"
+msgstr "Questi elementi avranno dei collegamenti rotti"
+
 #. Default: "Third"
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
 msgid "Third"
@@ -3708,9 +3724,9 @@ msgid "This is a working copy of {title}"
 msgstr "Questa è una copia di lavoro di {title}"
 
 #. Default: "This item is also a folder. By deleting it you will delete {containedItemsToDelete} {variation} inside the folder."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "This item is also a folder. By deleting it you will delete {containedItemsToDelete} {variation} inside the folder."
-msgstr ""
+msgstr "Questo elemento è anche una cartella. Eliminandola eliminerai anche i {containedItemsToDelete} {variation} contenuti in questa cartella."
 
 #. Default: "This item was locked by {creator} on {date}"
 #: components/manage/LockingToastsFactory/LockingToastsFactory
@@ -3949,7 +3965,7 @@ msgstr "Aggiorna"
 #. Default: "Update User"
 #: helpers/MessageLabels/MessageLabels
 msgid "Update User"
-msgstr ""
+msgstr "Aggiorna utente"
 
 #. Default: "Update installed addons"
 #: components/manage/Controlpanels/AddonsControlpanel
@@ -4060,7 +4076,7 @@ msgstr "Utente creato"
 #. Default: "User deleted"
 #: helpers/MessageLabels/MessageLabels
 msgid "User deleted"
-msgstr ""
+msgstr "Utente eliminato"
 
 #. Default: "User name"
 #: components/manage/Controlpanels/Users/UsersControlpanel
@@ -4075,7 +4091,7 @@ msgstr "Ruoli utente aggiornati"
 #. Default: "User updated successfuly"
 #: helpers/MessageLabels/MessageLabels
 msgid "User updated successfuly"
-msgstr ""
+msgstr "Utente aggiornato con successo"
 
 #. Default: "Username"
 #: helpers/MessageLabels/MessageLabels
@@ -4132,9 +4148,9 @@ msgid "View changes"
 msgstr "Mostra le modifiche"
 
 #. Default: "View links and references to this item"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "View links and references to this item"
-msgstr ""
+msgstr "Vedi i link e le referenze a questo elemento"
 
 #. Default: "View this revision"
 #: components/manage/History/History
@@ -4403,7 +4419,7 @@ msgstr "Confronta con"
 #. Default: "{countofrelation} broken {countofrelation, plural, one {relation} other {relations}} of type {typeofrelation}"
 #: components/manage/Controlpanels/Relations/BrokenRelations
 msgid "countBrokenRelations"
-msgstr ""
+msgstr "{countofrelation} {countofrelation, plural, one {relazione rotta} other {relazioni rotte}} di tipo {typeofrelation}"
 
 #. Default: "Date Range"
 #: config/Blocks
@@ -4546,14 +4562,14 @@ msgid "intranet"
 msgstr "Pubblicato internamente"
 
 #. Default: "item"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "item"
-msgstr ""
+msgstr "elemento"
 
 #. Default: "items"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "items"
-msgstr ""
+msgstr "elementi"
 
 #. Default: "My email is"
 #: components/theme/PasswordReset/RequestPasswordReset
@@ -4570,10 +4586,25 @@ msgstr "Il mio nome utente è"
 msgid "leadimage"
 msgstr "Immagine di testata"
 
+#. Default: "Delete"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "link-integrity: Delete"
+msgstr "Elimina"
+
+#. Default: "Delete item and break links"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "link-integrity: Delete item and break links"
+msgstr "Elimina questo elemento e rompi i collegamenti"
+
+#. Default: "Checking references..."
+#: components/manage/Contents/ContentsDeleteModal
+msgid "link-integrity: loading references"
+msgstr "Sto verificando i riferimenti a questo contenuto..."
+
 #. Default: "Enter a URL to an image"
 #: components/manage/Widgets/ImageWidget
 msgid "linkAnImage"
-msgstr ""
+msgstr "Inserisci un URL a una immagine"
 
 #. Default: "Listing"
 #: config/Blocks
@@ -4672,7 +4703,7 @@ msgstr "In attesa"
 #. Default: "Pick an existing image"
 #: components/manage/Widgets/ImageWidget
 msgid "pickAnImage"
-msgstr ""
+msgstr "Scegli una immagine esistente"
 
 #. Default: "Private"
 #: components/manage/Contents/ContentsItem
@@ -4695,14 +4726,19 @@ msgid "rebuild relations"
 msgstr "ricrea le relazioni"
 
 #. Default: "reference"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "reference"
-msgstr ""
+msgstr "referenzia"
 
 #. Default: "references"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "references"
-msgstr ""
+msgstr "referenze"
+
+#. Default: "refers to"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "refers to"
+msgstr "fa riferimento a"
 
 #. Default: "results"
 #: components/theme/Search/Search

--- a/locales/ja/LC_MESSAGES/volto.po
+++ b/locales/ja/LC_MESSAGES/volto.po
@@ -530,6 +530,7 @@ msgstr "ふるまいの<strong>ブロックが有効</strong>で、かつ<strong
 
 #. Default: "Cancel"
 #: components/manage/Add/Add
+#: components/manage/Contents/ContentsDeleteModal
 #: components/manage/Contents/ContentsUploadModal
 #: components/manage/Controlpanels/ContentType
 #: components/manage/Controlpanels/ContentTypeLayout
@@ -1011,12 +1012,12 @@ msgid "Delete row"
 msgstr "行を削除"
 
 #. Default: "Delete selected items?"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Delete selected items?"
 msgstr ""
 
 #. Default: "Delete this item?"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Delete this item?"
 msgstr ""
 
@@ -1026,7 +1027,7 @@ msgid "Deleted"
 msgstr ""
 
 #. Default: "Deleting this item breaks {brokenReferences} {variation}."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
@@ -2259,6 +2260,11 @@ msgstr ""
 msgid "Navigate back"
 msgstr "元に戻る"
 
+#. Default: "Navigate to this item"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "Navigate to this item"
+msgstr ""
+
 #. Default: "Navigation"
 #: components/theme/Navigation/ContextNavigation
 msgid "Navigation"
@@ -3130,6 +3136,11 @@ msgstr "表示する列を選択"
 msgid "Select relation"
 msgstr ""
 
+#. Default: "Select rule"
+#: components/manage/Rules/Rules
+msgid "Select rule"
+msgstr ""
+
 #. Default: "Select the transition to be used for modifying the items state."
 #: components/manage/Contents/ContentsWorkflowModal
 msgid "Select the transition to be used for modifying the items state."
@@ -3327,12 +3338,12 @@ msgid "Small"
 msgstr ""
 
 #. Default: "Some items are also a folder. By deleting them you will delete {containedItemsToDelete} {variation} inside the folders."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Some items are also a folder. By deleting them you will delete {containedItemsToDelete} {variation} inside the folders."
 msgstr ""
 
 #. Default: "Some items are referenced by other contents. By deleting them {brokenReferences} {variation} will be broken."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Some items are referenced by other contents. By deleting them {brokenReferences} {variation} will be broken."
 msgstr ""
 
@@ -3692,6 +3703,11 @@ msgstr "エラーが発生しました"
 msgid "There were some errors."
 msgstr "いくつかのエラーが発生しました"
 
+#. Default: "These items will have broken links"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "These items will have broken links"
+msgstr ""
+
 #. Default: "Third"
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
 msgid "Third"
@@ -3713,7 +3729,7 @@ msgid "This is a working copy of {title}"
 msgstr ""
 
 #. Default: "This item is also a folder. By deleting it you will delete {containedItemsToDelete} {variation} inside the folder."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "This item is also a folder. By deleting it you will delete {containedItemsToDelete} {variation} inside the folder."
 msgstr ""
 
@@ -4137,7 +4153,7 @@ msgid "View changes"
 msgstr "表示"
 
 #. Default: "View links and references to this item"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "View links and references to this item"
 msgstr ""
 
@@ -4551,12 +4567,12 @@ msgid "intranet"
 msgstr "イントラネット"
 
 #. Default: "item"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "item"
 msgstr ""
 
 #. Default: "items"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "items"
 msgstr ""
 
@@ -4574,6 +4590,21 @@ msgstr "私のユーザー名は"
 #: config/Blocks
 msgid "leadimage"
 msgstr "リード画像"
+
+#. Default: "Delete"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "link-integrity: Delete"
+msgstr ""
+
+#. Default: "Delete item and break links"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "link-integrity: Delete item and break links"
+msgstr ""
+
+#. Default: "Checking references..."
+#: components/manage/Contents/ContentsDeleteModal
+msgid "link-integrity: loading references"
+msgstr ""
 
 #. Default: "Enter a URL to an image"
 #: components/manage/Widgets/ImageWidget
@@ -4700,13 +4731,18 @@ msgid "rebuild relations"
 msgstr ""
 
 #. Default: "reference"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "reference"
 msgstr ""
 
 #. Default: "references"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "references"
+msgstr ""
+
+#. Default: "refers to"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "refers to"
 msgstr ""
 
 #. Default: "results"

--- a/locales/nl/LC_MESSAGES/volto.po
+++ b/locales/nl/LC_MESSAGES/volto.po
@@ -529,6 +529,7 @@ msgstr ""
 
 #. Default: "Cancel"
 #: components/manage/Add/Add
+#: components/manage/Contents/ContentsDeleteModal
 #: components/manage/Contents/ContentsUploadModal
 #: components/manage/Controlpanels/ContentType
 #: components/manage/Controlpanels/ContentTypeLayout
@@ -1010,12 +1011,12 @@ msgid "Delete row"
 msgstr ""
 
 #. Default: "Delete selected items?"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Delete selected items?"
 msgstr ""
 
 #. Default: "Delete this item?"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Delete this item?"
 msgstr ""
 
@@ -1025,7 +1026,7 @@ msgid "Deleted"
 msgstr ""
 
 #. Default: "Deleting this item breaks {brokenReferences} {variation}."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
@@ -2258,6 +2259,11 @@ msgstr ""
 msgid "Navigate back"
 msgstr ""
 
+#. Default: "Navigate to this item"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "Navigate to this item"
+msgstr ""
+
 #. Default: "Navigation"
 #: components/theme/Navigation/ContextNavigation
 msgid "Navigation"
@@ -3129,6 +3135,11 @@ msgstr "Selecteer de te tonen kolommen"
 msgid "Select relation"
 msgstr ""
 
+#. Default: "Select rule"
+#: components/manage/Rules/Rules
+msgid "Select rule"
+msgstr ""
+
 #. Default: "Select the transition to be used for modifying the items state."
 #: components/manage/Contents/ContentsWorkflowModal
 msgid "Select the transition to be used for modifying the items state."
@@ -3326,12 +3337,12 @@ msgid "Small"
 msgstr ""
 
 #. Default: "Some items are also a folder. By deleting them you will delete {containedItemsToDelete} {variation} inside the folders."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Some items are also a folder. By deleting them you will delete {containedItemsToDelete} {variation} inside the folders."
 msgstr ""
 
 #. Default: "Some items are referenced by other contents. By deleting them {brokenReferences} {variation} will be broken."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Some items are referenced by other contents. By deleting them {brokenReferences} {variation} will be broken."
 msgstr ""
 
@@ -3691,6 +3702,11 @@ msgstr ""
 msgid "There were some errors."
 msgstr "Er zijn fouten opgetreden."
 
+#. Default: "These items will have broken links"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "These items will have broken links"
+msgstr ""
+
 #. Default: "Third"
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
 msgid "Third"
@@ -3712,7 +3728,7 @@ msgid "This is a working copy of {title}"
 msgstr ""
 
 #. Default: "This item is also a folder. By deleting it you will delete {containedItemsToDelete} {variation} inside the folder."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "This item is also a folder. By deleting it you will delete {containedItemsToDelete} {variation} inside the folder."
 msgstr ""
 
@@ -4136,7 +4152,7 @@ msgid "View changes"
 msgstr "Bekijk wijzigingen"
 
 #. Default: "View links and references to this item"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "View links and references to this item"
 msgstr ""
 
@@ -4550,12 +4566,12 @@ msgid "intranet"
 msgstr ""
 
 #. Default: "item"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "item"
 msgstr ""
 
 #. Default: "items"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "items"
 msgstr ""
 
@@ -4572,6 +4588,21 @@ msgstr "Mijn gebruikersnaam is"
 #. Default: "Lead Image Field"
 #: config/Blocks
 msgid "leadimage"
+msgstr ""
+
+#. Default: "Delete"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "link-integrity: Delete"
+msgstr ""
+
+#. Default: "Delete item and break links"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "link-integrity: Delete item and break links"
+msgstr ""
+
+#. Default: "Checking references..."
+#: components/manage/Contents/ContentsDeleteModal
+msgid "link-integrity: loading references"
 msgstr ""
 
 #. Default: "Enter a URL to an image"
@@ -4699,13 +4730,18 @@ msgid "rebuild relations"
 msgstr ""
 
 #. Default: "reference"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "reference"
 msgstr ""
 
 #. Default: "references"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "references"
+msgstr ""
+
+#. Default: "refers to"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "refers to"
 msgstr ""
 
 #. Default: "results"

--- a/locales/pt/LC_MESSAGES/volto.po
+++ b/locales/pt/LC_MESSAGES/volto.po
@@ -530,6 +530,7 @@ msgstr ""
 
 #. Default: "Cancel"
 #: components/manage/Add/Add
+#: components/manage/Contents/ContentsDeleteModal
 #: components/manage/Contents/ContentsUploadModal
 #: components/manage/Controlpanels/ContentType
 #: components/manage/Controlpanels/ContentTypeLayout
@@ -1011,12 +1012,12 @@ msgid "Delete row"
 msgstr "Eliminar linha"
 
 #. Default: "Delete selected items?"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Delete selected items?"
 msgstr ""
 
 #. Default: "Delete this item?"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Delete this item?"
 msgstr ""
 
@@ -1026,7 +1027,7 @@ msgid "Deleted"
 msgstr ""
 
 #. Default: "Deleting this item breaks {brokenReferences} {variation}."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
@@ -2259,6 +2260,11 @@ msgstr ""
 msgid "Navigate back"
 msgstr ""
 
+#. Default: "Navigate to this item"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "Navigate to this item"
+msgstr ""
+
 #. Default: "Navigation"
 #: components/theme/Navigation/ContextNavigation
 msgid "Navigation"
@@ -3130,6 +3136,11 @@ msgstr "Seleccione colunas a apresentar"
 msgid "Select relation"
 msgstr ""
 
+#. Default: "Select rule"
+#: components/manage/Rules/Rules
+msgid "Select rule"
+msgstr ""
+
 #. Default: "Select the transition to be used for modifying the items state."
 #: components/manage/Contents/ContentsWorkflowModal
 msgid "Select the transition to be used for modifying the items state."
@@ -3327,12 +3338,12 @@ msgid "Small"
 msgstr ""
 
 #. Default: "Some items are also a folder. By deleting them you will delete {containedItemsToDelete} {variation} inside the folders."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Some items are also a folder. By deleting them you will delete {containedItemsToDelete} {variation} inside the folders."
 msgstr ""
 
 #. Default: "Some items are referenced by other contents. By deleting them {brokenReferences} {variation} will be broken."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Some items are referenced by other contents. By deleting them {brokenReferences} {variation} will be broken."
 msgstr ""
 
@@ -3692,6 +3703,11 @@ msgstr ""
 msgid "There were some errors."
 msgstr "Ocorreram alguns erros."
 
+#. Default: "These items will have broken links"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "These items will have broken links"
+msgstr ""
+
 #. Default: "Third"
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
 msgid "Third"
@@ -3713,7 +3729,7 @@ msgid "This is a working copy of {title}"
 msgstr ""
 
 #. Default: "This item is also a folder. By deleting it you will delete {containedItemsToDelete} {variation} inside the folder."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "This item is also a folder. By deleting it you will delete {containedItemsToDelete} {variation} inside the folder."
 msgstr ""
 
@@ -4137,7 +4153,7 @@ msgid "View changes"
 msgstr "Ver modificações"
 
 #. Default: "View links and references to this item"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "View links and references to this item"
 msgstr ""
 
@@ -4551,12 +4567,12 @@ msgid "intranet"
 msgstr ""
 
 #. Default: "item"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "item"
 msgstr ""
 
 #. Default: "items"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "items"
 msgstr ""
 
@@ -4573,6 +4589,21 @@ msgstr "Meu nome de usuário é"
 #. Default: "Lead Image Field"
 #: config/Blocks
 msgid "leadimage"
+msgstr ""
+
+#. Default: "Delete"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "link-integrity: Delete"
+msgstr ""
+
+#. Default: "Delete item and break links"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "link-integrity: Delete item and break links"
+msgstr ""
+
+#. Default: "Checking references..."
+#: components/manage/Contents/ContentsDeleteModal
+msgid "link-integrity: loading references"
 msgstr ""
 
 #. Default: "Enter a URL to an image"
@@ -4700,13 +4731,18 @@ msgid "rebuild relations"
 msgstr ""
 
 #. Default: "reference"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "reference"
 msgstr ""
 
 #. Default: "references"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "references"
+msgstr ""
+
+#. Default: "refers to"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "refers to"
 msgstr ""
 
 #. Default: "results"

--- a/locales/pt_BR/LC_MESSAGES/volto.po
+++ b/locales/pt_BR/LC_MESSAGES/volto.po
@@ -531,6 +531,7 @@ msgstr "Não é possível editar layout para o tipo de conteúdo <strong>{type}<
 
 #. Default: "Cancel"
 #: components/manage/Add/Add
+#: components/manage/Contents/ContentsDeleteModal
 #: components/manage/Contents/ContentsUploadModal
 #: components/manage/Controlpanels/ContentType
 #: components/manage/Controlpanels/ContentTypeLayout
@@ -1012,12 +1013,12 @@ msgid "Delete row"
 msgstr "Excluir linha"
 
 #. Default: "Delete selected items?"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Delete selected items?"
 msgstr ""
 
 #. Default: "Delete this item?"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Delete this item?"
 msgstr ""
 
@@ -1027,7 +1028,7 @@ msgid "Deleted"
 msgstr "Removida"
 
 #. Default: "Deleting this item breaks {brokenReferences} {variation}."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
@@ -2260,6 +2261,11 @@ msgstr "Estreito"
 msgid "Navigate back"
 msgstr "Voltar"
 
+#. Default: "Navigate to this item"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "Navigate to this item"
+msgstr ""
+
 #. Default: "Navigation"
 #: components/theme/Navigation/ContextNavigation
 msgid "Navigation"
@@ -3131,6 +3137,11 @@ msgstr "Selecione colunas para mostrar"
 msgid "Select relation"
 msgstr "Selecione um relacionamento"
 
+#. Default: "Select rule"
+#: components/manage/Rules/Rules
+msgid "Select rule"
+msgstr ""
+
 #. Default: "Select the transition to be used for modifying the items state."
 #: components/manage/Contents/ContentsWorkflowModal
 msgid "Select the transition to be used for modifying the items state."
@@ -3328,12 +3339,12 @@ msgid "Small"
 msgstr "Pequeno"
 
 #. Default: "Some items are also a folder. By deleting them you will delete {containedItemsToDelete} {variation} inside the folders."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Some items are also a folder. By deleting them you will delete {containedItemsToDelete} {variation} inside the folders."
 msgstr ""
 
 #. Default: "Some items are referenced by other contents. By deleting them {brokenReferences} {variation} will be broken."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Some items are referenced by other contents. By deleting them {brokenReferences} {variation} will be broken."
 msgstr ""
 
@@ -3693,6 +3704,11 @@ msgstr "Houve alguns erros"
 msgid "There were some errors."
 msgstr "Houve alguns erros."
 
+#. Default: "These items will have broken links"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "These items will have broken links"
+msgstr ""
+
 #. Default: "Third"
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
 msgid "Third"
@@ -3714,7 +3730,7 @@ msgid "This is a working copy of {title}"
 msgstr "Esta é uma cópia de trabalho de {title}"
 
 #. Default: "This item is also a folder. By deleting it you will delete {containedItemsToDelete} {variation} inside the folder."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "This item is also a folder. By deleting it you will delete {containedItemsToDelete} {variation} inside the folder."
 msgstr ""
 
@@ -4138,7 +4154,7 @@ msgid "View changes"
 msgstr "Ver mudanças"
 
 #. Default: "View links and references to this item"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "View links and references to this item"
 msgstr ""
 
@@ -4552,12 +4568,12 @@ msgid "intranet"
 msgstr "Intranet"
 
 #. Default: "item"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "item"
 msgstr ""
 
 #. Default: "items"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "items"
 msgstr ""
 
@@ -4575,6 +4591,21 @@ msgstr "Meu nome de usuário é "
 #: config/Blocks
 msgid "leadimage"
 msgstr "Imagem principal"
+
+#. Default: "Delete"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "link-integrity: Delete"
+msgstr ""
+
+#. Default: "Delete item and break links"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "link-integrity: Delete item and break links"
+msgstr ""
+
+#. Default: "Checking references..."
+#: components/manage/Contents/ContentsDeleteModal
+msgid "link-integrity: loading references"
+msgstr ""
 
 #. Default: "Enter a URL to an image"
 #: components/manage/Widgets/ImageWidget
@@ -4701,13 +4732,18 @@ msgid "rebuild relations"
 msgstr "reconstruir relacionamentos"
 
 #. Default: "reference"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "reference"
 msgstr ""
 
 #. Default: "references"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "references"
+msgstr ""
+
+#. Default: "refers to"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "refers to"
 msgstr ""
 
 #. Default: "results"

--- a/locales/ro/LC_MESSAGES/volto.po
+++ b/locales/ro/LC_MESSAGES/volto.po
@@ -525,6 +525,7 @@ msgstr "Nu se poate edita aspectul pentru tipul de conținut <strong>{type}</str
 
 #. Default: "Cancel"
 #: components/manage/Add/Add
+#: components/manage/Contents/ContentsDeleteModal
 #: components/manage/Contents/ContentsUploadModal
 #: components/manage/Controlpanels/ContentType
 #: components/manage/Controlpanels/ContentTypeLayout
@@ -1006,12 +1007,12 @@ msgid "Delete row"
 msgstr "Șterge rând"
 
 #. Default: "Delete selected items?"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Delete selected items?"
 msgstr ""
 
 #. Default: "Delete this item?"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Delete this item?"
 msgstr ""
 
@@ -1021,7 +1022,7 @@ msgid "Deleted"
 msgstr ""
 
 #. Default: "Deleting this item breaks {brokenReferences} {variation}."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
@@ -2254,6 +2255,11 @@ msgstr ""
 msgid "Navigate back"
 msgstr "Navigați înapoi"
 
+#. Default: "Navigate to this item"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "Navigate to this item"
+msgstr ""
+
 #. Default: "Navigation"
 #: components/theme/Navigation/ContextNavigation
 msgid "Navigation"
@@ -3125,6 +3131,11 @@ msgstr "Selectați coloane de afișat"
 msgid "Select relation"
 msgstr ""
 
+#. Default: "Select rule"
+#: components/manage/Rules/Rules
+msgid "Select rule"
+msgstr ""
+
 #. Default: "Select the transition to be used for modifying the items state."
 #: components/manage/Contents/ContentsWorkflowModal
 msgid "Select the transition to be used for modifying the items state."
@@ -3322,12 +3333,12 @@ msgid "Small"
 msgstr ""
 
 #. Default: "Some items are also a folder. By deleting them you will delete {containedItemsToDelete} {variation} inside the folders."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Some items are also a folder. By deleting them you will delete {containedItemsToDelete} {variation} inside the folders."
 msgstr ""
 
 #. Default: "Some items are referenced by other contents. By deleting them {brokenReferences} {variation} will be broken."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Some items are referenced by other contents. By deleting them {brokenReferences} {variation} will be broken."
 msgstr ""
 
@@ -3687,6 +3698,11 @@ msgstr "Au aparut unele erori"
 msgid "There were some errors."
 msgstr "Au aparut unele erori."
 
+#. Default: "These items will have broken links"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "These items will have broken links"
+msgstr ""
+
 #. Default: "Third"
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
 msgid "Third"
@@ -3708,7 +3724,7 @@ msgid "This is a working copy of {title}"
 msgstr "Aceasta este o copie de lucru a {title}"
 
 #. Default: "This item is also a folder. By deleting it you will delete {containedItemsToDelete} {variation} inside the folder."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "This item is also a folder. By deleting it you will delete {containedItemsToDelete} {variation} inside the folder."
 msgstr ""
 
@@ -4132,7 +4148,7 @@ msgid "View changes"
 msgstr "Vizualizare modificări"
 
 #. Default: "View links and references to this item"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "View links and references to this item"
 msgstr ""
 
@@ -4546,12 +4562,12 @@ msgid "intranet"
 msgstr "intranet"
 
 #. Default: "item"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "item"
 msgstr ""
 
 #. Default: "items"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "items"
 msgstr ""
 
@@ -4569,6 +4585,21 @@ msgstr "Numele meu de utilizator este"
 #: config/Blocks
 msgid "leadimage"
 msgstr "Imagine (copertă)"
+
+#. Default: "Delete"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "link-integrity: Delete"
+msgstr ""
+
+#. Default: "Delete item and break links"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "link-integrity: Delete item and break links"
+msgstr ""
+
+#. Default: "Checking references..."
+#: components/manage/Contents/ContentsDeleteModal
+msgid "link-integrity: loading references"
+msgstr ""
 
 #. Default: "Enter a URL to an image"
 #: components/manage/Widgets/ImageWidget
@@ -4695,13 +4726,18 @@ msgid "rebuild relations"
 msgstr ""
 
 #. Default: "reference"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "reference"
 msgstr ""
 
 #. Default: "references"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "references"
+msgstr ""
+
+#. Default: "refers to"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "refers to"
 msgstr ""
 
 #. Default: "results"

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2024-08-01T17:04:31.246Z\n"
+"POT-Creation-Date: 2024-12-06T13:58:41.138Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Content-Type: text/plain; charset=utf-8\n"
@@ -527,6 +527,7 @@ msgstr ""
 
 #. Default: "Cancel"
 #: components/manage/Add/Add
+#: components/manage/Contents/ContentsDeleteModal
 #: components/manage/Contents/ContentsUploadModal
 #: components/manage/Controlpanels/ContentType
 #: components/manage/Controlpanels/ContentTypeLayout
@@ -1008,12 +1009,12 @@ msgid "Delete row"
 msgstr ""
 
 #. Default: "Delete selected items?"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Delete selected items?"
 msgstr ""
 
 #. Default: "Delete this item?"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Delete this item?"
 msgstr ""
 
@@ -1023,7 +1024,7 @@ msgid "Deleted"
 msgstr ""
 
 #. Default: "Deleting this item breaks {brokenReferences} {variation}."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
@@ -2256,6 +2257,11 @@ msgstr ""
 msgid "Navigate back"
 msgstr ""
 
+#. Default: "Navigate to this item"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "Navigate to this item"
+msgstr ""
+
 #. Default: "Navigation"
 #: components/theme/Navigation/ContextNavigation
 msgid "Navigation"
@@ -3127,6 +3133,11 @@ msgstr ""
 msgid "Select relation"
 msgstr ""
 
+#. Default: "Select rule"
+#: components/manage/Rules/Rules
+msgid "Select rule"
+msgstr ""
+
 #. Default: "Select the transition to be used for modifying the items state."
 #: components/manage/Contents/ContentsWorkflowModal
 msgid "Select the transition to be used for modifying the items state."
@@ -3324,12 +3335,12 @@ msgid "Small"
 msgstr ""
 
 #. Default: "Some items are also a folder. By deleting them you will delete {containedItemsToDelete} {variation} inside the folders."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Some items are also a folder. By deleting them you will delete {containedItemsToDelete} {variation} inside the folders."
 msgstr ""
 
 #. Default: "Some items are referenced by other contents. By deleting them {brokenReferences} {variation} will be broken."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Some items are referenced by other contents. By deleting them {brokenReferences} {variation} will be broken."
 msgstr ""
 
@@ -3689,6 +3700,11 @@ msgstr ""
 msgid "There were some errors."
 msgstr ""
 
+#. Default: "These items will have broken links"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "These items will have broken links"
+msgstr ""
+
 #. Default: "Third"
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
 msgid "Third"
@@ -3710,7 +3726,7 @@ msgid "This is a working copy of {title}"
 msgstr ""
 
 #. Default: "This item is also a folder. By deleting it you will delete {containedItemsToDelete} {variation} inside the folder."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "This item is also a folder. By deleting it you will delete {containedItemsToDelete} {variation} inside the folder."
 msgstr ""
 
@@ -4134,7 +4150,7 @@ msgid "View changes"
 msgstr ""
 
 #. Default: "View links and references to this item"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "View links and references to this item"
 msgstr ""
 
@@ -4548,12 +4564,12 @@ msgid "intranet"
 msgstr ""
 
 #. Default: "item"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "item"
 msgstr ""
 
 #. Default: "items"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "items"
 msgstr ""
 
@@ -4570,6 +4586,21 @@ msgstr ""
 #. Default: "Lead Image Field"
 #: config/Blocks
 msgid "leadimage"
+msgstr ""
+
+#. Default: "Delete"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "link-integrity: Delete"
+msgstr ""
+
+#. Default: "Delete item and break links"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "link-integrity: Delete item and break links"
+msgstr ""
+
+#. Default: "Checking references..."
+#: components/manage/Contents/ContentsDeleteModal
+msgid "link-integrity: loading references"
 msgstr ""
 
 #. Default: "Enter a URL to an image"
@@ -4697,13 +4728,18 @@ msgid "rebuild relations"
 msgstr ""
 
 #. Default: "reference"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "reference"
 msgstr ""
 
 #. Default: "references"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "references"
+msgstr ""
+
+#. Default: "refers to"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "refers to"
 msgstr ""
 
 #. Default: "results"

--- a/locales/zh_CN/LC_MESSAGES/volto.po
+++ b/locales/zh_CN/LC_MESSAGES/volto.po
@@ -531,6 +531,7 @@ msgstr ""
 
 #. Default: "Cancel"
 #: components/manage/Add/Add
+#: components/manage/Contents/ContentsDeleteModal
 #: components/manage/Contents/ContentsUploadModal
 #: components/manage/Controlpanels/ContentType
 #: components/manage/Controlpanels/ContentTypeLayout
@@ -1012,12 +1013,12 @@ msgid "Delete row"
 msgstr "删除条件"
 
 #. Default: "Delete selected items?"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Delete selected items?"
 msgstr ""
 
 #. Default: "Delete this item?"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Delete this item?"
 msgstr ""
 
@@ -1027,7 +1028,7 @@ msgid "Deleted"
 msgstr "已删除"
 
 #. Default: "Deleting this item breaks {brokenReferences} {variation}."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
@@ -2260,6 +2261,11 @@ msgstr ""
 msgid "Navigate back"
 msgstr "导航返回"
 
+#. Default: "Navigate to this item"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "Navigate to this item"
+msgstr ""
+
 #. Default: "Navigation"
 #: components/theme/Navigation/ContextNavigation
 msgid "Navigation"
@@ -3131,6 +3137,11 @@ msgstr "选择要显示的列"
 msgid "Select relation"
 msgstr ""
 
+#. Default: "Select rule"
+#: components/manage/Rules/Rules
+msgid "Select rule"
+msgstr ""
+
 #. Default: "Select the transition to be used for modifying the items state."
 #: components/manage/Contents/ContentsWorkflowModal
 msgid "Select the transition to be used for modifying the items state."
@@ -3328,12 +3339,12 @@ msgid "Small"
 msgstr "小"
 
 #. Default: "Some items are also a folder. By deleting them you will delete {containedItemsToDelete} {variation} inside the folders."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Some items are also a folder. By deleting them you will delete {containedItemsToDelete} {variation} inside the folders."
 msgstr ""
 
 #. Default: "Some items are referenced by other contents. By deleting them {brokenReferences} {variation} will be broken."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "Some items are referenced by other contents. By deleting them {brokenReferences} {variation} will be broken."
 msgstr ""
 
@@ -3693,6 +3704,11 @@ msgstr "这里出现了一些错误"
 msgid "There were some errors."
 msgstr "这里出现了一些错误。"
 
+#. Default: "These items will have broken links"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "These items will have broken links"
+msgstr ""
+
 #. Default: "Third"
 #: components/manage/Widgets/RecurrenceWidget/WeekdayOfTheMonthIndexField
 msgid "Third"
@@ -3714,7 +3730,7 @@ msgid "This is a working copy of {title}"
 msgstr "这是{title}的一个工作副本"
 
 #. Default: "This item is also a folder. By deleting it you will delete {containedItemsToDelete} {variation} inside the folder."
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "This item is also a folder. By deleting it you will delete {containedItemsToDelete} {variation} inside the folder."
 msgstr ""
 
@@ -4138,7 +4154,7 @@ msgid "View changes"
 msgstr ""
 
 #. Default: "View links and references to this item"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "View links and references to this item"
 msgstr ""
 
@@ -4552,12 +4568,12 @@ msgid "intranet"
 msgstr "内部"
 
 #. Default: "item"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "item"
 msgstr ""
 
 #. Default: "items"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "items"
 msgstr ""
 
@@ -4574,6 +4590,21 @@ msgstr "我的用户名是"
 #. Default: "Lead Image Field"
 #: config/Blocks
 msgid "leadimage"
+msgstr ""
+
+#. Default: "Delete"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "link-integrity: Delete"
+msgstr ""
+
+#. Default: "Delete item and break links"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "link-integrity: Delete item and break links"
+msgstr ""
+
+#. Default: "Checking references..."
+#: components/manage/Contents/ContentsDeleteModal
+msgid "link-integrity: loading references"
 msgstr ""
 
 #. Default: "Enter a URL to an image"
@@ -4701,13 +4732,18 @@ msgid "rebuild relations"
 msgstr ""
 
 #. Default: "reference"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "reference"
 msgstr ""
 
 #. Default: "references"
-#: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 msgid "references"
+msgstr ""
+
+#. Default: "refers to"
+#: components/manage/Contents/ContentsDeleteModal
+msgid "refers to"
 msgstr ""
 
 #. Default: "results"

--- a/news/6517.bugfix
+++ b/news/6517.bugfix
@@ -1,0 +1,1 @@
+improved Contents delete modal and linkintegrity check. @giuliaghisini

--- a/src/components/manage/Contents/Contents.jsx
+++ b/src/components/manage/Contents/Contents.jsx
@@ -11,7 +11,6 @@ import { Portal } from 'react-portal';
 import { Link } from 'react-router-dom';
 import {
   Button,
-  Confirm,
   Container as SemanticContainer,
   Divider,
   Dropdown,
@@ -35,7 +34,6 @@ import {
 import move from 'lodash-move';
 import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
 import { asyncConnect } from '@plone/volto/helpers';
-import { flattenToAppURL } from '@plone/volto/helpers';
 
 import {
   searchContent,
@@ -48,7 +46,6 @@ import {
   orderContent,
   sortContent,
   updateColumnsContent,
-  linkIntegrityCheck,
   getContent,
 } from '@plone/volto/actions';
 import Indexes, { defaultIndexes } from '@plone/volto/constants/Indexes';
@@ -68,6 +65,7 @@ import {
   Icon,
   Unauthorized,
 } from '@plone/volto/components';
+import ContentsDeleteModal from '@plone/volto/components/manage/Contents/ContentsDeleteModal';
 
 import { Helmet, getBaseUrl } from '@plone/volto/helpers';
 import { injectLazyLibs } from '@plone/volto/helpers/Loadable/Loadable';
@@ -118,14 +116,6 @@ const messages = defineMessages({
   delete: {
     id: 'Delete',
     defaultMessage: 'Delete',
-  },
-  deleteConfirmSingleItem: {
-    id: 'Delete this item?',
-    defaultMessage: 'Delete this item?',
-  },
-  deleteConfirmMultipleItems: {
-    id: 'Delete selected items?',
-    defaultMessage: 'Delete selected items?',
   },
   deleteError: {
     id: 'The item could not be deleted.',
@@ -300,7 +290,6 @@ class Contents extends Component {
     orderContent: PropTypes.func.isRequired,
     sortContent: PropTypes.func.isRequired,
     updateColumnsContent: PropTypes.func.isRequired,
-    linkIntegrityCheck: PropTypes.func.isRequired,
     clipboardRequest: PropTypes.shape({
       loading: PropTypes.bool,
       loaded: PropTypes.bool,
@@ -399,7 +388,6 @@ class Contents extends Component {
     this.paste = this.paste.bind(this);
     this.fetchContents = this.fetchContents.bind(this);
     this.orderTimeout = null;
-    this.deleteItemsToShowThreshold = 10;
 
     this.state = {
       selected: [],
@@ -410,10 +398,6 @@ class Contents extends Component {
       showProperties: false,
       showWorkflow: false,
       itemsToDelete: [],
-      containedItemsToDelete: [],
-      brokenReferences: 0,
-      breaches: [],
-      showAllItemsToDelete: true,
       items: this.props.items,
       filter: '',
       currentPage: 0,
@@ -429,7 +413,6 @@ class Contents extends Component {
       sort_on: this.props.sort?.on || 'getObjPositionInParent',
       sort_order: this.props.sort?.order || 'ascending',
       isClient: false,
-      linkIntegrityBreakages: [],
     };
     this.filterTimeout = null;
   }
@@ -442,50 +425,6 @@ class Contents extends Component {
   componentDidMount() {
     this.fetchContents();
     this.setState({ isClient: true });
-  }
-  async componentDidUpdate(_, prevState) {
-    if (
-      this.state.itemsToDelete !== prevState.itemsToDelete &&
-      this.state.itemsToDelete.length > 0
-    ) {
-      const linkintegrityInfo = await this.props.linkIntegrityCheck(
-        map(this.state.itemsToDelete, (item) => this.getFieldById(item, 'UID')),
-      );
-      const containedItems = linkintegrityInfo
-        .map((result) => result.items_total ?? 0)
-        .reduce((acc, value) => acc + value, 0);
-      const breaches = linkintegrityInfo.flatMap((result) =>
-        result.breaches.map((source) => ({
-          source: source,
-          target: result,
-        })),
-      );
-      const source_by_uid = breaches.reduce(
-        (acc, value) => acc.set(value.source.uid, value.source),
-        new Map(),
-      );
-      const by_source = breaches.reduce((acc, value) => {
-        if (acc.get(value.source.uid) === undefined) {
-          acc.set(value.source.uid, new Set());
-        }
-        acc.get(value.source.uid).add(value.target);
-        return acc;
-      }, new Map());
-
-      this.setState({
-        containedItemsToDelete: containedItems,
-        brokenReferences: by_source.size,
-        linksAndReferencesViewLink: linkintegrityInfo.length
-          ? linkintegrityInfo[0]['@id'] + '/links-to-item'
-          : null,
-        breaches: Array.from(by_source, (entry) => ({
-          source: source_by_uid.get(entry[0]),
-          targets: Array.from(entry[1]),
-        })),
-        showAllItemsToDelete:
-          this.state.itemsToDelete.length < this.deleteItemsToShowThreshold,
-      });
-    }
   }
 
   /**
@@ -1208,296 +1147,12 @@ class Contents extends Component {
               />
               <div className="container">
                 <article id="content">
-                  <Confirm
+                  <ContentsDeleteModal
                     open={this.state.showDelete}
-                    confirmButton={
-                      this.state.brokenReferences === 0
-                        ? 'Delete'
-                        : 'Delete item and break links'
-                    }
-                    header={
-                      this.state.itemsToDelete.length === 1
-                        ? this.props.intl.formatMessage(
-                            messages.deleteConfirmSingleItem,
-                          )
-                        : this.props.intl.formatMessage(
-                            messages.deleteConfirmMultipleItems,
-                          )
-                    }
-                    content={
-                      <div className="content">
-                        {this.state.itemsToDelete.length > 1 ? (
-                          this.state.containedItemsToDelete > 0 ? (
-                            <>
-                              <FormattedMessage
-                                id="Some items are also a folder. By deleting them you will delete {containedItemsToDelete} {variation} inside the folders."
-                                defaultMessage="Some items are also a folder. By deleting them you will delete {containedItemsToDelete} {variation} inside the folders."
-                                values={{
-                                  containedItemsToDelete: (
-                                    <span>
-                                      {this.state.containedItemsToDelete}
-                                    </span>
-                                  ),
-                                  variation: (
-                                    <span>
-                                      {this.state.containedItemsToDelete ===
-                                      1 ? (
-                                        <FormattedMessage
-                                          id="item"
-                                          defaultMessage="item"
-                                        />
-                                      ) : (
-                                        <FormattedMessage
-                                          id="items"
-                                          defaultMessage="items"
-                                        />
-                                      )}
-                                    </span>
-                                  ),
-                                }}
-                              />
-                              {this.state.brokenReferences > 0 && (
-                                <>
-                                  <br />
-                                  <FormattedMessage
-                                    id="Some items are referenced by other contents. By deleting them {brokenReferences} {variation} will be broken."
-                                    defaultMessage="Some items are referenced by other contents. By deleting them {brokenReferences} {variation} will be broken."
-                                    values={{
-                                      brokenReferences: (
-                                        <span>
-                                          {this.state.brokenReferences}
-                                        </span>
-                                      ),
-                                      variation: (
-                                        <span>
-                                          {this.state.brokenReferences === 1 ? (
-                                            <FormattedMessage
-                                              id="reference"
-                                              defaultMessage="reference"
-                                            />
-                                          ) : (
-                                            <FormattedMessage
-                                              id="references"
-                                              defaultMessage="references"
-                                            />
-                                          )}
-                                        </span>
-                                      ),
-                                    }}
-                                  />
-                                </>
-                              )}
-                            </>
-                          ) : (
-                            <>
-                              {this.state.brokenReferences > 0 && (
-                                <>
-                                  <FormattedMessage
-                                    id="Some items are referenced by other contents. By deleting them {brokenReferences} {variation} will be broken."
-                                    defaultMessage="Some items are referenced by other contents. By deleting them {brokenReferences} {variation} will be broken."
-                                    values={{
-                                      brokenReferences: (
-                                        <span>
-                                          {this.state.brokenReferences}
-                                        </span>
-                                      ),
-                                      variation: (
-                                        <span>
-                                          {this.state.brokenReferences === 1 ? (
-                                            <FormattedMessage
-                                              id="reference"
-                                              defaultMessage="reference"
-                                            />
-                                          ) : (
-                                            <FormattedMessage
-                                              id="references"
-                                              defaultMessage="references"
-                                            />
-                                          )}
-                                        </span>
-                                      ),
-                                    }}
-                                  />
-                                </>
-                              )}
-                            </>
-                          )
-                        ) : this.state.containedItemsToDelete > 0 ? (
-                          <>
-                            <FormattedMessage
-                              id="This item is also a folder. By deleting it you will delete {containedItemsToDelete} {variation} inside the folder."
-                              defaultMessage="This item is also a folder. By deleting it you will delete {containedItemsToDelete} {variation} inside the folder."
-                              values={{
-                                containedItemsToDelete: (
-                                  <span>
-                                    {this.state.containedItemsToDelete}
-                                  </span>
-                                ),
-                                variation: (
-                                  <span>
-                                    {this.state.containedItemsToDelete === 1 ? (
-                                      <FormattedMessage
-                                        id="item"
-                                        defaultMessage="item"
-                                      />
-                                    ) : (
-                                      <FormattedMessage
-                                        id="items"
-                                        defaultMessage="items"
-                                      />
-                                    )}
-                                  </span>
-                                ),
-                              }}
-                            />
-                            {this.state.brokenReferences > 0 && (
-                              <>
-                                <br />
-                                <FormattedMessage
-                                  id="Deleting this item breaks {brokenReferences} {variation}."
-                                  defaultMessage="Deleting this item breaks {brokenReferences} {variation}."
-                                  values={{
-                                    brokenReferences: (
-                                      <span>{this.state.brokenReferences}</span>
-                                    ),
-                                    variation: (
-                                      <span>
-                                        {this.state.brokenReferences === 1 ? (
-                                          <FormattedMessage
-                                            id="reference"
-                                            defaultMessage="reference"
-                                          />
-                                        ) : (
-                                          <FormattedMessage
-                                            id="references"
-                                            defaultMessage="references"
-                                          />
-                                        )}
-                                      </span>
-                                    ),
-                                  }}
-                                />
-                                <div className="broken-links-list">
-                                  <FormattedMessage id="These items will have broken links" />
-                                  <ul>
-                                    {this.state.breaches.map((breach) => (
-                                      <li key={breach.source['@id']}>
-                                        <Link
-                                          to={flattenToAppURL(
-                                            breach.source['@id'],
-                                          )}
-                                          title="Navigate to this item"
-                                        >
-                                          {breach.source.title}
-                                        </Link>{' '}
-                                        refers to{' '}
-                                        {breach.targets
-                                          .map((target) => (
-                                            <Link
-                                              to={flattenToAppURL(
-                                                target['@id'],
-                                              )}
-                                              title="Navigate to this item"
-                                            >
-                                              {target.title}
-                                            </Link>
-                                          ))
-                                          .reduce((result, item) => (
-                                            <>
-                                              {result}, {item}
-                                            </>
-                                          ))}
-                                      </li>
-                                    ))}
-                                  </ul>
-                                  {this.state.linksAndReferencesViewLink && (
-                                    <Link
-                                      to={flattenToAppURL(
-                                        this.state.linksAndReferencesViewLink,
-                                      )}
-                                    >
-                                      <FormattedMessage
-                                        id="View links and references to this item"
-                                        defaultMessage="View links and references to this item"
-                                      />
-                                    </Link>
-                                  )}
-                                </div>
-                              </>
-                            )}
-                          </>
-                        ) : this.state.brokenReferences > 0 ? (
-                          <>
-                            <FormattedMessage
-                              id="Deleting this item breaks {brokenReferences} {variation}."
-                              defaultMessage="Deleting this item breaks {brokenReferences} {variation}."
-                              values={{
-                                brokenReferences: (
-                                  <span>{this.state.brokenReferences}</span>
-                                ),
-                                variation: (
-                                  <span>
-                                    {this.state.brokenReferences === 1 ? (
-                                      <FormattedMessage
-                                        id="reference"
-                                        defaultMessage="reference"
-                                      />
-                                    ) : (
-                                      <FormattedMessage id="references" />
-                                    )}
-                                  </span>
-                                ),
-                              }}
-                            />
-                            <div className="broken-links-list">
-                              <FormattedMessage id="These items will have broken links" />
-                              <ul>
-                                {this.state.breaches.map((breach) => (
-                                  <li key={breach.source['@id']}>
-                                    <Link
-                                      to={flattenToAppURL(breach.source['@id'])}
-                                      title="Navigate to this item"
-                                    >
-                                      {breach.source.title}
-                                    </Link>{' '}
-                                    refers to{' '}
-                                    {breach.targets
-                                      .map((target) => (
-                                        <Link
-                                          to={flattenToAppURL(target['@id'])}
-                                          title="Navigate to this item"
-                                        >
-                                          {target.title}
-                                        </Link>
-                                      ))
-                                      .reduce((result, item) => (
-                                        <>
-                                          {result}, {item}
-                                        </>
-                                      ))}
-                                  </li>
-                                ))}
-                              </ul>
-                              {this.state.linksAndReferencesViewLink && (
-                                <Link
-                                  to={flattenToAppURL(
-                                    this.state.linksAndReferencesViewLink,
-                                  )}
-                                >
-                                  <FormattedMessage
-                                    id="View links and references to this item"
-                                    defaultMessage="View links and references to this item"
-                                  />
-                                </Link>
-                              )}
-                            </div>
-                          </>
-                        ) : null}
-                      </div>
-                    }
                     onCancel={this.onDeleteCancel}
-                    onConfirm={this.onDeleteOk}
-                    size="medium"
+                    onOk={this.onDeleteOk}
+                    items={this.state.items}
+                    itemsToDelete={this.state.itemsToDelete}
                   />
                   <ContentsUploadModal
                     open={this.state.showUpload}
@@ -2249,7 +1904,6 @@ export const __test__ = compose(
       orderContent,
       sortContent,
       updateColumnsContent,
-      linkIntegrityCheck,
       getContent,
     },
   ),
@@ -2291,7 +1945,6 @@ export default compose(
       orderContent,
       sortContent,
       updateColumnsContent,
-      linkIntegrityCheck,
       getContent,
     },
   ),

--- a/src/components/manage/Contents/ContentsDeleteModal.jsx
+++ b/src/components/manage/Contents/ContentsDeleteModal.jsx
@@ -1,0 +1,379 @@
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { useDispatch, useSelector } from 'react-redux';
+import { Link } from 'react-router-dom';
+import { map, find } from 'lodash';
+import { defineMessages, useIntl, FormattedMessage } from 'react-intl';
+import { linkIntegrityCheck } from '@plone/volto/actions';
+import { flattenToAppURL } from '@plone/volto/helpers';
+
+import { Confirm, Dimmer, Loader, Table } from 'semantic-ui-react';
+
+const messages = defineMessages({
+  deleteConfirmSingleItem: {
+    id: 'Delete this item?',
+    defaultMessage: 'Delete this item?',
+  },
+  deleteConfirmMultipleItems: {
+    id: 'Delete selected items?',
+    defaultMessage: 'Delete selected items?',
+  },
+  navigate_to_this_item: {
+    id: 'Navigate to this item',
+    defaultMessage: 'Navigate to this item',
+  },
+  loading: {
+    id: 'link-integrity: loading references',
+    defaultMessage: 'Checking references...',
+  },
+  delete: {
+    id: 'link-integrity: Delete',
+    defaultMessage: 'Delete',
+  },
+  delete_and_broken_links: {
+    id: 'link-integrity: Delete item and break links',
+    defaultMessage: 'Delete item and break links',
+  },
+  cancel: {
+    id: 'Cancel',
+    defaultMessage: 'Cancel',
+  },
+});
+
+const ContentsDeleteModal = (props) => {
+  const { itemsToDelete = [], open, onCancel, onOk, items } = props;
+  const intl = useIntl();
+  const dispatch = useDispatch();
+  const linkintegrityInfo = useSelector((state) => state.linkIntegrity?.result);
+  const loading = useSelector((state) => state.linkIntegrity?.loading);
+
+  const [brokenReferences, setBrokenReferences] = useState(0);
+  const [containedItemsToDelete, setContainedItemsToDelete] = useState([]);
+  const [breaches, setBreaches] = useState([]);
+
+  const [linksAndReferencesViewLink, setLinkAndReferencesViewLink] =
+    useState(null);
+
+  useEffect(() => {
+    const getFieldById = (id, field) => {
+      const item = find(items, { '@id': id });
+      return item ? item[field] : '';
+    };
+
+    if (itemsToDelete.length > 0 && open) {
+      dispatch(
+        linkIntegrityCheck(
+          map(itemsToDelete, (item) => getFieldById(item, 'UID')),
+        ),
+      );
+    }
+  }, [itemsToDelete, items, open, dispatch]);
+
+  useEffect(() => {
+    if (linkintegrityInfo) {
+      const containedItems = linkintegrityInfo
+        .map((result) => result.items_total ?? 0)
+        .reduce((acc, value) => acc + value, 0);
+      const breaches = linkintegrityInfo.flatMap((result) =>
+        result.breaches.map((source) => ({
+          source: source,
+          target: result,
+        })),
+      );
+      const source_by_uid = breaches.reduce(
+        (acc, value) => acc.set(value.source.uid, value.source),
+        new Map(),
+      );
+      const by_source = breaches.reduce((acc, value) => {
+        if (acc.get(value.source.uid) === undefined) {
+          acc.set(value.source.uid, new Set());
+        }
+        acc.get(value.source.uid).add(value.target);
+        return acc;
+      }, new Map());
+
+      setContainedItemsToDelete(containedItems);
+      setBrokenReferences(by_source.size);
+      setLinkAndReferencesViewLink(
+        linkintegrityInfo.length
+          ? linkintegrityInfo[0]['@id'] + '/links-to-item'
+          : null,
+      );
+      setBreaches(
+        Array.from(by_source, (entry) => ({
+          source: source_by_uid.get(entry[0]),
+          targets: Array.from(entry[1]),
+        })),
+      );
+    } else {
+      setContainedItemsToDelete([]);
+      setBrokenReferences(0);
+      setLinkAndReferencesViewLink(null);
+      setBreaches([]);
+    }
+  }, [linkintegrityInfo]);
+
+  return (
+    open && (
+      <Confirm
+        open={open}
+        confirmButton={
+          brokenReferences === 0
+            ? intl.formatMessage(messages.delete)
+            : intl.formatMessage(messages.delete_and_broken_links)
+        }
+        cancelButton={intl.formatMessage(messages.cancel)}
+        header={
+          itemsToDelete.length === 1
+            ? intl.formatMessage(messages.deleteConfirmSingleItem)
+            : intl.formatMessage(messages.deleteConfirmMultipleItems)
+        }
+        content={
+          <div className="content">
+            <Dimmer active={loading} inverted>
+              <Loader indeterminate size="massive">
+                {intl.formatMessage(messages.loading)}
+              </Loader>
+            </Dimmer>
+
+            {itemsToDelete.length > 1 ? (
+              containedItemsToDelete > 0 ? (
+                <>
+                  <FormattedMessage
+                    id="Some items are also a folder. By deleting them you will delete {containedItemsToDelete} {variation} inside the folders."
+                    defaultMessage="Some items are also a folder. By deleting them you will delete {containedItemsToDelete} {variation} inside the folders."
+                    values={{
+                      containedItemsToDelete: (
+                        <span>{containedItemsToDelete}</span>
+                      ),
+                      variation: (
+                        <span>
+                          {containedItemsToDelete === 1 ? (
+                            <FormattedMessage id="item" defaultMessage="item" />
+                          ) : (
+                            <FormattedMessage
+                              id="items"
+                              defaultMessage="items"
+                            />
+                          )}
+                        </span>
+                      ),
+                    }}
+                  />
+                  {brokenReferences > 0 && (
+                    <>
+                      <br />
+                      <FormattedMessage
+                        id="Some items are referenced by other contents. By deleting them {brokenReferences} {variation} will be broken."
+                        defaultMessage="Some items are referenced by other contents. By deleting them {brokenReferences} {variation} will be broken."
+                        values={{
+                          brokenReferences: <span>{brokenReferences}</span>,
+                          variation: (
+                            <span>
+                              {brokenReferences === 1 ? (
+                                <FormattedMessage
+                                  id="reference"
+                                  defaultMessage="reference"
+                                />
+                              ) : (
+                                <FormattedMessage
+                                  id="references"
+                                  defaultMessage="references"
+                                />
+                              )}
+                            </span>
+                          ),
+                        }}
+                      />
+                    </>
+                  )}
+                </>
+              ) : (
+                <>
+                  {brokenReferences > 0 && (
+                    <>
+                      <FormattedMessage
+                        id="Some items are referenced by other contents. By deleting them {brokenReferences} {variation} will be broken."
+                        defaultMessage="Some items are referenced by other contents. By deleting them {brokenReferences} {variation} will be broken."
+                        values={{
+                          brokenReferences: <span>{brokenReferences}</span>,
+                          variation: (
+                            <span>
+                              {brokenReferences === 1 ? (
+                                <FormattedMessage
+                                  id="reference"
+                                  defaultMessage="reference"
+                                />
+                              ) : (
+                                <FormattedMessage
+                                  id="references"
+                                  defaultMessage="references"
+                                />
+                              )}
+                            </span>
+                          ),
+                        }}
+                      />
+                    </>
+                  )}
+                </>
+              )
+            ) : containedItemsToDelete > 0 ? (
+              <>
+                <FormattedMessage
+                  id="This item is also a folder. By deleting it you will delete {containedItemsToDelete} {variation} inside the folder."
+                  defaultMessage="This item is also a folder. By deleting it you will delete {containedItemsToDelete} {variation} inside the folder."
+                  values={{
+                    containedItemsToDelete: (
+                      <span>{containedItemsToDelete}</span>
+                    ),
+                    variation: (
+                      <span>
+                        {containedItemsToDelete === 1 ? (
+                          <FormattedMessage id="item" defaultMessage="item" />
+                        ) : (
+                          <FormattedMessage id="items" defaultMessage="items" />
+                        )}
+                      </span>
+                    ),
+                  }}
+                />
+                {brokenReferences > 0 && (
+                  <>
+                    <br />
+                    <FormattedMessage
+                      id="Deleting this item breaks {brokenReferences} {variation}."
+                      defaultMessage="Deleting this item breaks {brokenReferences} {variation}."
+                      values={{
+                        brokenReferences: <span>{brokenReferences}</span>,
+                        variation: (
+                          <span>
+                            {brokenReferences === 1 ? (
+                              <FormattedMessage
+                                id="reference"
+                                defaultMessage="reference"
+                              />
+                            ) : (
+                              <FormattedMessage
+                                id="references"
+                                defaultMessage="references"
+                              />
+                            )}
+                          </span>
+                        ),
+                      }}
+                    />
+                    <BrokenLinksList
+                      intl={intl}
+                      breaches={breaches}
+                      linksAndReferencesViewLink={linksAndReferencesViewLink}
+                    />
+                  </>
+                )}
+              </>
+            ) : brokenReferences > 0 ? (
+              <>
+                <FormattedMessage
+                  id="Deleting this item breaks {brokenReferences} {variation}."
+                  defaultMessage="Deleting this item breaks {brokenReferences} {variation}."
+                  values={{
+                    brokenReferences: <span>{brokenReferences}</span>,
+                    variation: (
+                      <span>
+                        {brokenReferences === 1 ? (
+                          <FormattedMessage
+                            id="reference"
+                            defaultMessage="reference"
+                          />
+                        ) : (
+                          <FormattedMessage
+                            id="references"
+                            defaultMessage="references"
+                          />
+                        )}
+                      </span>
+                    ),
+                  }}
+                />
+                <BrokenLinksList
+                  intl={intl}
+                  breaches={breaches}
+                  linksAndReferencesViewLink={linksAndReferencesViewLink}
+                />
+              </>
+            ) : null}
+          </div>
+        }
+        onCancel={onCancel}
+        onConfirm={onOk}
+        size="medium"
+      />
+    )
+  );
+};
+
+const BrokenLinksList = ({ intl, breaches, linksAndReferencesViewLink }) => {
+  return (
+    <div className="broken-links-list">
+      <FormattedMessage
+        id="These items will have broken links"
+        defaultMessage="These items will have broken links"
+      />
+      :
+      <Table compact>
+        <Table.Body>
+          {breaches.map((breach) => (
+            <Table.Row key={breach.source['@id']} verticalAlign="top">
+              <Table.Cell>
+                <Link
+                  to={flattenToAppURL(breach.source['@id'])}
+                  title={intl.formatMessage(messages.navigate_to_this_item)}
+                >
+                  {breach.source.title}
+                </Link>
+              </Table.Cell>
+              <Table.Cell style={{ minWidth: '140px' }}>
+                <FormattedMessage id="refers to" defaultMessage="refers to" />:
+              </Table.Cell>
+              <Table.Cell>
+                <ul style={{ margin: 0 }}>
+                  {breach.targets.map((target) => (
+                    <li key={target['@id']}>
+                      <Link
+                        to={flattenToAppURL(target['@id'])}
+                        title={intl.formatMessage(
+                          messages.navigate_to_this_item,
+                        )}
+                      >
+                        {target.title}
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </Table.Cell>
+            </Table.Row>
+          ))}
+        </Table.Body>
+      </Table>
+      {linksAndReferencesViewLink && (
+        <Link to={flattenToAppURL(linksAndReferencesViewLink)}>
+          <FormattedMessage
+            id="View links and references to this item"
+            defaultMessage="View links and references to this item"
+          />
+        </Link>
+      )}
+    </div>
+  );
+};
+ContentsDeleteModal.propTypes = {
+  itemsToDelete: PropTypes.arrayOf(
+    PropTypes.shape({
+      UID: PropTypes.string,
+    }),
+  ).isRequired,
+  open: PropTypes.bool.isRequired,
+  onOk: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
+};
+export default ContentsDeleteModal;

--- a/src/components/manage/Rules/Rules.jsx
+++ b/src/components/manage/Rules/Rules.jsx
@@ -75,6 +75,10 @@ const messages = defineMessages({
     id: 'Unassigned',
     defaultMessage: 'Unassigned',
   },
+  select_rule: {
+    id: 'Select rule',
+    defaultMessage: 'Select rule',
+  },
 });
 
 /**
@@ -365,7 +369,9 @@ class Rules extends Component {
             />
             <div style={{ display: 'flex' }}>
               <Select
-                placeholder="Select rule"
+                placeholder={this.props.intl.formatMessage(
+                  messages.select_rule,
+                )}
                 value={this.state.newRule}
                 onChange={(e, { value }) => this.setState({ newRule: value })}
                 options={assignable_rules.map((rule, i) => {

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -20,6 +20,7 @@ import emailNotification from '@plone/volto/reducers/emailNotification/emailNoti
 import emailSend from '@plone/volto/reducers/emailSend/emailSend';
 import form from '@plone/volto/reducers/form/form';
 import history from '@plone/volto/reducers/history/history';
+import linkIntegrity from '@plone/volto/reducers/linkIntegrity/linkIntegrity';
 import groups from '@plone/volto/reducers/groups/groups';
 import messages from '@plone/volto/reducers/messages/messages';
 import navigation from '@plone/volto/reducers/navigation/navigation';
@@ -79,6 +80,7 @@ const reducers = {
   form,
   groups,
   history,
+  linkIntegrity,
   messages,
   navigation,
   querystring,

--- a/src/reducers/linkIntegrity/linkIntegrity.js
+++ b/src/reducers/linkIntegrity/linkIntegrity.js
@@ -1,0 +1,51 @@
+/**
+ * Linkintegrity reducer.
+ * @module reducers/linkIntegrity/linkIntegrity
+ */
+
+import { LINK_INTEGRITY_CHECK } from '@plone/volto/constants/ActionTypes';
+
+const initialState = {
+  error: null,
+  loaded: false,
+  loading: false,
+  result: null,
+};
+
+/**
+ * History reducer.
+ * @function linkIntegrity
+ * @param {Object} state Current state.
+ * @param {Object} action Action to be handled.
+ * @returns {Object} New state.
+ */
+export default function linkIntegrity(state = initialState, action = {}) {
+  switch (action.type) {
+    case `${LINK_INTEGRITY_CHECK}_PENDING`:
+      return {
+        ...state,
+        error: null,
+        loaded: false,
+        loading: true,
+        result: null,
+      };
+    case `${LINK_INTEGRITY_CHECK}_SUCCESS`:
+      return {
+        ...state,
+        error: null,
+        loaded: true,
+        loading: false,
+        result: action.result,
+      };
+    case `${LINK_INTEGRITY_CHECK}_FAIL`:
+      return {
+        ...state,
+        error: action.error,
+        loaded: true,
+        loading: false,
+        result: null,
+      };
+    default:
+      return state;
+  }
+}

--- a/src/reducers/linkIntegrity/linkIntegrity.test.js
+++ b/src/reducers/linkIntegrity/linkIntegrity.test.js
@@ -1,0 +1,54 @@
+import linkIntegrity from './linkIntegrity';
+import { LINK_INTEGRITY_CHECK } from '@plone/volto/constants/ActionTypes';
+
+describe('Link integrity reducer', () => {
+  it('should return the initial state', () => {
+    expect(linkIntegrity()).toEqual({
+      error: null,
+      loaded: false,
+      loading: false,
+      result: null,
+    });
+  });
+
+  it('should handle LINK_INTEGRITY_CHECK_PENDING', () => {
+    expect(
+      linkIntegrity(undefined, {
+        type: `${LINK_INTEGRITY_CHECK}_PENDING`,
+      }),
+    ).toEqual({
+      error: null,
+      loaded: false,
+      loading: true,
+      result: null,
+    });
+  });
+
+  it('should handle LINK_INTEGRITY_CHECK_SUCCESS', () => {
+    expect(
+      linkIntegrity(undefined, {
+        type: `${LINK_INTEGRITY_CHECK}_SUCCESS`,
+        result: 'result',
+      }),
+    ).toEqual({
+      error: null,
+      loaded: true,
+      loading: false,
+      result: 'result',
+    });
+  });
+
+  it('should handle LINK_INTEGRITY_CHECK_FAIL', () => {
+    expect(
+      linkIntegrity(undefined, {
+        type: `${LINK_INTEGRITY_CHECK}_FAIL`,
+        error: 'failed',
+      }),
+    ).toEqual({
+      error: 'failed',
+      loaded: true,
+      loading: false,
+      result: null,
+    });
+  });
+});


### PR DESCRIPTION
backport of https://github.com/plone/volto/pull/6516/


fixed and improved link integrity popup when deleting item/items from folder contents. 
Moved all code in a separate component 'ContentsDeleteModal'.

Added loader when loading references. If the call to @linkintegrity took a long time to load, it wasn't clear to the user that it was checking for broken references:
 
<img width="1311" alt="loading" src="https://github.com/user-attachments/assets/4ff90bfb-4176-4e1b-afed-0b9d8a5a6190">

If only one item is selected to delete, it will display all the possibile broken references in a table, instead in a list. In the last column could be more than one reference: 
<img width="1191" alt="1-selected-item" src="https://github.com/user-attachments/assets/1035c15e-a4d4-4de0-9680-d4243b5dd1fe">

If more than one item is selected to delete, it will not display the possibile broken references, but only the number, because it  will be a very long list (It worked like that before too):
<img width="1146" alt="more-than-one-selected" src="https://github.com/user-attachments/assets/42ac64de-7666-4de5-950c-7567613ddc9b">




<!-- readthedocs-preview volto start -->
----
📚 Documentation preview 📚: https://volto--6517.org.readthedocs.build/

<!-- readthedocs-preview volto end -->