### PR TITLE
fixed #6577 issue

### DIFF
--- a/packages/volto-slate/src/editor/plugins/Markdown/constants.js
+++ b/packages/volto-slate/src/editor/plugins/Markdown/constants.js
@@ -22,12 +22,16 @@ export const localToggleList = (editor, format) => {
  */
 export const autoformatRules = [
   {
-    type: H2,
+    type: H1,
     markup: '#',
   },
   {
-    type: H3,
+    type: H2,
     markup: '##',
+  },
+  {
+    type: H3,
+    markup: '###',
   },
   {
     type: LI,


### PR DESCRIPTION
- [ok] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [ok] I verified there aren't other open [pull requests](https://github.com/plone/volto/pulls) for the same change.
- [ok] I followed the guidelines in [Contributing to Volto](https://6.docs.plone.org/volto/contributing/index.html).
- [ok] I succesfully ran [code linting checks](https://6.docs.plone.org/volto/contributing/linting.html) on my changes locally.
- [ok] I succesfully ran [unit tests](https://6.docs.plone.org/volto/contributing/testing.html) on my changes locally.
- [ok] I succesfully ran [acceptance tests](https://6.docs.plone.org/volto/contributing/acceptance-tests.html) on my changes locally.
- [ok] If needed, I added new tests for my changes.
- [ok] If needed, I added [documentation](https://6.docs.plone.org/volto/contributing/documentation.html#narrative-documentation) for my changes, either in the Storybook or narrative documentation.
- [ok] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

If your pull request closes an open issue, include the exact text below, immediately followed by the issue number. When your pull request gets merged, then that issue will close automatically.

Pull Request Description
This pull request addresses issue #6577, which involved incorrect Markdown implementation for heading levels. The following changes were made:

Updated the autoformatRules in volto/packages/volto-slate/src/editor/plugins/Markdown/constants.js to align with [CommonMark specifications](https://spec.commonmark.org/0.31.2/#atx-heading).
Modified the autoformat rule for a single # to generate an <h1> tag, ## to generate <h2>, and so on, ensuring consistency with Markdown standards.
Verified that these changes maintain compatibility with existing functionality and do not introduce regressions.


Closes #6577
