### PR TITLE
Fix QueryWidget focus issue by checking this.node before calling focus

### DIFF
--- a/packages/volto/src/components/manage/Widgets/QueryWidget.jsx
+++ b/packages/volto/src/components/manage/Widgets/QueryWidget.jsx
@@ -105,7 +105,7 @@ export class QuerystringWidgetComponent extends Component {
    * @returns {undefined}
    */
   componentDidMount() {
-    if (this.props.focus) {
+    if (this.props.focus && this.node) {
       this.node.focus();
     }
     this.props.getQuerystring();


### PR DESCRIPTION

This PR fixes an issue where `QueryWidget` tries to call `focus()` on `this.node` 
without ensuring `this.node` is defined. This caused a crash when the widget 
was the first in a form and automatically focused.

- Added a check for `this.node` before calling `focus()`.
- Fixes issue #2281.

Closes #2281
