### PR TITLE
Fixed button types in forms

### DIFF
--- a/packages/volto/news/6791.bugfix
+++ b/packages/volto/news/6791.bugfix
@@ -1,0 +1,1 @@
+Fixed button types across several components to allow reuse in more complex forms @pnicolli

--- a/packages/volto/src/components/manage/Add/Add.jsx
+++ b/packages/volto/src/components/manage/Add/Add.jsx
@@ -425,7 +425,11 @@ class Add extends Component {
                         title={this.props.intl.formatMessage(messages.save)}
                       />
                     </Button>
-                    <Button className="cancel" onClick={() => this.onCancel()}>
+                    <Button
+                      className="cancel"
+                      onClick={() => this.onCancel()}
+                      type="button"
+                    >
                       <Icon
                         name={clearSVG}
                         className="circled"

--- a/packages/volto/src/components/manage/AnchorPlugin/components/LinkButton/AddLinkForm.jsx
+++ b/packages/volto/src/components/manage/AnchorPlugin/components/LinkButton/AddLinkForm.jsx
@@ -258,6 +258,7 @@ class AddLinkForm extends Component {
             {value.length > 0 ? (
               <Button.Group>
                 <Button
+                  type="button"
                   basic
                   className="cancel"
                   aria-label={this.props.intl.formatMessage(messages.clear)}
@@ -274,6 +275,7 @@ class AddLinkForm extends Component {
             ) : this.props.objectBrowserPickerType === 'link' ? (
               <Button.Group>
                 <Button
+                  type="button"
                   basic
                   icon
                   aria-label={this.props.intl.formatMessage(

--- a/packages/volto/src/components/manage/BlockChooser/BlockChooser.jsx
+++ b/packages/volto/src/components/manage/BlockChooser/BlockChooser.jsx
@@ -128,6 +128,7 @@ const BlockChooser = ({
     return (
       <Button.Group key={block.id}>
         <Button
+          type="button"
           icon
           basic
           className={block.id}

--- a/packages/volto/src/components/manage/BlockChooser/BlockChooserButton.jsx
+++ b/packages/volto/src/components/manage/BlockChooser/BlockChooserButton.jsx
@@ -29,6 +29,7 @@ export const ButtonComponent = (props) => {
 
   return (
     <Button
+      type="button"
       icon
       basic
       title={intl.formatMessage(messages.addBlock)}

--- a/packages/volto/src/components/manage/BlockChooser/BlockChooserSearch.jsx
+++ b/packages/volto/src/components/manage/BlockChooser/BlockChooserSearch.jsx
@@ -38,6 +38,7 @@ const BlockChooserSearch = ({ onChange, searchValue }) => {
         />
         {searchValue && (
           <Button
+            type="button"
             className="clear-search-button"
             aria-label={intl.formatMessage(messages.clear)}
             onClick={() => {

--- a/packages/volto/src/components/manage/BlockChooser/__snapshots__/BlockChooser.test.jsx.snap
+++ b/packages/volto/src/components/manage/BlockChooser/__snapshots__/BlockChooser.test.jsx.snap
@@ -63,6 +63,7 @@ exports[`BlocksChooser Fallback BlockChooser component onMutateBlock 1`] = `
             >
               <button
                 class="ui basic icon button image"
+                type="button"
               >
                 <svg
                   class="icon"
@@ -76,6 +77,7 @@ exports[`BlocksChooser Fallback BlockChooser component onMutateBlock 1`] = `
             >
               <button
                 class="ui basic icon button listing"
+                type="button"
               >
                 <svg
                   class="icon"
@@ -89,6 +91,7 @@ exports[`BlocksChooser Fallback BlockChooser component onMutateBlock 1`] = `
             >
               <button
                 class="ui basic icon button video"
+                type="button"
               >
                 <svg
                   class="icon"
@@ -132,6 +135,7 @@ exports[`BlocksChooser Fallback BlockChooser component onMutateBlock 1`] = `
             >
               <button
                 class="ui basic icon button text"
+                type="button"
               >
                 <svg
                   class="icon"
@@ -175,6 +179,7 @@ exports[`BlocksChooser Fallback BlockChooser component onMutateBlock 1`] = `
             >
               <button
                 class="ui basic icon button image"
+                type="button"
               >
                 <svg
                   class="icon"
@@ -188,6 +193,7 @@ exports[`BlocksChooser Fallback BlockChooser component onMutateBlock 1`] = `
             >
               <button
                 class="ui basic icon button leadimage"
+                type="button"
               >
                 <svg
                   class="icon"
@@ -201,6 +207,7 @@ exports[`BlocksChooser Fallback BlockChooser component onMutateBlock 1`] = `
             >
               <button
                 class="ui basic icon button video"
+                type="button"
               >
                 <svg
                   class="icon"
@@ -244,6 +251,7 @@ exports[`BlocksChooser Fallback BlockChooser component onMutateBlock 1`] = `
             >
               <button
                 class="ui basic icon button listing"
+                type="button"
               >
                 <svg
                   class="icon"
@@ -257,6 +265,7 @@ exports[`BlocksChooser Fallback BlockChooser component onMutateBlock 1`] = `
             >
               <button
                 class="ui basic icon button toc"
+                type="button"
               >
                 <svg
                   class="icon"
@@ -270,6 +279,7 @@ exports[`BlocksChooser Fallback BlockChooser component onMutateBlock 1`] = `
             >
               <button
                 class="ui basic icon button hero"
+                type="button"
               >
                 <svg
                   class="icon"
@@ -283,6 +293,7 @@ exports[`BlocksChooser Fallback BlockChooser component onMutateBlock 1`] = `
             >
               <button
                 class="ui basic icon button maps"
+                type="button"
               >
                 <svg
                   class="icon"
@@ -296,6 +307,7 @@ exports[`BlocksChooser Fallback BlockChooser component onMutateBlock 1`] = `
             >
               <button
                 class="ui basic icon button html"
+                type="button"
               >
                 <svg
                   class="icon"
@@ -309,6 +321,7 @@ exports[`BlocksChooser Fallback BlockChooser component onMutateBlock 1`] = `
             >
               <button
                 class="ui basic icon button table"
+                type="button"
               >
                 <svg
                   class="icon"
@@ -388,6 +401,7 @@ exports[`BlocksChooser renders a BlockChooser component 1`] = `
             >
               <button
                 class="ui basic icon button image"
+                type="button"
               >
                 <svg
                   class="icon"
@@ -401,6 +415,7 @@ exports[`BlocksChooser renders a BlockChooser component 1`] = `
             >
               <button
                 class="ui basic icon button listing"
+                type="button"
               >
                 <svg
                   class="icon"
@@ -414,6 +429,7 @@ exports[`BlocksChooser renders a BlockChooser component 1`] = `
             >
               <button
                 class="ui basic icon button video"
+                type="button"
               >
                 <svg
                   class="icon"
@@ -457,6 +473,7 @@ exports[`BlocksChooser renders a BlockChooser component 1`] = `
             >
               <button
                 class="ui basic icon button text"
+                type="button"
               >
                 <svg
                   class="icon"
@@ -500,6 +517,7 @@ exports[`BlocksChooser renders a BlockChooser component 1`] = `
             >
               <button
                 class="ui basic icon button image"
+                type="button"
               >
                 <svg
                   class="icon"
@@ -513,6 +531,7 @@ exports[`BlocksChooser renders a BlockChooser component 1`] = `
             >
               <button
                 class="ui basic icon button leadimage"
+                type="button"
               >
                 <svg
                   class="icon"
@@ -526,6 +545,7 @@ exports[`BlocksChooser renders a BlockChooser component 1`] = `
             >
               <button
                 class="ui basic icon button video"
+                type="button"
               >
                 <svg
                   class="icon"
@@ -569,6 +589,7 @@ exports[`BlocksChooser renders a BlockChooser component 1`] = `
             >
               <button
                 class="ui basic icon button listing"
+                type="button"
               >
                 <svg
                   class="icon"
@@ -582,6 +603,7 @@ exports[`BlocksChooser renders a BlockChooser component 1`] = `
             >
               <button
                 class="ui basic icon button toc"
+                type="button"
               >
                 <svg
                   class="icon"
@@ -595,6 +617,7 @@ exports[`BlocksChooser renders a BlockChooser component 1`] = `
             >
               <button
                 class="ui basic icon button hero"
+                type="button"
               >
                 <svg
                   class="icon"
@@ -608,6 +631,7 @@ exports[`BlocksChooser renders a BlockChooser component 1`] = `
             >
               <button
                 class="ui basic icon button maps"
+                type="button"
               >
                 <svg
                   class="icon"
@@ -621,6 +645,7 @@ exports[`BlocksChooser renders a BlockChooser component 1`] = `
             >
               <button
                 class="ui basic icon button html"
+                type="button"
               >
                 <svg
                   class="icon"
@@ -634,6 +659,7 @@ exports[`BlocksChooser renders a BlockChooser component 1`] = `
             >
               <button
                 class="ui basic icon button table"
+                type="button"
               >
                 <svg
                   class="icon"

--- a/packages/volto/src/components/manage/BlockChooser/__snapshots__/BlockChooserButton.test.jsx.snap
+++ b/packages/volto/src/components/manage/BlockChooser/__snapshots__/BlockChooserButton.test.jsx.snap
@@ -15,6 +15,7 @@ exports[`Renders a button 1`] = `
   <button
     class="ui basic icon button block-add-button"
     title="Add block"
+    type="button"
   >
     <svg
       class="icon block-add-button"

--- a/packages/volto/src/components/manage/Blocks/Block/EditBlockWrapper.jsx
+++ b/packages/volto/src/components/manage/Blocks/Block/EditBlockWrapper.jsx
@@ -106,6 +106,7 @@ const EditBlockWrapper = (props) => {
           {children}
           {selected && !required && editable && (
             <Button
+              type="button"
               icon
               basic
               onClick={() => onDeleteBlock(block, true)}

--- a/packages/volto/src/components/manage/Blocks/Block/__snapshots__/BlocksForm.test.jsx.snap
+++ b/packages/volto/src/components/manage/Blocks/Block/__snapshots__/BlocksForm.test.jsx.snap
@@ -57,6 +57,7 @@ exports[`Allow override of blocksConfig 1`] = `
               <button
                 aria-label="delete"
                 class="ui basic icon button delete-button"
+                type="button"
               >
                 <svg
                   class="icon"

--- a/packages/volto/src/components/manage/Blocks/Container/EditBlockWrapper.jsx
+++ b/packages/volto/src/components/manage/Blocks/Container/EditBlockWrapper.jsx
@@ -66,6 +66,7 @@ const EditBlockWrapper = (props) => {
             aria-label={intl.formatMessage(messages.reset, {
               index,
             })}
+            type="button"
             basic
             icon
             onClick={(e) => onResetBlock(block, {})}
@@ -75,6 +76,7 @@ const EditBlockWrapper = (props) => {
           </Button>
         ) : (
           <Button
+            type="button"
             basic
             icon
             className="remove-block-button"

--- a/packages/volto/src/components/manage/Blocks/Container/NewBlockAddButton.jsx
+++ b/packages/volto/src/components/manage/Blocks/Container/NewBlockAddButton.jsx
@@ -49,6 +49,7 @@ const NewBlockAddButton = (props) => {
     <>
       <Ref innerRef={setReferenceElement}>
         <Button
+          type="button"
           basic
           icon
           onClick={() => setOpenMenu(true)}

--- a/packages/volto/src/components/manage/Blocks/Container/SimpleContainerToolbar.jsx
+++ b/packages/volto/src/components/manage/Blocks/Container/SimpleContainerToolbar.jsx
@@ -25,6 +25,7 @@ const SimpleContainerToolbar = (props) => {
       <Button.Group>
         <Button
           aria-label={intl.formatMessage(messages.addBlock)}
+          type="button"
           icon
           basic
           disabled={data?.blocks_layout?.items?.length >= maxLength}
@@ -36,6 +37,7 @@ const SimpleContainerToolbar = (props) => {
       <Button.Group>
         <Button
           aria-label={intl.formatMessage(messages.blockSettings)}
+          type="button"
           icon
           basic
           onClick={(e) => {

--- a/packages/volto/src/components/manage/Blocks/HTML/Edit.jsx
+++ b/packages/volto/src/components/manage/Blocks/HTML/Edit.jsx
@@ -248,6 +248,7 @@ class Edit extends Component {
             <Popup
               trigger={
                 <Button
+                  type="button"
                   icon
                   basic
                   aria-label={this.props.intl.formatMessage(messages.source)}
@@ -264,6 +265,7 @@ class Edit extends Component {
             <Popup
               trigger={
                 <Button
+                  type="button"
                   icon
                   basic
                   aria-label={this.props.intl.formatMessage(messages.preview)}
@@ -280,6 +282,7 @@ class Edit extends Component {
             <Popup
               trigger={
                 <Button
+                  type="button"
                   icon
                   basic
                   aria-label={this.props.intl.formatMessage(messages.prettier)}
@@ -296,7 +299,12 @@ class Edit extends Component {
             <Popup
               trigger={
                 <Button.Group>
-                  <Button icon basic onClick={() => this.onChangeCode('')}>
+                  <Button
+                    type="button"
+                    icon
+                    basic
+                    onClick={() => this.onChangeCode('')}
+                  >
                     <Icon name={clearSVG} size="24px" color="#e40166" />
                   </Button>
                 </Button.Group>

--- a/packages/volto/src/components/manage/Blocks/Image/ImageSidebar.jsx
+++ b/packages/volto/src/components/manage/Blocks/Image/ImageSidebar.jsx
@@ -31,6 +31,7 @@ const ImageSidebar = (props) => {
         <Button.Group>
           <Button
             title={intl.formatMessage(messages.clear)}
+            type="button"
             basic
             disabled={!data.url}
             onClick={() => {

--- a/packages/volto/src/components/manage/Blocks/Image/__snapshots__/ImageSidebar.test.jsx.snap
+++ b/packages/volto/src/components/manage/Blocks/Image/__snapshots__/ImageSidebar.test.jsx.snap
@@ -15,6 +15,7 @@ Array [
         className="ui basic button"
         onClick={[Function]}
         title="Clear image"
+        type="button"
       >
         <svg
           className="icon"

--- a/packages/volto/src/components/manage/Blocks/LeadImage/__snapshots__/LeadImageSidebar.test.jsx.snap
+++ b/packages/volto/src/components/manage/Blocks/LeadImage/__snapshots__/LeadImageSidebar.test.jsx.snap
@@ -66,6 +66,7 @@ exports[`renders a Lead Image block Sidebar component 1`] = `
                   aria-label="Left"
                   className="ui basic icon button"
                   onClick={[Function]}
+                  type="button"
                 >
                   <svg
                     className="icon"
@@ -94,6 +95,7 @@ exports[`renders a Lead Image block Sidebar component 1`] = `
                   aria-label="Right"
                   className="ui basic icon button"
                   onClick={[Function]}
+                  type="button"
                 >
                   <svg
                     className="icon"
@@ -122,6 +124,7 @@ exports[`renders a Lead Image block Sidebar component 1`] = `
                   aria-label="Center"
                   className="ui active basic icon button"
                   onClick={[Function]}
+                  type="button"
                 >
                   <svg
                     className="icon"
@@ -150,6 +153,7 @@ exports[`renders a Lead Image block Sidebar component 1`] = `
                   aria-label="Full"
                   className="ui basic icon button"
                   onClick={[Function]}
+                  type="button"
                 >
                   <svg
                     className="icon"

--- a/packages/volto/src/components/manage/Blocks/Listing/ImageGallery.jsx
+++ b/packages/volto/src/components/manage/Blocks/Listing/ImageGallery.jsx
@@ -19,6 +19,7 @@ const ImageGallery = loadable(() => import('react-image-gallery'));
 const renderLeftNav = (onClick, disabled) => {
   return (
     <Button
+      type="button"
       className="image-gallery-icon image-gallery-left-nav primary basic"
       disabled={disabled}
       onClick={onClick}
@@ -30,6 +31,7 @@ const renderLeftNav = (onClick, disabled) => {
 const renderRightNav = (onClick, disabled) => {
   return (
     <Button
+      type="button"
       className="image-gallery-icon image-gallery-right-nav primary basic"
       disabled={disabled}
       onClick={onClick}

--- a/packages/volto/src/components/manage/Blocks/Maps/Edit.jsx
+++ b/packages/volto/src/components/manage/Blocks/Maps/Edit.jsx
@@ -135,6 +135,7 @@ const Edit = React.memo((props) => {
               {url && (
                 <Button.Group>
                   <Button
+                    type="button"
                     basic
                     className="cancel"
                     onClick={(e) => {
@@ -148,6 +149,7 @@ const Edit = React.memo((props) => {
               )}
               <Button.Group>
                 <Button
+                  type="button"
                   basic
                   primary
                   onClick={(e) => {

--- a/packages/volto/src/components/manage/Blocks/Search/components/Facets.jsx
+++ b/packages/volto/src/components/manage/Blocks/Search/components/Facets.jsx
@@ -145,6 +145,7 @@ const Facets = (props) => {
           className="toggle-advanced-facets"
         >
           <Button
+            type="button"
             onClick={() => {
               setHidden((prevHidden) => !prevHidden);
             }}

--- a/packages/volto/src/components/manage/Blocks/Search/components/FilterList.jsx
+++ b/packages/volto/src/components/manage/Blocks/Search/components/FilterList.jsx
@@ -53,6 +53,7 @@ const FilterList = (props) => {
           {intl.formatMessage(messages.currentFilters)}: {totalFilters}
         </div>
         <Button
+          type="button"
           icon
           basic
           compact

--- a/packages/volto/src/components/manage/Blocks/Search/components/SearchInput.jsx
+++ b/packages/volto/src/components/manage/Blocks/Search/components/SearchInput.jsx
@@ -46,6 +46,7 @@ const SearchInput = (props) => {
       <div className="search-input-actions">
         {searchText && (
           <Button
+            type="button"
             basic
             icon
             className="search-input-clear-icon-button"

--- a/packages/volto/src/components/manage/Blocks/Search/components/SortOn.jsx
+++ b/packages/volto/src/components/manage/Blocks/Search/components/SortOn.jsx
@@ -113,6 +113,7 @@ const SortOn = (props) => {
       {activeSortOn ? (
         <>
           <Button
+            type="button"
             icon
             basic
             compact
@@ -127,6 +128,7 @@ const SortOn = (props) => {
             <Icon name={downSVG} size="25px" />
           </Button>
           <Button
+            type="button"
             icon
             basic
             compact

--- a/packages/volto/src/components/manage/Blocks/Search/components/__snapshots__/FilterList.test.jsx.snap
+++ b/packages/volto/src/components/manage/Blocks/Search/components/__snapshots__/FilterList.test.jsx.snap
@@ -36,6 +36,7 @@ exports[`FilterList renders filters listing component for search block 1`] = `
     <button
       className="ui small basic compact icon button"
       onClick={[Function]}
+      type="button"
     >
       <i
         aria-hidden="true"

--- a/packages/volto/src/components/manage/Blocks/Search/components/__snapshots__/SearchInput.test.jsx.snap
+++ b/packages/volto/src/components/manage/Blocks/Search/components/__snapshots__/SearchInput.test.jsx.snap
@@ -22,6 +22,7 @@ exports[`SearchInput renders a search input component 1`] = `
     <button
       className="ui basic icon button search-input-clear-icon-button"
       onClick={[Function]}
+      type="button"
     >
       <svg
         className="icon"

--- a/packages/volto/src/components/manage/Blocks/Teaser/Data.jsx
+++ b/packages/volto/src/components/manage/Blocks/Teaser/Data.jsx
@@ -117,6 +117,7 @@ const TeaserData = (props) => {
     <Button.Group>
       <Button
         aria-label={intl.formatMessage(messages.resetTeaser)}
+        type="button"
         basic
         disabled={isReseteable}
         onClick={() => reset()}
@@ -130,6 +131,7 @@ const TeaserData = (props) => {
     <Button.Group className="refresh teaser">
       <Button
         aria-label={intl.formatMessage(messages.refreshTeaser)}
+        type="button"
         basic
         onClick={() => refresh()}
         disabled={isEmpty(data.href)}

--- a/packages/volto/src/components/manage/Blocks/Video/Edit.jsx
+++ b/packages/volto/src/components/manage/Blocks/Video/Edit.jsx
@@ -96,6 +96,7 @@ const Edit = (props) => {
               {url && (
                 <Button.Group>
                   <Button
+                    type="button"
                     basic
                     className="cancel"
                     onClick={(e) => {
@@ -109,6 +110,7 @@ const Edit = (props) => {
               )}
               <Button.Group>
                 <Button
+                  type="button"
                   basic
                   primary
                   onClick={(e) => {

--- a/packages/volto/src/components/manage/Delete/Delete.jsx
+++ b/packages/volto/src/components/manage/Delete/Delete.jsx
@@ -101,6 +101,7 @@ const Delete = () => {
                 onClick={onSubmit}
               />
               <Button
+                type="button"
                 basic
                 circular
                 secondary

--- a/packages/volto/src/components/manage/Delete/__snapshots__/Delete.test.jsx.snap
+++ b/packages/volto/src/components/manage/Delete/__snapshots__/Delete.test.jsx.snap
@@ -48,6 +48,7 @@ exports[`Delete renders a delete component 1`] = `
             aria-label="Cancel"
             class="ui big basic circular icon secondary right floated button"
             title="Cancel"
+            type="button"
           >
             <i
               aria-hidden="true"

--- a/packages/volto/src/components/manage/Diff/Diff.jsx
+++ b/packages/volto/src/components/manage/Diff/Diff.jsx
@@ -249,6 +249,7 @@ class Diff extends Component {
                 ],
                 (view) => (
                   <Button
+                    type="button"
                     key={view.id}
                     value={view.id}
                     active={this.props.view === view.id}

--- a/packages/volto/src/components/manage/Diff/__snapshots__/Diff.test.jsx.snap
+++ b/packages/volto/src/components/manage/Diff/__snapshots__/Diff.test.jsx.snap
@@ -29,12 +29,14 @@ exports[`Diff renders a diff component 1`] = `
         >
           <button
             class="ui active button"
+            type="button"
             value="split"
           >
             Split
           </button>
           <button
             class="ui button"
+            type="button"
             value="unified"
           >
             Unified

--- a/packages/volto/src/components/manage/Edit/Edit.jsx
+++ b/packages/volto/src/components/manage/Edit/Edit.jsx
@@ -447,6 +447,7 @@ class Edit extends Component {
                     />
                   </Button>
                   <Button
+                    type="button"
                     className="cancel"
                     aria-label={this.props.intl.formatMessage(messages.cancel)}
                     onClick={() => this.onCancel()}

--- a/packages/volto/src/components/manage/Form/Form.jsx
+++ b/packages/volto/src/components/manage/Form/Form.jsx
@@ -1020,6 +1020,7 @@ class Form extends Component {
                   )}
                   {onCancel && (
                     <Button
+                      type="button"
                       basic
                       secondary
                       aria-label={this.props.intl.formatMessage(

--- a/packages/volto/src/components/manage/Form/ModalForm.jsx
+++ b/packages/volto/src/components/manage/Form/ModalForm.jsx
@@ -308,6 +308,7 @@ class ModalForm extends Component {
           </Button>
           {onCancel && (
             <Button
+              type="button"
               basic
               circular
               secondary

--- a/packages/volto/src/components/manage/Form/UndoToolbar.jsx
+++ b/packages/volto/src/components/manage/Form/UndoToolbar.jsx
@@ -39,6 +39,7 @@ const UndoToolbar = ({ state, onUndoRedo, maxUndoLevels, enableHotKeys }) => {
         dependencies={[canUndo, canRedo]}
       >
         <Button
+          type="button"
           className="undo"
           onClick={() => doUndo()}
           aria-label={intl.formatMessage(messages.undo)}
@@ -58,6 +59,7 @@ const UndoToolbar = ({ state, onUndoRedo, maxUndoLevels, enableHotKeys }) => {
         dependencies={[canUndo, canRedo]}
       >
         <Button
+          type="button"
           className="redo"
           onClick={() => doRedo()}
           aria-label={intl.formatMessage(messages.redo)}

--- a/packages/volto/src/components/manage/Form/__snapshots__/Form.test.jsx.snap
+++ b/packages/volto/src/components/manage/Form/__snapshots__/Form.test.jsx.snap
@@ -57,6 +57,7 @@ exports[`Form renders a form component 1`] = `
             className="ui basic secondary right floated button"
             onClick={[Function]}
             title="Cancel"
+            type="button"
           >
             <svg
               className="icon circled"

--- a/packages/volto/src/components/manage/Preferences/__snapshots__/PersonalInformation.test.jsx.snap
+++ b/packages/volto/src/components/manage/Preferences/__snapshots__/PersonalInformation.test.jsx.snap
@@ -52,6 +52,7 @@ exports[`PersonalInformation renders a personal information component 1`] = `
             className="ui basic secondary right floated button"
             onClick={[Function]}
             title="Cancel"
+            type="button"
           >
             <svg
               className="icon circled"
@@ -131,6 +132,7 @@ exports[`PersonalInformation renders a personal information component embedded i
             className="ui basic secondary right floated button"
             onClick={[Function]}
             title="Cancel"
+            type="button"
           >
             <svg
               className="icon circled"

--- a/packages/volto/src/components/manage/Sidebar/AlignBlock.jsx
+++ b/packages/volto/src/components/manage/Sidebar/AlignBlock.jsx
@@ -59,6 +59,7 @@ const AlignBlock = ({
       {actions.map((action) => (
         <Button.Group key={action}>
           <Button
+            type="button"
             icon
             basic
             aria-label={intl.formatMessage(messages[action])}

--- a/packages/volto/src/components/manage/Sidebar/ObjectBrowserNav.jsx
+++ b/packages/volto/src/components/manage/Sidebar/ObjectBrowserNav.jsx
@@ -164,6 +164,7 @@ const ObjectBrowserNav = ({
                   >
                     <Button.Group>
                       <Button
+                        type="button"
                         basic
                         icon
                         aria-label={`${intl.formatMessage(messages.browse)} ${

--- a/packages/volto/src/components/manage/Sidebar/Sidebar.jsx
+++ b/packages/volto/src/components/manage/Sidebar/Sidebar.jsx
@@ -113,6 +113,7 @@ const Sidebar = (props) => {
         style={size > 0 ? { width: size } : null}
       >
         <Button
+          type="button"
           aria-label={
             expanded
               ? intl.formatMessage(messages.shrinkSidebar)
@@ -126,6 +127,7 @@ const Sidebar = (props) => {
           onClick={onToggleExpanded}
         />
         <Button
+          type="button"
           className="full-size-sidenav-btn"
           onClick={onToggleFullSize}
           aria-label="full-screen-sidenav"

--- a/packages/volto/src/components/manage/Sidebar/__snapshots__/Sidebar.test.jsx.snap
+++ b/packages/volto/src/components/manage/Sidebar/__snapshots__/Sidebar.test.jsx.snap
@@ -10,11 +10,13 @@ Array [
       aria-label="Shrink sidebar"
       className="ui button trigger"
       onClick={[Function]}
+      type="button"
     />
     <button
       aria-label="full-screen-sidenav"
       className="ui button full-size-sidenav-btn"
       onClick={[Function]}
+      type="button"
     >
       <svg
         className="icon full-size-icon"

--- a/packages/volto/src/components/manage/TemplateChooser/TemplateChooser.jsx
+++ b/packages/volto/src/components/manage/TemplateChooser/TemplateChooser.jsx
@@ -11,6 +11,7 @@ const TemplateChooser = ({ templates, onSelectTemplate }) => {
           {templates(intl).map((template, index) => (
             <Grid.Column key={template.id}>
               <Button
+                type="button"
                 className="template-chooser-item"
                 onClick={() => onSelectTemplate(index)}
               >

--- a/packages/volto/src/components/manage/TemplateChooser/__snapshots__/TemplateChooser.test.jsx.snap
+++ b/packages/volto/src/components/manage/TemplateChooser/__snapshots__/TemplateChooser.test.jsx.snap
@@ -16,6 +16,7 @@ exports[`renders a TemplateChooser component 1`] = `
         <button
           className="ui button template-chooser-item"
           onClick={[Function]}
+          type="button"
         >
           <img
             alt=""

--- a/packages/volto/src/storybook.jsx
+++ b/packages/volto/src/storybook.jsx
@@ -1490,6 +1490,7 @@ export const FormUndoWrapper = ({
             onClick={() => doUndo()}
             aria-label="Undo"
             disabled={!canUndo}
+            type="button"
           >
             Undo
           </Button>
@@ -1500,6 +1501,7 @@ export const FormUndoWrapper = ({
             onClick={() => doRedo()}
             aria-label="Redo"
             disabled={!canRedo}
+            type="button"
           >
             Redo
           </Button>


### PR DESCRIPTION
Several uses of the `Button` component from `semantic-ui-react` don't specify the `type="button"` attribute even if it would be needed. Semantic UI, in fact, honors the HTML standard and has the `submit` type as its default button type.

This is mostly handled by `event.stopPropagation` in core Volto, but it's sort of fragile when some components are reused elsewhere. For instance, I am currently building a controlpanel with a form that allows the user to choose a block, create it and edit it in the controlpanel, in order to show it somewhere else in the website. I am reusing some of the GridBlock/Container machinery there but my controlpanel is saving its input every time I click buttons in the chooser, in the block (e.g. Image Block) etc.

I specifically avoided touching most views and controlpanels because those are more self-consistent components that we can't really reuse and also avoided touching widgets because it's more likely to cause breakage since they are already meant to be used in forms.