### PR TITLE
Add validator for `default_language` in language control panel

### DIFF
--- a/docs/source/configuration/validation.md
+++ b/docs/source/configuration/validation.md
@@ -95,6 +95,7 @@ In the following example, the `urlValidator` method validator will be applied fo
 config.registerUtility({
   type: 'validator',
   name: 'url',
+  dependencies: { format: 'url' },
   method: urlValidator,
 })
 ```

--- a/packages/volto/locales/ca/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ca/LC_MESSAGES/volto.po
@@ -3769,9 +3769,9 @@ msgstr ""
 msgid "The registration process has been successful. Please check your e-mail inbox for information on how activate your account."
 msgstr "El procés de registre ha estat satisfactori. Si us plau, comproveu la vostra bústia d'entrada de correu electrònic per obtenir informació sobre com activar el vostre compte."
 
-#. Default: "The selected default language must be in the list of the field "Available languages""
+#. Default: "The selected default language must be in the list of the field 'Available languages'"
 #: helpers/MessageLabels/MessageLabels
-msgid "The selected default language must be in the list of the field "Available languages""
+msgid "The selected default language must be in the list of the field 'Available languages'"
 msgstr ""
 
 #. Default: "The site configuration is outdated and needs to be upgraded."

--- a/packages/volto/locales/ca/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ca/LC_MESSAGES/volto.po
@@ -3769,6 +3769,11 @@ msgstr ""
 msgid "The registration process has been successful. Please check your e-mail inbox for information on how activate your account."
 msgstr "El procés de registre ha estat satisfactori. Si us plau, comproveu la vostra bústia d'entrada de correu electrònic per obtenir informació sobre com activar el vostre compte."
 
+#. Default: "The selected default language must be in the list of the field "Available languages""
+#: helpers/MessageLabels/MessageLabels
+msgid "The selected default language must be in the list of the field "Available languages""
+msgstr ""
+
 #. Default: "The site configuration is outdated and needs to be upgraded."
 #: components/manage/Controlpanels/Controlpanels
 #: components/manage/Controlpanels/UpgradeControlPanel

--- a/packages/volto/locales/de/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/de/LC_MESSAGES/volto.po
@@ -3768,6 +3768,11 @@ msgstr "Die angegebene alternative URL existiert bereits."
 msgid "The registration process has been successful. Please check your e-mail inbox for information on how activate your account."
 msgstr "Bitte prüfen Sie Ihr E-Mail Postfach. Sie sollten eine E-Mail erhalten haben mit Anweisungen, wie Sie Ihren Zugang aktivieren können."
 
+#. Default: "The selected default language must be in the list of the field "Available languages""
+#: helpers/MessageLabels/MessageLabels
+msgid "The selected default language must be in the list of the field "Available languages""
+msgstr ""
+
 #. Default: "The site configuration is outdated and needs to be upgraded."
 #: components/manage/Controlpanels/Controlpanels
 #: components/manage/Controlpanels/UpgradeControlPanel

--- a/packages/volto/locales/de/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/de/LC_MESSAGES/volto.po
@@ -3768,9 +3768,9 @@ msgstr "Die angegebene alternative URL existiert bereits."
 msgid "The registration process has been successful. Please check your e-mail inbox for information on how activate your account."
 msgstr "Bitte prüfen Sie Ihr E-Mail Postfach. Sie sollten eine E-Mail erhalten haben mit Anweisungen, wie Sie Ihren Zugang aktivieren können."
 
-#. Default: "The selected default language must be in the list of the field "Available languages""
+#. Default: "The selected default language must be in the list of the field 'Available languages'"
 #: helpers/MessageLabels/MessageLabels
-msgid "The selected default language must be in the list of the field "Available languages""
+msgid "The selected default language must be in the list of the field 'Available languages'"
 msgstr ""
 
 #. Default: "The site configuration is outdated and needs to be upgraded."

--- a/packages/volto/locales/en/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/en/LC_MESSAGES/volto.po
@@ -3763,9 +3763,9 @@ msgstr ""
 msgid "The registration process has been successful. Please check your e-mail inbox for information on how activate your account."
 msgstr ""
 
-#. Default: "The selected default language must be in the list of the field "Available languages""
+#. Default: "The selected default language must be in the list of the field 'Available languages'"
 #: helpers/MessageLabels/MessageLabels
-msgid "The selected default language must be in the list of the field "Available languages""
+msgid "The selected default language must be in the list of the field 'Available languages'"
 msgstr ""
 
 #. Default: "The site configuration is outdated and needs to be upgraded."

--- a/packages/volto/locales/en/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/en/LC_MESSAGES/volto.po
@@ -3763,6 +3763,11 @@ msgstr ""
 msgid "The registration process has been successful. Please check your e-mail inbox for information on how activate your account."
 msgstr ""
 
+#. Default: "The selected default language must be in the list of the field "Available languages""
+#: helpers/MessageLabels/MessageLabels
+msgid "The selected default language must be in the list of the field "Available languages""
+msgstr ""
+
 #. Default: "The site configuration is outdated and needs to be upgraded."
 #: components/manage/Controlpanels/Controlpanels
 #: components/manage/Controlpanels/UpgradeControlPanel

--- a/packages/volto/locales/es/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/es/LC_MESSAGES/volto.po
@@ -3770,9 +3770,9 @@ msgstr "¡La URL alternativa ya existe!"
 msgid "The registration process has been successful. Please check your e-mail inbox for information on how activate your account."
 msgstr "El registro fue exitoso. Por favor, verifique su bandeja de entrada para obtener información sobre cómo activar su cuenta."
 
-#. Default: "The selected default language must be in the list of the field "Available languages""
+#. Default: "The selected default language must be in the list of the field 'Available languages'"
 #: helpers/MessageLabels/MessageLabels
-msgid "The selected default language must be in the list of the field "Available languages""
+msgid "The selected default language must be in the list of the field 'Available languages'"
 msgstr ""
 
 #. Default: "The site configuration is outdated and needs to be upgraded."

--- a/packages/volto/locales/es/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/es/LC_MESSAGES/volto.po
@@ -3770,6 +3770,11 @@ msgstr "¡La URL alternativa ya existe!"
 msgid "The registration process has been successful. Please check your e-mail inbox for information on how activate your account."
 msgstr "El registro fue exitoso. Por favor, verifique su bandeja de entrada para obtener información sobre cómo activar su cuenta."
 
+#. Default: "The selected default language must be in the list of the field "Available languages""
+#: helpers/MessageLabels/MessageLabels
+msgid "The selected default language must be in the list of the field "Available languages""
+msgstr ""
+
 #. Default: "The site configuration is outdated and needs to be upgraded."
 #: components/manage/Controlpanels/Controlpanels
 #: components/manage/Controlpanels/UpgradeControlPanel

--- a/packages/volto/locales/eu/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/eu/LC_MESSAGES/volto.po
@@ -3770,9 +3770,9 @@ msgstr "Eman duzun ordezko bidea jada badago!"
 msgid "The registration process has been successful. Please check your e-mail inbox for information on how activate your account."
 msgstr "Izen-emate prozesua ondo egin duzu. Begiratu zure eposta, kontua aktibatzeko informazioa bertara bidali dizugu-eta."
 
-#. Default: "The selected default language must be in the list of the field "Available languages""
+#. Default: "The selected default language must be in the list of the field 'Available languages'"
 #: helpers/MessageLabels/MessageLabels
-msgid "The selected default language must be in the list of the field "Available languages""
+msgid "The selected default language must be in the list of the field 'Available languages'"
 msgstr ""
 
 #. Default: "The site configuration is outdated and needs to be upgraded."

--- a/packages/volto/locales/eu/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/eu/LC_MESSAGES/volto.po
@@ -3770,6 +3770,11 @@ msgstr "Eman duzun ordezko bidea jada badago!"
 msgid "The registration process has been successful. Please check your e-mail inbox for information on how activate your account."
 msgstr "Izen-emate prozesua ondo egin duzu. Begiratu zure eposta, kontua aktibatzeko informazioa bertara bidali dizugu-eta."
 
+#. Default: "The selected default language must be in the list of the field "Available languages""
+#: helpers/MessageLabels/MessageLabels
+msgid "The selected default language must be in the list of the field "Available languages""
+msgstr ""
+
 #. Default: "The site configuration is outdated and needs to be upgraded."
 #: components/manage/Controlpanels/Controlpanels
 #: components/manage/Controlpanels/UpgradeControlPanel

--- a/packages/volto/locales/fi/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/fi/LC_MESSAGES/volto.po
@@ -3768,6 +3768,11 @@ msgstr "Ehdotettu vaihtoehtoinen URL on jo olemassa!"
 msgid "The registration process has been successful. Please check your e-mail inbox for information on how activate your account."
 msgstr "Rekisteröinti onnistui. Tarkista, saitko sähköpostiisi ohjeet käyttäjätunnuksesi aktivoimiseksi."
 
+#. Default: "The selected default language must be in the list of the field "Available languages""
+#: helpers/MessageLabels/MessageLabels
+msgid "The selected default language must be in the list of the field "Available languages""
+msgstr ""
+
 #. Default: "The site configuration is outdated and needs to be upgraded."
 #: components/manage/Controlpanels/Controlpanels
 #: components/manage/Controlpanels/UpgradeControlPanel

--- a/packages/volto/locales/fi/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/fi/LC_MESSAGES/volto.po
@@ -3768,9 +3768,9 @@ msgstr "Ehdotettu vaihtoehtoinen URL on jo olemassa!"
 msgid "The registration process has been successful. Please check your e-mail inbox for information on how activate your account."
 msgstr "Rekisteröinti onnistui. Tarkista, saitko sähköpostiisi ohjeet käyttäjätunnuksesi aktivoimiseksi."
 
-#. Default: "The selected default language must be in the list of the field "Available languages""
+#. Default: "The selected default language must be in the list of the field 'Available languages'"
 #: helpers/MessageLabels/MessageLabels
-msgid "The selected default language must be in the list of the field "Available languages""
+msgid "The selected default language must be in the list of the field 'Available languages'"
 msgstr ""
 
 #. Default: "The site configuration is outdated and needs to be upgraded."

--- a/packages/volto/locales/fr/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/fr/LC_MESSAGES/volto.po
@@ -3770,6 +3770,11 @@ msgstr "L'URL alternative fournie existe déjà !"
 msgid "The registration process has been successful. Please check your e-mail inbox for information on how activate your account."
 msgstr "Le processus d'inscription a réussi. Veuillez vérifier votre boîte e-mail pour savoir comment activer votre compte."
 
+#. Default: "The selected default language must be in the list of the field "Available languages""
+#: helpers/MessageLabels/MessageLabels
+msgid "The selected default language must be in the list of the field "Available languages""
+msgstr ""
+
 #. Default: "The site configuration is outdated and needs to be upgraded."
 #: components/manage/Controlpanels/Controlpanels
 #: components/manage/Controlpanels/UpgradeControlPanel

--- a/packages/volto/locales/fr/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/fr/LC_MESSAGES/volto.po
@@ -3770,9 +3770,9 @@ msgstr "L'URL alternative fournie existe déjà !"
 msgid "The registration process has been successful. Please check your e-mail inbox for information on how activate your account."
 msgstr "Le processus d'inscription a réussi. Veuillez vérifier votre boîte e-mail pour savoir comment activer votre compte."
 
-#. Default: "The selected default language must be in the list of the field "Available languages""
+#. Default: "The selected default language must be in the list of the field 'Available languages'"
 #: helpers/MessageLabels/MessageLabels
-msgid "The selected default language must be in the list of the field "Available languages""
+msgid "The selected default language must be in the list of the field 'Available languages'"
 msgstr ""
 
 #. Default: "The site configuration is outdated and needs to be upgraded."

--- a/packages/volto/locales/hi/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/hi/LC_MESSAGES/volto.po
@@ -3763,9 +3763,9 @@ msgstr "प्रदान किया गया वैकल्पिक य�
 msgid "The registration process has been successful. Please check your e-mail inbox for information on how activate your account."
 msgstr "रजिस्ट्रेशन प्रक्रिया सफल रही है। कृपया अपने ईमेल इनबॉक्स में अपने खाते को सक्रिय करने के लिए जानकारी के लिए जाँच करें।"
 
-#. Default: "The selected default language must be in the list of the field "Available languages""
+#. Default: "The selected default language must be in the list of the field 'Available languages'"
 #: helpers/MessageLabels/MessageLabels
-msgid "The selected default language must be in the list of the field "Available languages""
+msgid "The selected default language must be in the list of the field 'Available languages'"
 msgstr ""
 
 #. Default: "The site configuration is outdated and needs to be upgraded."

--- a/packages/volto/locales/hi/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/hi/LC_MESSAGES/volto.po
@@ -3763,6 +3763,11 @@ msgstr "प्रदान किया गया वैकल्पिक य�
 msgid "The registration process has been successful. Please check your e-mail inbox for information on how activate your account."
 msgstr "रजिस्ट्रेशन प्रक्रिया सफल रही है। कृपया अपने ईमेल इनबॉक्स में अपने खाते को सक्रिय करने के लिए जानकारी के लिए जाँच करें।"
 
+#. Default: "The selected default language must be in the list of the field "Available languages""
+#: helpers/MessageLabels/MessageLabels
+msgid "The selected default language must be in the list of the field "Available languages""
+msgstr ""
+
 #. Default: "The site configuration is outdated and needs to be upgraded."
 #: components/manage/Controlpanels/Controlpanels
 #: components/manage/Controlpanels/UpgradeControlPanel

--- a/packages/volto/locales/it/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/it/LC_MESSAGES/volto.po
@@ -3763,9 +3763,9 @@ msgstr "L'url alternativo inserito è già stato utilizzato!"
 msgid "The registration process has been successful. Please check your e-mail inbox for information on how activate your account."
 msgstr "La registrazione è avvenuta correttamente. Per favore controlla la tua casella di posta per informazioni su come attivare il tuo account."
 
-#. Default: "The selected default language must be in the list of the field "Available languages""
+#. Default: "The selected default language must be in the list of the field 'Available languages'"
 #: helpers/MessageLabels/MessageLabels
-msgid "The selected default language must be in the list of the field "Available languages""
+msgid "The selected default language must be in the list of the field 'Available languages'"
 msgstr ""
 
 #. Default: "The site configuration is outdated and needs to be upgraded."

--- a/packages/volto/locales/it/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/it/LC_MESSAGES/volto.po
@@ -3763,6 +3763,11 @@ msgstr "L'url alternativo inserito è già stato utilizzato!"
 msgid "The registration process has been successful. Please check your e-mail inbox for information on how activate your account."
 msgstr "La registrazione è avvenuta correttamente. Per favore controlla la tua casella di posta per informazioni su come attivare il tuo account."
 
+#. Default: "The selected default language must be in the list of the field "Available languages""
+#: helpers/MessageLabels/MessageLabels
+msgid "The selected default language must be in the list of the field "Available languages""
+msgstr ""
+
 #. Default: "The site configuration is outdated and needs to be upgraded."
 #: components/manage/Controlpanels/Controlpanels
 #: components/manage/Controlpanels/UpgradeControlPanel

--- a/packages/volto/locales/ja/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ja/LC_MESSAGES/volto.po
@@ -3768,9 +3768,9 @@ msgstr ""
 msgid "The registration process has been successful. Please check your e-mail inbox for information on how activate your account."
 msgstr "The registration process has been successful. Please check your e-mail inbox for information on how activate your account. (未翻訳)"
 
-#. Default: "The selected default language must be in the list of the field "Available languages""
+#. Default: "The selected default language must be in the list of the field 'Available languages'"
 #: helpers/MessageLabels/MessageLabels
-msgid "The selected default language must be in the list of the field "Available languages""
+msgid "The selected default language must be in the list of the field 'Available languages'"
 msgstr ""
 
 #. Default: "The site configuration is outdated and needs to be upgraded."

--- a/packages/volto/locales/ja/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ja/LC_MESSAGES/volto.po
@@ -3768,6 +3768,11 @@ msgstr ""
 msgid "The registration process has been successful. Please check your e-mail inbox for information on how activate your account."
 msgstr "The registration process has been successful. Please check your e-mail inbox for information on how activate your account. (未翻訳)"
 
+#. Default: "The selected default language must be in the list of the field "Available languages""
+#: helpers/MessageLabels/MessageLabels
+msgid "The selected default language must be in the list of the field "Available languages""
+msgstr ""
+
 #. Default: "The site configuration is outdated and needs to be upgraded."
 #: components/manage/Controlpanels/Controlpanels
 #: components/manage/Controlpanels/UpgradeControlPanel

--- a/packages/volto/locales/nl/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/nl/LC_MESSAGES/volto.po
@@ -3767,6 +3767,11 @@ msgstr "De ingevoerde alternatieve URL bestaat reeds!"
 msgid "The registration process has been successful. Please check your e-mail inbox for information on how activate your account."
 msgstr "Het registratieproces was succesvol. Controleer jouw e-mails voor informatie over hoe jouw account te activeren."
 
+#. Default: "The selected default language must be in the list of the field "Available languages""
+#: helpers/MessageLabels/MessageLabels
+msgid "The selected default language must be in the list of the field "Available languages""
+msgstr ""
+
 #. Default: "The site configuration is outdated and needs to be upgraded."
 #: components/manage/Controlpanels/Controlpanels
 #: components/manage/Controlpanels/UpgradeControlPanel

--- a/packages/volto/locales/nl/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/nl/LC_MESSAGES/volto.po
@@ -3767,9 +3767,9 @@ msgstr "De ingevoerde alternatieve URL bestaat reeds!"
 msgid "The registration process has been successful. Please check your e-mail inbox for information on how activate your account."
 msgstr "Het registratieproces was succesvol. Controleer jouw e-mails voor informatie over hoe jouw account te activeren."
 
-#. Default: "The selected default language must be in the list of the field "Available languages""
+#. Default: "The selected default language must be in the list of the field 'Available languages'"
 #: helpers/MessageLabels/MessageLabels
-msgid "The selected default language must be in the list of the field "Available languages""
+msgid "The selected default language must be in the list of the field 'Available languages'"
 msgstr ""
 
 #. Default: "The site configuration is outdated and needs to be upgraded."

--- a/packages/volto/locales/pt/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/pt/LC_MESSAGES/volto.po
@@ -3768,6 +3768,11 @@ msgstr ""
 msgid "The registration process has been successful. Please check your e-mail inbox for information on how activate your account."
 msgstr "O processo de registo foi bem sucedido. Por favor verifique no seu e-mail a informação sobre como activar a sua conta."
 
+#. Default: "The selected default language must be in the list of the field "Available languages""
+#: helpers/MessageLabels/MessageLabels
+msgid "The selected default language must be in the list of the field "Available languages""
+msgstr ""
+
 #. Default: "The site configuration is outdated and needs to be upgraded."
 #: components/manage/Controlpanels/Controlpanels
 #: components/manage/Controlpanels/UpgradeControlPanel

--- a/packages/volto/locales/pt/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/pt/LC_MESSAGES/volto.po
@@ -3768,9 +3768,9 @@ msgstr ""
 msgid "The registration process has been successful. Please check your e-mail inbox for information on how activate your account."
 msgstr "O processo de registo foi bem sucedido. Por favor verifique no seu e-mail a informação sobre como activar a sua conta."
 
-#. Default: "The selected default language must be in the list of the field "Available languages""
+#. Default: "The selected default language must be in the list of the field 'Available languages'"
 #: helpers/MessageLabels/MessageLabels
-msgid "The selected default language must be in the list of the field "Available languages""
+msgid "The selected default language must be in the list of the field 'Available languages'"
 msgstr ""
 
 #. Default: "The site configuration is outdated and needs to be upgraded."

--- a/packages/volto/locales/pt_BR/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/pt_BR/LC_MESSAGES/volto.po
@@ -3769,6 +3769,11 @@ msgstr "A URL alternativa já existe!"
 msgid "The registration process has been successful. Please check your e-mail inbox for information on how activate your account."
 msgstr "O processo de registro foi bem sucedido. Verifique sua caixa de entrada de e-mail para obter informações sobre como ativar sua conta."
 
+#. Default: "The selected default language must be in the list of the field "Available languages""
+#: helpers/MessageLabels/MessageLabels
+msgid "The selected default language must be in the list of the field "Available languages""
+msgstr ""
+
 #. Default: "The site configuration is outdated and needs to be upgraded."
 #: components/manage/Controlpanels/Controlpanels
 #: components/manage/Controlpanels/UpgradeControlPanel

--- a/packages/volto/locales/pt_BR/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/pt_BR/LC_MESSAGES/volto.po
@@ -3769,9 +3769,9 @@ msgstr "A URL alternativa já existe!"
 msgid "The registration process has been successful. Please check your e-mail inbox for information on how activate your account."
 msgstr "O processo de registro foi bem sucedido. Verifique sua caixa de entrada de e-mail para obter informações sobre como ativar sua conta."
 
-#. Default: "The selected default language must be in the list of the field "Available languages""
+#. Default: "The selected default language must be in the list of the field 'Available languages'"
 #: helpers/MessageLabels/MessageLabels
-msgid "The selected default language must be in the list of the field "Available languages""
+msgid "The selected default language must be in the list of the field 'Available languages'"
 msgstr ""
 
 #. Default: "The site configuration is outdated and needs to be upgraded."

--- a/packages/volto/locales/ro/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ro/LC_MESSAGES/volto.po
@@ -3769,6 +3769,11 @@ msgstr "URL-ul alternativ furnizat există deja!"
 msgid "The registration process has been successful. Please check your e-mail inbox for information on how activate your account."
 msgstr "Procesul de înregistrare a avut succes. Vă rugăm să verificați căsuța de e-mail pentru informații despre modul de activare a contului dvs."
 
+#. Default: "The selected default language must be in the list of the field "Available languages""
+#: helpers/MessageLabels/MessageLabels
+msgid "The selected default language must be in the list of the field "Available languages""
+msgstr ""
+
 #. Default: "The site configuration is outdated and needs to be upgraded."
 #: components/manage/Controlpanels/Controlpanels
 #: components/manage/Controlpanels/UpgradeControlPanel

--- a/packages/volto/locales/ro/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ro/LC_MESSAGES/volto.po
@@ -3769,9 +3769,9 @@ msgstr "URL-ul alternativ furnizat există deja!"
 msgid "The registration process has been successful. Please check your e-mail inbox for information on how activate your account."
 msgstr "Procesul de înregistrare a avut succes. Vă rugăm să verificați căsuța de e-mail pentru informații despre modul de activare a contului dvs."
 
-#. Default: "The selected default language must be in the list of the field "Available languages""
+#. Default: "The selected default language must be in the list of the field 'Available languages'"
 #: helpers/MessageLabels/MessageLabels
-msgid "The selected default language must be in the list of the field "Available languages""
+msgid "The selected default language must be in the list of the field 'Available languages'"
 msgstr ""
 
 #. Default: "The site configuration is outdated and needs to be upgraded."

--- a/packages/volto/locales/volto.pot
+++ b/packages/volto/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2024-12-06T13:45:21.266Z\n"
+"POT-Creation-Date: 2025-03-05T10:53:16.765Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Content-Type: text/plain; charset=utf-8\n"
@@ -3763,6 +3763,11 @@ msgstr ""
 #. Default: "The registration process has been successful. Please check your e-mail inbox for information on how activate your account."
 #: components/theme/Register/Register
 msgid "The registration process has been successful. Please check your e-mail inbox for information on how activate your account."
+msgstr ""
+
+#. Default: "The selected default language must be in the list of the field "Available languages""
+#: helpers/MessageLabels/MessageLabels
+msgid "The selected default language must be in the list of the field "Available languages""
 msgstr ""
 
 #. Default: "The site configuration is outdated and needs to be upgraded."

--- a/packages/volto/locales/volto.pot
+++ b/packages/volto/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2025-03-05T10:53:16.765Z\n"
+"POT-Creation-Date: 2025-03-05T13:04:20.470Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Content-Type: text/plain; charset=utf-8\n"
@@ -3765,9 +3765,9 @@ msgstr ""
 msgid "The registration process has been successful. Please check your e-mail inbox for information on how activate your account."
 msgstr ""
 
-#. Default: "The selected default language must be in the list of the field "Available languages""
+#. Default: "The selected default language must be in the list of the field 'Available languages'"
 #: helpers/MessageLabels/MessageLabels
-msgid "The selected default language must be in the list of the field "Available languages""
+msgid "The selected default language must be in the list of the field 'Available languages'"
 msgstr ""
 
 #. Default: "The site configuration is outdated and needs to be upgraded."

--- a/packages/volto/locales/zh_CN/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/zh_CN/LC_MESSAGES/volto.po
@@ -3769,9 +3769,9 @@ msgstr "提供的替代url已经存在!"
 msgid "The registration process has been successful. Please check your e-mail inbox for information on how activate your account."
 msgstr "注册过程成功完成。请在您的电子邮箱中查看有关如何激活账户的信息。"
 
-#. Default: "The selected default language must be in the list of the field "Available languages""
+#. Default: "The selected default language must be in the list of the field 'Available languages'"
 #: helpers/MessageLabels/MessageLabels
-msgid "The selected default language must be in the list of the field "Available languages""
+msgid "The selected default language must be in the list of the field 'Available languages'"
 msgstr ""
 
 #. Default: "The site configuration is outdated and needs to be upgraded."

--- a/packages/volto/locales/zh_CN/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/zh_CN/LC_MESSAGES/volto.po
@@ -3769,6 +3769,11 @@ msgstr "提供的替代url已经存在!"
 msgid "The registration process has been successful. Please check your e-mail inbox for information on how activate your account."
 msgstr "注册过程成功完成。请在您的电子邮箱中查看有关如何激活账户的信息。"
 
+#. Default: "The selected default language must be in the list of the field "Available languages""
+#: helpers/MessageLabels/MessageLabels
+msgid "The selected default language must be in the list of the field "Available languages""
+msgstr ""
+
 #. Default: "The site configuration is outdated and needs to be upgraded."
 #: components/manage/Controlpanels/Controlpanels
 #: components/manage/Controlpanels/UpgradeControlPanel

--- a/packages/volto/news/6811.feature
+++ b/packages/volto/news/6811.feature
@@ -1,0 +1,1 @@
+Add validator for `default_language` in language control panel. @sneridagh

--- a/packages/volto/src/components/manage/Widgets/SelectWidget.jsx
+++ b/packages/volto/src/components/manage/Widgets/SelectWidget.jsx
@@ -251,6 +251,7 @@ class SelectWidget extends Component {
             this.props.placeholder ??
             this.props.intl.formatMessage(messages.select)
           }
+          onBlur={() => this.props.onBlur(id, value)}
           onChange={(selectedOption) => {
             if (isMulti) {
               return onChange(

--- a/packages/volto/src/config/validation.ts
+++ b/packages/volto/src/config/validation.ts
@@ -15,6 +15,7 @@ import {
   startEventDateRangeValidator,
   endEventDateRangeValidator,
   patternValidator,
+  defaultLanguageControlPanelValidator,
 } from '@plone/volto/helpers/FormValidation/validators';
 
 const registerValidators = (config: ConfigType) => {
@@ -149,6 +150,13 @@ const registerValidators = (config: ConfigType) => {
     type: 'validator',
     dependencies: { behaviorName: 'plone.eventbasic', fieldName: 'end' },
     method: endEventDateRangeValidator,
+  });
+
+  config.registerUtility({
+    name: 'default_language',
+    type: 'validator',
+    dependencies: { format: 'default_language' },
+    method: defaultLanguageControlPanelValidator,
   });
 };
 

--- a/packages/volto/src/helpers/FormValidation/validators.ts
+++ b/packages/volto/src/helpers/FormValidation/validators.ts
@@ -203,3 +203,17 @@ export const minItemsValidator = ({
     ? formatMessage(messages.minItems, { minItems: field.minItems })
     : null;
 };
+
+export const defaultLanguageControlPanelValidator = ({
+  value,
+  formData,
+  formatMessage,
+}: Validator) => {
+  const isValid =
+    value &&
+    (formData.available_languages.find(
+      (lang: { token: string }) => lang.token === value,
+    ) ||
+      formData.available_languages.includes(value));
+  return !isValid ? formatMessage(messages.defaultLanguage) : null;
+};

--- a/packages/volto/src/helpers/MessageLabels/MessageLabels.js
+++ b/packages/volto/src/helpers/MessageLabels/MessageLabels.js
@@ -404,8 +404,8 @@ export const messages = defineMessages({
       'The number of items must be greater than or equal to {minItems}',
   },
   defaultLanguage: {
-    id: 'The selected default language must be in the list of the field "Available languages"',
+    id: "The selected default language must be in the list of the field 'Available languages'",
     defaultMessage:
-      'The selected default language must be in the list of the field "Available languages"',
+      "The selected default language must be in the list of the field 'Available languages'",
   },
 });

--- a/packages/volto/src/helpers/MessageLabels/MessageLabels.js
+++ b/packages/volto/src/helpers/MessageLabels/MessageLabels.js
@@ -403,4 +403,9 @@ export const messages = defineMessages({
     defaultMessage:
       'The number of items must be greater than or equal to {minItems}',
   },
+  defaultLanguage: {
+    id: 'The selected default language must be in the list of the field "Available languages"',
+    defaultMessage:
+      'The selected default language must be in the list of the field "Available languages"',
+  },
 });


### PR DESCRIPTION
Fixes the use case that you can save a new default language without adding it to the list of available languages.
Now it complains, on blur and on save.
Probably, it would need a server side validator too.

Depends on https://github.com/plone/plone.i18n/pull/73 but not requires it.

Also fixes a section of the docs that was incorrect.

<!-- readthedocs-preview volto start -->
----
📚 Documentation preview 📚: https://volto--6811.org.readthedocs.build/

<!-- readthedocs-preview volto end -->