### PR TITLE
Fixed circular import error in dev with HMR in core Views and Widgets shadow customizations

### DIFF
--- a/packages/volto/news/6526.bugfix
+++ b/packages/volto/news/6526.bugfix
@@ -1,0 +1,1 @@
+Fixed circular import error in dev with HMR in core Views and Widgets shadow customizations. @sneridagh

--- a/packages/volto/src/config/Views.jsx
+++ b/packages/volto/src/config/Views.jsx
@@ -138,3 +138,13 @@ export const layoutViewsNamesMapping = {
   view: 'Default view',
   default: 'Default view',
 };
+
+export function installDefaultViews(config) {
+  config.views.layoutViews = layoutViews;
+  config.views.contentTypesViews = contentTypesViews;
+  config.views.defaultView = defaultView;
+  config.views.errorViews = errorViews;
+  config.views.layoutViewsNamesMapping = layoutViewsNamesMapping;
+
+  return config;
+}

--- a/packages/volto/src/config/Widgets.jsx
+++ b/packages/volto/src/config/Widgets.jsx
@@ -151,3 +151,8 @@ export const widgetMapping = {
 
 // Default Widget
 export const defaultWidget = TextWidget;
+
+export function installDefaultWidgets(config) {
+  config.widgets = widgetMapping;
+  config.widgets.default = defaultWidget;
+}

--- a/packages/volto/src/config/index.js
+++ b/packages/volto/src/config/index.js
@@ -1,13 +1,5 @@
 import ConfigRegistry from '@plone/volto/registry';
 import { parse as parseUrl } from 'url';
-import { defaultWidget, widgetMapping } from './Widgets';
-import {
-  layoutViews,
-  contentTypesViews,
-  defaultView,
-  errorViews,
-  layoutViewsNamesMapping,
-} from './Views';
 import { nonContentRoutes } from './NonContentRoutes';
 import { nonContentRoutesPublic } from './NonContentRoutesPublic';
 import { loadables } from './Loadables';
@@ -26,6 +18,8 @@ import {
 import applyAddonConfiguration, { addonsInfo } from 'load-volto-addons';
 
 import { installDefaultComponents } from './Components';
+import { installDefaultWidgets } from './Widgets';
+import { installDefaultViews } from './Views';
 import { installDefaultBlocks } from './Blocks';
 
 import { getSiteAsyncPropExtender } from '@plone/volto/helpers/Site';
@@ -189,17 +183,8 @@ let config = {
       enabled: true,
     },
   },
-  widgets: {
-    ...widgetMapping,
-    default: defaultWidget,
-  },
-  views: {
-    layoutViews,
-    contentTypesViews,
-    defaultView,
-    errorViews,
-    layoutViewsNamesMapping,
-  },
+  widgets: {},
+  views: {},
   blocks: {},
   addonRoutes: [],
   addonReducers: {},
@@ -249,6 +234,8 @@ Object.entries(slots).forEach(([slotName, components]) => {
 
 registerValidators(ConfigRegistry);
 installDefaultComponents(ConfigRegistry);
+installDefaultWidgets(ConfigRegistry);
+installDefaultViews(ConfigRegistry);
 installDefaultBlocks(ConfigRegistry);
 
 applyAddonConfiguration(ConfigRegistry);


### PR DESCRIPTION
More refining of #6509 HMR still failing in some use cases.

Used the usual solution reorder imports and use function for applying the config instead of relying on the import side effect.