### PR TITLE
Add Latin-1 password validation with custom message

### DIFF
--- a/packages/volto/src/components/manage/Controlpanels/Users/UsersControlpanel.jsx
+++ b/packages/volto/src/components/manage/Controlpanels/Users/UsersControlpanel.jsx
@@ -497,7 +497,9 @@ class UsersControlpanel extends Component {
         description: this.props.intl.formatMessage(
           messages.addUserFormPasswordDescription,
         ),
+        pattern: '^[\x00-\xFF]*$',
         widget: 'password',
+        minLength: 8,
       };
       adduserschema.properties['sendPasswordReset'] = {
         title: this.props.intl.formatMessage(

--- a/packages/volto/src/helpers/FormValidation/validators.ts
+++ b/packages/volto/src/helpers/FormValidation/validators.ts
@@ -171,6 +171,13 @@ export const patternValidator = ({
   }
   const regex = new RegExp(field.pattern);
   const isValid = regex.test(value);
+
+  if (field.type === 'password' && field.pattern === '^[\x00-\xFF]*$') {
+    return !isValid
+      ? formatMessage(messages.addUserFormPasswordLatinOnly)
+      : null;
+  }
+
   return !isValid ? formatMessage(messages.pattern) : null;
 };
 

--- a/packages/volto/src/helpers/MessageLabels/MessageLabels.js
+++ b/packages/volto/src/helpers/MessageLabels/MessageLabels.js
@@ -136,6 +136,11 @@ export const messages = defineMessages({
     id: 'addUserFormPasswordDescription',
     defaultMessage: 'Enter your new password. Minimum 8 characters.',
   },
+  addUserFormPasswordLatinOnly: {
+    id: 'addUserFormPasswordLatinOnly',
+    defaultMessage:
+      'Password can only contain Latin-1 characters (no €, emojis or other special characters)',
+  },
   addGroupsFormTitleTitle: {
     id: 'Title',
     defaultMessage: 'Title',


### PR DESCRIPTION

- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't other open [pull requests](https://github.com/plone/volto/pulls) for the same change.
- [x] I followed the guidelines in [Contributing to Volto](https://6.docs.plone.org/volto/contributing/index.html).
- [x] I succesfully ran [code linting checks](https://6.docs.plone.org/volto/contributing/linting.html) on my changes locally.
- [x] I succesfully ran [unit tests](https://6.docs.plone.org/volto/contributing/testing.html) on my changes locally.
- [x] I succesfully ran [acceptance tests](https://6.docs.plone.org/volto/contributing/acceptance-tests.html) on my changes locally.
- [x] If needed, I added new tests for my changes.
- [x] If needed, I added [documentation](https://6.docs.plone.org/volto/contributing/documentation.html#narrative-documentation) for my changes, either in the Storybook or narrative documentation.
- [x] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

## Testing

1. Try creating a new user with non-Latin-1 characters in password (like €, emojis)
2. Verify the custom message appears: "Password can only contain Latin-1 characters (no €, emojis or other special characters)"
3. Verify other pattern validations still show generic message
4. Verify password minimum length validation still works

I Have included a video demonstration  fixing the issue:
https://github.com/user-attachments/assets/e7b0f516-d40b-4ee4-b90c-30c4b11399f1

If your pull request closes an open issue, include the exact text below, immediately followed by the issue number. When your pull request gets merged, then that issue will close automatically.

Closes #6764 