### PR TITLE
Datetime widget a11y

### DIFF
--- a/packages/volto/locales/ca/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ca/LC_MESSAGES/volto.po
@@ -4839,6 +4839,11 @@ msgstr ""
 msgid "private"
 msgstr "privat"
 
+#. Default: "Navigate forward to interact with the calendar and select a date. Press the question mark key to get the keyboard shortcuts for changing dates."
+#: components/manage/Widgets/DatetimeWidget
+msgid "publicationDateMessage"
+msgstr "Navega cap endavant per interactuar amb el calendari i seleccionar una data. Prem la tecla de signe d’interrogació per obtenir les dreceres de teclat per canviar les dates."
+
 #. Default: "Published"
 #: components/manage/Contents/ContentsItem
 msgid "published"

--- a/packages/volto/locales/de/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/de/LC_MESSAGES/volto.po
@@ -4838,6 +4838,11 @@ msgstr ""
 msgid "private"
 msgstr "Privat"
 
+#. Default: "Navigate forward to interact with the calendar and select a date. Press the question mark key to get the keyboard shortcuts for changing dates."
+#: components/manage/Widgets/DatetimeWidget
+msgid "publicationDateMessage"
+msgstr "Navigieren Sie vorwärts, um mit dem Kalender zu interagieren und ein Datum auszuwählen. Drücken Sie die Fragezeichen-Taste, um die Tastaturkürzel zum Ändern von Daten zu erhalten"
+
 #. Default: "Published"
 #: components/manage/Contents/ContentsItem
 msgid "published"

--- a/packages/volto/locales/en/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/en/LC_MESSAGES/volto.po
@@ -4833,6 +4833,11 @@ msgstr ""
 msgid "private"
 msgstr ""
 
+#. Default: "Navigate forward to interact with the calendar and select a date. Press the question mark key to get the keyboard shortcuts for changing dates."
+#: components/manage/Widgets/DatetimeWidget
+msgid "publicationDateMessage"
+msgstr ""
+
 #. Default: "Published"
 #: components/manage/Contents/ContentsItem
 msgid "published"

--- a/packages/volto/locales/es/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/es/LC_MESSAGES/volto.po
@@ -4840,6 +4840,11 @@ msgstr ""
 msgid "private"
 msgstr "Privado"
 
+#. Default: "Navigate forward to interact with the calendar and select a date. Press the question mark key to get the keyboard shortcuts for changing dates."
+#: components/manage/Widgets/DatetimeWidget
+msgid "publicationDateMessage"
+msgstr "Navega hacia adelante para interactuar con el calendario y seleccionar una fecha. Presiona la tecla de interrogación para obtener los atajos de teclado para cambiar las fechas."
+
 #. Default: "Published"
 #: components/manage/Contents/ContentsItem
 msgid "published"

--- a/packages/volto/locales/eu/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/eu/LC_MESSAGES/volto.po
@@ -4840,6 +4840,11 @@ msgstr ""
 msgid "private"
 msgstr "Pribatua"
 
+#. Default: "Navigate forward to interact with the calendar and select a date. Press the question mark key to get the keyboard shortcuts for changing dates."
+#: components/manage/Widgets/DatetimeWidget
+msgid "publicationDateMessage"
+msgstr "Aurrera nabigatu egutegiarekin elkarreragiteko eta data bat hautatzeko. Sakatu galdera ikurra data aldatzeko teklatuko lasterbideak lortzekos"
+
 #. Default: "Published"
 #: components/manage/Contents/ContentsItem
 msgid "published"

--- a/packages/volto/locales/fi/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/fi/LC_MESSAGES/volto.po
@@ -4838,6 +4838,11 @@ msgstr ""
 msgid "private"
 msgstr "yksityinen"
 
+#. Default: "Navigate forward to interact with the calendar and select a date. Press the question mark key to get the keyboard shortcuts for changing dates."
+#: components/manage/Widgets/DatetimeWidget
+msgid "publicationDateMessage"
+msgstr "Siirry eteenpäin ollaksesi vuorovaikutuksessa kalenterin kanssa ja valitaksesi päivämäärän. Paina kysymysmerkkinäppäintä saadaksesi näppäinoikotiet päivämäärien muuttamiseen."
+
 #. Default: "Published"
 #: components/manage/Contents/ContentsItem
 msgid "published"

--- a/packages/volto/locales/fr/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/fr/LC_MESSAGES/volto.po
@@ -4840,6 +4840,11 @@ msgstr ""
 msgid "private"
 msgstr "Privé"
 
