### PR TITLE
Use Cookieplone for installation and project generation

### DIFF
--- a/docs/source/contributing/developing-core.md
+++ b/docs/source/contributing/developing-core.md
@@ -21,7 +21,7 @@ Additionally you can build each version of Volto documentation by running `make 
 ```
 
 ```{seealso}
-To create a full Plone project with both frontend and backend, see {doc}`plone:install/create-project` instead.
+To create a full Plone project with both frontend and backend, see {doc}`plone:install/create-project-cookieplone` instead.
 ```
 
 
@@ -370,7 +370,7 @@ Volto is the default frontend, and is React-based.
 Classic UI is the Python-based, server-side rendered frontend.
 
 In Volto's `apps` folder, you'll find a Volto project scaffolding that uses Volto as a library.
-This is the same as that which you'll have when you follow the instructions in {doc}`plone:install/create-project`).
+This is the same as that which you'll have when you follow the instructions in {doc}`plone:install/create-project-cookieplone`).
 
 
 ## Experimental frontends

--- a/docs/source/development/creating-project.md
+++ b/docs/source/development/creating-project.md
@@ -17,7 +17,5 @@ Even if you don't need the backend, you can create a Plone project, then use onl
 As a bonus, it will contain the means for deploying your project.
 
 ```{seealso}
-To create a full Plone project with both frontend and backend, see {doc}`plone:install/create-project` instead.
-
 To contribute to Volto, see {doc}`../contributing/developing-core`.
 ```

--- a/docs/source/development/overview.md
+++ b/docs/source/development/overview.md
@@ -37,7 +37,7 @@ As is the case with similar modern JavaScript-based applications, you should be 
 
 ## Basic Volto development
 
-Once you've {doc}`bootstrapped your Volto project <plone:install/create-project>`, you can immediately start hacking.
+Once you've {doc}`bootstrapped your Volto project <plone:install/create-project-cookieplone>`, you can immediately start hacking.
 The following is a list of some the things you can do at this stage.
 
 -   {ref}`Configure your text editor for JavaScript and Volto development <linting-editor-integration-label>`

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -31,7 +31,7 @@ Choose from the following sections to begin your journey with Volto.
 
 An integrator is someone who uses Volto to build a project.
 
--   {doc}`plone:install/create-project` is a guide to bootstrap a new Volto project and start hacking.
+-   {doc}`plone:install/create-project-cookieplone` is a guide to bootstrap a new Volto project and start hacking.
 -   {doc}`development/overview` is intended for integrators to assess their knowledge and determine what gaps they would like to fill through available resources.
 -   {doc}`tutorials/index` lists several tutorials and references for further research and learning.
 

--- a/packages/volto/news/6820.documentation
+++ b/packages/volto/news/6820.documentation
@@ -1,0 +1,1 @@
+Use Cookieplone for installation everywhere. @stevepiercy


### PR DESCRIPTION
This was an oversight and is urgent to fix. I'll merge it without a review, but we should have caught this with the release of Plone 6.1, as we did elsewhere in the docs.

<!-- readthedocs-preview volto start -->
----
📚 Documentation preview 📚: https://volto--6820.org.readthedocs.build/

<!-- readthedocs-preview volto end -->