### PR TITLE
feat(types): Add batching type to QuerystringSearchResponse interface

### DIFF
--- a/packages/types/src/services/querystring-search.d.ts
+++ b/packages/types/src/services/querystring-search.d.ts
@@ -1,7 +1,9 @@
 import { Brain } from './common';
+import { Batching } from './registry';
 
 export interface QuerystringSearchResponse {
   '@id': string;
   items: Brain[];
   items_total: number;
+  batching?: Batching;
 }


### PR DESCRIPTION
Add batching type information to QuerystringSearchResponse
Description
The QuerystringSearchResponse interface was missing type information for the batching object that's returned by Plone's /@querystring-search endpoint. This PR adds proper typing support for the pagination metadata.

Changes
Import Batching interface from registry.d.ts
Add optional batching field to QuerystringSearchResponse
Maintain backward compatibility by making the field optional

Realted Issue:#6267