+#. Default: "Navigate forward to interact with the calendar and select a date. Press the question mark key to get the keyboard shortcuts for changing dates."
+#: components/manage/Widgets/DatetimeWidget
+msgid "publicationDateMessage"
+msgstr "Naviguez vers l’avant pour interagir avec le calendrier et sélectionner une date. Appuyez sur la touche point d’interrogation pour obtenir les raccourcis clavier permettant de changer les dates."
+
 #. Default: "Published"
 #: components/manage/Contents/ContentsItem
 msgid "published"

--- a/packages/volto/locales/hi/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/hi/LC_MESSAGES/volto.po
@@ -4833,6 +4833,11 @@ msgstr ""
 msgid "private"
 msgstr "निजी"
 
+#. Default: "Navigate forward to interact with the calendar and select a date. Press the question mark key to get the keyboard shortcuts for changing dates."
+#: components/manage/Widgets/DatetimeWidget
+msgid "publicationDateMessage"
+msgstr "कैलेंडर के साथ इंटरैक्ट करने और तारीख चुनने के लिए आगे बढ़ें। तारीख बदलने के लिए कीबोर्ड शॉर्टकट देखने के लिए प्रश्नवाचक चिह्न कुंजी दबाएं।"
+
 #. Default: "Published"
 #: components/manage/Contents/ContentsItem
 msgid "published"

--- a/packages/volto/locales/it/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/it/LC_MESSAGES/volto.po
@@ -4833,6 +4833,11 @@ msgstr "Seleziona un'immagine esistente"
 msgid "private"
 msgstr "Privato"
 
+#. Default: "Navigate forward to interact with the calendar and select a date. Press the question mark key to get the keyboard shortcuts for changing dates."
+#: components/manage/Widgets/DatetimeWidget
+msgid "publicationDateMessage"
+msgstr "Naviga in avanti per interagire con il calendario e selezionare una data. Premi il tasto del punto interrogativo per ottenere le scorciatoie da tastiera per cambiare le date."
+
 #. Default: "Published"
 #: components/manage/Contents/ContentsItem
 msgid "published"

--- a/packages/volto/locales/ja/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ja/LC_MESSAGES/volto.po
@@ -4838,6 +4838,11 @@ msgstr ""
 msgid "private"
 msgstr "非表示"
 
+#. Default: "Navigate forward to interact with the calendar and select a date. Press the question mark key to get the keyboard shortcuts for changing dates."
+#: components/manage/Widgets/DatetimeWidget
+msgid "publicationDateMessage"
+msgstr "カレンダーを操作して日付を選択するには、前に進んでください。日付を変更するためのキーボードショートカットを表示するには、クエスチョンマークキーを押してください"
+
 #. Default: "Published"
 #: components/manage/Contents/ContentsItem
 msgid "published"

--- a/packages/volto/locales/nl/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/nl/LC_MESSAGES/volto.po
@@ -4837,6 +4837,11 @@ msgstr "Kies een bestaande afbeelding"
 msgid "private"
 msgstr "Privé"
 
+#. Default: "Navigate forward to interact with the calendar and select a date. Press the question mark key to get the keyboard shortcuts for changing dates."
+#: components/manage/Widgets/DatetimeWidget
+msgid "publicationDateMessage"
+msgstr "Navigeer vooruit om met de kalender te interageren en een datum te selecteren. Druk op de vraagteken-toets om de sneltoetsen voor het wijzigen van datums te bekijken"
+
 #. Default: "Published"
 #: components/manage/Contents/ContentsItem
 msgid "published"

--- a/packages/volto/locales/pt/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/pt/LC_MESSAGES/volto.po
@@ -4838,6 +4838,11 @@ msgstr ""
 msgid "private"
 msgstr ""
 
+#. Default: "Navigate forward to interact with the calendar and select a date. Press the question mark key to get the keyboard shortcuts for changing dates."
+#: components/manage/Widgets/DatetimeWidget
+msgid "publicationDateMessage"
+msgstr "Navegue para a frente para interagir com o calendário e selecionar uma data. Pressione a tecla de interrogação para ver os atalhos de teclado para alterar as datas."
+
 #. Default: "Published"
 #: components/manage/Contents/ContentsItem
 msgid "published"

