### PR TITLE
Does not show empty class attribute when rendering img tag with Image component

### DIFF
--- a/packages/volto/news/6788.bugfix
+++ b/packages/volto/news/6788.bugfix
@@ -1,0 +1,1 @@
+Does not show empty `class` attribute when rendering `img` tag with `Image` component. @wesleybl

--- a/packages/volto/src/components/theme/Image/Image.jsx
+++ b/packages/volto/src/components/theme/Image/Image.jsx
@@ -27,10 +27,10 @@ export default function Image({
   // TypeScript hints for editor autocomplete :)
   /** @type {React.ImgHTMLAttributes<HTMLImageElement>} */
   const attrs = {};
+  attrs.className = cx(className, { responsive }) || undefined;
 
   if (!item && src) {
     attrs.src = src;
-    attrs.className = cx(className, { responsive });
   } else {
     const isFromRealObject = !item.image_scales;
     const imageFieldWithDefault = imageField || item.image_field || 'image';
@@ -51,7 +51,6 @@ export default function Image({
     attrs.src = `${flattenToAppURL(basePath)}/${image.download}`;
     attrs.width = image.width;
     attrs.height = image.height;
-    attrs.className = cx(className, { responsive });
 
     if (!isSvg && image.scales && Object.keys(image.scales).length > 0) {
       const sortedScales = Object.values({

--- a/packages/volto/src/components/theme/Image/Image.test.jsx
+++ b/packages/volto/src/components/theme/Image/Image.test.jsx
@@ -155,3 +155,11 @@ test('renders an image component from a string src', () => {
   const json = component.toJSON();
   expect(json).toMatchSnapshot();
 });
+
+test('should not render empty class attribute in img tag', () => {
+  const component = renderer.create(
+    <Image src="/image.png" alt="no class attribute" />,
+  );
+  const json = component.toJSON();
+  expect(json).toMatchSnapshot();
+});

--- a/packages/volto/src/components/theme/Image/__snapshots__/Image.test.jsx.snap
+++ b/packages/volto/src/components/theme/Image/__snapshots__/Image.test.jsx.snap
@@ -3,7 +3,6 @@
 exports[`renders an image component from a catalog brain 1`] = `
 <img
   alt="alt text"
-  className=""
   fetchpriority="high"
   height={400}
   src="/image/@@images/image.png"
@@ -15,7 +14,6 @@ exports[`renders an image component from a catalog brain 1`] = `
 exports[`renders an image component from a catalog brain using \`preview_image_link\` 1`] = `
 <img
   alt="alt text"
-  className=""
   fetchpriority="high"
   height={400}
   src="/image.png/@@images/image.png"
@@ -27,7 +25,6 @@ exports[`renders an image component from a catalog brain using \`preview_image_l
 exports[`renders an image component from a string src 1`] = `
 <img
   alt="alt text"
-  className=""
   fetchpriority="high"
   src="http://localhost:3000/image/@@images/image/image.png"
 />
@@ -36,7 +33,6 @@ exports[`renders an image component from a string src 1`] = `
 exports[`renders an image component with fetchpriority high 1`] = `
 <img
   alt="alt text"
-  className=""
   fetchpriority="high"
   height={400}
   src="/image/@@images/image.png"
@@ -48,7 +44,6 @@ exports[`renders an image component with fetchpriority high 1`] = `
 exports[`renders an image component with lazy loading 1`] = `
 <img
   alt="alt text"
-  className=""
   decoding="async"
   height={400}
   loading="lazy"
@@ -67,5 +62,13 @@ exports[`renders an image component with responsive class 1`] = `
   src="/image/@@images/image-1200.png"
   srcSet="/image/@@images/image-400.png 400w, /image/@@images/image-1200.png 400w"
   width={400}
+/>
+`;
+
+exports[`should not render empty class attribute in img tag 1`] = `
+<img
+  alt="no class attribute"
+  fetchpriority="high"
+  src="/image.png"
 />
 `;


### PR DESCRIPTION
This was happening when the c`lassName` prop was not passed and the `responsive` prop was `false`.

> [!CAUTION]
The Volto Team has suspended its review of new pull requests from first-time contributors until the [release of Plone 7](https://plone.org/download/release-schedule), which is preliminarily scheduled for the second quarter of 2026.
> [Read details](https://6.docs.plone.org/volto/contributing/index.html).

-----

- [ ] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [ ] I verified there aren't other open [pull requests](https://github.com/plone/volto/pulls) for the same change.
- [ ] I followed the guidelines in [Contributing to Volto](https://6.docs.plone.org/volto/contributing/index.html).
- [ ] I succesfully ran [code linting checks](https://6.docs.plone.org/volto/contributing/linting.html) on my changes locally.
- [ ] I succesfully ran [unit tests](https://6.docs.plone.org/volto/contributing/testing.html) on my changes locally.
- [ ] I succesfully ran [acceptance tests](https://6.docs.plone.org/volto/contributing/acceptance-tests.html) on my changes locally.
- [ ] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/volto/contributing/documentation.html#narrative-documentation) for my changes, either in the Storybook or narrative documentation.
- [ ] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

If your pull request closes an open issue, include the exact text below, immediately followed by the issue number. When your pull request gets merged, then that issue will close automatically.

Closes #6788 
