### PR TITLE
Add missing styleWrapper style builder information in container/Grid

### DIFF
--- a/packages/volto/news/6527.bugfix
+++ b/packages/volto/news/6527.bugfix
@@ -1,0 +1,1 @@
+Add missing styleWrapper style builder information in container/Grid. @sneridagh

--- a/packages/volto/news/6527.feature
+++ b/packages/volto/news/6527.feature
@@ -1,0 +1,1 @@
+Add disable Teaser block Align handlers for teasers inside containers. @sneridagh

--- a/packages/volto/src/components/manage/Blocks/Container/EditBlockWrapper.jsx
+++ b/packages/volto/src/components/manage/Blocks/Container/EditBlockWrapper.jsx
@@ -4,7 +4,7 @@ import { defineMessages, useIntl } from 'react-intl';
 import NewBlockAddButton from './NewBlockAddButton';
 import cx from 'classnames';
 import { isInteractiveElement } from '@plone/volto/helpers/Utils/Utils';
-
+import { buildStyleObjectFromData } from '@plone/volto/helpers/Blocks/Blocks';
 import clearSVG from '@plone/volto/icons/clear.svg';
 
 const messages = defineMessages({
@@ -38,12 +38,15 @@ const EditBlockWrapper = (props) => {
     onChangeBlock(block, { '@type': 'empty' });
   }
 
+  const style = buildStyleObjectFromData(data);
+
   return (
     <div
       ref={draginfo.innerRef}
       {...draginfo.draggableProps}
       {...draginfo.dragHandleProps}
       className={cx(`block-editor-${data['@type']} contained`, { selected })}
+      style={style}
     >
       <div
         role="presentation"

--- a/packages/volto/src/components/manage/Blocks/Teaser/schema.js
+++ b/packages/volto/src/components/manage/Blocks/Teaser/schema.js
@@ -127,3 +127,15 @@ export const gridTeaserDisableStylingSchema = ({ schema, formData, intl }) => {
   schema.fieldsets = schema.fieldsets.filter((item) => item.id !== 'styling');
   return schema;
 };
+
+export const gridTeaserDisableAlignHandlersSchema = ({
+  schema,
+  formData,
+  intl,
+}) => {
+  schema.properties.styles.schema.fieldsets[0].fields =
+    schema.properties.styles.schema.fieldsets[0].fields.filter(
+      (item) => !['align'].includes(item),
+    );
+  return schema;
+};

--- a/packages/volto/src/components/manage/Blocks/Teaser/schema.js
+++ b/packages/volto/src/components/manage/Blocks/Teaser/schema.js
@@ -127,15 +127,3 @@ export const gridTeaserDisableStylingSchema = ({ schema, formData, intl }) => {
   schema.fieldsets = schema.fieldsets.filter((item) => item.id !== 'styling');
   return schema;
 };
-
-export const gridTeaserDisableAlignHandlersSchema = ({
-  schema,
-  formData,
-  intl,
-}) => {
-  schema.properties.styles.schema.fieldsets[0].fields =
-    schema.properties.styles.schema.fieldsets[0].fields.filter(
-      (item) => !['align'].includes(item),
-    );
-  return schema;
-};


### PR DESCRIPTION
This PR fixes the missing style information for inner container/grid blocks.
Adds a schemaEnhancer for disabling Teaser align handlers for inner container teaser elements.