### PR TITLE
File widget a11y

### DIFF
--- a/news/6798.bugfix
+++ b/news/6798.bugfix
@@ -1,0 +1,1 @@
+Improved the accessibility of the ‘FileWidget’ component by adding ‘aria-labelledby’ and ‘aria-describedby’ to the dropzone area. @Wagner3UB

--- a/src/components/manage/Widgets/FileWidget.jsx
+++ b/src/components/manage/Widgets/FileWidget.jsx
@@ -141,7 +141,7 @@ const FileWidget = (props) => {
                 src={imgsrc}
               />
             ) : (
-              <div id={'abc'} className="dropzone-placeholder">
+              <div className="dropzone-placeholder">
                 <p id="dropzone-description" className="dropzone-text">
                   {isDragActive
                     ? intl.formatMessage(messages.releaseDrag)

--- a/src/components/manage/Widgets/FileWidget.jsx
+++ b/src/components/manage/Widgets/FileWidget.jsx
@@ -124,7 +124,14 @@ const FileWidget = (props) => {
     <FormFieldWrapper {...props}>
       <Dropzone onDrop={onDrop}>
         {({ getRootProps, getInputProps, isDragActive }) => (
-          <div className="file-widget-dropzone" {...getRootProps()}>
+          <div
+            id="drop-field"
+            className="file-widget-dropzone"
+            {...getRootProps({
+              'aria-labelledby': `fieldset-${props.fieldSet}-field-label-${id}`,
+              'aria-describedby': 'dropzone-description',
+            })}
+          >
             {isDragActive && <Dimmer active></Dimmer>}
             {fileType ? (
               <Image
@@ -134,20 +141,14 @@ const FileWidget = (props) => {
                 src={imgsrc}
               />
             ) : (
-              <div className="dropzone-placeholder">
-                {isDragActive ? (
-                  <p className="dropzone-text">
-                    {intl.formatMessage(messages.releaseDrag)}
-                  </p>
-                ) : value ? (
-                  <p className="dropzone-text">
-                    {intl.formatMessage(messages.editFile)}
-                  </p>
-                ) : (
-                  <p className="dropzone-text">
-                    {intl.formatMessage(messages.fileDrag)}
-                  </p>
-                )}
+              <div id={'abc'} className="dropzone-placeholder">
+                <p id="dropzone-description" className="dropzone-text">
+                  {isDragActive
+                    ? intl.formatMessage(messages.releaseDrag)
+                    : value
+                    ? intl.formatMessage(messages.editFile)
+                    : intl.formatMessage(messages.fileDrag)}
+                </p>
               </div>
             )}
 

--- a/src/components/manage/Widgets/__snapshots__/FileWidget.test.jsx.snap
+++ b/src/components/manage/Widgets/__snapshots__/FileWidget.test.jsx.snap
@@ -29,7 +29,10 @@ exports[`FileWidget renders a file widget component with value 1`] = `
           class="eight wide column"
         >
           <div
+            aria-describedby="dropzone-description"
+            aria-labelledby="fieldset-default-field-label-my-field"
             class="file-widget-dropzone"
+            id="drop-field"
             tabindex="0"
           >
             <img
@@ -104,7 +107,10 @@ exports[`FileWidget renders a file widget component with value in raw data 1`] =
           class="eight wide column"
         >
           <div
+            aria-describedby="dropzone-description"
+            aria-labelledby="fieldset-default-field-label-my-field"
             class="file-widget-dropzone"
+            id="drop-field"
             tabindex="0"
           >
             <img
@@ -179,14 +185,19 @@ exports[`FileWidget renders an empty file widget component 1`] = `
           class="eight wide column"
         >
           <div
+            aria-describedby="dropzone-description"
+            aria-labelledby="fieldset-default-field-label-my-field"
             class="file-widget-dropzone"
+            id="drop-field"
             tabindex="0"
           >
             <div
               class="dropzone-placeholder"
+              id="abc"
             >
               <p
                 class="dropzone-text"
+                id="dropzone-description"
               >
                 Drop file here to upload a new file
               </p>


### PR DESCRIPTION
The dropdown file widget isn’t properly reading the name of the field and is only reading the message in the content. Ideally, it should first read the name of the field, like ‘Header Image’, followed by the message, such as ‘Drop file here to replace the existing file’, or any of the other messages already set up.

PS. The changes made in this PR will also be applied to the ‘main’ branch as soon as the PR for the current version is approved.