### PR TITLE
Fix precedence of the quanta layer by adding a base layer for all the…

### DIFF
--- a/docs/source/configuration/settings-reference.md
+++ b/docs/source/configuration/settings-reference.md
@@ -464,7 +464,7 @@ querystringSearchGet
     Please test this setting properly before enabling in a production site.
 
 cssLayers
-    If you want to use CSS layers in Volto styling, it's possible to define them making sure that they are defined and applied at the very top level of the page (head tag).
+   To use CSS layers when styling Volto, you can define and apply them at the very top level of the page, where they appear in the `<head>` tag.
     By using this configuration, you can pass the layer list definition as an array:
 
     ```js

--- a/docs/source/configuration/settings-reference.md
+++ b/docs/source/configuration/settings-reference.md
@@ -463,6 +463,13 @@ querystringSearchGet
     [See an explanation of character limits in URLs](https://stackoverflow.com/questions/417142/what-is-the-maximum-length-of-a-url-in-different-browsers/417184#417184).
     Please test this setting properly before enabling in a production site.
 
+cssLayers
+    If you want to use CSS layers in Volto styling, it's possible to define them making sure that they are defined and applied at the very top level of the page (head tag).
+    By using this configuration, you can pass the layer list definition as an array:
+
+    ```js
+    config.settings.cssLayers = ['reset', 'plone-components', 'layout', 'addons', 'theme'];
+    ```
 ```
 
 ## Views settings

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -64,7 +64,7 @@ You can override them in your classes while maintaining them for others.
 
 ### CSS layers
 
-This package use CSS layers to provide a way to style the components in a more flexible way.
+This package uses CSS layers to style the components in a more flexible way.
 It uses the `plone-components` layer name to scope all the CSS declarations in the package.
 The basic styling uses the nested `plone-components.base` named layer.
 You can use the `plone-components` layer to override the basic styling, or use the `plone-components.base` layer to override the basic styling in a more specific way.
@@ -72,7 +72,7 @@ You can use the `plone-components` layer to override the basic styling, or use t
 ### Quanta
 
 This package also features the Quanta components.
-These components use the basic styling as a baseline, extending them to achieve Quanta look and feel.
+These components use the basic styling as a baseline, extending them to achieve the Quanta look and feel.
 They also extend the basic React components in a composable way.
 The Quanta styling is scoped in the `plone-components.quanta` named layer.
 

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -62,11 +62,19 @@ Using them as a baseline will allow you to quickly build your theme around them.
 `@plone/components` basic styles provide a simple, yet powerful, set of tokenized custom CSS properties that will help you customize your own styles on the top of the basic styling.
 You can override them in your classes while maintaining them for others.
 
+### CSS layers
+
+This package use CSS layers to provide a way to style the components in a more flexible way.
+It uses the `plone-components` layer name to scope all the CSS declarations in the package.
+The basic styling uses the nested `plone-components.base` named layer.
+You can use the `plone-components` layer to override the basic styling, or use the `plone-components.base` layer to override the basic styling in a more specific way.
+
 ### Quanta
 
 This package also features the Quanta components.
-The Quanta theme is an example of it.
-These components use the basic styling as a baseline, not only in styling, but also in the component side, reusing the CSS and custom CSS properties in it.
+These components use the basic styling as a baseline, extending them to achieve Quanta look and feel.
+They also extend the basic React components in a composable way.
+The Quanta styling is scoped in the `plone-components.quanta` named layer.
 
 Quanta is built upon the basic styles in an additive way.
 The use of the Quanta CSS implies using it upon basic styling.

--- a/packages/components/news/6539.bugfix
+++ b/packages/components/news/6539.bugfix
@@ -1,0 +1,1 @@
+Fixed precedence of the quanta layer by adding a base layer for all the basic components. @sneridagh

--- a/packages/components/news/6539.bugfix
+++ b/packages/components/news/6539.bugfix
@@ -1,1 +1,1 @@
-Fixed precedence of the quanta layer by adding a base layer for all the basic components. @sneridagh
+Fixed precedence of the Quanta layer by adding a base layer for all the basic components. @sneridagh

--- a/packages/components/src/stories/Introduction.mdx
+++ b/packages/components/src/stories/Introduction.mdx
@@ -11,8 +11,8 @@ The purpose of this package is to provide an agnostic set of baseline components
 
 ## Usage
 
