### PR TITLE
get multilingual settings and available languages from backend

### DIFF
--- a/packages/volto/src/actions/content/content.js
+++ b/packages/volto/src/actions/content/content.js
@@ -164,7 +164,6 @@ export function getContent(
           b_size: settings.defaultPageSize,
         }
       : {},
-    settings.isMultilingual ? { expand: 'translations' } : {},
   );
 
   let qs = Object.keys(query)

--- a/packages/volto/src/components/manage/Add/Add.jsx
+++ b/packages/volto/src/components/manage/Add/Add.jsx
@@ -223,7 +223,7 @@ class Add extends Component {
         ? keys(this.props.schema.definitions)
         : null,
       '@type': this.props.type,
-      ...(config.settings.isMultilingual &&
+      ...(this.props.isMultilingual &&
         this.props.location?.state?.translationOf && {
           translation_of: this.props.location.state.translationOf,
           language: this.props.location.state.language,
@@ -509,6 +509,7 @@ export default compose(
       pathname: props.location.pathname,
       returnUrl: qs.parse(props.location.search).return_url,
       type: qs.parse(props.location.search).type,
+      isMultilingual: state.addons.isMultilingual,
     }),
     { createContent, getSchema, changeLanguage, setFormData },
   ),

--- a/packages/volto/src/components/manage/Add/Add.test.jsx
+++ b/packages/volto/src/components/manage/Add/Add.test.jsx
@@ -9,7 +9,6 @@ import Add from './Add';
 const mockStore = configureStore();
 
 beforeAll(() => {
-  config.settings.supportedLanguages = ['de'];
   config.settings.lazyBundles = {
     cms: [],
   };
@@ -36,6 +35,9 @@ describe('Add', () => {
       intl: {
         locale: 'en',
         messages: {},
+      },
+      site: {
+        'plone.available_languages': ['de'],
       },
     });
     const { container } = render(

--- a/packages/volto/src/components/manage/Contents/ContentsBreadcrumbs.Multilingual.test.jsx
+++ b/packages/volto/src/components/manage/Contents/ContentsBreadcrumbs.Multilingual.test.jsx
@@ -7,10 +7,6 @@ import config from '@plone/volto/registry';
 
 import ContentsBreadcrumbs from './ContentsBreadcrumbs';
 
-beforeAll(() => {
-  config.settings.isMultilingual = true;
-});
-
 const mockStore = configureStore();
 
 describe('ContentsBreadcrumbs Multilingual', () => {
@@ -23,6 +19,9 @@ describe('ContentsBreadcrumbs Multilingual', () => {
       intl: {
         locale: 'en',
         messages: {},
+      },
+      addons: {
+        isMultilingual: true,
       },
     });
     const component = renderer.create(
@@ -48,6 +47,9 @@ describe('ContentsBreadcrumbs Multilingual', () => {
       intl: {
         locale: 'en',
         messages: {},
+      },
+      addons: {
+        isMultilingual: true,
       },
     });
     const component = renderer.create(

--- a/packages/volto/src/components/manage/Contents/ContentsBreadcrumbs.jsx
+++ b/packages/volto/src/components/manage/Contents/ContentsBreadcrumbs.jsx
@@ -2,11 +2,9 @@ import React from 'react';
 import { Breadcrumb } from 'semantic-ui-react';
 import { Link, useLocation } from 'react-router-dom';
 import { defineMessages, useIntl } from 'react-intl';
-import langmap from '@plone/volto/helpers/LanguageMap/LanguageMap';
+import { useSelector } from 'react-redux';
 import ContentsBreadcrumbsRootItem from '@plone/volto/components/manage/Contents/ContentsBreadcrumbsRootItem';
 import ContentsBreadcrumbsHomeItem from '@plone/volto/components/manage/Contents/ContentsBreadcrumbsHomeItem';
-
-import config from '@plone/volto/registry';
 
 const messages = defineMessages({
   home: {
@@ -20,15 +18,15 @@ const messages = defineMessages({
 });
 
 const ContentsBreadcrumbs = (props) => {
-  const { settings } = config;
   const { items } = props;
   const intl = useIntl();
   const pathname = useLocation().pathname;
-  const lang = pathname.split('/')[1];
+  const isMultilingual = useSelector((state) => state.addons.isMultilingual);
+  const navroot = useSelector((state) => state.navroot.data.navroot);
 
   return (
     <Breadcrumb>
-      {settings.isMultilingual && (
+      {isMultilingual && (
         <>
           <Link
             to="/contents"
@@ -40,16 +38,16 @@ const ContentsBreadcrumbs = (props) => {
           <Breadcrumb.Divider />
         </>
       )}
-      {settings.isMultilingual && pathname?.split('/')?.length > 2 && (
+      {isMultilingual && pathname?.split('/')?.length > 2 && (
         <Link
-          to={`/${lang}/contents`}
+          href={`/${navroot['@id']}/contents`}
           className="section"
           title={intl.formatMessage(messages.home)}
         >
-          {langmap?.[lang]?.nativeName ?? lang}
+          {navroot['title']}
         </Link>
       )}
-      {!settings.isMultilingual && (
+      {!isMultilingual && (
         <Link
           to="/contents"
           className="section"

--- a/packages/volto/src/components/manage/Edit/Edit.jsx
+++ b/packages/volto/src/components/manage/Edit/Edit.jsx
@@ -460,7 +460,7 @@ class Edit extends Component {
                     />
                   </Button>
 
-                  {config.settings.isMultilingual && (
+                  {this.props.settings.isMultilingual && (
                     <CompareLanguages
                       content={this.props.content}
                       visual={this.state.visual}
@@ -497,6 +497,7 @@ export const __test__ = compose(
       createRequest: state.content.create,
       pathname: props.location.pathname,
       returnUrl: qs.parse(props.location.search).return_url,
+      isMultilingual: state.addons.isMultilingual,
     }),
     {
       updateContent,

--- a/packages/volto/src/components/manage/Multilingual/CompareLanguages.jsx
+++ b/packages/volto/src/components/manage/Multilingual/CompareLanguages.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
-import config from '@plone/volto/registry';
+import { useSelector } from 'react-redux';
 import langmap from '@plone/volto/helpers/LanguageMap/LanguageMap';
 import { useDetectClickOutside } from '@plone/volto/helpers/Utils/useDetectClickOutside';
 
@@ -106,7 +106,8 @@ const CompareLanguages = React.forwardRef((props, ref) => {
 
   const intl = useIntl();
   const [viewMenu, setViewMenu] = useState(false);
-  const translations = config.settings.isMultilingual
+  const isMultilingual = useSelector((state) => state.addons.isMultilingual);
+  const translations = isMultilingual
     ? content?.['@components']?.translations?.items || []
     : [];
 
@@ -115,7 +116,7 @@ const CompareLanguages = React.forwardRef((props, ref) => {
     translationsObject[t.language] = t['@id'];
   });
 
-  if (config.settings.isMultilingual && translations.length > 0) {
+  if (isMultilingual && translations.length > 0) {
     return (
       <div className="toolbar-compare-translations-wrapper">
         <div className="toolbar-button-spacer" />

--- a/packages/volto/src/components/manage/Multilingual/CreateTranslation.jsx
+++ b/packages/volto/src/components/manage/Multilingual/CreateTranslation.jsx
@@ -14,6 +14,9 @@ const CreateTranslation = (props) => {
   const [translationLocation, setTranslationLocation] = React.useState(null);
   const [translationObject, setTranslationObject] = React.useState(null);
   const languageFrom = useSelector((state) => state.intl.locale);
+  const availableLanguages = useSelector(
+    (state) => state.site.data['plone.available_languages'],
+  );
 
   React.useEffect(() => {
     // Only on mount, we dispatch the locator query
@@ -31,7 +34,7 @@ const CreateTranslation = (props) => {
     // On unmount we dispatch the language change
     return () => {
       // We change the interface language
-      if (config.settings.supportedLanguages.includes(language)) {
+      if (availableLanguages.includes(language)) {
         const langFileName = toGettextLang(language);
         import(
           /* @vite-ignore */ '@root/../locales/' + langFileName + '.json'

--- a/packages/volto/src/components/manage/Multilingual/ManageTranslations.jsx
+++ b/packages/volto/src/components/manage/Multilingual/ManageTranslations.jsx
@@ -76,6 +76,9 @@ const ManageTranslations = (props) => {
   const { isObjectBrowserOpen, openObjectBrowser } = props;
 
   const currentSelectedItem = React.useRef(null);
+  const availableLanguages = useSelector(
+    (state) => state.site.data['plone.available_languages'],
+  );
 
   React.useEffect(() => {
     if (!content) {
@@ -189,7 +192,7 @@ const ManageTranslations = (props) => {
               </Table.Row>
             </Table.Header>
             <Table.Body>
-              {config.settings.supportedLanguages.map((lang) => (
+              {availableLanguages.map((lang) => (
                 <Table.Row key={lang}>
                   <Table.Cell collapsing>
                     {lang === content.language.token ? (

--- a/packages/volto/src/components/manage/Multilingual/ManageTranslations.test.jsx
+++ b/packages/volto/src/components/manage/Multilingual/ManageTranslations.test.jsx
@@ -7,11 +7,6 @@ import config from '@plone/volto/registry';
 
 import ManageTranslations from './ManageTranslations';
 
-beforeAll(() => {
-  config.settings.isMultilingual = true;
-  config.settings.supportedLanguages = ['de', 'es'];
-});
-
 jest.mock('../Toolbar/Toolbar', () => jest.fn(() => <div id="Portal" />));
 
 const mockStore = configureStore();
@@ -32,6 +27,12 @@ describe('ManageTranslations', () => {
           '@id': 'http://localhost:8080/Plone/my-page',
           language: 'en',
         },
+      },
+      site: {
+        'plone.available_languages': ['de', 'es'],
+      },
+      addons: {
+        isMultilingual: true,
       },
     });
     const { container } = render(

--- a/packages/volto/src/components/manage/Multilingual/TranslationObject.jsx
+++ b/packages/volto/src/components/manage/Multilingual/TranslationObject.jsx
@@ -6,6 +6,7 @@ import { Provider } from 'react-intl-redux';
 import { Form, Field } from '@plone/volto/components/manage/Form';
 import config from '@plone/volto/registry';
 import configureStore from '@plone/volto/store';
+import { useSelector } from 'react-redux';
 import Api from '@plone/volto/helpers/Api/Api';
 import { flattenToAppURL } from '@plone/volto/helpers/Url/Url';
 import langmap from '@plone/volto/helpers/LanguageMap/LanguageMap';
@@ -38,15 +39,17 @@ const TranslationObject = ({
   const handleMenuClick = (e, { name }) => {
     setActiveMenu(name);
   };
+  const availableLanguages = useSelector(
+    (state) => state.site.data['plone.available_languages'],
+  );
 
   useEffect(() => {
     if (
       !loadingLocale &&
-      Object.keys(locales).length < config.settings.supportedLanguages.length
+      Object.keys(locales).length < availableLanguages.length
     ) {
       setLoadingLocale(true);
-      let lang =
-        config.settings.supportedLanguages[Object.keys(locales).length];
+      let lang = availableLanguages[Object.keys(locales).length];
       const langFileName = toGettextLang(lang);
       import(
         /* @vite-ignore */ '@root/../locales/' + langFileName + '.json'
@@ -55,7 +58,7 @@ const TranslationObject = ({
         setLoadingLocale(false);
       });
     }
-  }, [loadingLocale, locales]);
+  }, [loadingLocale, locales, availableLanguages]);
 
   const api = new Api();
   const history = createBrowserHistory();

--- a/packages/volto/src/components/manage/Preferences/PersonalPreferences.jsx
+++ b/packages/volto/src/components/manage/Preferences/PersonalPreferences.jsx
@@ -12,7 +12,7 @@ import { Form } from '@plone/volto/components/manage/Form';
 import languages from '@plone/volto/constants/Languages.cjs';
 import { changeLanguage } from '@plone/volto/actions/language/language';
 import { toGettextLang } from '@plone/volto/helpers/Utils/Utils';
-import config from '@plone/volto/registry';
+import { useSelector } from 'react-redux';
 
 const messages = defineMessages({
   personalPreferences: {
@@ -49,9 +49,12 @@ const PersonalPreferences = (props) => {
   const intl = useIntl();
   const dispatch = useDispatch();
   const { closeMenu } = props;
+  const availableLanguages = useSelector(
+    (state) => state.site.data['plone.available_languages'],
+  );
   const onSubmit = (data) => {
     let language = data.language || 'en';
-    if (config.settings.supportedLanguages.includes(language)) {
+    if (availableLanguages.includes(language)) {
       const langFileName = toGettextLang(language);
       import(
         /* @vite-ignore */ '@root/../locales/' + langFileName + '.json'

--- a/packages/volto/src/components/manage/Toolbar/More.jsx
+++ b/packages/volto/src/components/manage/Toolbar/More.jsx
@@ -117,6 +117,8 @@ const More = (props) => {
 
   const actions = useSelector((state) => state.actions.actions, shallowEqual);
 
+  const isMultilingual = useSelector((state) => state.addons.isMultilingual);
+
   const workingCopyApply = workingCopy?.apply.loading;
   const workingCopyCreate = workingCopy?.create.loading;
   const workingCopyRemove = workingCopy?.remove.loading;
@@ -435,7 +437,7 @@ const More = (props) => {
           </li>
         </Plug>
       )}
-      {editAction && config.settings.isMultilingual && (
+      {editAction && isMultilingual && (
         <Plug pluggable="toolbar-more-manage-content" id="multilingual">
           <li>
             <Link to={`${path}/manage-translations`}>

--- a/packages/volto/src/components/manage/Toolbar/Toolbar.jsx
+++ b/packages/volto/src/components/manage/Toolbar/Toolbar.jsx
@@ -539,7 +539,7 @@ class Toolbar extends Component {
                     {this.props.content &&
                       ((this.props.content.is_folderish &&
                         this.props.types.length > 0) ||
-                        (config.settings.isMultilingual &&
+                        (this.props.isMultilingual &&
                           this.props.content['@components']?.translations)) && (
                         <button
                           className="add"
@@ -649,6 +649,7 @@ export default compose(
       pathname: props.pathname,
       types: filter(state.types.types, 'addable'),
       unlockRequest: state.content.unlock,
+      isMultilingual: state.addons.isMultilingual,
     }),
     { getTypes, listActions, setExpandedToolbar, unlockContent },
   ),

--- a/packages/volto/src/components/manage/Toolbar/Types.jsx
+++ b/packages/volto/src/components/manage/Toolbar/Types.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { connect, useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 import filter from 'lodash/filter';
 import find from 'lodash/find';
@@ -14,8 +14,13 @@ import config from '@plone/volto/registry';
 
 const Types = ({ types, pathname, content, currentLanguage }) => {
   const { settings } = config;
+  const isMultilingual = useSelector((state) => state.addons.isMultilingual);
+  const availableLanguages = useSelector(
+    (state) => state.site.data['plone.available_languages'],
+  );
+
   return types.length > 0 ||
-    (settings.isMultilingual && content['@components'].translations) ? (
+    (isMultilingual && content['@components'].translations) ? (
     <div className="menu-more pastanaga-menu">
       {types.length > 0 && (
         <>
@@ -57,7 +62,7 @@ const Types = ({ types, pathname, content, currentLanguage }) => {
         content['@components'].translations &&
         (() => {
           const translationsLeft = filter(
-            settings.supportedLanguages,
+            availableLanguages,
             (lang) =>
               !Boolean(
                 content['@components'].translations &&

--- a/packages/volto/src/components/theme/LanguageSelector/LanguageSelector.jsx
+++ b/packages/volto/src/components/theme/LanguageSelector/LanguageSelector.jsx
@@ -34,12 +34,16 @@ const LanguageSelector = (props) => {
   const translations = useSelector(
     (state) => state.content.data?.['@components']?.translations?.items,
   );
+  const availableLanguages = useSelector(
+    (state) => state.site.data['plone.available_languages'],
+  );
+  const isMultilingual = useSelector((state) => state.addons.isMultilingual);
 
   const { settings } = config;
 
-  return settings.isMultilingual ? (
+  return isMultilingual ? (
     <div className="language-selector">
-      {map(settings.supportedLanguages, (lang) => {
+      {map(availableLanguages, (lang) => {
         const translation = find(translations, { language: lang });
         return (
           <Link

--- a/packages/volto/src/components/theme/LanguageSelector/LanguageSelector.test.jsx
+++ b/packages/volto/src/components/theme/LanguageSelector/LanguageSelector.test.jsx
@@ -7,11 +7,6 @@ import config from '@plone/volto/registry';
 
 import LanguageSelector from './LanguageSelector';
 
-beforeAll(() => {
-  config.settings.isMultilingual = true;
-  config.settings.supportedLanguages = ['de', 'es'];
-});
-
 const mockStore = configureStore();
 
 describe('LanguageSelector', () => {
@@ -29,6 +24,12 @@ describe('LanguageSelector', () => {
             },
           },
         },
+      },
+      site: {
+        'plone.available_languages': ['de', 'es'],
+      },
+      addons: {
+        isMultilingual: true,
       },
     });
     const component = renderer.create(

--- a/packages/volto/src/components/theme/Logo/Logo.Multilingual.test.jsx
+++ b/packages/volto/src/components/theme/Logo/Logo.Multilingual.test.jsx
@@ -3,13 +3,8 @@ import renderer from 'react-test-renderer';
 import configureStore from 'redux-mock-store';
 import { Provider } from 'react-intl-redux';
 import { MemoryRouter } from 'react-router-dom';
-import config from '@plone/volto/registry';
 
 import Logo from './Logo';
-
-beforeAll(() => {
-  config.settings.isMultilingual = true;
-});
 
 const mockStore = configureStore();
 
@@ -31,6 +26,9 @@ describe('Multilingual Logo', () => {
       },
       site: {
         data: { 'plone.site_title': 'Plone Site' },
+      },
+      addons: {
+        isMultilingual: true,
       },
     });
     const component = renderer.create(
@@ -63,6 +61,9 @@ describe('Multilingual Logo', () => {
         data: {
           'plone.site_title': 'Plone Site',
         },
+      },
+      addons: {
+        isMultilingual: true,
       },
     });
     const component = renderer.create(
@@ -98,6 +99,9 @@ describe('Multilingual Logo', () => {
           'plone.site_title': 'Plone Site',
         },
       },
+      addons: {
+        isMultilingual: true,
+      },
     });
     const component = renderer.create(
       <Provider store={store}>
@@ -131,6 +135,9 @@ describe('Multilingual Logo', () => {
             'http://localhost:3000/@@site-logo/logo.cab945d8.svg',
           'plone.site_title': 'Plone Site',
         },
+      },
+      addons: {
+        isMultilingual: true,
       },
     });
     const component = renderer.create(

--- a/packages/volto/src/components/theme/MultilingualRedirector/MultilingualRedirector.jsx
+++ b/packages/volto/src/components/theme/MultilingualRedirector/MultilingualRedirector.jsx
@@ -1,28 +1,29 @@
 import React from 'react';
 import { Redirect } from 'react-router-dom';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { useCookies } from 'react-cookie';
-import config from '@plone/volto/registry';
 import { changeLanguage } from '@plone/volto/actions/language/language';
 import { toGettextLang } from '@plone/volto/helpers/Utils/Utils';
 
 const MultilingualRedirector = (props) => {
-  const { settings } = config;
   const { pathname, children } = props;
   const [cookies] = useCookies();
-  const currentLanguage = cookies['I18N_LANGUAGE'] || settings.defaultLanguage;
-  const redirectToLanguage = settings.supportedLanguages.includes(
+  const site = useSelector((state) => state.site.data);
+  const currentLanguage =
+    cookies['I18N_LANGUAGE'] || site['plone.default_language'];
+  const redirectToLanguage = site['plone.available_languages'].includes(
     currentLanguage,
   )
     ? currentLanguage
-    : settings.defaultLanguage;
+    : site['plone.default_language'];
+  const isMultilingual = useSelector((state) => state.addons.isMultilingual);
   const dispatch = useDispatch();
 
   React.useEffect(() => {
     // ToDo: Add means to support language negotiation (with config)
     // const detectedLang = (navigator.language || navigator.userLanguage).substring(0, 2);
     let mounted = true;
-    if (settings.isMultilingual && pathname === '/') {
+    if (isMultilingual && pathname === '/') {
       const langFileName = toGettextLang(redirectToLanguage);
       import(
         /* @vite-ignore */ '@root/../locales/' + langFileName + '.json'
@@ -35,9 +36,9 @@ const MultilingualRedirector = (props) => {
     return () => {
       mounted = false;
     };
-  }, [pathname, dispatch, redirectToLanguage, settings.isMultilingual]);
+  }, [pathname, dispatch, redirectToLanguage, isMultilingual]);
 
-  return pathname === '/' && settings.isMultilingual ? (
+  return pathname === '/' && isMultilingual ? (
     <Redirect to={`/${redirectToLanguage}`} />
   ) : (
     <>{children}</>

--- a/packages/volto/src/components/theme/MultilingualRedirector/MultilingualRedirector.test.jsx
+++ b/packages/volto/src/components/theme/MultilingualRedirector/MultilingualRedirector.test.jsx
@@ -3,13 +3,8 @@ import renderer from 'react-test-renderer';
 import configureStore from 'redux-mock-store';
 import { Provider } from 'react-intl-redux';
 import { MemoryRouter } from 'react-router-dom';
-import config from '@plone/volto/registry';
 
 import MultilingualRedirector from './MultilingualRedirector';
-
-beforeAll(() => {
-  config.settings.isMultilingual = true;
-});
 
 const mockStore = configureStore();
 
@@ -19,6 +14,9 @@ describe('MultilingualRedirector', () => {
       intl: {
         locale: 'en',
         messages: {},
+      },
+      addons: {
+        isMultilingual: true,
       },
     });
     const component = renderer.create(

--- a/packages/volto/src/components/theme/Navigation/Navigation.Multilingual.test.jsx
+++ b/packages/volto/src/components/theme/Navigation/Navigation.Multilingual.test.jsx
@@ -3,13 +3,8 @@ import renderer from 'react-test-renderer';
 import configureStore from 'redux-mock-store';
 import { Provider } from 'react-intl-redux';
 import { MemoryRouter } from 'react-router-dom';
-import config from '@plone/volto/registry';
 
 import Navigation from './Navigation';
-
-beforeAll(() => {
-  config.settings.isMultilingual = true;
-});
 
 const mockStore = configureStore();
 
@@ -27,6 +22,9 @@ describe('Navigation Multilingual', () => {
       intl: {
         locale: 'en',
         messages: {},
+      },
+      addons: {
+        isMultilingual: true,
       },
     });
     const component = renderer.create(
@@ -54,6 +52,9 @@ describe('Navigation Multilingual', () => {
         locale: 'en',
         messages: {},
       },
+      addons: {
+        isMultilingual: true,
+      },
     });
     const component = renderer.create(
       <Provider store={store}>
@@ -79,6 +80,9 @@ describe('Navigation Multilingual', () => {
       intl: {
         locale: 'en',
         messages: {},
+      },
+      addons: {
+        isMultilingual: true,
       },
     });
     const component = renderer.create(

--- a/packages/volto/src/components/theme/Navigation/__snapshots__/Navigation.Multilingual.test.jsx.snap
+++ b/packages/volto/src/components/theme/Navigation/__snapshots__/Navigation.Multilingual.test.jsx.snap
@@ -31,10 +31,11 @@ exports[`Navigation Multilingual renders a navigation component with an active i
     onClick={[Function]}
   >
     <a
-      aria-current={null}
-      className="item"
+      aria-current="page"
+      className="item active"
       href="/en"
       onClick={[Function]}
+      style={Object {}}
     >
       Home
     </a>
@@ -90,10 +91,11 @@ exports[`Navigation Multilingual renders a navigation component with an active i
     onClick={[Function]}
   >
     <a
-      aria-current={null}
-      className="item"
+      aria-current="page"
+      className="item active"
       href="/en"
       onClick={[Function]}
+      style={Object {}}
     >
       Home
     </a>
@@ -149,10 +151,11 @@ exports[`Navigation Multilingual renders a navigation component with only one ac
     onClick={[Function]}
   >
     <a
-      aria-current={null}
-      className="item"
+      aria-current="page"
+      className="item active"
       href="/en"
       onClick={[Function]}
+      style={Object {}}
     >
       Home
     </a>
@@ -216,10 +219,11 @@ exports[`Navigation Multilingual renders a navigation component without active i
     onClick={[Function]}
   >
     <a
-      aria-current={null}
-      className="item"
+      aria-current="page"
+      className="item active"
       href="/en"
       onClick={[Function]}
+      style={Object {}}
     >
       Home
     </a>

--- a/packages/volto/src/components/theme/NotFound/NotFound.jsx
+++ b/packages/volto/src/components/theme/NotFound/NotFound.jsx
@@ -19,15 +19,16 @@ import config from '@plone/volto/registry';
 const NotFound = () => {
   const dispatch = useDispatch();
   const lang = useSelector((state) => state.intl.locale);
+  const isMultilingual = useSelector((state) => state.addons.isMultilingual);
 
   useEffect(() => {
     dispatch(
       getNavigation(
-        config.settings.isMultilingual ? `/${toBackendLang(lang)}` : '/',
+        isMultilingual.isMultilingual ? `/${toBackendLang(lang)}` : '/',
         config.settings.navDepth,
       ),
     );
-  }, [dispatch, lang]);
+  }, [dispatch, lang, isMultilingual]);
 
   return (
     <Container className="view-wrapper">

--- a/packages/volto/src/components/theme/Sitemap/Sitemap.jsx
+++ b/packages/volto/src/components/theme/Sitemap/Sitemap.jsx
@@ -36,14 +36,14 @@ function Sitemap(props) {
     location: { pathname },
     lang,
     getNavigation,
+    isMultilingual,
   } = props;
 
   useEffect(() => {
-    const { settings } = config;
-    const language = settings.isMultilingual ? `${toBackendLang(lang)}` : null;
+    const language = isMultilingual ? `${toBackendLang(lang)}` : null;
     const path = getSitemapPath(pathname, language);
     getNavigation(path, 4);
-  }, [pathname, lang, getNavigation]);
+  }, [pathname, lang, getNavigation, isMultilingual]);
 
   const renderItems = (items) => {
     return (
@@ -89,6 +89,7 @@ export const __test__ = compose(
     (state) => ({
       items: state.navigation.items,
       lang: state.intl.locale,
+      isMultilingual: state.addons.isMultilingual,
     }),
     { getNavigation },
   ),
@@ -100,6 +101,7 @@ export default compose(
     (state) => ({
       items: state.navigation.items,
       lang: state.intl.locale,
+      isMultilingual: state.addons.isMultilingual,
     }),
     { getNavigation },
   ),

--- a/packages/volto/src/config/index.js
+++ b/packages/volto/src/config/index.js
@@ -23,6 +23,7 @@ import { installDefaultViews } from './Views';
 import { installDefaultBlocks } from './Blocks';
 
 import { getSiteAsyncPropExtender } from '@plone/volto/helpers/Site';
+import { getMultilingualInstalledAsyncPropExtender } from '@plone/volto/helpers/Multilingual';
 import { registerValidators } from './validation';
 
 const host = process.env.HOST || 'localhost';
@@ -121,7 +122,10 @@ let config = {
     useEmailAsLogin: false,
     persistentReducers: ['blocksClipboard'],
     initialReducersBlacklist: [], // reducers in this list won't be hydrated in windows.__data
-    asyncPropsExtenders: [getSiteAsyncPropExtender], // per route asyncConnect customizers
+    asyncPropsExtenders: [
+      getSiteAsyncPropExtender,
+      getMultilingualInstalledAsyncPropExtender,
+    ], // per route asyncConnect customizers
     contentIcons: contentIcons,
     loadables,
     lazyBundles: {
@@ -198,7 +202,14 @@ config.settings.apiExpanders = [
   ...config.settings.apiExpanders,
   {
     match: '',
-    GET_CONTENT: ['breadcrumbs', 'actions', 'types', 'navroot'],
+    GET_CONTENT: [
+      'breadcrumbs',
+      'actions',
+      'types',
+      'navroot',
+      // How to do this?
+      config.settings.isMultilingual && 'translations',
+    ],
   },
   {
     match: '',

--- a/packages/volto/src/helpers/Multilingual/index.js
+++ b/packages/volto/src/helpers/Multilingual/index.js
@@ -1,0 +1,21 @@
+import { LIST_ADDONS } from '@plone/volto/constants/ActionTypes';
+import { listAddons } from '@plone/volto/actions/addons/addons';
+
+const getMultilingualInstalledAsyncPropExtender = {
+  path: '/',
+  extend: (dispatchActions) => {
+    if (
+      dispatchActions.filter((asyncAction) => asyncAction.key === LIST_ADDONS)
+        .length === 0
+    ) {
+      dispatchActions.push({
+        key: LIST_ADDONS,
+        promise: ({ location, store: { dispatch } }) =>
+          __SERVER__ && dispatch(listAddons()),
+      });
+    }
+    return dispatchActions;
+  },
+};
+
+export { getMultilingualInstalledAsyncPropExtender };

--- a/packages/volto/src/middleware/api.js
+++ b/packages/volto/src/middleware/api.js
@@ -136,6 +136,8 @@ const apiMiddlewareFactory =
     const { settings } = config;
 
     const token = getState().userSession.token;
+    const availableLanguages =
+      getState().site.data['plone.available_languages'] || [];
     let uploadedFiles = getState().content.uploadedFiles;
     let isAnonymous = true;
     if (token) {
@@ -241,7 +243,7 @@ const apiMiddlewareFactory =
               lang &&
               state.intl.locale !== toReactIntlLang(lang) &&
               !subrequest &&
-              config.settings.supportedLanguages.includes(lang)
+              availableLanguages.includes(lang)
             ) {
               const langFileName = toGettextLang(lang);
               import(

--- a/packages/volto/src/reducers/addons/addons.js
+++ b/packages/volto/src/reducers/addons/addons.js
@@ -16,6 +16,7 @@ const initialState = {
   upgradableAddons: [],
   loaded: false,
   loading: false,
+  isMultilingual: false,
 };
 
 /**
@@ -69,6 +70,10 @@ export default function addons(state = initialState, action = {}) {
           .sort(addonsSorter),
         loaded: true,
         loading: false,
+        isMultilingual: action.result.items
+          .filter((elem) => elem.is_installed === true)
+          .map((item) => item['id'])
+          .includes('plone.app.multilingual'),
       };
     case `${INSTALL_ADDON}_SUCCESS`:
     case `${UNINSTALL_ADDON}_SUCCESS`:


### PR DESCRIPTION
> [!CAUTION]
The Volto Team has suspended its review of new pull requests from first-time contributors until the [release of Plone 7](https://plone.org/download/release-schedule), which is preliminarily scheduled for the second quarter of 2026.
> [Read details](https://6.docs.plone.org/volto/contributing/index.html).

-----

- [ ] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [ ] I verified there aren't other open [pull requests](https://github.com/plone/volto/pulls) for the same change.
- [ ] I followed the guidelines in [Contributing to Volto](https://6.docs.plone.org/volto/contributing/index.html).
- [ ] I succesfully ran [code linting checks](https://6.docs.plone.org/volto/contributing/linting.html) on my changes locally.
- [ ] I succesfully ran [unit tests](https://6.docs.plone.org/volto/contributing/testing.html) on my changes locally.
- [ ] I succesfully ran [acceptance tests](https://6.docs.plone.org/volto/contributing/acceptance-tests.html) on my changes locally.
- [ ] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/volto/contributing/documentation.html#narrative-documentation) for my changes, either in the Storybook or narrative documentation.
- [ ] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

This supersedes #5506 

@sneridagh as commented, I have created a new PR with the changes.

We have 2 things (at least), to address:

- The `@addons` endpoint is for Managers only, so we would need to get the `isMultilingual` to the `@site` endpoint. 
- How do we configure Volto to get the `translations` expander in each content request? Right now we do this in the getContent action getting the value from settings. I don't know if querying the redux state in the action body is acceptable at all.

Anyway, this is open to discussion.
