### PR TITLE
Fix warnings in Sphinx 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,5 +194,4 @@ You should check the dependencies in their `package.json` for more details.
 - [volto-centraalmuseum-theme](https://github.com/intk/volto-centraalmuseum-theme) - Volto project for the [Centraal Museum & Rietveld](https://www.centraalmuseum.nl/nl) made for [INTK](https://www.intk.com/en).
 - [volto-eea-design-system](https://github.com/eea/volto-eea-design-system) - EEA Design System Plone 6 Kit Volto project for [European Environment Agency web sites](https://eea.github.io/volto-eea-design-system/)
 - [volto-eea-kitkat](https://github.com/eea/volto-eea-kitkat) - A known good set of Volto add-ons to be used within all EEA projects and beyond, made for [European Environment Agency](https://www.eea.europa.eu/en)
-- [volto-rietveldschroderhuis-theme](https://github.com/intk/volto-rietveldschroderhuis-theme) - Volto project for the [Rietveld Schröder House](https://www.rietveldschroderhuis.nl/en) made for [INTK](https://www.intk.com/en).
 - [volto-zeeuwsmuseum-theme](https://github.com/intk/volto-zeeuwsmuseum-theme) - Volto project for the [Zeeuws Museum](https://www.zeeuwsmuseum.nl/en) made for [INTK](https://www.intk.com/en).

--- a/docs/source/configuration/backend.md
+++ b/docs/source/configuration/backend.md
@@ -20,7 +20,9 @@ copy the ones you need for your project and create your own integration package.
 https://github.com/plone/plone.volto
 
 ```{tip}
-From Volto 5.1 and above, Volto features an internal proxy to your API server. So
-you don't have to deal with CORS issues. It's enabled by default, pointing to the server specified in the `devProxyToApiPath` Volto settings
-(http://localhost:8080/Plone). See [here](../configuration/internalproxy.md) for more information.
+From Volto 5.1 and above, Volto features an internal proxy to your API server.
+So you don't have to deal with CORS issues.
+It's enabled by default, pointing to the server specified in the `devProxyToApiPath` Volto settings
+`http://localhost:8080/Plone`.
+See {doc}`internalproxy` for more information.
 ```

--- a/docs/source/contributing/developing-core.md
+++ b/docs/source/contributing/developing-core.md
@@ -353,14 +353,14 @@ Used by Volto, you can also use it in other JavaScript frameworks and environmen
 
 ### Volto project generator
 
-`@plone/generator-volto` is a Yeoman generator that helps you set up Volto via command line.
-It generates all the boilerplate needed to start developing a Plone Volto project.
-It is used by [CookieCutter Plone Starter](https://github.com/collective/cookiecutter-plone-starter), the recommended way to set up Plone projects.
-The generator features an `addon` template for scaffolding Volto add-ons in your projects.
-
 ```{deprecated} 18.0.0-alpha.43
 For Volto 18, `@plone/generator-volto` is replaced by [Cookieplone](https://github.com/plone/cookieplone).
 ```
+
+`@plone/generator-volto` is a Yeoman generator that helps you set up Volto via command line.
+It generates all the boilerplate needed to start developing a Plone Volto project.
+It was used by `cookiecutter-plone-starter`, the deprecated way to set up Plone projects.
+The generator features an `addon` template for scaffolding Volto add-ons in your projects.
 
 
 ## Supported frontends

--- a/docs/source/contributing/index.md
+++ b/docs/source/contributing/index.md
@@ -67,7 +67,7 @@ For developing Volto, follow {doc}`developing-core`.
 ## Translations
 
 All text that can be shown in a browser must be translatable.
-Please mark all such strings as translatable as defined in the [i18n guide](../development/i18n.md).
+Please mark all such strings as translatable as defined in {doc}`../development/i18n`.
 
 
 (contributing-branch-policy-for-translations-label)=
@@ -96,7 +96,7 @@ For details see {ref}`contributing-change-log-label`.
 
 ## Document breaking changes
 
-If the feature includes a breaking change, you must include instructions for how to upgrade in the [upgrade guide](../upgrade-guide/index.md).
+If the feature includes a breaking change, you must include instructions for how to upgrade in the {doc}`../upgrade-guide/index`.
 
 
 (contributing-code-quality-label)=

--- a/docs/source/development/folder-structure.md
+++ b/docs/source/development/folder-structure.md
@@ -61,4 +61,4 @@ The site customizations also should be located inside this folder following
 ## Locales
 
 The `locales` folder contains all the artifacts relating to the translations.
-For more details how to translate individual strings, please refer to the [internationalization section](i18n.md).
+For more details how to translate individual strings, please refer to {doc}`i18n`.

--- a/packages/volto/README.md
+++ b/packages/volto/README.md
@@ -194,5 +194,4 @@ You should check the dependencies in their `package.json` for more details.
 - [volto-centraalmuseum-theme](https://github.com/intk/volto-centraalmuseum-theme) - Volto project for the [Centraal Museum & Rietveld](https://www.centraalmuseum.nl/nl) made for [INTK](https://www.intk.com/en).
 - [volto-eea-design-system](https://github.com/eea/volto-eea-design-system) - EEA Design System Plone 6 Kit Volto project for [European Environment Agency web sites](https://eea.github.io/volto-eea-design-system/)
 - [volto-eea-kitkat](https://github.com/eea/volto-eea-kitkat) - A known good set of Volto add-ons to be used within all EEA projects and beyond, made for [European Environment Agency](https://www.eea.europa.eu/en)
-- [volto-rietveldschroderhuis-theme](https://github.com/intk/volto-rietveldschroderhuis-theme) - Volto project for the [Rietveld Schröder House](https://www.rietveldschroderhuis.nl/en) made for [INTK](https://www.intk.com/en).
 - [volto-zeeuwsmuseum-theme](https://github.com/intk/volto-zeeuwsmuseum-theme) - Volto project for the [Zeeuws Museum](https://www.zeeuwsmuseum.nl/en) made for [INTK](https://www.intk.com/en).

--- a/packages/volto/news/6812.documentation
+++ b/packages/volto/news/6812.documentation
@@ -1,1 +1,1 @@
-Fix MyST warnings about bad references, and remove cookiecutter-plone-starter link. @stevepiercy
+Fix MyST warnings about bad references, remove cookiecutter-plone-starter link, and remove `rietveldschroderhuis.nl` due to repeated failures and no response in https://github.com/collective/awesome-volto/pull/27. @stevepiercy

--- a/packages/volto/news/6812.documentation
+++ b/packages/volto/news/6812.documentation
@@ -1,0 +1,1 @@
+Fix MyST warnings about bad references, and remove cookiecutter-plone-starter link. @stevepiercy


### PR DESCRIPTION
This PR removes a cookiecutter-plone-starter link and fixes other MyST reference warnings. Merge before https://github.com/plone/documentation/pull/1891.

<!-- readthedocs-preview volto start -->
----
📚 Documentation preview 📚: https://volto--6812.org.readthedocs.build/

<!-- readthedocs-preview volto end -->