### PR TITLE
Stylewrapper `buildStyleObjectFromData` fixes accounting for container blocks

### DIFF
--- a/docs/source/blocks/block-style-wrapper.md
+++ b/docs/source/blocks/block-style-wrapper.md
@@ -344,3 +344,28 @@ Each block in the Block Engine has a main wrapper with an automatic class name `
 ```
 
 You can use it for further control over the positioning and layout of the block.
+
+## Custom style wrapper build style object enhancer
+
+The style wrapper has a helper method that generates a style object from the block data.
+This generated style object is ready to be injected into the style property.
+
+You can tap into this helper method by applying your own rules programmatically.
+You can achieve this by defining an utility of the `type` `styleWrapperStyleObjectEnhancer`:
+
+```ts
+  config.registerUtility({
+    name: 'blockThemesEnhancer',
+    type: 'styleWrapperStyleObjectEnhancer',
+    method: blockThemesEnhancer,
+  });
+```
+
+The registered method has this signature:
+
+```ts
+type blockThemesEnhancerType = ({data, container}: {data: BlocksFormData, container: BlocksFormData}) => Record<`--${string}`, string>
+```
+
+being `data` the current block, and `container` is the parent block (if the block is in a block container).
+It returns a record of CSS properties.

--- a/docs/source/blocks/block-style-wrapper.md
+++ b/docs/source/blocks/block-style-wrapper.md
@@ -345,13 +345,13 @@ Each block in the Block Engine has a main wrapper with an automatic class name `
 
 You can use it for further control over the positioning and layout of the block.
 
-## Custom style wrapper build style object enhancer
+## Style object builder enhancer
 
 The style wrapper has a helper method that generates a style object from the block data.
-This generated style object is ready to be injected into the style property.
+This generated style object is available to inject into the style property.
 
 You can tap into this helper method by applying your own rules programmatically.
-You can achieve this by defining an utility of the `type` `styleWrapperStyleObjectEnhancer`:
+Define a utility of the `type` `styleWrapperStyleObjectEnhancer` as follows.
 
 ```ts
   config.registerUtility({
@@ -361,11 +361,11 @@ You can achieve this by defining an utility of the `type` `styleWrapperStyleObje
   });
 ```
 
-The registered method has this signature:
+The registered method has the following signature.
 
 ```ts
 type blockThemesEnhancerType = ({data, container}: {data: BlocksFormData, container: BlocksFormData}) => Record<`--${string}`, string>
 ```
 
-being `data` the current block, and `container` is the parent block (if the block is in a block container).
+`data` is the current block, and `container` is its parent block, if the current block is in a block container.
 It returns a record of CSS properties.

--- a/docs/source/blocks/block-style-wrapper.md
+++ b/docs/source/blocks/block-style-wrapper.md
@@ -364,7 +364,13 @@ Define a utility of the `type` `styleWrapperStyleObjectEnhancer` as follows.
 The registered method has the following signature.
 
 ```ts
-type blockThemesEnhancerType = ({data, container}: {data: BlocksFormData, container: BlocksFormData}) => Record<`--${string}`, string>
+type blockThemesEnhancerType = ({
+  data,
+  container,
+}: {
+  data: BlocksFormData;
+  container: BlocksFormData;
+}) => Record<`--${string}`, string>;
 ```
 
 `data` is the current block, and `container` is its parent block, if the current block is in a block container.

--- a/packages/volto/news/6832.bugfix
+++ b/packages/volto/news/6832.bugfix
@@ -1,1 +1,1 @@
-Stylewrapper `buildStyleObjectFromData` fixes accounting for container blocks. @sneridagh
+The style wrapper `buildStyleObjectFromData` now accounts for container blocks. @sneridagh

--- a/packages/volto/news/6832.bugfix
+++ b/packages/volto/news/6832.bugfix
@@ -1,0 +1,1 @@
+Stylewrapper `buildStyleObjectFromData` fixes accounting for container blocks. @sneridagh

--- a/packages/volto/src/components/manage/Blocks/Block/StyleWrapper.jsx
+++ b/packages/volto/src/components/manage/Blocks/Block/StyleWrapper.jsx
@@ -9,7 +9,7 @@ import {
 const StyleWrapper = (props) => {
   let classNames,
     style = [];
-  const { children, content, data = {}, block } = props;
+  const { block, children, content, data = {}, isContainer } = props;
   classNames = buildStyleClassNamesFromData(data.styles);
 
   classNames = buildStyleClassNamesExtenders({
@@ -19,7 +19,13 @@ const StyleWrapper = (props) => {
     classNames,
   });
 
-  style = buildStyleObjectFromData(data);
+  style = buildStyleObjectFromData(
+    data,
+    '',
+    // If we are rendering blocks inside a container, then pass also the data from the container
+    // This is needed in order to calculate properly the styles for the blocks inside the container
+    isContainer && content.blocks ? content : {},
+  );
 
   const rewrittenChildren = React.Children.map(children, (child) => {
     if (React.isValidElement(child)) {

--- a/packages/volto/src/components/manage/Blocks/Container/EditBlockWrapper.jsx
+++ b/packages/volto/src/components/manage/Blocks/Container/EditBlockWrapper.jsx
@@ -32,13 +32,21 @@ const EditBlockWrapper = (props) => {
     onSelectBlock,
     data,
     index,
+    properties,
   } = blockProps;
 
   function onResetBlock() {
     onChangeBlock(block, { '@type': 'empty' });
   }
 
-  const style = buildStyleObjectFromData(data);
+  const style = buildStyleObjectFromData(
+    data,
+    '',
+    // in a container, we have the parent container data in the properties prop
+    // passing the data of the container too
+    // This is needed in order to calculate properly the styles for the blocks inside the container
+    properties.blocks ? properties : {},
+  );
 
   // We need to merge the StyleWrapper styles with the draggable props from b-D&D
   const styleMergedWithDragProps = {

--- a/packages/volto/src/components/theme/View/RenderBlocks.jsx
+++ b/packages/volto/src/components/theme/View/RenderBlocks.jsx
@@ -26,7 +26,7 @@ const messages = defineMessages({
 });
 
 const RenderBlocks = (props) => {
-  const { content, location, metadata, blockWrapperTag } = props;
+  const { blockWrapperTag, content, location, isContainer, metadata } = props;
   const intl = useIntl();
   const blocksFieldname = getBlocksFieldname(content);
   const blocksLayoutFieldname = getBlocksLayoutFieldname(content);
@@ -72,6 +72,7 @@ const RenderBlocks = (props) => {
                 id={block}
                 block={block}
                 data={blockData}
+                isContainer={isContainer}
               >
                 <Block
                   id={block}

--- a/packages/volto/src/helpers/Blocks/Blocks.js
+++ b/packages/volto/src/helpers/Blocks/Blocks.js
@@ -661,7 +661,11 @@ export const styleDataToStyleObject = (key, value, prefix = '') => {
  * @param {string} prefix The prefix (could be dragged from a recursive call, initially empty)
  * @return {Object} The style object ready to be passed as prop
  */
-export const buildStyleObjectFromData = (data = {}, prefix = '') => {
+export const buildStyleObjectFromData = (
+  data = {},
+  prefix = '',
+  container = {},
+) => {
   // style wrapper object has the form:
   // const styles = {
   //   color: 'red',
@@ -720,7 +724,7 @@ export const buildStyleObjectFromData = (data = {}, prefix = '') => {
     enhancers.forEach(({ method }) => {
       stylesFromObjectStyleEnhancers = {
         ...stylesFromObjectStyleEnhancers,
-        ...method(data),
+        ...method({ data, container }),
       };
     });
 

--- a/packages/volto/src/helpers/Blocks/Blocks.test.js
+++ b/packages/volto/src/helpers/Blocks/Blocks.test.js
@@ -1151,7 +1151,7 @@ describe('Blocks', () => {
 
   describe('buildStyleObjectFromData', () => {
     beforeEach(() => {
-      function blockThemesEnhancer(data) {
+      function blockThemesEnhancer({ data }) {
         const blockConfig = config.blocks.blocksConfig[data['@type']];
         const blockStyleDefinitions =
           // We look up for the blockThemes in the block's data, then in the global config


### PR DESCRIPTION
There were some edge cases in blocks contained in container blocks (blocks in block) when the style applied was incorrect.
This was mainly because at the moment of applying the styles, there was no way of telling if a block is a contained block or not.

This PR fixes this, passing down the container block data and accounting for this fact along the way.