### PR TITLE
Bugfix remove query string inclusion in body class generation logic

### DIFF
--- a/packages/volto/news/6493.bugfix
+++ b/packages/volto/news/6493.bugfix
@@ -1,1 +1,1 @@
-Fixed body class handling to prevent query string inclusion in is-adding-contenttype.@Abhishek-17h
+No longer add classes from the query string search text in the `body` tag. @Abhishek-17h

--- a/packages/volto/news/6493.bugfix
+++ b/packages/volto/news/6493.bugfix
@@ -1,0 +1,1 @@
+Fixed body class handling to prevent query string inclusion in is-adding-contenttype.@Abhishek-17h

--- a/packages/volto/src/components/theme/App/App.jsx
+++ b/packages/volto/src/components/theme/App/App.jsx
@@ -146,10 +146,13 @@ export class App extends Component {
               this.props.pathname !== '/',
             siteroot: this.props.pathname === '/',
             [`is-adding-contenttype-${decodeURIComponent(
-              this.props.location?.search?.replace('?type=', ''),
+              this.props.location?.search?.startsWith('?type=')
+                ? this.props.location?.search?.replace('?type=', '')
+                : '',
             )
               .replaceAll(' ', '-')
-              .toLowerCase()}`]: this.props.location?.search,
+              .toLowerCase()}`]:
+              this.props.location?.search?.startsWith('?type='),
             'is-authenticated': !!this.props.token,
             'is-anonymous': !this.props.token,
             'cms-ui': isCmsUI,


### PR DESCRIPTION
- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't other open [pull requests](https://github.com/plone/volto/pulls) for the same change.
- [x] I followed the guidelines in [Contributing to Volto](https://6.docs.plone.org/volto/contributing/index.html).
- [x] I succesfully ran [code linting checks](https://6.docs.plone.org/volto/contributing/linting.html) on my changes locally.
- [x] I succesfully ran [unit tests](https://6.docs.plone.org/volto/contributing/testing.html) on my changes locally.
- [x] I succesfully ran [acceptance tests](https://6.docs.plone.org/volto/contributing/acceptance-tests.html) on my changes locally.
- [ ] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/volto/contributing/documentation.html#narrative-documentation) for my changes, either in the Storybook or narrative documentation.
- [x] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

If your pull request closes an open issue, include the exact text below, immediately followed by the issue number. When your pull request gets merged, then that issue will close automatically.

After fix body class only include the ?type= query_string in is-adding-contenttype class. All other query strings are ignored. If there's no type, no is-adding-contenttype class will be present.

Screenshots after fixing bug:
![Screenshot from 2024-12-18 21-54-48](https://github.com/user-attachments/assets/45756093-fc28-4005-92cb-40b88fc83605)
![Screenshot from 2024-12-18 21-54-24](https://github.com/user-attachments/assets/5259d774-f05b-40be-83b9-a652371a0528)


Closes #6493 

