### PR TITLE
Fixed circular import error in dev with HMR in core Blocks shadow customizations

### DIFF
--- a/packages/volto/news/6525.bugfix
+++ b/packages/volto/news/6525.bugfix
@@ -1,0 +1,1 @@
+Fixed circular import error in dev with HMR in core Blocks shadow customizations. @sneridagh

--- a/packages/volto/src/config/Blocks.jsx
+++ b/packages/volto/src/config/Blocks.jsx
@@ -530,6 +530,15 @@ const requiredBlocks = ['title'];
 const initialBlocks = {};
 const initialBlocksFocus = {}; //{Document:'title'}
 
+export function installDefaultBlocks(config) {
+  config.blocks.requiredBlocks = requiredBlocks;
+  config.blocks.blocksConfig = blocksConfig;
+  config.blocks.groupBlocksOrder = groupBlocksOrder;
+  config.blocks.initialBlocks = initialBlocks;
+  config.blocks.initialBlocksFocus = initialBlocksFocus;
+  config.blocks.showEditBlocksInBabelView = false;
+}
+
 export {
   groupBlocksOrder,
   requiredBlocks,

--- a/packages/volto/src/config/index.js
+++ b/packages/volto/src/config/index.js
@@ -1,3 +1,4 @@
+import ConfigRegistry from '@plone/volto/registry';
 import { parse as parseUrl } from 'url';
 import { defaultWidget, widgetMapping } from './Widgets';
 import {
@@ -9,13 +10,6 @@ import {
 } from './Views';
 import { nonContentRoutes } from './NonContentRoutes';
 import { nonContentRoutesPublic } from './NonContentRoutesPublic';
-import {
-  groupBlocksOrder,
-  requiredBlocks,
-  blocksConfig,
-  initialBlocks,
-  initialBlocksFocus,
-} from './Blocks';
 import { loadables } from './Loadables';
 import { workflowMapping } from './Workflows';
 import slots from './slots';
@@ -31,8 +25,8 @@ import {
 
 import applyAddonConfiguration, { addonsInfo } from 'load-volto-addons';
 
-import ConfigRegistry from '@plone/volto/registry';
 import { installDefaultComponents } from './Components';
+import { installDefaultBlocks } from './Blocks';
 
 import { getSiteAsyncPropExtender } from '@plone/volto/helpers/Site';
 import { registerValidators } from './validation';
@@ -206,14 +200,7 @@ let config = {
     errorViews,
     layoutViewsNamesMapping,
   },
-  blocks: {
-    requiredBlocks,
-    blocksConfig,
-    groupBlocksOrder,
-    initialBlocks,
-    initialBlocksFocus,
-    showEditBlocksInBabelView: false,
-  },
+  blocks: {},
   addonRoutes: [],
   addonReducers: {},
   components: {},
@@ -262,5 +249,6 @@ Object.entries(slots).forEach(([slotName, components]) => {
 
 registerValidators(ConfigRegistry);
 installDefaultComponents(ConfigRegistry);
+installDefaultBlocks(ConfigRegistry);
 
 applyAddonConfiguration(ConfigRegistry);


### PR DESCRIPTION
More fixes related to https://github.com/plone/volto/pull/6509 and #6524 .

Moved the blocks config to use a init function too, plus some reordering in the `src/config/index.js`