### PR TITLE
Stop generating sitemap.xml.gz (#6561)

### DIFF
--- a/packages/volto/news/6561.bugfix
+++ b/packages/volto/news/6561.bugfix
@@ -1,1 +1,1 @@
-Stop generating sitemap.xml.gz @reebalazs
+Serve `sitemap.xml.gz` as an alias for `sitemap-index.xml`. @reebalazs

--- a/packages/volto/news/6561.bugfix
+++ b/packages/volto/news/6561.bugfix
@@ -1,0 +1,1 @@
+Stop generating sitemap.xml.gz @reebalazs

--- a/packages/volto/src/express-middleware/sitemap.js
+++ b/packages/volto/src/express-middleware/sitemap.js
@@ -47,11 +47,24 @@ export const sitemapIndex = function (req, res, next) {
   });
 };
 
+export const sitemapIndexCompatibility = function (req, res, next) {
+  generateSitemapIndex(req, true).then((sitemapIndex) => {
+    res.set('Content-Type', 'application/x-gzip');
+    res.set('Content-Disposition', 'attachment; filename="sitemap.xml.gz"');
+    res.send(sitemapIndex);
+  });
+};
+
 export default function sitemapMiddleware() {
   const middleware = express.Router();
 
-  middleware.all('**/sitemap.xml.gz', sitemap);
+  // For backwards compatibility, and allow a graceful transition for
+  // sites that are already set up on the Google Search Console, we continue delivering
+  // the new batched sitemap under the old sitemap.xml.gz name.
+  middleware.all('**/sitemap.xml.gz', sitemapIndexCompatibility);
   middleware.all('**/sitemap:batch.xml.gz', sitemap);
+  // For new setups, `sitemap-index.xml` should be added to the
+  // Google Search Console.
   middleware.all('**/sitemap-index.xml', sitemapIndex);
   middleware.id = 'sitemap.xml.gz';
   return middleware;

--- a/packages/volto/src/helpers/Sitemap/Sitemap.js
+++ b/packages/volto/src/helpers/Sitemap/Sitemap.js
@@ -61,7 +61,7 @@ export const generateSitemap = (_req, start = 0, size = undefined) =>
  * @param {Object} _req Request object
  * @return {string} Generated sitemap index
  */
-export const generateSitemapIndex = (_req) =>
+export const generateSitemapIndex = (_req, gzip = false) =>
   new Promise((resolve) => {
     const { settings } = config;
     const APISUFIX = settings.legacyTraverse ? '' : '/++api++';
@@ -88,7 +88,14 @@ export const generateSitemapIndex = (_req) =>
         const result = `<?xml version="1.0" encoding="UTF-8"?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 ${items.join('\n')}\n</sitemapindex>`;
-        resolve(result);
+
+        if (gzip) {
+          zlib.gzip(Buffer.from(result, 'utf8'), (_err, buffer) => {
+            resolve(buffer);
+          });
+        } else {
+          resolve(result);
+        }
       }
     });
   });


### PR DESCRIPTION
We generate sitemap-index.xml which is also put correctly into robots.txt. However we still provide the old sitemap.xml.gz.

But, while this serves no purpose in addition to the index, it can cause problems if Google somehow parses it (for example it's submitted to the Google Search console). For this reason, we  stop providing sitemap.xml.gz.

- [X] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [X] I verified there aren't other open [pull requests](https://github.com/plone/volto/pulls) for the same change.
- [X] I followed the guidelines in [Contributing to Volto](https://6.docs.plone.org/volto/contributing/index.html).
- [X] I succesfully ran [code linting checks](https://6.docs.plone.org/volto/contributing/linting.html) on my changes locally.
- [X] I succesfully ran [unit tests](https://6.docs.plone.org/volto/contributing/testing.html) on my changes locally.
- [X] I succesfully ran [acceptance tests](https://6.docs.plone.org/volto/contributing/acceptance-tests.html) on my changes locally.
- [X] If needed, I added new tests for my changes.
- [X] If needed, I added [documentation](https://6.docs.plone.org/volto/contributing/documentation.html#narrative-documentation) for my changes, either in the Storybook or narrative documentation.
- [X] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

Closes #6561
