### PR TITLE
fix manual link error handling

### DIFF
--- a/packages/volto/src/components/manage/Widgets/ObjectBrowserWidget.jsx
+++ b/packages/volto/src/components/manage/Widgets/ObjectBrowserWidget.jsx
@@ -355,7 +355,7 @@ export class ObjectBrowserWidgetComponent extends Component {
       <FormFieldWrapper
         {...this.props}
         // At the moment, OBW handles its own errors and validation
-        error={this.state.errors}
+        error={this.state.errors.length > 0 ? this.state.errors[0] : null}
         className={description ? 'help text' : 'text'}
       >
         <div


### PR DESCRIPTION
fix #6787

Ensuring empty URLs do not trigger validation errors.
Optimizing setState calls to prevent unnecessary re-renders.
Handling error messages properly in <FormFieldWrapper>.
Making className assignment safer when using description.