### PR TITLE
Token Widget Label

### DIFF
--- a/packages/volto/news/6804.bugfix
+++ b/packages/volto/news/6804.bugfix
@@ -1,0 +1,1 @@
+Added an `aria-label` to `CreatableSelect` inside `TokenWidget` to improve the component’s accessibility. @Wagner3UB

--- a/packages/volto/src/components/manage/Widgets/TokenWidget.jsx
+++ b/packages/volto/src/components/manage/Widgets/TokenWidget.jsx
@@ -199,6 +199,7 @@ class TokenWidget extends Component {
           noOptionsMessage={() =>
             this.props.intl.formatMessage(messages.no_options)
           }
+          aria-label={this.props.title}
         />
       </FormFieldWrapper>
     );

--- a/packages/volto/src/components/manage/Widgets/__snapshots__/TokenWidget.test.jsx.snap
+++ b/packages/volto/src/components/manage/Widgets/__snapshots__/TokenWidget.test.jsx.snap
@@ -64,6 +64,7 @@ exports[`renders a token widget component 1`] = `
                 >
                   <input
                     aria-autocomplete="list"
+                    aria-label="My field"
                     aria-labelledby="fieldset-default-field-label-my-field"
                     autoCapitalize="none"
                     autoComplete="off"


### PR DESCRIPTION
Added aria-label to CreatableSelect inside the TokenWidget to better accessibility.

PR for Volto 17: https://github.com/plone/volto/pull/6786