### PR TITLE
Fix broken references

### DIFF
--- a/docs/source/_inc/_install-browser-reqs-volto.md
+++ b/docs/source/_inc/_install-browser-reqs-volto.md
@@ -1,0 +1,10 @@
+You can view the list of supported browsers for Volto at [Browserslist](https://browsersl.ist/#q=%3E1%25%0Alast+4+versions%0AFirefox+ESR%0Anot+dead).
+
+These browsers are set according to the `browserslist` key in Volto's [`package.json`](https://github.com/plone/volto/blob/1aff8d0451f5cb375ca9f5afe9b2b72a0555afd8/packages/volto/package.json#L170-L176) file, whose content is below.
+
+```shell
+>1%
+last 4 versions
+Firefox ESR
+not dead
+```

--- a/docs/source/contributing/version-policy.md
+++ b/docs/source/contributing/version-policy.md
@@ -99,7 +99,7 @@ We recommend using the current LTS version.
 
 ## Supported web browsers
 
-```{include} ../../_inc/_install-browser-reqs-volto.md
+```{include} ../_inc/_install-browser-reqs-volto.md
 ```
 
 

--- a/docs/source/user-manual/blocks.md
+++ b/docs/source/user-manual/blocks.md
@@ -61,7 +61,7 @@ To rearrange blocks, to the right of the block you want to move, click on its dr
 
 (copy-anchor-links-label)=
 
-### Copy Slate headings as anchor links
+### Copy headings as anchor links
 
 When you move your mouse over a heading, a link icon <img alt="Link icon" src="../_static/link.svg" class="inline"> appears on the right side.
 Click this icon to copy a direct link to that specific heading on the page onto your clipboard.

--- a/docs/source/user-manual/blocks.md
+++ b/docs/source/user-manual/blocks.md
@@ -63,7 +63,7 @@ To rearrange blocks, to the right of the block you want to move, click on its dr
 
 ### Copy Slate headings as anchor links
 
-When you move your mouse over a heading, a link icon <img alt="Link icon" src="../../_static/link.svg" class="inline"> appears on the right side.
+When you move your mouse over a heading, a link icon <img alt="Link icon" src="../_static/link.svg" class="inline"> appears on the right side.
 Click this icon to copy a direct link to that specific heading on the page onto your clipboard.
 
 Now you can paste the copied link to share a specific section of a page with others.

--- a/packages/volto/news/6760.documentation
+++ b/packages/volto/news/6760.documentation
@@ -1,0 +1,1 @@
+Fix reference to `link.svg` and include of `_inc/_install-browser-reqs-volto.md`. @stevepiercy


### PR DESCRIPTION
- `link.svg`
- `_inc/_install-browser-reqs-volto.md`

<!-- readthedocs-preview volto start -->
----
📚 Documentation preview 📚: 

- https://volto--6760.org.readthedocs.build/contributing/version-policy.html#supported-web-browsers
- https://volto--6760.org.readthedocs.build/user-manual/blocks.html#copy-headings-as-anchor-links

<!-- readthedocs-preview volto end -->