### PR TITLE
Check first if the destination (build public directory) exists before trying to create it in `AfterBuildPlugin`

### DIFF
--- a/packages/volto/news/6853.bugfix
+++ b/packages/volto/news/6853.bugfix
@@ -1,0 +1,1 @@
+Check if the destination (build public directory) exists before trying to create it in AfterBuildPlugin when consolidating `public` folders from add-ons. @sneridagh

--- a/packages/volto/razzle.config.js
+++ b/packages/volto/razzle.config.js
@@ -201,7 +201,10 @@ const defaultModify = ({
               `${registry.packages[addon].modulePath}/../.`,
             );
             if (fs.existsSync(path.join(p, 'public'))) {
-              if (!dev) {
+              if (
+                !dev &&
+                fs.existsSync(path.join(paths.appBuildPublic, 'public'))
+              ) {
                 mergeDirectories(path.join(p, 'public'), paths.appBuildPublic);
               }
               if (


### PR DESCRIPTION
This is the process where it copies over the `public` folder for add-ons into the build resultant folder.

It happens that if something go wrong in the build, this error swallows any previous error with the build, which makes you look into the wrong direction. Now, it will be more resilient and show the real error happening.