### PR TITLE
Validation for internal blocks.

### DIFF
--- a/packages/volto/src/components/manage/Blocks/Container/Edit.jsx
+++ b/packages/volto/src/components/manage/Blocks/Container/Edit.jsx
@@ -121,6 +121,8 @@ const ContainerBlockEdit = (props) => {
       )}
 
       <BlocksForm
+        errors={props.erros}
+        blocksErrors={props.blocksErrors}
         metadata={metadata}
         properties={properties}
         direction={direction}

--- a/packages/volto/src/helpers/BlockValidation/BlockValidation.jsx
+++ b/packages/volto/src/helpers/BlockValidation/BlockValidation.jsx
@@ -1,0 +1,171 @@
+import config from '@plone/volto/registry';
+import FormValidation from '../FormValidation/FormValidation';
+
+/**
+ * Validates a block and its internal blocks (if it has blocks and blocks_layout).
+ * @param {Object} blockFormData - The block data to validate.
+ * @param {Object} intl - The internationalization object. -
+ * @param {number} depth - The current depth of block validation.
+ * @param {boolean} isColumn - Whether the block is a column.
+ * @returns {Object} - An object containing the validation errors.
+ */
+const blockFormDataValidator = (
+  blockFormData,
+  intl,
+  depth = 0,
+  isColumn = false,
+) => {
+  const blockSchema = getBlockSchema(blockFormData, intl);
+  const validationErrors = FormValidation.validateFieldsPerFieldset({
+    schema: blockSchema,
+    formData: blockFormData,
+    formatMessage: intl.formatMessage,
+  });
+  const internalBlockErrors = validateInternalBlocks(
+    blockFormData,
+    intl,
+    depth,
+    isColumn,
+  );
+  return mergeErrors(validationErrors, internalBlockErrors, depth);
+};
+
+/**
+ * Retrieves the schema for the block.
+ * @param {Object} blockFormData - The block data to validate.
+ * @param {Object} intl - The internationalization object.
+ * @returns {Object} - The schema for the block.
+ */
+const getBlockSchema = (blockFormData, intl) => {
+  const defaultSchema = {
+    properties: {},
+    fieldsets: [],
+    required: [],
+  };
+  const blockType = blockFormData['@type'];
+  const blockSchema =
+    config.blocks.blocksConfig[blockType]?.blockSchema || defaultSchema;
+  return typeof blockSchema === 'function'
+    ? blockSchema({ intl, formData: blockFormData })
+    : blockSchema;
+};
+
+/**
+ * Validates internal blocks and their layout.
+ * @param {Object} blockFormData - The block data to validate.
+ * @param {Object} intl - The internationalization object.
+ * @param {number} depth - The current depth of block validation.
+ * @param {boolean} isColumn - Whether the block is a column.
+ * @returns {Object} - The validation errors for the internal blocks.
+ */
+const validateInternalBlocks = (blockFormData, intl, depth, isColumn) => {
+  const blocks = blockFormData.blocks || blockFormData.data?.blocks;
+  const blocksLayout =
+    blockFormData.blocks_layout || blockFormData.data?.blocks_layout;
+  const column = isColumn || Boolean(blockFormData.data?.blocks_layout);
+
+  if (!blocks || !blocksLayout) return {};
+
+  return blocksLayout.items.reduce((acc, internalBlockId) => {
+    const internalBlockFormData = blocks[internalBlockId];
+    if (!internalBlockFormData) return acc;
+
+    const internalBlockErrors = blockFormDataValidator(
+      internalBlockFormData,
+      intl,
+      depth + 1,
+      column,
+    );
+
+    return mergeErrors(
+      acc,
+      internalBlockErrors,
+      depth,
+      isColumn,
+      internalBlockId,
+    );
+  }, {});
+};
+
+/**
+ * Merges the validation errors.
+ * @param {Object} validationErrors - The current validation errors.
+ * @param {Object} internalBlockErrors - The internal block validation errors.
+ * @param {number} depth - The current depth of block validation.
+ * @param {string} [internalBlockId] - The ID of the internal block (if applicable).
+ * @returns {Object} - The merged validation errors.
+ */
+const mergeErrors = (
+  validationErrors,
+  internalBlockErrors,
+  depth,
+  isColumn,
+  internalBlockId,
+) => {
+  if (Object.keys(internalBlockErrors).length === 0) return validationErrors;
+
+  if (internalBlockId) {
+    return {
+      ...validationErrors,
+      ...(isColumn
+        ? internalBlockErrors
+        : { [internalBlockId]: internalBlockErrors }),
+    };
+  }
+
+  return {
+    ...validationErrors,
+    ...(depth === 0
+      ? { '@internal_errors': internalBlockErrors }
+      : internalBlockErrors),
+  };
+};
+
+class BlockValidation {
+  /**
+   * Validates a block and its internal blocks (if it has blocks and blocks_layout).
+   * @param {Object} blockFormData - The block form data to validate.
+   * @param {Object} intl - The internationalization object. -
+   * @returns {Object} - An object containing the validation errors.
+   */
+  static blockFormDataValidator(blockFormData, intl) {
+    return blockFormDataValidator(blockFormData, intl);
+  }
+}
+
+export default BlockValidation;
+
+export const extractFirstMessageToast = (blocksErrors) => {
+  const [blockId, blockError] = Object.entries(blocksErrors)[0];
+  const [errorField, errorMessage] = Object.entries(blockError)[0];
+
+  if (errorField === '@internal_errors') {
+    const [internalBlockId, internalErrors] = Object.entries(
+      blockError['@internal_errors'],
+    )[0];
+    const [internalErrorField, internalErrorMessage] =
+      Object.entries(internalErrors)[0];
+
+    return {
+      blockId,
+      errorField: internalErrorField,
+      errorMessage: internalErrorMessage,
+      uiState: {
+        selected: blockId,
+        multiSelected: [],
+        gridSelected: internalBlockId,
+      },
+    };
+  }
+
+  return {
+    blockId,
+    errorField,
+    errorMessage,
+    uiState: {
+      selected: blockId,
+      multiSelected: [],
+      hovered: null,
+    },
+  };
+};


