### PR TITLE
Added id to Checkbox component to proper a11y identification

### DIFF
--- a/packages/volto/news/6802.bugfix
+++ b/packages/volto/news/6802.bugfix
@@ -1,0 +1,1 @@
+a11y - Added id attribute to checkbox widget for proper identification and fixes label functionality for screen readers. @Wagner3UB

--- a/packages/volto/src/components/manage/Widgets/CheckboxWidget.jsx
+++ b/packages/volto/src/components/manage/Widgets/CheckboxWidget.jsx
@@ -31,6 +31,7 @@ const CheckboxWidget = (props) => {
     <FormFieldWrapper {...props} columns={1}>
       <div className="wrapper">
         <Checkbox
+          id={`field-${id}`}
           name={`field-${id}`}
           checked={value || false}
           disabled={isDisabled}

--- a/packages/volto/src/components/manage/Widgets/__snapshots__/CheckboxWidget.test.jsx.snap
+++ b/packages/volto/src/components/manage/Widgets/__snapshots__/CheckboxWidget.test.jsx.snap
@@ -22,6 +22,7 @@ exports[`CheckboxWidget renders a checkbox widget component 1`] = `
             >
               <input
                 class="hidden"
+                id="field-my-field"
                 name="field-my-field"
                 readonly=""
                 tabindex="0"
@@ -65,6 +66,7 @@ exports[`CheckboxWidget renders a checkbox widget component checked 1`] = `
               <input
                 checked=""
                 class="hidden"
+                id="field-my-field"
                 name="field-my-field"
                 readonly=""
                 tabindex="0"

--- a/packages/volto/src/config/index.js
+++ b/packages/volto/src/config/index.js
@@ -112,8 +112,8 @@ let config = {
     notSupportedBrowsers: ['ie'],
     defaultPageSize: 25,
     isMultilingual: false,
-    supportedLanguages: ['en'],
-    defaultLanguage: 'en',
+    supportedLanguages: ['it'],
+    defaultLanguage: 'it',
     navDepth: 1,
     expressMiddleware: serverConfig.expressMiddleware, // BBB
     defaultBlockType: 'slate',

--- a/packages/volto/src/config/index.js
+++ b/packages/volto/src/config/index.js
@@ -112,8 +112,8 @@ let config = {
     notSupportedBrowsers: ['ie'],
     defaultPageSize: 25,
     isMultilingual: false,
-    supportedLanguages: ['it'],
-    defaultLanguage: 'it',
+    supportedLanguages: ['en'],
+    defaultLanguage: 'en',
     navDepth: 1,
     expressMiddleware: serverConfig.expressMiddleware, // BBB
     defaultBlockType: 'slate',


### PR DESCRIPTION
Screen readers are not correctly reading the checkbox because the label, although present, is not properly referenced.
While it suggests an htmlFor attribute, the necessary association is missing, causing it to be ignored.
To resolve this issue, an id has been added to the checkbox, ensuring proper identification and correct label functionality for assistive technologies.

V17 PR: https://github.com/plone/volto/pull/6771/