### PR TITLE
Added stale checker

### DIFF
--- a/.github/stale-items.yml
+++ b/.github/stale-items.yml
@@ -1,4 +1,4 @@
-# This workflow warns and then closes issues that have had no activity for a
+# This workflow checks issues and PRs that have had no activity for a
 # specified amount of time. You can adjust the behavior by modifying this file.
 # For more information, see:
 #   https://github.com/actions/stale

--- a/.github/stale-items.yml
+++ b/.github/stale-items.yml
@@ -1,0 +1,30 @@
+# This workflow warns and then closes issues that have had no activity for a
+# specified amount of time. You can adjust the behavior by modifying this file.
+# For more information, see:
+#   https://github.com/actions/stale
+---
+name: 'Stale Items Policy'
+on:
+  schedule:
+    - cron: '0 0 * * *' # Run at 00:00 UTC every day
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - name: '🧹 Mark stale issues and PRs'
+        id: stale_items
+        uses: actions/stale@v9.1.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-stale: 180
+          days-before-close: -1 # never close issues and prs
+          stale-issue-label: '30.1 needs: confirmation'
+          stale-pr-label: '30.1 needs: confirmation'
+          operations-per-run: 1000


### PR DESCRIPTION
Adds an action for checking stale issues and PRs and marking them as stale.
As discussed in the last Volto team meeting, there is not automatic closing of Issues/PRs right now, let's see how this works for us.