--- a/packages/volto/locales/pt_BR/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/pt_BR/LC_MESSAGES/volto.po
@@ -4839,6 +4839,11 @@ msgstr "Selecione uma imagem existente"
 msgid "private"
 msgstr "Privado"
 
+#. Default: "Navigate forward to interact with the calendar and select a date. Press the question mark key to get the keyboard shortcuts for changing dates."
+#: components/manage/Widgets/DatetimeWidget
+msgid "publicationDateMessage"
+msgstr "Navegue para frente para interagir com o calendário e selecionar uma data. Pressione a tecla de interrogação para ver os atalhos de teclado para alterar as datas."
+
 #. Default: "Published"
 #: components/manage/Contents/ContentsItem
 msgid "published"

--- a/packages/volto/locales/ro/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ro/LC_MESSAGES/volto.po
@@ -4839,6 +4839,11 @@ msgstr "Alegeți o imagine existentă"
 msgid "private"
 msgstr "privat"
 
+#. Default: "Navigate forward to interact with the calendar and select a date. Press the question mark key to get the keyboard shortcuts for changing dates."
+#: components/manage/Widgets/DatetimeWidget
+msgid "publicationDateMessage"
+msgstr "Navigați înainte pentru a interacționa cu calendarul și a selecta o dată. Apăsați tasta semn de întrebare pentru a obține comenzile rapide de la tastatură pentru schimbarea datelor."
+
 #. Default: "Published"
 #: components/manage/Contents/ContentsItem
 msgid "published"

--- a/packages/volto/locales/volto.pot
+++ b/packages/volto/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2024-12-06T13:45:21.266Z\n"
+"POT-Creation-Date: 2025-03-04T11:40:01.749Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Content-Type: text/plain; charset=utf-8\n"
@@ -4833,6 +4833,11 @@ msgstr ""
 #. Default: "Private"
 #: components/manage/Contents/ContentsItem
 msgid "private"
+msgstr ""
+
+#. Default: "Navigate forward to interact with the calendar and select a date. Press the question mark key to get the keyboard shortcuts for changing dates."
+#: components/manage/Widgets/DatetimeWidget
+msgid "publicationDateMessage"
 msgstr ""
 
 #. Default: "Published"

--- a/packages/volto/locales/zh_CN/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/zh_CN/LC_MESSAGES/volto.po
@@ -4839,6 +4839,11 @@ msgstr ""
 msgid "private"
 msgstr "保密"
 
+#. Default: "Navigate forward to interact with the calendar and select a date. Press the question mark key to get the keyboard shortcuts for changing dates."
+#: components/manage/Widgets/DatetimeWidget
+msgid "publicationDateMessage"
+msgstr "向前导航以与日历交互并选择日期。按问号键可获取更改日期的键盘快捷键。向前导航以与日历交互并选择日期。按问号键可获取更改日期的键盘快捷键。"
+
 #. Default: "Published"
 #: components/manage/Contents/ContentsItem
 msgid "published"

--- a/packages/volto/src/components/manage/Widgets/DatetimeWidget.jsx
+++ b/packages/volto/src/components/manage/Widgets/DatetimeWidget.jsx
@@ -27,6 +27,11 @@ const messages = defineMessages({
     id: 'Time',
     defaultMessage: 'Time',
   },
+  publicationDateMessage: {
+    id: 'publicationDateMessage',
+    defaultMessage:
+      'Navigate forward to interact with the calendar and select a date. Press the question mark key to get the keyboard shortcuts for changing dates.',
+  },
 });
 
 const PrevIcon = () => (
@@ -151,6 +156,10 @@ const DatetimeWidgetComponent = (props) => {
   const datetime = getInternalValue();
   const isDateOnly = getDateOnly();
 
+  const screenReaderInputMessage = intl.formatMessage(
+    messages.publicationDateMessage,
+  );
+
   return (
     <FormFieldWrapper {...props}>
       <div className="date-time-widget-wrapper">
@@ -175,6 +184,8 @@ const DatetimeWidgetComponent = (props) => {
             navNext={<NextIcon />}
             id={`${id}-date`}
             placeholder={intl.formatMessage(messages.date)}
+            ariaLabel={props.title}
+            screenReaderInputMessage={screenReaderInputMessage}
           />
         </div>
         {!isDateOnly && (


### PR DESCRIPTION
Improved accessibility for the ‘Datetime-Widget’ component by adding an ‘aria-label’ and a translation for the ‘screenReaderInputMessage’.

PR Volto 17: https://github.com/plone/volto/pull/6793/