### PR TITLE
Fixes intermittent error in cypress "Index Text Block" test

### DIFF
--- a/packages/volto/cypress/support/commands.js
+++ b/packages/volto/cypress/support/commands.js
@@ -730,10 +730,13 @@ Cypress.Commands.add('getSlate', (createNewSlate = false) => {
   cy.getIfExists(
     SLATE_SELECTOR,
     () => {
-      slate = cy.get(SLATE_SELECTOR).last();
+      slate = cy.get(SLATE_SELECTOR).last().should('be.visible');
     },
     () => {
-      slate = cy.get(SLATE_SELECTOR, { timeout: 10000 }).last();
+      slate = cy
+        .get(SLATE_SELECTOR, { timeout: 10000 })
+        .last()
+        .should('be.visible');
     },
   );
   return slate;

--- a/packages/volto/news/6755.internal
+++ b/packages/volto/news/6755.internal
@@ -1,0 +1,1 @@
+Fixes intermittent error in cypress "Index Text Block" test. @wesleybl


### PR DESCRIPTION
Waits for the slate editor to be visible before attempting to insert text.

This fixes the error:

```
  1) Block Indexing Tests
       Index Text Block:
     AssertionError: Timed out retrying after 4000ms: Expected to find content: 'Noam Avram Chomsky' within the element: <div> but never did.
      at Context.eval (webpack://@plone/volto/./cypress/tests/core/blocks/blocks-indexing.js:19:51)
```

See: https://github.com/plone/volto/actions/runs/13332572803/job/37240061119?pr=6754#step:4:445

> [!CAUTION]
The Volto Team has suspended its review of new pull requests from first-time contributors until the [release of Plone 7](https://plone.org/download/release-schedule), which is preliminarily scheduled for the second quarter of 2026.
> [Read details](https://6.docs.plone.org/volto/contributing/index.html).

-----

- [ ] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [ ] I verified there aren't other open [pull requests](https://github.com/plone/volto/pulls) for the same change.
- [ ] I followed the guidelines in [Contributing to Volto](https://6.docs.plone.org/volto/contributing/index.html).
- [ ] I succesfully ran [code linting checks](https://6.docs.plone.org/volto/contributing/linting.html) on my changes locally.
- [ ] I succesfully ran [unit tests](https://6.docs.plone.org/volto/contributing/testing.html) on my changes locally.
- [ ] I succesfully ran [acceptance tests](https://6.docs.plone.org/volto/contributing/acceptance-tests.html) on my changes locally.
- [ ] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/volto/contributing/documentation.html#narrative-documentation) for my changes, either in the Storybook or narrative documentation.
- [ ] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

If your pull request closes an open issue, include the exact text below, immediately followed by the issue number. When your pull request gets merged, then that issue will close automatically.

Closes #
