### PR TITLE
Add id to Checkbox component to proper a11y identification

### DIFF
--- a/news/6771.bugfix
+++ b/news/6771.bugfix
@@ -1,1 +1,1 @@
-Added an id to the “Checkbox” component in the checkbox widget for proper identification and correct label functionality for screen readers. @Wagner3UB
+a11y - Added id attribute to checkbox widget for proper identification and fixex label functionality for screen readers. @Wagner3UB

--- a/news/6771.bugfix
+++ b/news/6771.bugfix
@@ -1,1 +1,1 @@
-a11y - Added id attribute to checkbox widget for proper identification and fixex label functionality for screen readers. @Wagner3UB
+a11y - Added id attribute to checkbox widget for proper identification and fixes label functionality for screen readers. @Wagner3UB

--- a/news/6771.bugfix
+++ b/news/6771.bugfix
@@ -1,0 +1,1 @@
+Added an id to the “Checkbox” component in the checkbox widget for proper identification and correct label functionality for screen readers. @Wagner3UB

--- a/src/components/manage/Blocks/LeadImage/__snapshots__/LeadImageSidebar.test.jsx.snap
+++ b/src/components/manage/Blocks/LeadImage/__snapshots__/LeadImageSidebar.test.jsx.snap
@@ -387,6 +387,7 @@ exports[`renders a Lead Image block Sidebar component 1`] = `
                   <input
                     checked={false}
                     className="hidden"
+                    id="field-openLinkInNewTab"
                     name="field-openLinkInNewTab"
                     readOnly={true}
                     tabIndex={0}

--- a/src/components/manage/Widgets/CheckboxWidget.jsx
+++ b/src/components/manage/Widgets/CheckboxWidget.jsx
@@ -31,6 +31,7 @@ const CheckboxWidget = (props) => {
     <FormFieldWrapper {...props} columns={1}>
       <div className="wrapper">
         <Checkbox
+          id={`field-${id}`}
           name={`field-${id}`}
           checked={value || false}
           disabled={isDisabled}

--- a/src/components/manage/Widgets/__snapshots__/CheckboxWidget.test.jsx.snap
+++ b/src/components/manage/Widgets/__snapshots__/CheckboxWidget.test.jsx.snap
@@ -22,6 +22,7 @@ exports[`CheckboxWidget renders a checkbox widget component 1`] = `
             >
               <input
                 class="hidden"
+                id="field-my-field"
                 name="field-my-field"
                 readonly=""
                 tabindex="0"
@@ -65,6 +66,7 @@ exports[`CheckboxWidget renders a checkbox widget component checked 1`] = `
               <input
                 checked=""
                 class="hidden"
+                id="field-my-field"
                 name="field-my-field"
                 readonly=""
                 tabindex="0"


### PR DESCRIPTION
Screen readers are not correctly reading the checkbox because the label, although present, is not properly referenced. 
While it suggests an htmlFor attribute, the necessary association is missing, causing it to be ignored.
To resolve this issue, an id has been added to the checkbox, ensuring proper identification and correct label functionality for assistive technologies.

v18 PR: https://github.com/plone/volto/pull/6802