-Using the package manager of your choice (npm, yarn, pnpm) to install the package in your app.
-Use pnpm in case you are adding them a Volto add-on/workspace:
+You can use your choice of package manager (npm, yarn, or pnpm) to install the package in your app.
+If you add the components to a Volto add-on or workspace, use pnpm, as shown.
 
 ```shell
 pnpm add @plone/components
@@ -56,15 +56,15 @@ import '@plone/components/src/styles/basic/TextField.css';
 
 ### CSS layers
 
-This package use CSS layers to provide a way to style the components in a more flexible way.
+This package uses CSS layers to style the components in a more flexible way.
 It uses the `plone-components` layer name to scope all the CSS declarations in the package.
 The basic styling uses the nested `plone-components.base` named layer.
 You can use the `plone-components` layer to override the basic styling, or use the `plone-components.base` layer to override the basic styling in a more specific way.
 
-## Quanta
+### Quanta
 
 This package also features the Quanta components.
-These components use the basic styling as a baseline, extending them to achieve Quanta look and feel.
+These components use the basic styling as a baseline, extending them to achieve the Quanta look and feel.
 They also extend the basic React components in a composable way.
 The Quanta styling is scoped in the `plone-components.quanta` named layer.
 

--- a/packages/components/src/stories/Introduction.mdx
+++ b/packages/components/src/stories/Introduction.mdx
@@ -5,16 +5,17 @@ import { Meta } from '@storybook/blocks';
 
 # `@plone/components`
 
-This package contains ReactJS components for using Plone as a headless CMS.
+This package contains ReactJS components for Plone 7 and Plone's API-first CMS story.
 
 The purpose of this package is to provide an agnostic set of baseline components to build Plone sites upon.
 
 ## Usage
 
-Using the package manager of your choice (npm, yarn, pnpm) install the package:
+Using the package manager of your choice (npm, yarn, pnpm) to install the package in your app.
+Use pnpm in case you are adding them a Volto add-on/workspace:
 
 ```shell
-yarn add @plone/components
+pnpm add @plone/components
 ```
 
 Whenever you want to use the components, all are exported as named exports:
@@ -53,12 +54,19 @@ or selectively:
 import '@plone/components/src/styles/basic/TextField.css';
 ```
 
+### CSS layers
+
+This package use CSS layers to provide a way to style the components in a more flexible way.
+It uses the `plone-components` layer name to scope all the CSS declarations in the package.
+The basic styling uses the nested `plone-components.base` named layer.
+You can use the `plone-components` layer to override the basic styling, or use the `plone-components.base` layer to override the basic styling in a more specific way.
 
 ## Quanta
 
 This package also features the Quanta components.
-The Quanta theme is an example of it.
-These components use the basic styling as a baseline, not only in styling, but also in the component side, reusing the CSS and custom CSS properties in it.
+These components use the basic styling as a baseline, extending them to achieve Quanta look and feel.
+They also extend the basic React components in a composable way.
+The Quanta styling is scoped in the `plone-components.quanta` named layer.
 
 Quanta is built upon the basic styles in an additive way.
 The use of the Quanta CSS implies using it upon basic styling.

--- a/packages/components/src/styles/basic/BlockToolbar.css
+++ b/packages/components/src/styles/basic/BlockToolbar.css
@@ -4,7 +4,7 @@
 @import './Menu.css';
 @import './theme.css';
 
