### PR TITLE
Fix QueryWidget focus issue by checking this.node before calling focus

### DIFF
--- a/packages/volto/src/components/manage/Widgets/QueryWidget.jsx
+++ b/packages/volto/src/components/manage/Widgets/QueryWidget.jsx
@@ -105,7 +105,7 @@ export class QuerystringWidgetComponent extends Component {
    * @returns {undefined}
    */
   componentDidMount() {
-    if (this.props.focus) {
+    if (this.props.focus && this.node) {
       this.node.focus();
     }
     this.props.getQuerystring();


### PR DESCRIPTION
This PR fixes an issue where the QueryWidget component attempts to call the focus() method on this.node without ensuring that this.node is defined. This caused a crash when the widget was the first in a form and automatically focused.

Changes
Added a check to ensure this.node is defined before calling focus() in the componentDidMount lifecycle method.

Impact
Prevents the application from crashing when this.node is undefined.

Improves the stability of forms using the QueryWidget.