### PR TITLE
Fix: Prevent ScrollToTop from interrupting initial load scrolling

### DIFF
--- a/packages/volto/src/helpers/ScrollToTop/ScrollToTop.jsx
+++ b/packages/volto/src/helpers/ScrollToTop/ScrollToTop.jsx
@@ -3,18 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import config from '@plone/volto/registry';
 
-/**
- *
- *
- * @class ScrollToTop
- * @extends {Component}
- */
 class ScrollToTop extends React.Component {
-  /**
-   * Property types.
-   * @property {Object} propTypes Property types.
-   * @static
-   */
   static propTypes = {
     location: PropTypes.shape({
       pathname: PropTypes.string,
@@ -22,32 +11,34 @@ class ScrollToTop extends React.Component {
     children: PropTypes.node.isRequired,
   };
 
-  /**
-   * @param {*} prevProps Previous Props
-   * @returns {null} Null
-   * @memberof ScrollToTop
-   */
+  constructor(props) {
+    super(props);
+    this.isInitialLoad = true; // Add a flag for the initial load
+  }
+
   componentDidUpdate(prevProps) {
     const { location } = this.props;
-    const noInitialBlocksFocus = // Do not scroll on /edit
+    const noInitialBlocksFocus =
       config.blocks?.initialBlocksFocus === null
         ? this.props.location?.pathname.slice(-5) !== '/edit'
         : true;
 
     const isHash = location?.hash || location?.pathname.hash;
+
+    // Scroll only if it's not the initial load and other conditions are met
     if (
+      !this.isInitialLoad && // Prevent scrolling on the initial load
       !isHash &&
       noInitialBlocksFocus &&
       location?.pathname !== prevProps.location?.pathname
     ) {
       window.scrollTo(0, 0);
     }
+
+    // Reset the initial load flag after the first render
+    this.isInitialLoad = false;
   }
 
-  /**
-   * @returns {node} Children
-   * @memberof ScrollToTop
-   */
   render() {
     return this.props.children;
   }


### PR DESCRIPTION
- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't other open [pull requests](https://github.com/plone/volto/pulls) for the same change.
- [x] I followed the guidelines in [Contributing to Volto](https://6.docs.plone.org/volto/contributing/index.html).
- [ ] I succesfully ran [code linting checks](https://6.docs.plone.org/volto/contributing/linting.html) on my changes locally.
- [ ] I succesfully ran [unit tests](https://6.docs.plone.org/volto/contributing/testing.html) on my changes locally.
- [ ] I succesfully ran [acceptance tests](https://6.docs.plone.org/volto/contributing/acceptance-tests.html) on my changes locally.
- [x] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/volto/contributing/documentation.html#narrative-documentation) for my changes, either in the Storybook or narrative documentation.
- [ ] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

If your pull request closes an open issue, include the exact text below, immediately followed by the issue number. When your pull request gets merged, then that issue will close automatically.

Closes #
