### PR TITLE
fix: render Ordertab only when iti is active

### DIFF
--- a/packages/volto/news/6492.bugfix
+++ b/packages/volto/news/6492.bugfix
@@ -1,0 +1,1 @@
+You can now render the order side panel only when the 'Order' tab is active. Previously, the panel would render unnecessarily even when not active.@Abhishek-17h

--- a/packages/volto/src/components/manage/Blocks/Block/BlocksForm.jsx
+++ b/packages/volto/src/components/manage/Blocks/Block/BlocksForm.jsx
@@ -276,6 +276,7 @@ const BlocksForm = (props) => {
     <>
       {isMainForm &&
         isClient &&
+        document.getElementById('sidebar-order') &&
         createPortal(
           <div>
             <Order
@@ -353,7 +354,6 @@ const BlocksForm = (props) => {
                 editable,
                 showBlockChooser: selectedBlock === childId,
                 detached: isContainer,
-                // Properties to pass to the BlocksForm to match the View ones
                 content: properties,
                 history,
                 location,
@@ -373,5 +373,4 @@ const BlocksForm = (props) => {
     </>
   );
 };
-
 export default BlocksForm;

--- a/packages/volto/src/components/manage/Sidebar/Sidebar.jsx
+++ b/packages/volto/src/components/manage/Sidebar/Sidebar.jsx
@@ -186,19 +186,20 @@ const Sidebar = (props) => {
             },
             !!orderTab && {
               menuItem: intl.formatMessage(messages.order),
-              pane: (
-                <Tab.Pane
-                  key="order"
-                  className="tab-wrapper"
-                  id="sidebar-order"
-                >
-                  <Icon
-                    className="tab-forbidden"
-                    name={forbiddenSVG}
-                    size="48px"
-                  />
-                </Tab.Pane>
-              ),
+              pane:
+                tab === 2 ? (
+                  <Tab.Pane
+                    key="order"
+                    className="tab-wrapper"
+                    id="sidebar-order"
+                  >
+                    <Icon
+                      className="tab-forbidden"
+                      name={forbiddenSVG}
+                      size="48px"
+                    />
+                  </Tab.Pane>
+                ) : null,
             },
             !!settingsTab && {
               menuItem: intl.formatMessage(messages.settings),

--- a/packages/volto/src/components/manage/Sidebar/__snapshots__/Sidebar.test.jsx.snap
+++ b/packages/volto/src/components/manage/Sidebar/__snapshots__/Sidebar.test.jsx.snap
@@ -87,29 +87,6 @@ Array [
           xmlns=""
         />
       </div>
-      <div
-        className="ui bottom attached segment tab tab-wrapper"
-        id="sidebar-order"
-      >
-        <svg
-          className="icon tab-forbidden"
-          dangerouslySetInnerHTML={
-            Object {
-              "__html": undefined,
-            }
-          }
-          onClick={null}
-          style={
-            Object {
-              "fill": "currentColor",
-              "height": "48px",
-              "width": "auto",
-            }
-          }
-          viewBox=""
-          xmlns=""
-        />
-      </div>
     </div>
   </div>,
   <div


### PR DESCRIPTION
- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't other open [pull requests](https://github.com/plone/volto/pulls) for the same change.
- [x] I followed the guidelines in [Contributing to Volto](https://6.docs.plone.org/volto/contributing/index.html).
- [x] I succesfully ran [code linting checks](https://6.docs.plone.org/volto/contributing/linting.html) on my changes locally.
- [x]I succesfully ran [unit tests](https://6.docs.plone.org/volto/contributing/testing.html) on my changes locally.
- [x] I succesfully ran [acceptance tests](https://6.docs.plone.org/volto/contributing/acceptance-tests.html) on my changes locally.
- [ ] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/volto/contributing/documentation.html#narrative-documentation) for my changes, either in the Storybook or narrative documentation.
- [x] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

The video showcases the behavior after the fix:
[Screencast from 2025-01-13 09-17-05.webm](https://github.com/user-attachments/assets/05b32c56-1bef-4575-8efd-60d1ab5bbd39)


Closes #6492
