### PR TITLE
Route registry

### DIFF
--- a/packages/coresandbox/src/index.ts
+++ b/packages/coresandbox/src/index.ts
@@ -236,11 +236,16 @@ const applyConfig = (config: ConfigType) => {
   });
 
   config.registerRoute({
+    type: 'route',
     path: '/hello',
     file: 'src/components/Views/NewsAndEvents/asd.tsx',
-    {index: true},
     children: [],
+    options: {
+      id: 'hello',
+      index: true,
+    },
   });
+
   return config;
 };
 

--- a/packages/coresandbox/src/index.ts
+++ b/packages/coresandbox/src/index.ts
@@ -239,7 +239,6 @@ const applyConfig = (config: ConfigType) => {
     type: 'route',
     path: '/hello',
     file: 'src/components/Views/NewsAndEvents/asd.tsx',
-    children: [],
     options: {
       id: 'hello',
       index: true,

--- a/packages/coresandbox/src/index.ts
+++ b/packages/coresandbox/src/index.ts
@@ -235,6 +235,12 @@ const applyConfig = (config: ConfigType) => {
     predicates: [ContentTypeCondition(['Document']), RouteCondition('/hello')],
   });
 
+  config.registerRoute({
+    path: '/hello',
+    file: 'src/components/Views/NewsAndEvents/asd.tsx',
+    {index: true},
+    children: [],
+  });
   return config;
 };
 

--- a/packages/registry/news/6600.feature
+++ b/packages/registry/news/6600.feature
@@ -1,0 +1,1 @@
+Added route registry. @sneridagh