### PR DESCRIPTION
Hello, This may be a more drastic change, and there may be better ways to work around the problem. However, I leave the suggestion here for analysis and consideration.

Although the solutions described below have solved the problems encountered, I recognize that there may be more appropriate places within the project architecture to implement these functions. Due to lack of experience with the current architecture, I chose to implement them in the places I considered most appropriate. With that in mind, I open it for comments and analysis and suggestions for improvements and adjustments, if necessary, to better adapt to the project flow.

## Initial Problem:

Block validations are not working correctly within aligned blocks, such as Grid, Column, among others.

## Root of the Problem:

Validation, in the onSubmit method within Form, is being applied only to the blocks that are at the root of the structure. This results in the failure to validate internal blocks within aligned components.

## Implemented Solutions:

### Internal Block Validation:

To work around the aforementioned problem, an auxiliary function called blockValidator was created, which checks the presence of the blocks and blocks_layout fields in a recursive block.

https://github.com/alexandreIFB/volto/blob/8d45c5bd25a0a85e534af3a7fc27d54820283d83/packages/volto/src/components/manage/Form/Form.jsx#L539-L546

### Error Differentiation:

The second challenge was to identify and differentiate internal errors from common block errors. To do this, an approach was implemented where internal errors are assigned to the @internal_blocks key. This distinction allows error messages to be analyzed and displayed correctly, associating them with their respective internal elements.

### Error Forwarding in Aligned Blocks:

The third problem identified was that errors in aligned blocks (such as Grid, Column) were not being forwarded correctly. To solve this, errors forwarding for aligned blocks were added to the ContainerEdit component, ensuring that it is possible to access 'blocksErrors'.

https://github.com/alexandreIFB/volto/blob/8d45c5bd25a0a85e534af3a7fc27d54820283d83/packages/volto/src/components/manage/Blocks/Container/Edit.jsx#L123-L125

### Visibility of Errors in Internal Block Forms:

The last problem arose when internal block forms were unable to see the errors associated with them, since the validation of the errors depended on the ID of the elements in the root of the 'blockErrors;' object. To solve this, internal block errors were also added to the root of the structure, allowing them to be recognized and displayed correctly. (I didn't find the alternative elegant but I couldn't think of another way without too much impact)

https://github.com/alexandreIFB/volto/blob/8d45c5bd25a0a85e534af3a7fc27d54820283d83/packages/volto/src/components/manage/Form/Form.jsx#L548-L552



Closes #6776