### PR TITLE
Fix supported languages and i18N cookie

### DIFF
--- a/packages/volto/news/6761.bugfix
+++ b/packages/volto/news/6761.bugfix
@@ -1,0 +1,1 @@
+Fix supported languages and i18N cookie #6761 @dobri1408

--- a/packages/volto/src/server.jsx
+++ b/packages/volto/src/server.jsx
@@ -58,7 +58,7 @@ function reactIntlErrorHandler(error) {
   debug('i18n')(error);
 }
 
-const supported = new locale.Locales(keys(languages), 'en');
+const supported = config.settings.supportedLanguages.length > 0 ? new locale.Locales(config.settings.supportedLanguages, 'en') : new locale.Locales(keys(languages), 'en');
 
 const server = express()
   .disable('x-powered-by')

--- a/packages/volto/src/server.jsx
+++ b/packages/volto/src/server.jsx
@@ -59,7 +59,7 @@ function reactIntlErrorHandler(error) {
 }
 
 const supported =
-  config.settings.supportedLanguages.length > 0
+  config?.settings?.supportedLanguages?.length > 0
     ? new locale.Locales(config.settings.supportedLanguages, 'en')
     : new locale.Locales(keys(languages), 'en');
 

--- a/packages/volto/src/server.jsx
+++ b/packages/volto/src/server.jsx
@@ -58,7 +58,10 @@ function reactIntlErrorHandler(error) {
   debug('i18n')(error);
 }
 
-const supported = config.settings.supportedLanguages.length > 0 ? new locale.Locales(config.settings.supportedLanguages, 'en') : new locale.Locales(keys(languages), 'en');
+const supported =
+  config.settings.supportedLanguages.length > 0
+    ? new locale.Locales(config.settings.supportedLanguages, 'en')
+    : new locale.Locales(keys(languages), 'en');
 
 const server = express()
   .disable('x-powered-by')


### PR DESCRIPTION
I've identified a logical bug in Volto related to language settings.

Currently, we define supported languages using config.settings.supportedLanguages. For example, in the case of EEA, this is set as:

config.settings.supportedLanguages = ['en'];

This configuration implies that all website resources such as taxonomies should be available only in English.

However, if a editor sets a page’s content to Italian (e.g., for just one page), Volto updates the i18N cookie accordingly. As a result, it attempts to fetch Italian taxonomies, which do not exist since our configuration explicitly supports only English. This behavior is incorrect because Volto should respect the predefined language settings and not attempt to request unsupported taxonomies.

To fix this, I propose modifying how supported languages are set in server.jsx. Instead of using hardcoded values from Volto core ([Languages.cjs](https://github.com/plone/volto/blob/main/packages/volto/src/constants/Languages.cjs)), we should dynamically check and apply only the explicitly supported languages defined in the configuration.

Let me know your thoughts on this approach!
[screen-capture (28).webm](https://github.com/user-attachments/assets/764ea7d9-b6b0-4c8f-b8c4-7baca667a239)