### PR TITLE
Allow setting the default language via a RUNTIME environment variable

### DIFF
--- a/docs/source/configuration/environmentvariables.md
+++ b/docs/source/configuration/environmentvariables.md
@@ -186,7 +186,7 @@ You can also generate builds on your continuous integration, then deploy them an
     ```
 
 `SITE_DEFAULT_LANGUAGE`
-    This is a runtime environment variable that sets the `config.settings.defaultLanguage`, allowing you to specify the default language of a site.
+    This is a runtime environment variable that sets the `config.settings.defaultLanguage`, allowing you to specify the default language of a site. It needs to match the default language that is configured in the backend's Language control panel.
 
     ```shell
     SITE_DEFAULT_LANGUAGE=ca pnpm start

--- a/docs/source/configuration/environmentvariables.md
+++ b/docs/source/configuration/environmentvariables.md
@@ -184,6 +184,13 @@ You can also generate builds on your continuous integration, then deploy them an
     ```shell
     VOLTOCONFIG=../../volto.config.js pnpm start
     ```
+
+`SITE_DEFAULT_LANGUAGE`
+    This is a runtime environment variable that setups the `config.settings.defaultLanguage` allowing you to specify the default language of a site.
+
+    ```shell
+    SITE_DEFAULT_LANGUAGE=ca pnpm start
+    ```
 ````
 
 

--- a/docs/source/configuration/environmentvariables.md
+++ b/docs/source/configuration/environmentvariables.md
@@ -186,7 +186,7 @@ You can also generate builds on your continuous integration, then deploy them an
     ```
 
 `SITE_DEFAULT_LANGUAGE`
-    This is a runtime environment variable that setups the `config.settings.defaultLanguage` allowing you to specify the default language of a site.
+    This is a runtime environment variable that sets the `config.settings.defaultLanguage`, allowing you to specify the default language of a site.
 
     ```shell
     SITE_DEFAULT_LANGUAGE=ca pnpm start

--- a/docs/source/configuration/settings-reference.md
+++ b/docs/source/configuration/settings-reference.md
@@ -183,7 +183,7 @@ hasWorkingCopySupport
     ```
 
     For Plone sites using a Volto version prior to 18.8.0, this setting enables working copy support.
-    
+
     ```{seealso}
     See {doc}`workingcopy` for configuration.
     ```
@@ -489,6 +489,10 @@ showRelatedItems
 
 showTags
     If true, the `Tags` component will show tags from the `subjects` field. Default: true.
+
+
+defaultLanguage
+    Defines the default language of the site.
 ```
 
 ## Views settings

--- a/packages/volto/news/6830.feature
+++ b/packages/volto/news/6830.feature
@@ -1,1 +1,1 @@
-Allow setting the default language via a RUNTIME environment variable. @sneridagh
+Allow setting the default language via a runtime environment variable. @sneridagh

--- a/packages/volto/news/6830.feature
+++ b/packages/volto/news/6830.feature
@@ -1,0 +1,1 @@
+Allow setting the default language via a RUNTIME environment variable. @sneridagh

--- a/packages/volto/src/config/index.js
+++ b/packages/volto/src/config/index.js
@@ -113,7 +113,7 @@ let config = {
     defaultPageSize: 25,
     isMultilingual: false,
     supportedLanguages: ['en'],
-    defaultLanguage: 'en',
+    defaultLanguage: process.env.SITE_DEFAULT_LANGUAGE || 'en',
     navDepth: 1,
     expressMiddleware: serverConfig.expressMiddleware, // BBB
     defaultBlockType: 'slate',
@@ -231,6 +231,16 @@ Object.entries(slots).forEach(([slotName, components]) => {
     });
   });
 });
+
+// Make sure that process.env.SITE_DEFAULT_LANGUAGE is set in availableLanguages
+if (
+  process.env.SITE_DEFAULT_LANGUAGE &&
+  !config.settings.supportedLanguages.includes(
+    process.env.SITE_DEFAULT_LANGUAGE,
+  )
+) {
+  config.settings.supportedLanguages.push(process.env.SITE_DEFAULT_LANGUAGE);
+}
 
 registerValidators(ConfigRegistry);
 installDefaultComponents(ConfigRegistry);

--- a/packages/volto/src/helpers/Html/Html.jsx
+++ b/packages/volto/src/helpers/Html/Html.jsx
@@ -122,6 +122,9 @@ class Html extends Component {
                 ...(publicURL && {
                   publicURL,
                 }),
+                ...(process.env.SITE_DEFAULT_LANGUAGE && {
+                  defaultLanguage: process.env.SITE_DEFAULT_LANGUAGE,
+                }),
               })};`,
             }}
           />

--- a/packages/volto/src/start-client.jsx
+++ b/packages/volto/src/start-client.jsx
@@ -58,7 +58,7 @@ export default function client() {
   if (window.env.RAZZLE_LEGACY_TRAVERSE) {
     config.settings.legacyTraverse = true;
   }
-  // Suport for setting the default language from a server environment variable
+  // Support for setting the default language from a server environment variable
   if (window.env.defaultLanguage) {
     config.settings.defaultLanguage = window.env.defaultLanguage;
   }

--- a/packages/volto/src/start-client.jsx
+++ b/packages/volto/src/start-client.jsx
@@ -58,6 +58,10 @@ export default function client() {
   if (window.env.RAZZLE_LEGACY_TRAVERSE) {
     config.settings.legacyTraverse = true;
   }
+  // Suport for setting the default language from a server environment variable
+  if (window.env.defaultLanguage) {
+    config.settings.defaultLanguage = window.env.defaultLanguage;
+  }
 
   loadableReady(() => {
     hydrateRoot(


### PR DESCRIPTION
This PR allows you to setup the default language (`config.settings.defaultLanguage`) from a RUNTIME variable `SITE_DEFAULT_LANGUAGE`.

This is a non-breaking change workaround for 18, since we decided that #6807 will be targeted for 19. 

The idea is to incorporate this also in #6807 since it might be valuable to have both ways of doing it.
