### PR TITLE
Fix blurry images (volto17)

### DIFF
--- a/news/6637.bugfix
+++ b/news/6637.bugfix
@@ -1,0 +1,1 @@
+Display the appropriately sized image to eliminate blurring from upsizing smaller images in the `srcSet` generation. @giuliaghisini

--- a/src/components/manage/Blocks/LeadImage/__snapshots__/LeadImageSidebar.test.jsx.snap
+++ b/src/components/manage/Blocks/LeadImage/__snapshots__/LeadImageSidebar.test.jsx.snap
@@ -21,7 +21,7 @@ exports[`renders a Lead Image block Sidebar component 1`] = `
       height={400}
       sizes="188px"
       src="/image.png/@@images/image-1200.png"
-      srcSet="/image.png/@@images/image-400.png 400w"
+      srcSet="/image.png/@@images/image-400.png 400w, /image.png/@@images/image-1200.png 400w"
       width={400}
     />
   </div>

--- a/src/components/theme/Image/Image.jsx
+++ b/src/components/theme/Image/Image.jsx
@@ -54,7 +54,14 @@ export default function Image({
     attrs.className = cx(className, { responsive });
 
     if (!isSvg && image.scales && Object.keys(image.scales).length > 0) {
-      const sortedScales = Object.values(image.scales).sort((a, b) => {
+      const sortedScales = Object.values({
+        ...image.scales,
+        original: {
+          download: `${image.download}`,
+          width: image.width,
+          height: image.height,
+        },
+      }).sort((a, b) => {
         if (a.width > b.width) return 1;
         else if (a.width < b.width) return -1;
         else return 0;

--- a/src/components/theme/Image/__snapshots__/Image.test.jsx.snap
+++ b/src/components/theme/Image/__snapshots__/Image.test.jsx.snap
@@ -7,7 +7,7 @@ exports[`renders an image component from a catalog brain 1`] = `
   fetchpriority="high"
   height={400}
   src="/image/@@images/image.png"
-  srcSet="/image/@@images/image-400.png 400w"
+  srcSet="/image/@@images/image-400.png 400w, /image/@@images/image.png 400w"
   width={400}
 />
 `;
@@ -19,7 +19,7 @@ exports[`renders an image component from a catalog brain using \`preview_image_l
   fetchpriority="high"
   height={400}
   src="/image.png/@@images/image.png"
-  srcSet="/image.png/@@images/image-400.png 400w"
+  srcSet="/image.png/@@images/image-400.png 400w, /image.png/@@images/image.png 400w"
   width={400}
 />
 `;
@@ -40,7 +40,7 @@ exports[`renders an image component with fetchpriority high 1`] = `
   fetchpriority="high"
   height={400}
   src="/image/@@images/image.png"
-  srcSet="/image/@@images/image-400.png 400w"
+  srcSet="/image/@@images/image-400.png 400w, /image/@@images/image.png 400w"
   width={400}
 />
 `;
@@ -53,7 +53,7 @@ exports[`renders an image component with lazy loading 1`] = `
   height={400}
   loading="lazy"
   src="/image/@@images/image.png"
-  srcSet="/image/@@images/image-400.png 400w"
+  srcSet="/image/@@images/image-400.png 400w, /image/@@images/image.png 400w"
   width={400}
 />
 `;
@@ -65,7 +65,7 @@ exports[`renders an image component with responsive class 1`] = `
   fetchpriority="high"
   height={400}
   src="/image/@@images/image-1200.png"
-  srcSet="/image/@@images/image-400.png 400w"
+  srcSet="/image/@@images/image-400.png 400w, /image/@@images/image-1200.png 400w"
   width={400}
 />
 `;


### PR DESCRIPTION
backport for Volto 17 of https://github.com/plone/volto/pull/6634

___________________

If we have for example image size defined in volto images controlpanel as:
<img width="1124" alt="Screenshot 2025-01-30 alle 10 52 19" src="https://github.com/user-attachments/assets/d4c1ad72-bb11-4614-ab62-82aee72af413" />

