### PR TITLE
Improve the usability of the ObjectBrowser when inputting a manual value, checking it on blur, and adding a local validator

### DIFF
--- a/packages/volto/news/6576.bugfix
+++ b/packages/volto/news/6576.bugfix
@@ -1,1 +1,1 @@
-Improve the usability of the ObjectBrowser when inputting a manual value, checking it on blur, and adding a local validator. @sneridagh
+Improve the usability of the `ObjectBrowser` when inputting a manual value, checking it on blur, and adding a local validator. @sneridagh

--- a/packages/volto/news/6576.bugfix
+++ b/packages/volto/news/6576.bugfix
@@ -1,0 +1,1 @@
+Improve the usability of the ObjectBrowser when inputting a manual value, checking it on blur, and adding a local validator. @sneridagh

--- a/packages/volto/src/components/manage/Widgets/ObjectBrowserWidget.jsx
+++ b/packages/volto/src/components/manage/Widgets/ObjectBrowserWidget.jsx
@@ -351,14 +351,11 @@ export class ObjectBrowserWidgetComponent extends Component {
             onChange(id, this.props.return === 'single' ? null : []);
           };
 
-    const props = {
-      ...this.props,
-      error: this.props.error.concat(this.state.errors),
-    };
-
     return (
       <FormFieldWrapper
-        {...props}
+        {...this.props}
+        // At the moment, OBW handles its own errors and validation
+        error={this.state.errors}
         className={description ? 'help text' : 'text'}
       >
         <div


### PR DESCRIPTION
Instead of requiring to press enter to validate the value, it does it on blur too.
Also, moved to use the URL validator from the main Validators.