### PR TITLE
Use build.commands to disable RTD build on 17.x.x

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,8 +3,7 @@ build:
   os: "ubuntu-22.04"
   tools:
     python: "3.12"
-  jobs:
-    post_checkout:
-      # Cancel the Read the Docs build
-      # https://docs.readthedocs.io/en/stable/build-customization.html#cancel-build-based-on-a-condition
-      - exit 183;
+  commands:
+    # Cancel the Read the Docs build
+    # https://docs.readthedocs.io/en/stable/build-customization.html#cancel-build-based-on-a-condition
+    - exit 183;


### PR DESCRIPTION
This takes care of the Volto RTD build failure, which is an improvement.

I also think that #6617 will prevent pull request preview builds against non-main branches.