### PR TITLE
fix: block chooser position in experimental.addBlockButton

### DIFF
--- a/packages/volto/news/6751.bugfix
+++ b/packages/volto/news/6751.bugfix
@@ -1,0 +1,1 @@
+Move the block chooser beneath the block, instead of covering the block and preventing making a choice, when `config.experimental.addBlockButton` is enabled. @giuliaghisini

--- a/packages/volto/news/6751.bugifx
+++ b/packages/volto/news/6751.bugifx
@@ -1,1 +1,0 @@
-Move the block chooser beneath the block, instead of covering the block and preventing making a choice, when `config.experimental.addBlockButton` is enabled. @giuliaghisini

--- a/packages/volto/news/6751.bugifx
+++ b/packages/volto/news/6751.bugifx
@@ -1,1 +1,1 @@
-Fixed block chooser position when config.experimental.addBlockButton is enabled. @giuliaghisini
+Move the block chooser beneath the block, instead of covering the block and preventing making a choice, when `config.experimental.addBlockButton` is enabled. @giuliaghisini

--- a/packages/volto/news/6751.bugifx
+++ b/packages/volto/news/6751.bugifx
@@ -1,0 +1,1 @@
+Fixed block chooser position when config.experimental.addBlockButton is enabled. @giuliaghisini

--- a/packages/volto/src/components/manage/BlockChooser/BlockChooserButton.jsx
+++ b/packages/volto/src/components/manage/BlockChooser/BlockChooserButton.jsx
@@ -98,7 +98,9 @@ const BlockChooserButton = (props) => {
       {
         name: 'flip',
         options: {
-          fallbackPlacements: ['right-end', 'top-start'],
+          fallbackPlacements: config.experimental.addBlockButton.enabled
+            ? ['bottom-start', 'bottom-end']
+            : ['right-end', 'top-start'],
         },
       },
     ],


### PR DESCRIPTION
problem: with 
config.experimental.addBlockButton.enabled=true prop
the placement of block chooser was wrong sometimes and search bar or some portion of block ckooser was not visible and usable (expecially when you have a lot of blocks in a block chooser section). See the problem here:

https://github.com/user-attachments/assets/fb37ec0e-9027-4103-a210-ea6522d73fa9

With this fix, block chooser will placed bottom to the block, without mentioned problems:

https://github.com/user-attachments/assets/3337bdee-5ad1-44ab-81e2-57bc730c2cf2

