### PR TITLE
Fixed folder contents issues with persistent selection

### DIFF
--- a/packages/volto/news/6554.bugfix
+++ b/packages/volto/news/6554.bugfix
@@ -1,0 +1,1 @@
+Fixed folder contents issues with persistent selection across page changes. @pnicolli

--- a/packages/volto/src/components/manage/Contents/Contents.jsx
+++ b/packages/volto/src/components/manage/Contents/Contents.jsx
@@ -456,6 +456,7 @@ class Contents extends Component {
       this.setState(
         {
           currentPage: 0,
+          selected: [],
         },
         () =>
           this.setState({ filter: '' }, () =>
@@ -652,6 +653,7 @@ class Contents extends Component {
     this.setState(
       {
         currentPage: value,
+        selected: [],
       },
       () => this.fetchContents(),
     );
@@ -669,6 +671,7 @@ class Contents extends Component {
       {
         pageSize: value,
         currentPage: 0,
+        selected: [],
       },
       () => this.fetchContents(),
     );
@@ -728,6 +731,7 @@ class Contents extends Component {
     this.setState({
       sort_on: values[0],
       sort_order: values[1],
+      selected: [],
     });
     this.props.sortContent(
       getBaseUrl(this.props.pathname),
@@ -755,6 +759,7 @@ class Contents extends Component {
         this.setState(
           {
             currentPage: 0,
+            selected: [],
           },
           () => this.fetchContents(),
         );
@@ -780,6 +785,7 @@ class Contents extends Component {
         this.setState(
           {
             currentPage: 0,
+            selected: [],
           },
           () => this.fetchContents(),
         );


### PR DESCRIPTION
Closes #5209
Closes #5931

Reset the selection when navigating, when changing page and when sorting items.
The idea is basically to reset the selection when you could have selected items that are now shown on the page.

I left one case where this is possible, but I am open for discussion about it: since the default page size is 50, a user might want to filter the contents using the text filter in the top right corner to find items in a quicker way, while still keeping the multiselection. What do you think?