-@layer plone-components {
+@layer plone-components.base {
   .blocks-toolbar {
     display: flex;
     flex-wrap: wrap;

--- a/packages/components/src/styles/basic/Breadcrumbs.css
+++ b/packages/components/src/styles/basic/Breadcrumbs.css
@@ -1,6 +1,6 @@
 @import './theme.css';
 
-@layer plone-components {
+@layer plone-components.base {
   .react-aria-Breadcrumbs {
     display: flex;
     align-items: center;

--- a/packages/components/src/styles/basic/Button.css
+++ b/packages/components/src/styles/basic/Button.css
@@ -1,6 +1,6 @@
 @import './theme.css';
 
-@layer plone-components {
+@layer plone-components.base {
   .react-aria-Button {
     padding: 8px 8px;
     border: 1px solid var(--border-color);

--- a/packages/components/src/styles/basic/Calendar.css
+++ b/packages/components/src/styles/basic/Calendar.css
@@ -1,7 +1,7 @@
 @import './Button.css';
 @import './theme.css';
 
-@layer plone-components {
+@layer plone-components.base {
   .react-aria-Calendar {
     width: fit-content;
     max-width: 100%;

--- a/packages/components/src/styles/basic/Checkbox.css
+++ b/packages/components/src/styles/basic/Checkbox.css
@@ -1,6 +1,6 @@
 @import './theme.css';
 
-@layer plone-components {
+@layer plone-components.base {
   .react-aria-Checkbox {
     --selected-color: var(--highlight-background);
     --selected-color-pressed: var(--highlight-background-pressed);

--- a/packages/components/src/styles/basic/CheckboxGroup.css
+++ b/packages/components/src/styles/basic/CheckboxGroup.css
@@ -3,7 +3,7 @@
 @import './Button.css';
 @import './theme.css';
 
-@layer plone-components {
+@layer plone-components.base {
   .react-aria-CheckboxGroup {
     display: flex;
     flex-direction: column;

--- a/packages/components/src/styles/basic/ColorArea.css
+++ b/packages/components/src/styles/basic/ColorArea.css
@@ -1,6 +1,6 @@
 @import './ColorSlider.css';
 
-@layer plone-components {
+@layer plone-components.base {
   .react-aria-ColorArea {
     width: 192px;
     height: 192px;

--- a/packages/components/src/styles/basic/ColorField.css
+++ b/packages/components/src/styles/basic/ColorField.css
@@ -2,7 +2,7 @@
 @import './Form.css';
 @import './theme.css';
 
-@layer plone-components {
+@layer plone-components.base {
   .react-aria-ColorField {
     display: flex;
     flex-direction: column;

--- a/packages/components/src/styles/basic/ColorPicker.css
+++ b/packages/components/src/styles/basic/ColorPicker.css
@@ -10,7 +10,7 @@
 @import './Select.css';
 @import './theme.css';
 
-@layer plone-components {
+@layer plone-components.base {
   .color-picker {
     display: flex;
     align-items: center;

--- a/packages/components/src/styles/basic/ColorSlider.css
+++ b/packages/components/src/styles/basic/ColorSlider.css
@@ -1,4 +1,4 @@
-@layer plone-components {
+@layer plone-components.base {
   .react-aria-ColorSlider {
     display: grid;
     max-width: 300px;

--- a/packages/components/src/styles/basic/ColorSwatch.css
+++ b/packages/components/src/styles/basic/ColorSwatch.css
@@ -1,6 +1,6 @@
 @import './ColorSlider.css';
 
-@layer plone-components {
+@layer plone-components.base {
   .react-aria-ColorSwatch {
     width: 32px;
     height: 32px;

--- a/packages/components/src/styles/basic/ColorSwatchPicker.css
+++ b/packages/components/src/styles/basic/ColorSwatchPicker.css
@@ -2,7 +2,7 @@
 @import './ColorField.css';
 @import './theme.css';
 
-@layer plone-components {
+@layer plone-components.base {
   .react-aria-ColorSwatchPicker {
     display: flex;
     flex-wrap: wrap;

--- a/packages/components/src/styles/basic/ColorWheel.css
+++ b/packages/components/src/styles/basic/ColorWheel.css
@@ -1,4 +1,4 @@
-@layer plone-components {
+@layer plone-components.base {
   .react-aria-ColorThumb {
     width: 20px;
     height: 20px;

--- a/packages/components/src/styles/basic/ComboBox.css
+++ b/packages/components/src/styles/basic/ComboBox.css
@@ -5,7 +5,7 @@
 @import './Button.css';
 @import './theme.css';
 
-@layer plone-components {
+@layer plone-components.base {
   .react-aria-ComboBox {
     color: var(--text-color);
 

--- a/packages/components/src/styles/basic/Container.css
+++ b/packages/components/src/styles/basic/Container.css
@@ -1,4 +1,4 @@
-@layer plone-components {
+@layer plone-components.base {
   .q.container {
     container-type: inline-size;
 

--- a/packages/components/src/styles/basic/DateField.css
+++ b/packages/components/src/styles/basic/DateField.css
@@ -2,7 +2,7 @@
 @import './Button.css';
 @import './theme.css';
 
-@layer plone-components {
+@layer plone-components.base {
   .react-aria-DateField {
     color: var(--text-color);
   }

--- a/packages/components/src/styles/basic/DatePicker.css
+++ b/packages/components/src/styles/basic/DatePicker.css
@@ -6,7 +6,7 @@
 @import './Form.css';
 @import './theme.css';
 
-@layer plone-components {
+@layer plone-components.base {
   .react-aria-DatePicker {
     color: var(--text-color);
 

--- a/packages/components/src/styles/basic/DateRangePicker.css
+++ b/packages/components/src/styles/basic/DateRangePicker.css
@@ -6,7 +6,7 @@
 @import './Form.css';
 @import './theme.css';
 
-@layer plone-components {
+@layer plone-components.base {
   .react-aria-DateRangePicker {
     color: var(--text-color);
 

--- a/packages/components/src/styles/basic/Dialog.css
+++ b/packages/components/src/styles/basic/Dialog.css
@@ -3,7 +3,7 @@
 @import './Modal.css';
 @import './theme.css';
 
-@layer plone-components {
+@layer plone-components.base {
   .react-aria-Dialog {
     padding: 30px;
     outline: none;

--- a/packages/components/src/styles/basic/Disclosure.css
+++ b/packages/components/src/styles/basic/Disclosure.css
@@ -1,7 +1,7 @@
 @import './theme.css';
 @import './Button.css';
 
-@layer plone-components {
+@layer plone-components.base {
   .react-aria-Disclosure {
     .react-aria-Button[slot='trigger'] {
       display: flex;

--- a/packages/components/src/styles/basic/Form.css
+++ b/packages/components/src/styles/basic/Form.css
@@ -2,7 +2,7 @@
 @import './Button.css';
 @import './theme.css';
 
-@layer plone-components {
+@layer plone-components.base {
   .react-aria-Form {
     display: flex;
     flex-direction: column;

--- a/packages/components/src/styles/basic/GridList.css
+++ b/packages/components/src/styles/basic/GridList.css
@@ -3,7 +3,7 @@
 @import './ToggleButton.css';
 @import './theme.css';
 
-@layer plone-components {
+@layer plone-components.base {
   .react-aria-GridList {
     display: flex;
     overflow: auto;

--- a/packages/components/src/styles/basic/Label.css
+++ b/packages/components/src/styles/basic/Label.css
@@ -1,6 +1,6 @@
 @import './theme.css';
 
-@layer plone-components {
+@layer plone-components.base {
   .react-aria-Label {
     /* TODO: Review since taken from default quanta */
     font-size: 0.9rem;

--- a/packages/components/src/styles/basic/Link.css
+++ b/packages/components/src/styles/basic/Link.css
@@ -1,6 +1,6 @@
 @import './theme.css';
 
-@layer plone-components {
+@layer plone-components.base {
   .react-aria-Link {
     position: relative;
     color: var(--link-color);

--- a/packages/components/src/styles/basic/ListBox.css
+++ b/packages/components/src/styles/basic/ListBox.css
@@ -1,7 +1,7 @@
 @import './Checkbox.css';
 @import './theme.css';
 
-@layer plone-components {
+@layer plone-components.base {
   .react-aria-ListBox {
     display: flex;
     overflow: auto;

--- a/packages/components/src/styles/basic/Menu.css
+++ b/packages/components/src/styles/basic/Menu.css
@@ -2,7 +2,7 @@
 @import './Popover.css';
 @import './theme.css';
 
-@layer plone-components {
+@layer plone-components.base {
   .react-aria-Menu {
     overflow: auto;
     min-width: 150px;

--- a/packages/components/src/styles/basic/Meter.css
+++ b/packages/components/src/styles/basic/Meter.css
@@ -1,6 +1,6 @@
 @import './theme.css';
 
-@layer plone-components {
+@layer plone-components.base {
   .react-aria-Meter {
     --fill-color: forestgreen;
 

--- a/packages/components/src/styles/basic/Modal.css
+++ b/packages/components/src/styles/basic/Modal.css
@@ -2,7 +2,7 @@
 @import './TextField.css';
 @import './theme.css';
 
-@layer plone-components {
+@layer plone-components.base {
   .react-aria-ModalOverlay {
     position: fixed;
     z-index: 100;

--- a/packages/components/src/styles/basic/NumberField.css
+++ b/packages/components/src/styles/basic/NumberField.css
@@ -2,7 +2,7 @@
 @import './Form.css';
 @import './theme.css';
 
-@layer plone-components {
+@layer plone-components.base {
   .react-aria-NumberField {
     margin-bottom: 8px;
     color: var(--text-color);

--- a/packages/components/src/styles/basic/Popover.css
+++ b/packages/components/src/styles/basic/Popover.css
@@ -3,7 +3,7 @@
 @import './Switch.css';
 @import './theme.css';
 
-@layer plone-components {
+@layer plone-components.base {
   .react-aria-Popover {
     --background-color: var(--overlay-background);
     max-width: 250px;

--- a/packages/components/src/styles/basic/ProgressBar.css
+++ b/packages/components/src/styles/basic/ProgressBar.css
@@ -1,6 +1,6 @@
 @import './theme.css';
 
-@layer plone-components {
+@layer plone-components.base {
   .react-aria-ProgressBar {
     display: grid;
     width: 250px;

--- a/packages/components/src/styles/basic/RadioGroup.css
+++ b/packages/components/src/styles/basic/RadioGroup.css
@@ -2,7 +2,7 @@
 @import './Form.css';
 @import './theme.css';
 
-@layer plone-components {
+@layer plone-components.base {
   .react-aria-RadioGroup {
     display: flex;
     flex-direction: column;

--- a/packages/components/src/styles/basic/RangeCalendar.css
+++ b/packages/components/src/styles/basic/RangeCalendar.css
@@ -1,7 +1,7 @@
 @import './Button.css';
 @import './theme.css';
 
-@layer plone-components {
+@layer plone-components.base {
   .react-aria-RangeCalendar {
     width: fit-content;
     max-width: 100%;

--- a/packages/components/src/styles/basic/SearchField.css
+++ b/packages/components/src/styles/basic/SearchField.css
@@ -2,7 +2,7 @@
 @import './Form.css';
 @import './theme.css';
 
-@layer plone-components {
+@layer plone-components.base {
   .react-aria-SearchField {
     display: grid;
     width: fit-content;

--- a/packages/components/src/styles/basic/Select.css
+++ b/packages/components/src/styles/basic/Select.css
@@ -4,7 +4,7 @@
 @import './Form.css';
 @import './theme.css';
 
-@layer plone-components {
+@layer plone-components.base {
   .react-aria-Select {
     color: var(--text-color);
 

--- a/packages/components/src/styles/basic/Slider.css
+++ b/packages/components/src/styles/basic/Slider.css
@@ -1,7 +1,7 @@
 @import './NumberField.css';
 @import './theme.css';
 
-@layer plone-components {
+@layer plone-components.base {
   .react-aria-Slider {
     display: grid;
     max-width: 300px;

--- a/packages/components/src/styles/basic/Switch.css
+++ b/packages/components/src/styles/basic/Switch.css
@@ -1,6 +1,6 @@
 @import './theme.css';
 
-@layer plone-components {
+@layer plone-components.base {
   .react-aria-Switch {
     display: flex;
     align-items: center;

--- a/packages/components/src/styles/basic/Table.css
+++ b/packages/components/src/styles/basic/Table.css
@@ -5,7 +5,7 @@
 @import './Menu.css';
 @import './theme.css';
 
-@layer plone-components {
+@layer plone-components.base {
   :root {
     --plone-table-border: 0 none;
     --plone-table-border-radius: 0;

--- a/packages/components/src/styles/basic/Tabs.css
+++ b/packages/components/src/styles/basic/Tabs.css
@@ -2,7 +2,7 @@
 @import './Link.css';
 @import './theme.css';
 
-@layer plone-components {
+@layer plone-components.base {
   .react-aria-Tabs {
     display: flex;
     color: var(--text-color);

--- a/packages/components/src/styles/basic/TagGroup.css
+++ b/packages/components/src/styles/basic/TagGroup.css
@@ -1,7 +1,7 @@
 @import './ToggleButton.css';
 @import './theme.css';
 
-@layer plone-components {
+@layer plone-components.base {
   .react-aria-TagGroup {
     display: flex;
     flex-direction: column;

--- a/packages/components/src/styles/basic/TextField.css
+++ b/packages/components/src/styles/basic/TextField.css
@@ -2,7 +2,7 @@
 @import './Label.css';
 @import './theme.css';
 
-@layer plone-components {
+@layer plone-components.base {
   .react-aria-TextField {
     display: flex;
     width: fit-content;

--- a/packages/components/src/styles/basic/TimeField.css
+++ b/packages/components/src/styles/basic/TimeField.css
@@ -2,7 +2,7 @@
 @import './Button.css';
 @import './theme.css';
 
-@layer plone-components {
+@layer plone-components.base {
   .react-aria-TimeField {
     color: var(--text-color);
   }

--- a/packages/components/src/styles/basic/ToggleButton.css
+++ b/packages/components/src/styles/basic/ToggleButton.css
@@ -1,6 +1,6 @@
 @import './theme.css';
 
-@layer plone-components {
+@layer plone-components.base {
   .react-aria-ToggleButton {
     padding: 8px 8px;
     border: 1px solid var(--border-color);

--- a/packages/components/src/styles/basic/Toolbar.css
+++ b/packages/components/src/styles/basic/Toolbar.css
@@ -4,7 +4,7 @@
 @import './Menu.css';
 @import './theme.css';
 
-@layer plone-components {
+@layer plone-components.base {
   .react-aria-Toolbar {
     display: flex;
     flex-wrap: wrap;

--- a/packages/components/src/styles/basic/Tooltip.css
+++ b/packages/components/src/styles/basic/Tooltip.css
@@ -1,7 +1,7 @@
 @import './Button.css';
 @import './theme.css';
 
-@layer plone-components {
+@layer plone-components.base {
   .react-aria-Tooltip {
     max-width: 150px;
     padding: 2px 8px;

--- a/packages/components/src/styles/basic/icons.css
+++ b/packages/components/src/styles/basic/icons.css
@@ -1,6 +1,6 @@
 @import './theme.css';
 
-@layer plone-components {
+@layer plone-components.base {
   :root {
     /* These has to be mapped to global css custom properties based on the SG scales */
     --quanta-icon-default-size-s: 18px;

--- a/packages/types/news/6539.feature
+++ b/packages/types/news/6539.feature
@@ -1,0 +1,1 @@
+Added the type for a setting in config object for setting the site's CSS layers. @sneridagh

--- a/packages/types/news/6539.feature
+++ b/packages/types/news/6539.feature
@@ -1,1 +1,1 @@
-Added the type for a setting in config object for setting the site's CSS layers. @sneridagh
+Added the typing for the new `cssLayers` configuration object setting. @sneridagh

--- a/packages/types/src/config/Settings.d.ts
+++ b/packages/types/src/config/Settings.d.ts
@@ -101,5 +101,5 @@ export interface SettingsConfig {
     includeSiteTitle: boolean;
     titleAndSiteTitleSeparator: string;
   };
-  cssLayers: string;
+  cssLayers: string[];
 }

--- a/packages/types/src/config/Settings.d.ts
+++ b/packages/types/src/config/Settings.d.ts
@@ -101,4 +101,5 @@ export interface SettingsConfig {
     includeSiteTitle: boolean;
     titleAndSiteTitleSeparator: string;
   };
+  cssLayers: string;
 }

--- a/packages/volto/news/6539.feature
+++ b/packages/volto/news/6539.feature
@@ -1,1 +1,1 @@
-Added a setting in config object for setting the site's CSS layers, if required. @sneridagh
+Added a setting in the `config` object to set the site's CSS layers, if required. @sneridagh

--- a/packages/volto/news/6539.feature
+++ b/packages/volto/news/6539.feature
@@ -1,0 +1,1 @@
+Added a setting in config object for setting the site's CSS layers, if required. @sneridagh

--- a/packages/volto/src/helpers/Html/Html.jsx
+++ b/packages/volto/src/helpers/Html/Html.jsx
@@ -105,7 +105,7 @@ class Html extends Component {
 
           {config.settings.cssLayers && (
             // Load the CSS layers from config, if any
-            <style>{config.settings.cssLayers}</style>
+            <style>{`@layer ${config.settings.cssLayers.join(', ')};`}</style>
           )}
 
           {head.style.toComponent()}

--- a/packages/volto/src/helpers/Html/Html.jsx
+++ b/packages/volto/src/helpers/Html/Html.jsx
@@ -102,6 +102,12 @@ class Html extends Component {
           {head.meta.toComponent()}
           {head.link.toComponent()}
           {head.script.toComponent()}
+
+          {config.settings.cssLayers && (
+            // Load the CSS layers from config, if any
+            <style>{config.settings.cssLayers}</style>
+          )}
+
           {head.style.toComponent()}
 
           <script


### PR DESCRIPTION
@pnicolli I found a bug in the definition of the layers, the quanta `plone-components.quanta` layer needs to have more priority than the base one. I misunderstood how nested layers worked.

I added a nested `plone-components.base` layer to all basic components. So, if we want to override declarations in the nested (default) layers, we only have to scope them to the main layer.

Also, I added the ability to setup the layers at the top (`Html.jsx` component), so we have a "main" centralized entry point to define them in Volto.