### PR TITLE
Fix the '30 needs: triage' label for bug reports template

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/1_bug_report.md
@@ -2,7 +2,7 @@
 name: '🐞 Bug report'
 about: 'Create a report to help us improve Volto'
 title: ''
-labels: ['01 type: bug', 'needs: triage']
+labels: ['01 type: bug', '30 needs: triage']
 assignees: ''
 ---
 


### PR DESCRIPTION
This does not need a news item because it's a follow up to #6683. I realized it was not correct after #6736 was published.