--- a/packages/registry/src/index.ts
+++ b/packages/registry/src/index.ts
@@ -13,6 +13,8 @@ import type {
   UtilitiesConfig,
   ViewsConfig,
   WidgetsConfig,
+  ReactRouterRouteEntry,
+  AddonRoutesEntry,
 } from '@plone/types';
 
 export type ConfigData = {
@@ -22,6 +24,7 @@ export type ConfigData = {
   widgets: WidgetsConfig | Record<string, never>;
   addonReducers?: AddonReducersConfig;
   addonRoutes?: AddonRoutesConfig;
+  routes?: Array<ReactRouterRouteEntry>;
   slots: SlotsConfig | Record<string, never>;
   components: ComponentsConfig | Record<string, never>;
   utilities: UtilitiesConfig | Record<string, never>;
@@ -124,6 +127,14 @@ class Config {
 
   set addonRoutes(addonRoutes) {
     this._data.addonRoutes = addonRoutes;
+  }
+
+  get routes() {
+    return this._data.routes;
+  }
+
+  set routes(routes) {
+    this._data.routes = routes;
   }
 
   get slots() {
@@ -493,6 +504,14 @@ class Config {
     );
 
     return utilities;
+  }
+
+  registerRoute(options: ReactRouterRouteEntry) {
+    console.log('component', options.file);
+
+    const route = this._data.routes || [];
+    route.push(options);
+    this._data.routes = route;
   }
 }
 

--- a/packages/registry/src/index.ts
+++ b/packages/registry/src/index.ts
@@ -14,7 +14,6 @@ import type {
   ViewsConfig,
   WidgetsConfig,
   ReactRouterRouteEntry,
-  AddonRoutesEntry,
 } from '@plone/types';
 
 export type ConfigData = {
@@ -507,8 +506,6 @@ class Config {
   }
 
   registerRoute(options: ReactRouterRouteEntry) {
-    console.log('component', options.file);
-
     const route = this._data.routes || [];
     route.push(options);
     this._data.routes = route;

--- a/packages/registry/src/registry.test.tsx
+++ b/packages/registry/src/registry.test.tsx
@@ -1095,6 +1095,24 @@ describe('Routes registry', () => {
     ]);
   });
 
+  it('registers a simple route with options', () => {
+    config.registerRoute({
+      type: 'route',
+      path: '/login',
+      file: 'login.tsx',
+      options: { id: 'login', caseSensitive: true },
+    });
+
+    expect(config.routes).toEqual([
+      {
+        type: 'route',
+        path: '/login',
+        file: 'login.tsx',
+        options: { id: 'login', caseSensitive: true },
+      },
+    ]);
+  });
+
   it('registers a nested route', () => {
     config.registerRoute({
       type: 'route',

--- a/packages/registry/src/registry.test.tsx
+++ b/packages/registry/src/registry.test.tsx
@@ -1073,3 +1073,16 @@ describe('Utilities registry', () => {
     ).toEqual([]);
   });
 });
+
+describe('Routes registry', () => {
+  afterEach(() => {
+    config.set('routes', []);
+  });
+
+  it.only('registers a simple route', () => {
+    config.registerRoute({
+      path: '/login',
+      file: 'login.tsx',
+    });
+  });
+});

--- a/packages/registry/src/registry.test.tsx
+++ b/packages/registry/src/registry.test.tsx
@@ -1079,10 +1079,76 @@ describe('Routes registry', () => {
     config.set('routes', []);
   });
 
-  it.only('registers a simple route', () => {
+  it('registers a simple route', () => {
     config.registerRoute({
+      type: 'route',
       path: '/login',
       file: 'login.tsx',
     });
+
+    expect(config.routes).toEqual([
+      {
+        type: 'route',
+        path: '/login',
+        file: 'login.tsx',
+      },
+    ]);
+  });
+
+  it('registers a nested route', () => {
+    config.registerRoute({
+      type: 'route',
+      path: '/login',
+      file: 'login.tsx',
+      children: [
+        {
+          type: 'route',
+          path: '/login/ok',
+          file: 'ok.tsx',
+        },
+      ],
+    });
+
+    expect(config.routes).toEqual([
+      {
+        type: 'route',
+        path: '/login',
+        file: 'login.tsx',
+        children: [
+          {
+            type: 'route',
+            path: '/login/ok',
+            file: 'ok.tsx',
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('registers a couple of routes', () => {
+    config.registerRoute({
+      type: 'route',
+      path: '/login',
+      file: 'login.tsx',
+    });
+
+    config.registerRoute({
+      type: 'route',
+      path: '/logout',
+      file: 'logout.tsx',
+    });
+
+    expect(config.routes).toEqual([
+      {
+        type: 'route',
+        path: '/login',
+        file: 'login.tsx',
+      },
+      {
+        type: 'route',
+        path: '/logout',
+        file: 'logout.tsx',
+      },
+    ]);
   });
 });

--- a/packages/types/news/6600.feature
+++ b/packages/types/news/6600.feature
@@ -1,0 +1,1 @@
+Added typings for the route registry. @sneridagh

--- a/packages/types/src/config/index.d.ts
+++ b/packages/types/src/config/index.d.ts
@@ -4,7 +4,6 @@ import type { ViewsConfig } from './Views';
 import type { WidgetsConfig } from './Widgets';
 import type { SlotsConfig } from './Slots';
 import type { UtilitiesConfig } from './Utilities';
-import type { RequireAtLeastOne } from './utils';
 
 export type AddonReducersConfig = Record<string, Function>;
 
@@ -20,14 +19,8 @@ export type AddonRoutesEntry = {
   component: React.ComponentType;
 };
 
-interface ReactRouterRouteHelpers {
-  route?: any;
-  index?: any;
-  prefix?: any;
-  layout?: any;
-}
-
 export type ReactRouterRouteEntry = {
+  type: 'route' | 'index' | 'layout' | 'prefix';
   path: string;
   file: string;
   options?: {

--- a/packages/types/src/config/index.d.ts
+++ b/packages/types/src/config/index.d.ts
@@ -4,6 +4,7 @@ import type { ViewsConfig } from './Views';
 import type { WidgetsConfig } from './Widgets';
 import type { SlotsConfig } from './Slots';
 import type { UtilitiesConfig } from './Utilities';
+import type { RequireAtLeastOne } from './utils';
 
 export type AddonReducersConfig = Record<string, Function>;
 
@@ -12,6 +13,30 @@ export type AddonRoutesConfig = {
   exact: boolean;
   component: React.ComponentType;
 }[];
+
+export type AddonRoutesEntry = {
+  path: string;
+  exact: boolean;
+  component: React.ComponentType;
+};
+
+interface ReactRouterRouteHelpers {
+  route?: any;
+  index?: any;
+  prefix?: any;
+  layout?: any;
+}
+
+export type ReactRouterRouteEntry = {
+  path: string;
+  file: string;
+  options?: {
+    id?: string;
+    index?: boolean;
+    caseSensitive?: boolean;
+  };
+  children?: ReactRouterRouteEntry[];
+};
 
 export type ComponentsConfig = Record<
   string,

--- a/packages/types/src/utils.d.ts
+++ b/packages/types/src/utils.d.ts
@@ -2,3 +2,11 @@
  * Get the type of the elements in an array
  */
 export type ArrayElement<A> = A extends readonly (infer T)[] ? T : never;
+
+export type RequireAtLeastOne<T, Keys extends keyof T = keyof T> = Pick<
+  T,
+  Exclude<keyof T, Keys>
+> &
+  {
+    [K in Keys]-?: Required<Pick<T, K>> & Partial<Pick<T, Exclude<Keys, K>>>;
+  }[Keys];


### PR DESCRIPTION
Added `registerRoute` API for the config. 
It allows to add a ReactRouter route to the configuration, that we can process and load later.
Quite simple, it only saves the configuration given a specific object.