### PR TITLE
Fix: a11y - edit page - add block/blocks-chooser

### DIFF
--- a/packages/volto/news/5212.bugfix
+++ b/packages/volto/news/5212.bugfix
@@ -1,0 +1,2 @@
+Fixed accessibility issues in the "Add Block" modal of the Plone editor. Focus now stays inside the modal while navigating.
+@Manas-Kenge

--- a/packages/volto/news/5212.bugfix
+++ b/packages/volto/news/5212.bugfix
@@ -1,2 +1,1 @@
-Fixed accessibility issues in the "Add Block" modal of the Plone editor. Focus now stays inside the modal while navigating.
-@Manas-Kenge
+Fixed accessibility issues in the "Add Block" modal of the editor where focus now stays inside the modal while navigating. @Manas-Kenge

--- a/packages/volto/src/components/manage/BlockChooser/BlockChooser.test.jsx
+++ b/packages/volto/src/components/manage/BlockChooser/BlockChooser.test.jsx
@@ -156,7 +156,11 @@ describe('BlocksChooser', () => {
     );
     expect(container.firstChild).not.toHaveTextContent('Video');
     // There are 2 because the others are aria-hidden="true"
-    expect(screen.getAllByRole('button')).toHaveLength(2);
+    const blockButtons = screen
+      .getAllByRole('button')
+      .filter((button) => button.classList.contains('basic'));
+
+    expect(blockButtons).toHaveLength(2);
   });
   it('allowedBlocks bypasses showRestricted', () => {
     config.blocks.blocksConfig.listing.restricted = true;
@@ -184,7 +188,10 @@ describe('BlocksChooser', () => {
     );
     expect(container.firstChild).not.toHaveTextContent('Video');
     // There's 1 because the others are aria-hidden="true"
-    expect(screen.getAllByRole('button')).toHaveLength(1);
+    const blockButtons = screen
+      .getAllByRole('button')
+      .filter((button) => button.classList.contains('basic'));
+    expect(blockButtons).toHaveLength(1);
     expect(container.firstChild).toHaveTextContent('Title');
   });
   it('uses custom blocksConfig test', () => {

--- a/packages/volto/src/components/manage/BlockChooser/BlockChooserButton.jsx
+++ b/packages/volto/src/components/manage/BlockChooser/BlockChooserButton.jsx
@@ -27,6 +27,13 @@ export const ButtonComponent = (props) => {
     onShowBlockChooser,
   } = props;
 
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter' || e.key === ' ' || e.key === 'Spacebar') {
+      e.preventDefault();
+      onShowBlockChooser();
+    }
+  };
+
   return (
     <Button
       icon
@@ -37,7 +44,10 @@ export const ButtonComponent = (props) => {
         e.stopPropagation();
         onShowBlockChooser();
       }}
+      onKeyDown={handleKeyDown}
       className={className}
+      aria-haspopup="dialog"
+      aria-expanded={false}
     >
       <Icon name={addSVG} className={className} size={size} />
     </Button>
@@ -61,7 +71,7 @@ const BlockChooserButton = (props) => {
 
   const { disableNewBlocks } = data;
   const [addNewBlockOpened, setAddNewBlockOpened] = React.useState(false);
-
+  const triggerButtonRef = React.useRef(null);
   const blockChooserRef = React.useRef();
 
   const handleClickOutside = React.useCallback((e) => {
@@ -73,6 +83,11 @@ const BlockChooserButton = (props) => {
     setAddNewBlockOpened(false);
   }, []);
 
+  const handleClose = React.useCallback(() => {
+    setAddNewBlockOpened(false);
+    triggerButtonRef.current?.focus();
+  }, []);
+
   const Component = buttonComponent || ButtonComponent;
 
   React.useEffect(() => {
@@ -81,6 +96,17 @@ const BlockChooserButton = (props) => {
       document.removeEventListener('mousedown', handleClickOutside, false);
     };
   }, [handleClickOutside]);
+
+  React.useEffect(() => {
+    const handleKeyDown = (e) => {
+      if (e.key === 'Escape' && addNewBlockOpened) {
+        handleClose();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [addNewBlockOpened, handleClose]);
 
   const [referenceElement, setReferenceElement] = React.useState(null);
   const [popperElement, setPopperElement] = React.useState(null);
@@ -109,10 +135,18 @@ const BlockChooserButton = (props) => {
       {!disableNewBlocks &&
         (config.experimental.addBlockButton.enabled ||
           !blockHasValue(data)) && (
-          <Ref innerRef={setReferenceElement}>
+          <Ref
+            innerRef={(node) => {
+              setReferenceElement(node);
+              if (node) {
+                triggerButtonRef.current = node;
+              }
+            }}
+          >
             <Component
               {...props}
               onShowBlockChooser={() => setAddNewBlockOpened(true)}
+              aria-expanded={addNewBlockOpened}
             />
           </Ref>
         )}
@@ -122,12 +156,14 @@ const BlockChooserButton = (props) => {
             ref={setPopperElement}
             style={styles.popper}
             {...attributes.popper}
+            role="dialog"
+            aria-modal="true"
           >
             <BlockChooser
               onMutateBlock={
                 onMutateBlock
                   ? (id, value) => {
-                      setAddNewBlockOpened(false);
+                      handleClose();
                       onMutateBlock(id, value);
                     }
                   : null
@@ -135,11 +171,12 @@ const BlockChooserButton = (props) => {
               onInsertBlock={
                 onInsertBlock
                   ? (id, value) => {
-                      setAddNewBlockOpened(false);
+                      handleClose();
                       onInsertBlock(id, value);
                     }
                   : null
               }
+              initialFocus="search"
               currentBlock={block}
               allowedBlocks={allowedBlocks}
               blocksConfig={blocksConfig}
@@ -148,6 +185,7 @@ const BlockChooserButton = (props) => {
               ref={blockChooserRef}
               navRoot={navRoot}
               contentType={contentType}
+              onClose={handleClose}
             />
           </div>,
           document.body,

--- a/packages/volto/src/components/manage/BlockChooser/BlockChooserSearch.jsx
+++ b/packages/volto/src/components/manage/BlockChooser/BlockChooserSearch.jsx
@@ -19,8 +19,23 @@ const BlockChooserSearch = ({ onChange, searchValue }) => {
   const intl = useIntl();
   const searchInput = useRef(null);
 
+  React.useEffect(() => {
+    searchInput.current?.focus();
+  }, []);
+
+  const handleClearSearch = () => {
+    onChange('');
+    searchInput.current.focus();
+  };
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Escape') {
+      handleClearSearch();
+    }
+  };
+
   return (
-    <Form style={{ padding: '0.5em' }}>
+    <Form style={{ padding: '0.5em' }} role="search">
       <Form.Field
         className="searchbox"
         style={{ borderLeft: 0, height: '2em', padding: 0 }}
@@ -29,21 +44,27 @@ const BlockChooserSearch = ({ onChange, searchValue }) => {
         <Input
           aria-label={intl.formatMessage(messages.search)}
           onChange={(event) => onChange(event.target.value)}
+          onKeyDown={handleKeyDown}
           name="SearchableText"
           value={searchValue}
           autoComplete="off"
           placeholder={intl.formatMessage(messages.search)}
           title={intl.formatMessage(messages.search)}
           ref={searchInput}
+          autofocus
         />
         {searchValue && (
           <Button
             className="clear-search-button"
             aria-label={intl.formatMessage(messages.clear)}
-            onClick={() => {
-              onChange('');
-              searchInput.current.focus();
+            onClick={handleClearSearch}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                handleClearSearch();
+              }
             }}
+            type="button"
           >
             <Icon name={clearSVG} size="18px" />
           </Button>

--- a/packages/volto/src/components/manage/BlockChooser/__snapshots__/BlockChooser.test.jsx.snap
+++ b/packages/volto/src/components/manage/BlockChooser/__snapshots__/BlockChooser.test.jsx.snap
@@ -3,10 +3,13 @@
 exports[`BlocksChooser Fallback BlockChooser component onMutateBlock 1`] = `
 <div>
   <div
+    aria-label="Block chooser"
     class="blocks-chooser"
+    role="dialog"
   >
     <form
       class="ui form"
+      role="search"
       style="padding: 0.5em;"
     >
       <div
@@ -32,8 +35,12 @@ exports[`BlocksChooser Fallback BlockChooser component onMutateBlock 1`] = `
       class="accordion ui fluid styled form"
     >
       <div
+        aria-controls="section-mostUsed"
+        aria-expanded="true"
         aria-label="Fold Most used blocks"
         class="active title"
+        role="button"
+        tabindex="0"
       >
         Most used
         <div
@@ -48,7 +55,10 @@ exports[`BlocksChooser Fallback BlockChooser component onMutateBlock 1`] = `
         </div>
       </div>
       <div
+        aria-labelledby="header-mostUsed"
         class="content active mostUsed"
+        id="section-mostUsed"
+        role="region"
       >
         <div
           aria-hidden="false"
@@ -59,50 +69,67 @@ exports[`BlocksChooser Fallback BlockChooser component onMutateBlock 1`] = `
             style="transition: opacity 500ms ease 0ms;"
           >
             <div
-              class="ui buttons"
+              role="list"
             >
-              <button
-                class="ui basic icon button image"
+              <div
+                class="ui buttons"
               >
-                <svg
-                  class="icon"
-                  style="height: 36px; width: auto; fill: currentColor;"
-                />
-                Image
-              </button>
-            </div>
-            <div
-              class="ui buttons"
-            >
-              <button
-                class="ui basic icon button listing"
+                <button
+                  aria-label="Image"
+                  class="ui basic icon button image"
+                  role="button"
+                  tabindex="0"
+                >
+                  <svg
+                    class="icon"
+                    style="height: 36px; width: auto; fill: currentColor;"
+                  />
+                  Image
+                </button>
+              </div>
+              <div
+                class="ui buttons"
               >
-                <svg
-                  class="icon"
-                  style="height: 36px; width: auto; fill: currentColor;"
-                />
-                Listing
-              </button>
-            </div>
-            <div
-              class="ui buttons"
-            >
-              <button
-                class="ui basic icon button video"
+                <button
+                  aria-label="Listing"
+                  class="ui basic icon button listing"
+                  role="button"
+                  tabindex="0"
+                >
+                  <svg
+                    class="icon"
+                    style="height: 36px; width: auto; fill: currentColor;"
+                  />
+                  Listing
+                </button>
+              </div>
+              <div
+                class="ui buttons"
               >
-                <svg
-                  class="icon"
-                  style="height: 36px; width: auto; fill: currentColor;"
-                />
-                Video
-              </button>
+                <button
+                  aria-label="Video"
+                  class="ui basic icon button video"
+                  role="button"
+                  tabindex="0"
+                >
+                  <svg
+                    class="icon"
+                    style="height: 36px; width: auto; fill: currentColor;"
+                  />
+                  Video
+                </button>
+              </div>
             </div>
           </div>
         </div>
       </div>
       <div
+        aria-controls="section-text"
+        aria-expanded="false"
         aria-label="Unfold Text blocks"
         class="title"
+        role="button"
+        tabindex="0"
       >
         Text
         <div
@@ -117,7 +144,10 @@ exports[`BlocksChooser Fallback BlockChooser component onMutateBlock 1`] = `
         </div>
       </div>
       <div
+        aria-labelledby="header-text"
         class="content text"
+        id="section-text"
+        role="region"
       >
         <div
           aria-hidden="true"
@@ -128,24 +158,35 @@ exports[`BlocksChooser Fallback BlockChooser component onMutateBlock 1`] = `
             style="transition: opacity 500ms ease 0ms; opacity: 0; display: none;"
           >
             <div
-              class="ui buttons"
+              role="list"
             >
-              <button
-                class="ui basic icon button text"
+              <div
+                class="ui buttons"
               >
-                <svg
-                  class="icon"
-                  style="height: 36px; width: auto; fill: currentColor;"
-                />
-                Text
-              </button>
+                <button
+                  aria-label="Text"
+                  class="ui basic icon button text"
+                  role="button"
+                  tabindex="0"
+                >
+                  <svg
+                    class="icon"
+                    style="height: 36px; width: auto; fill: currentColor;"
+                  />
+                  Text
+                </button>
+              </div>
             </div>
           </div>
         </div>
       </div>
       <div
+        aria-controls="section-media"
+        aria-expanded="false"
         aria-label="Unfold Media blocks"
         class="title"
+        role="button"
+        tabindex="0"
       >
         Media
         <div
@@ -160,7 +201,10 @@ exports[`BlocksChooser Fallback BlockChooser component onMutateBlock 1`] = `
         </div>
       </div>
       <div
+        aria-labelledby="header-media"
         class="content media"
+        id="section-media"
+        role="region"
       >
         <div
           aria-hidden="true"
@@ -171,50 +215,67 @@ exports[`BlocksChooser Fallback BlockChooser component onMutateBlock 1`] = `
             style="transition: opacity 500ms ease 0ms; opacity: 0; display: none;"
           >
             <div
-              class="ui buttons"
+              role="list"
             >
-              <button
-                class="ui basic icon button image"
+              <div
+                class="ui buttons"
               >
-                <svg
-                  class="icon"
-                  style="height: 36px; width: auto; fill: currentColor;"
-                />
-                Image
-              </button>
-            </div>
-            <div
-              class="ui buttons"
-            >
-              <button
-                class="ui basic icon button leadimage"
+                <button
+                  aria-label="Image"
+                  class="ui basic icon button image"
+                  role="button"
+                  tabindex="0"
+                >
+                  <svg
+                    class="icon"
+                    style="height: 36px; width: auto; fill: currentColor;"
+                  />
+                  Image
+                </button>
+              </div>
+              <div
+                class="ui buttons"
               >
-                <svg
-                  class="icon"
-                  style="height: 36px; width: auto; fill: currentColor;"
-                />
-                Lead Image Field
-              </button>
-            </div>
-            <div
-              class="ui buttons"
-            >
-              <button
-                class="ui basic icon button video"
+                <button
+                  aria-label="Lead Image Field"
+                  class="ui basic icon button leadimage"
+                  role="button"
+                  tabindex="0"
+                >
+                  <svg
+                    class="icon"
+                    style="height: 36px; width: auto; fill: currentColor;"
+                  />
+                  Lead Image Field
+                </button>
+              </div>
+              <div
+                class="ui buttons"
               >
-                <svg
-                  class="icon"
-                  style="height: 36px; width: auto; fill: currentColor;"
-                />
-                Video
-              </button>
+                <button
+                  aria-label="Video"
+                  class="ui basic icon button video"
+                  role="button"
+                  tabindex="0"
+                >
+                  <svg
+                    class="icon"
+                    style="height: 36px; width: auto; fill: currentColor;"
+                  />
+                  Video
+                </button>
+              </div>
             </div>
           </div>
         </div>
       </div>
       <div
+        aria-controls="section-common"
+        aria-expanded="false"
         aria-label="Unfold Common blocks"
         class="title"
+        role="button"
+        tabindex="0"
       >
         Common
         <div
@@ -229,7 +290,10 @@ exports[`BlocksChooser Fallback BlockChooser component onMutateBlock 1`] = `
         </div>
       </div>
       <div
+        aria-labelledby="header-common"
         class="content common"
+        id="section-common"
+        role="region"
       >
         <div
           aria-hidden="true"
@@ -240,82 +304,104 @@ exports[`BlocksChooser Fallback BlockChooser component onMutateBlock 1`] = `
             style="transition: opacity 500ms ease 0ms; opacity: 0; display: none;"
           >
             <div
-              class="ui buttons"
+              role="list"
             >
-              <button
-                class="ui basic icon button listing"
+              <div
+                class="ui buttons"
               >
-                <svg
-                  class="icon"
-                  style="height: 36px; width: auto; fill: currentColor;"
-                />
-                Listing
-              </button>
-            </div>
-            <div
-              class="ui buttons"
-            >
-              <button
-                class="ui basic icon button toc"
+                <button
+                  aria-label="Listing"
+                  class="ui basic icon button listing"
+                  role="button"
+                  tabindex="0"
+                >
+                  <svg
+                    class="icon"
+                    style="height: 36px; width: auto; fill: currentColor;"
+                  />
+                  Listing
+                </button>
+              </div>
+              <div
+                class="ui buttons"
               >
-                <svg
-                  class="icon"
-                  style="height: 36px; width: auto; fill: currentColor;"
-                />
-                Table of Contents
-              </button>
-            </div>
-            <div
-              class="ui buttons"
-            >
-              <button
-                class="ui basic icon button hero"
+                <button
+                  aria-label="Table of Contents"
+                  class="ui basic icon button toc"
+                  role="button"
+                  tabindex="0"
+                >
+                  <svg
+                    class="icon"
+                    style="height: 36px; width: auto; fill: currentColor;"
+                  />
+                  Table of Contents
+                </button>
+              </div>
+              <div
+                class="ui buttons"
               >
-                <svg
-                  class="icon"
-                  style="height: 36px; width: auto; fill: currentColor;"
-                />
-                Hero
-              </button>
-            </div>
-            <div
-              class="ui buttons"
-            >
-              <button
-                class="ui basic icon button maps"
+                <button
+                  aria-label="Hero"
+                  class="ui basic icon button hero"
+                  role="button"
+                  tabindex="0"
+                >
+                  <svg
+                    class="icon"
+                    style="height: 36px; width: auto; fill: currentColor;"
+                  />
+                  Hero
+                </button>
+              </div>
+              <div
+                class="ui buttons"
               >
-                <svg
-                  class="icon"
-                  style="height: 36px; width: auto; fill: currentColor;"
-                />
-                Maps
-              </button>
-            </div>
-            <div
-              class="ui buttons"
-            >
-              <button
-                class="ui basic icon button html"
+                <button
+                  aria-label="Maps"
+                  class="ui basic icon button maps"
+                  role="button"
+                  tabindex="0"
+                >
+                  <svg
+                    class="icon"
+                    style="height: 36px; width: auto; fill: currentColor;"
+                  />
+                  Maps
+                </button>
+              </div>
+              <div
+                class="ui buttons"
               >
-                <svg
-                  class="icon"
-                  style="height: 36px; width: auto; fill: currentColor;"
-                />
-                HTML
-              </button>
-            </div>
-            <div
-              class="ui buttons"
-            >
-              <button
-                class="ui basic icon button table"
+                <button
+                  aria-label="HTML"
+                  class="ui basic icon button html"
+                  role="button"
+                  tabindex="0"
+                >
+                  <svg
+                    class="icon"
+                    style="height: 36px; width: auto; fill: currentColor;"
+                  />
+                  HTML
+                </button>
+              </div>
+              <div
+                class="ui buttons"
               >
-                <svg
-                  class="icon"
-                  style="height: 36px; width: auto; fill: currentColor;"
-                />
-                Table
-              </button>
+                <button
+                  aria-label="Table"
+                  class="ui basic icon button table"
+                  role="button"
+                  tabindex="0"
+                >
+                  <svg
+                    class="icon"
+                    style="height: 36px; width: auto; fill: currentColor;"
+                  />
+                  Table
+                </button>
+              </div>
             </div>
           </div>
         </div>
@@ -328,10 +414,13 @@ exports[`BlocksChooser Fallback BlockChooser component onMutateBlock 1`] = `
 exports[`BlocksChooser renders a BlockChooser component 1`] = `
 <div>
   <div
+    aria-label="Block chooser"
     class="blocks-chooser"
+    role="dialog"
   >
     <form
       class="ui form"
+      role="search"
       style="padding: 0.5em;"
     >
       <div
@@ -357,8 +446,12 @@ exports[`BlocksChooser renders a BlockChooser component 1`] = `
       class="accordion ui fluid styled form"
     >
       <div
+        aria-controls="section-mostUsed"
+        aria-expanded="true"
         aria-label="Fold Most used blocks"
         class="active title"
+        role="button"
+        tabindex="0"
       >
         Most used
         <div
@@ -373,7 +466,10 @@ exports[`BlocksChooser renders a BlockChooser component 1`] = `
         </div>
       </div>
       <div
+        aria-labelledby="header-mostUsed"
         class="content active mostUsed"
+        id="section-mostUsed"
+        role="region"
       >
         <div
           aria-hidden="false"
@@ -384,50 +480,67 @@ exports[`BlocksChooser renders a BlockChooser component 1`] = `
             style="transition: opacity 500ms ease 0ms;"
           >
             <div
-              class="ui buttons"
+              role="list"
             >
-              <button
-                class="ui basic icon button image"
+              <div
+                class="ui buttons"
               >
-                <svg
-                  class="icon"
-                  style="height: 36px; width: auto; fill: currentColor;"
-                />
-                Image
-              </button>
-            </div>
-            <div
-              class="ui buttons"
-            >
-              <button
-                class="ui basic icon button listing"
+                <button
+                  aria-label="Image"
+                  class="ui basic icon button image"
+                  role="button"
+                  tabindex="0"
+                >
+                  <svg
+                    class="icon"
+                    style="height: 36px; width: auto; fill: currentColor;"
+                  />
+                  Image
+                </button>
+              </div>
+              <div
+                class="ui buttons"
               >
-                <svg
-                  class="icon"
-                  style="height: 36px; width: auto; fill: currentColor;"
-                />
-                Listing
-              </button>
-            </div>
-            <div
-              class="ui buttons"
-            >
-              <button
-                class="ui basic icon button video"
+                <button
+                  aria-label="Listing"
+                  class="ui basic icon button listing"
+                  role="button"
+                  tabindex="0"
+                >
+                  <svg
+                    class="icon"
+                    style="height: 36px; width: auto; fill: currentColor;"
+                  />
+                  Listing
+                </button>
+              </div>
+              <div
+                class="ui buttons"
               >
-                <svg
-                  class="icon"
-                  style="height: 36px; width: auto; fill: currentColor;"
-                />
-                Video
-              </button>
+                <button
+                  aria-label="Video"
+                  class="ui basic icon button video"
+                  role="button"
+                  tabindex="0"
+                >
+                  <svg
+                    class="icon"
+                    style="height: 36px; width: auto; fill: currentColor;"
+                  />
+                  Video
+                </button>
+              </div>
             </div>
           </div>
         </div>
       </div>
       <div
+        aria-controls="section-text"
+        aria-expanded="false"
         aria-label="Unfold Text blocks"
         class="title"
+        role="button"
+        tabindex="0"
       >
         Text
         <div
@@ -442,7 +555,10 @@ exports[`BlocksChooser renders a BlockChooser component 1`] = `
         </div>
       </div>
       <div
+        aria-labelledby="header-text"
         class="content text"
+        id="section-text"
+        role="region"
       >
         <div
           aria-hidden="true"
@@ -453,24 +569,35 @@ exports[`BlocksChooser renders a BlockChooser component 1`] = `
             style="transition: opacity 500ms ease 0ms; opacity: 0; display: none;"
           >
             <div
-              class="ui buttons"
+              role="list"
             >
-              <button
-                class="ui basic icon button text"
+              <div
+                class="ui buttons"
               >
-                <svg
-                  class="icon"
-                  style="height: 36px; width: auto; fill: currentColor;"
-                />
-                Text
-              </button>
+                <button
+                  aria-label="Text"
+                  class="ui basic icon button text"
+                  role="button"
+                  tabindex="0"
+                >
+                  <svg
+                    class="icon"
+                    style="height: 36px; width: auto; fill: currentColor;"
+                  />
+                  Text
+                </button>
+              </div>
             </div>
           </div>
         </div>
       </div>
       <div
+        aria-controls="section-media"
+        aria-expanded="false"
         aria-label="Unfold Media blocks"
         class="title"
+        role="button"
+        tabindex="0"
       >
         Media
         <div
@@ -485,7 +612,10 @@ exports[`BlocksChooser renders a BlockChooser component 1`] = `
         </div>
       </div>
       <div
+        aria-labelledby="header-media"
         class="content media"
+        id="section-media"
+        role="region"
       >
         <div
           aria-hidden="true"
@@ -496,50 +626,67 @@ exports[`BlocksChooser renders a BlockChooser component 1`] = `
             style="transition: opacity 500ms ease 0ms; opacity: 0; display: none;"
           >
             <div
-              class="ui buttons"
+              role="list"
             >
-              <button
-                class="ui basic icon button image"
+              <div
+                class="ui buttons"
               >
-                <svg
-                  class="icon"
-                  style="height: 36px; width: auto; fill: currentColor;"
-                />
-                Image
-              </button>
-            </div>
-            <div
-              class="ui buttons"
-            >
-              <button
-                class="ui basic icon button leadimage"
+                <button
+                  aria-label="Image"
+                  class="ui basic icon button image"
+                  role="button"
+                  tabindex="0"
+                >
+                  <svg
+                    class="icon"
+                    style="height: 36px; width: auto; fill: currentColor;"
+                  />
+                  Image
+                </button>
+              </div>
+              <div
+                class="ui buttons"
               >
-                <svg
-                  class="icon"
-                  style="height: 36px; width: auto; fill: currentColor;"
-                />
-                Lead Image Field
-              </button>
-            </div>
-            <div
-              class="ui buttons"
-            >
-              <button
-                class="ui basic icon button video"
+                <button
+                  aria-label="Lead Image Field"
+                  class="ui basic icon button leadimage"
+                  role="button"
+                  tabindex="0"
+                >
+                  <svg
+                    class="icon"
+                    style="height: 36px; width: auto; fill: currentColor;"
+                  />
+                  Lead Image Field
+                </button>
+              </div>
+              <div
+                class="ui buttons"
               >
-                <svg
-                  class="icon"
-                  style="height: 36px; width: auto; fill: currentColor;"
-                />
-                Video
-              </button>
+                <button
+                  aria-label="Video"
+                  class="ui basic icon button video"
+                  role="button"
+                  tabindex="0"
+                >
+                  <svg
+                    class="icon"
+                    style="height: 36px; width: auto; fill: currentColor;"
+                  />
+                  Video
+                </button>
+              </div>
             </div>
           </div>
         </div>
       </div>
       <div
+        aria-controls="section-common"
+        aria-expanded="false"
         aria-label="Unfold Common blocks"
         class="title"
+        role="button"
+        tabindex="0"
       >
         Common
         <div
@@ -554,7 +701,10 @@ exports[`BlocksChooser renders a BlockChooser component 1`] = `
         </div>
       </div>
       <div
+        aria-labelledby="header-common"
         class="content common"
+        id="section-common"
+        role="region"
       >
         <div
           aria-hidden="true"
@@ -565,82 +715,104 @@ exports[`BlocksChooser renders a BlockChooser component 1`] = `
             style="transition: opacity 500ms ease 0ms; opacity: 0; display: none;"
           >
             <div
-              class="ui buttons"
+              role="list"
             >
-              <button
-                class="ui basic icon button listing"
+              <div
+                class="ui buttons"
               >
-                <svg
-                  class="icon"
-                  style="height: 36px; width: auto; fill: currentColor;"
-                />
-                Listing
-              </button>
-            </div>
-            <div
-              class="ui buttons"
-            >
-              <button
-                class="ui basic icon button toc"
+                <button
+                  aria-label="Listing"
+                  class="ui basic icon button listing"
+                  role="button"
+                  tabindex="0"
+                >
+                  <svg
+                    class="icon"
+                    style="height: 36px; width: auto; fill: currentColor;"
+                  />
+                  Listing
+                </button>
+              </div>
+              <div
+                class="ui buttons"
               >
-                <svg
-                  class="icon"
-                  style="height: 36px; width: auto; fill: currentColor;"
-                />
-                Table of Contents
-              </button>
-            </div>
-            <div
-              class="ui buttons"
-            >
-              <button
-                class="ui basic icon button hero"
+                <button
+                  aria-label="Table of Contents"
+                  class="ui basic icon button toc"
+                  role="button"
+                  tabindex="0"
+                >
+                  <svg
+                    class="icon"
+                    style="height: 36px; width: auto; fill: currentColor;"
+                  />
+                  Table of Contents
+                </button>
+              </div>
+              <div
+                class="ui buttons"
               >
-                <svg
-                  class="icon"
-                  style="height: 36px; width: auto; fill: currentColor;"
-                />
-                Hero
-              </button>
-            </div>
-            <div
-              class="ui buttons"
-            >
-              <button
-                class="ui basic icon button maps"
+                <button
+                  aria-label="Hero"
+                  class="ui basic icon button hero"
+                  role="button"
+                  tabindex="0"
+                >
+                  <svg
+                    class="icon"
+                    style="height: 36px; width: auto; fill: currentColor;"
+                  />
+                  Hero
+                </button>
+              </div>
+              <div
+                class="ui buttons"
               >
-                <svg
-                  class="icon"
-                  style="height: 36px; width: auto; fill: currentColor;"
-                />
-                Maps
-              </button>
-            </div>
-            <div
-              class="ui buttons"
-            >
-              <button
-                class="ui basic icon button html"
+                <button
+                  aria-label="Maps"
+                  class="ui basic icon button maps"
+                  role="button"
+                  tabindex="0"
+                >
+                  <svg
+                    class="icon"
+                    style="height: 36px; width: auto; fill: currentColor;"
+                  />
+                  Maps
+                </button>
+              </div>
+              <div
+                class="ui buttons"
               >
-                <svg
-                  class="icon"
-                  style="height: 36px; width: auto; fill: currentColor;"
-                />
-                HTML
-              </button>
-            </div>
-            <div
-              class="ui buttons"
-            >
-              <button
-                class="ui basic icon button table"
+                <button
+                  aria-label="HTML"
+                  class="ui basic icon button html"
+                  role="button"
+                  tabindex="0"
+                >
+                  <svg
+                    class="icon"
+                    style="height: 36px; width: auto; fill: currentColor;"
+                  />
+                  HTML
+                </button>
+              </div>
+              <div
+                class="ui buttons"
               >
-                <svg
-                  class="icon"
-                  style="height: 36px; width: auto; fill: currentColor;"
-                />
-                Table
-              </button>
+                <button
+                  aria-label="Table"
+                  class="ui basic icon button table"
+                  role="button"
+                  tabindex="0"
+                >
+                  <svg
+                    class="icon"
+                    style="height: 36px; width: auto; fill: currentColor;"
+                  />
+                  Table
+                </button>
+              </div>
             </div>
           </div>
         </div>

--- a/packages/volto/src/components/manage/BlockChooser/__snapshots__/BlockChooserButton.test.jsx.snap
+++ b/packages/volto/src/components/manage/BlockChooser/__snapshots__/BlockChooserButton.test.jsx.snap
@@ -13,6 +13,8 @@ exports[`Can render a custom button 1`] = `
 exports[`Renders a button 1`] = `
 <div>
   <button
+    aria-expanded="false"
+    aria-haspopup="dialog"
     class="ui basic icon button block-add-button"
     title="Add block"
   >

--- a/packages/volto/src/components/manage/BlockChooser/__snapshots__/BlockChooserSearch.test.jsx.snap
+++ b/packages/volto/src/components/manage/BlockChooser/__snapshots__/BlockChooserSearch.test.jsx.snap
@@ -4,6 +4,7 @@ exports[`BlocksChooserSearch renders a BlockChooserSearch component 1`] = `
 <div>
   <form
     class="ui form"
+    role="search"
     style="padding: 0.5em;"
   >
     <div


### PR DESCRIPTION
- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't other open [pull requests](https://github.com/plone/volto/pulls) for the same change.
- [x] I followed the guidelines in [Contributing to Volto](https://6.docs.plone.org/volto/contributing/index.html).
- [x] I succesfully ran [code linting checks](https://6.docs.plone.org/volto/contributing/linting.html) on my changes locally.
- [x] I succesfully ran [unit tests](https://6.docs.plone.org/volto/contributing/testing.html) on my changes locally.
- [ ] I succesfully ran [acceptance tests](https://6.docs.plone.org/volto/contributing/acceptance-tests.html) on my changes locally.
- [ ] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/volto/contributing/documentation.html#narrative-documentation) for my changes, either in the Storybook or narrative documentation.
- [x] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

Closes #5212 

This pull request fixes accessibility in the "Add Block" modal. Focus now stays inside the modal, pressing Enter expands the accordion and moves focus inside, while ESC closes it and returns focus to the header.
