### PR TITLE
Issue #6805 fixed (with additional bug fixed)

### DIFF
--- a/packages/volto-slate/news/6805.bugfix
+++ b/packages/volto-slate/news/6805.bugfix
@@ -1,0 +1,1 @@
+These changes will ensure that slate text blocks do not behave weirdly when using the 'backspace' or 'delete' keys. @ManojaD2004

--- a/packages/volto-slate/src/blocks/Text/DefaultTextBlockEditor.jsx
+++ b/packages/volto-slate/src/blocks/Text/DefaultTextBlockEditor.jsx
@@ -67,6 +67,7 @@ export const DefaultTextBlockEditor = (props) => {
     formDescription,
     navRoot,
     contentType,
+    content,
   } = props;
 
   const { slate } = config.settings;
@@ -242,6 +243,7 @@ export const DefaultTextBlockEditor = (props) => {
                   placeholder={placeholder}
                   slateSettings={slateSettings}
                   editableProps={{ 'aria-multiline': 'false' }}
+                  content={content}
                 />
                 {DEBUG ? <div>{block}</div> : ''}
               </>


### PR DESCRIPTION
Fixed open issue #6805 

Addition bugs that I faced:

1. When the cursor is at the beginning of the slate text editor and pressed the 'backspace' key, it would append the content of the previous slate text block.
2. When we were at the end of the slate text editor and pressed the 'delete' key, it would append the content of the next slate text block.

**Note:**

> We need to make sure the slate text editor is removed and focused on the previous slate text block only when it has no content in the current slate text editor. 

**Bug Fix:**
- To handle this weird behavior, I created a function and checked these two edge cases. This pull request has fixed the main bug mentioned in the open issue, and also fixed the additional bugs mentioned above.

**Test the bug:**
1. Add a new page.
2. Add some three slate blocks with some text in them.
3. Be at the second slate block, make sure your cursor is at the beginning of the second slate block, and press 'backspace'. (Notice the weird behaviour.)
4. Again, be at the second slate block, make sure your cursor is at the end of the second slate block, and press 'delete'. 

**Bug screenshot:**
![Screenshot 2025-03-07 193148](https://github.com/user-attachments/assets/c1b10f31-7ff0-4633-8027-d239ff690fa9)
![Screenshot 2025-03-07 193215](https://github.com/user-attachments/assets/b577901b-bab9-4e89-9b83-42279f16aaeb)