and so we have scales ... 300x, 400x, 600px

and we have an image with original sizes 587x459, the generated image code and srcSet was: 

`<img src="/prova-news-immagine/test.png/@@images/image-587-0afb5e6bcbb1f1d0c94fc4256f78242f.png" **width="587"** **height="459"** class="responsive" srcset="/prova-news-immagine/test.png/@@images/image-16-a9e4943c736618d13a06af5bd63d5567.png 16w, /prova-news-immagine/test.png/@@images/image-32-22c97716e33946569fe9afa6d96bfd93.png 32w, /prova-news-immagine/test.png/@@images/image-64-ef5dc45106de9cd160b3a7da27f452b9.png 64w, /prova-news-immagine/test.png/@@images/image-128-f2750d92f764c72ea24226b78dff4d1a.png 128w, /prova-news-immagine/test.png/@@images/image-200-39b7501cf4c9616c05a3ddabb5625e10.png 200w, /prova-news-immagine/test.png/@@images/image-250-ed3285259b3706138f12f625ca57832c.png 250w, /prova-news-immagine/test.png/@@images/image-300-cb9508d069320bc8f81a86bfeb3ec6c7.png 300w, /prova-news-immagine/test.png/@@images/image-400-9dca6b745c557de4b30530b129fb64a0.png 400w" loading="lazy" decoding="async" alt="" sizes="100vw">`

where src attribute contains the original image url, but it seems browser ignore it and use the largest image provided by srcSet.

If i create an Image Block with default settings align: center and size: L
the image will results blurried, because it's width and height setted as attributes says that image will have that sizes in page, but srcSet only generates url until 400w (because restapi returned only that scales..), so it uses 400w scale inside a space of 597 and adapt it to that width with the result of blurried image.

The solution to avoid blurry images in this cases, is to add to srcSet the original size, so with this pr, the generated tag image with srcSet is:

`<img src="/prova-news-immagine/test.png/@@images/image-587-0afb5e6bcbb1f1d0c94fc4256f78242f.png" width="587" height="459" class="responsive" srcset="/prova-news-immagine/test.png/@@images/image-16-a9e4943c736618d13a06af5bd63d5567.png 16w, /prova-news-immagine/test.png/@@images/image-32-22c97716e33946569fe9afa6d96bfd93.png 32w, /prova-news-immagine/test.png/@@images/image-64-ef5dc45106de9cd160b3a7da27f452b9.png 64w, /prova-news-immagine/test.png/@@images/image-128-f2750d92f764c72ea24226b78dff4d1a.png 128w, /prova-news-immagine/test.png/@@images/image-200-39b7501cf4c9616c05a3ddabb5625e10.png 200w, /prova-news-immagine/test.png/@@images/image-250-ed3285259b3706138f12f625ca57832c.png 250w, /prova-news-immagine/test.png/@@images/image-300-cb9508d069320bc8f81a86bfeb3ec6c7.png 300w, /prova-news-immagine/test.png/@@images/image-400-9dca6b745c557de4b30530b129fb64a0.png 400w, **/prova-news-immagine/test.png/@@images/image-587-0afb5e6bcbb1f1d0c94fc4256f78242f.png 587w**" loading="lazy" decoding="async" alt="" sizes="100vw">`

and image will not blurried. 


Example before fix: 
<img width="866" alt="Screenshot 2025-01-30 alle 11 05 22" src="https://github.com/user-attachments/assets/b81ce999-c1ce-40bf-bf86-ed82554a229c" />

Example after fix:
<img width="865" alt="Screenshot 2025-01-30 alle 11 04 19" src="https://github.com/user-attachments/assets/c5fd8910-6b0c-4f3e-ad33-4199b6325036" />






<!-- readthedocs-preview plone-registry start -->
----
📚 Documentation preview 📚: https://plone-registry--6637.org.readthedocs.build/

<!-- readthedocs-preview plone-registry end -->