### PR TITLE
Fixed circular import error in dev with HMR in `App` component when imported in the main default config

### DIFF
--- a/packages/volto/news/6524.bugfix
+++ b/packages/volto/news/6524.bugfix
@@ -1,0 +1,1 @@
+Fixed circular import error in dev with HMR in `App` component when imported in the main default config. @sneridagh

--- a/packages/volto/src/config/Components.jsx
+++ b/packages/volto/src/config/Components.jsx
@@ -2,9 +2,12 @@ import App from '@plone/volto/components/theme/App/App';
 import PreviewImage from '@plone/volto/components/theme/PreviewImage/PreviewImage';
 import Image from '@plone/volto/components/theme/Image/Image';
 
-// Register components.
-export const components = {
-  PreviewImage: { component: PreviewImage },
-  App: { component: App },
-  Image: { component: Image },
-};
+export function installDefaultComponents(config) {
+  config.components = {
+    PreviewImage: { component: PreviewImage },
+    App: { component: App },
+    Image: { component: Image },
+  };
+
+  return config;
+}

--- a/packages/volto/src/config/index.js
+++ b/packages/volto/src/config/index.js
@@ -16,7 +16,6 @@ import {
   initialBlocks,
   initialBlocksFocus,
 } from './Blocks';
-import { components } from './Components';
 import { loadables } from './Loadables';
 import { workflowMapping } from './Workflows';
 import slots from './slots';
@@ -33,6 +32,7 @@ import {
 import applyAddonConfiguration, { addonsInfo } from 'load-volto-addons';
 
 import ConfigRegistry from '@plone/volto/registry';
+import { installDefaultComponents } from './Components';
 
 import { getSiteAsyncPropExtender } from '@plone/volto/helpers/Site';
 import { registerValidators } from './validation';
@@ -216,7 +216,7 @@ let config = {
   },
   addonRoutes: [],
   addonReducers: {},
-  components,
+  components: {},
   slots: {},
   utilities: {},
 };
@@ -261,5 +261,6 @@ Object.entries(slots).forEach(([slotName, components]) => {
 });
 
 registerValidators(ConfigRegistry);
+installDefaultComponents(ConfigRegistry);
 
 applyAddonConfiguration(ConfigRegistry);


### PR DESCRIPTION
For 18.2.0, after move the core code to use direct imports in #6509 in projects still using some barrel imports, in dev mode, HMR errored due to a circular import error. 

```
ReferenceError: Cannot access '__WEBPACK_DEFAULT_EXPORT__' before initialization
```

Investigating, I managed to pinpoint the problem in the default config of the component registry, since we have in there `App` registered. It seems that it's in there to provide maximum flexibility for providing a complete different `App`, if needed. It's used by the old generator, but not anymore by the project-less setup. So it has to go, and use shadowing for that purpose.

I'll add a note for React 19 to remove it.

I workaround it by not relying on import/export as side effect for the apply the setting for components, but as a function called exactly where we want it to be applied (hopefully, after all initialization and the import phase).