### PR TITLE
prefix-path with minimal changes

### DIFF
--- a/packages/volto/razzle.config.js
+++ b/packages/volto/razzle.config.js
@@ -417,6 +417,20 @@ const defaultModify = ({
         ]
       : [];
 
+  //prefix-path
+  const prefixPath = process.env.RAZZLE_PREFIX_PATH || '';
+  if (prefixPath) {
+    if (target === 'web' && dev) {
+      if (config.devServer.devMiddleware)
+        config.devServer.devMiddleware.publicPath = prefixPath;
+      else config.devServer.publicPath += `${prefixPath.slice(1)}/`;
+    }
+    const pp = config.output.publicPath;
+
+    //check if publicPath already has the prefixPath
+    if (pp.indexOf(prefixPath) === -1)
+      config.output.publicPath = `${pp}${prefixPath.slice(1)}/`;
+  }
   return config;
 };
 

--- a/packages/volto/src/components/theme/Image/Image.jsx
+++ b/packages/volto/src/components/theme/Image/Image.jsx
@@ -1,6 +1,10 @@
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import { flattenToAppURL, flattenScales } from '@plone/volto/helpers/Url/Url';
+import {
+  flattenToAppURL,
+  flattenScales,
+  addPrefixPath,
+} from '@plone/volto/helpers/Url/Url';
 
 /**
  * Image component
@@ -30,7 +34,7 @@ export default function Image({
   attrs.className = cx(className, { responsive }) || undefined;
 
   if (!item && src) {
-    attrs.src = src;
+    attrs.src = addPrefixPath(src);
   } else {
     const isFromRealObject = !item.image_scales;
     const imageFieldWithDefault = imageField || item.image_field || 'image';
@@ -46,9 +50,11 @@ export default function Image({
 
     const isSvg = image['content-type'] === 'image/svg+xml';
     // In case `base_path` is present (`preview_image_link`) use it as base path
-    const basePath = image.base_path || item['@id'];
+    const basePath = addPrefixPath(
+      flattenToAppURL(image.base_path || item['@id']),
+    );
+    attrs.src = `${basePath}/${image.download}`;
 
-    attrs.src = `${flattenToAppURL(basePath)}/${image.download}`;
     attrs.width = image.width;
     attrs.height = image.height;
 
@@ -67,10 +73,7 @@ export default function Image({
       });
 
       attrs.srcSet = sortedScales
-        .map(
-          (scale) =>
-            `${flattenToAppURL(basePath)}/${scale.download} ${scale.width}w`,
-        )
+        .map((scale) => `${basePath}/${scale.download} ${scale.width}w`)
         .join(', ');
     }
   }

--- a/packages/volto/src/config/index.js
+++ b/packages/volto/src/config/index.js
@@ -97,6 +97,7 @@ let config = {
     // apiPath: process.env.RAZZLE_API_PATH || 'http://localhost:8081/db/web', // for guillotina
     actions_raising_api_errors: ['GET_CONTENT', 'UPDATE_CONTENT'],
     internalApiPath: process.env.RAZZLE_INTERNAL_API_PATH || undefined,
+    prefixPath: process.env.RAZZLE_PREFIX_PATH || '',
     websockets: process.env.RAZZLE_WEBSOCKETS || false,
     // TODO: legacyTraverse to be removed when the use of the legacy traverse is deprecated.
     legacyTraverse: process.env.RAZZLE_LEGACY_TRAVERSE || false,

--- a/packages/volto/src/helpers/Api/APIResourceWithAuth.js
+++ b/packages/volto/src/helpers/Api/APIResourceWithAuth.js
@@ -6,6 +6,7 @@
 import superagent from 'superagent';
 import config from '@plone/volto/registry';
 import { addHeadersFactory } from '@plone/volto/helpers/Proxy/Proxy';
+import { stripPrefixPath } from '@plone/volto/helpers/Url/Url';
 
 /**
  * Get a resource image/file with authenticated (if token exist) API headers
@@ -17,8 +18,8 @@ export const getAPIResourceWithAuth = (req) =>
   new Promise((resolve, reject) => {
     const { settings } = config;
     const APISUFIX = settings.legacyTraverse ? '' : '/++api++';
-
     let apiPath = '';
+
     if (settings.internalApiPath && __SERVER__) {
       apiPath = settings.internalApiPath;
     } else if (__DEVELOPMENT__ && settings.devProxyToApiPath) {
@@ -26,8 +27,13 @@ export const getAPIResourceWithAuth = (req) =>
     } else {
       apiPath = settings.apiPath;
     }
+
+    let path = req.path;
+    //strip prefix if any
+    path = stripPrefixPath(path);
+
     const request = superagent
-      .get(`${apiPath}${__DEVELOPMENT__ ? '' : APISUFIX}${req.path}`)
+      .get(`${apiPath}${__DEVELOPMENT__ ? '' : APISUFIX}${path}`)
       .maxResponseSize(settings.maxResponseSize)
       .responseType('blob');
     const authToken = req.universalCookies.get('auth_token');

--- a/packages/volto/src/helpers/Api/Api.js
+++ b/packages/volto/src/helpers/Api/Api.js
@@ -7,7 +7,10 @@ import superagent from 'superagent';
 import Cookies from 'universal-cookie';
 import config from '@plone/volto/registry';
 import { addHeadersFactory } from '@plone/volto/helpers/Proxy/Proxy';
-import { stripQuerystring } from '@plone/volto/helpers/Url/Url';
+import {
+  stripQuerystring,
+  stripPrefixPath,
+} from '@plone/volto/helpers/Url/Url';
 
 const methods = ['get', 'post', 'put', 'patch', 'del'];
 
@@ -23,13 +26,15 @@ export function formatUrl(path) {
 
   if (path.startsWith('http://') || path.startsWith('https://')) return path;
 
-  const adjustedPath = path[0] !== '/' ? `/${path}` : path;
   let apiPath = '';
   if (settings.internalApiPath && __SERVER__) {
     apiPath = settings.internalApiPath;
   } else if (settings.apiPath) {
     apiPath = settings.apiPath;
   }
+
+  let adjustedPath = path[0] !== '/' ? `/${path}` : path;
+  adjustedPath = stripPrefixPath(adjustedPath);
 
   return `${apiPath}${APISUFIX}${adjustedPath}`;
 }

--- a/packages/volto/src/helpers/Html/Html.jsx
+++ b/packages/volto/src/helpers/Html/Html.jsx
@@ -129,14 +129,37 @@ class Html extends Component {
             }}
           />
 
-          <link rel="icon" href="/favicon.ico" sizes="any" />
-          <link rel="icon" href="/icon.svg" type="image/svg+xml" />
+          <link
+            rel="icon"
+            href={
+              (config.settings.prefixPath ? config.settings.prefixPath : '') +
+              '/favicon.ico'
+            }
+            sizes="any"
+          />
+          <link
+            rel="icon"
+            href={
+              (config.settings.prefixPath ? config.settings.prefixPath : '') +
+              '/icon.svg'
+            }
+            type="image/svg+xml"
+          />
           <link
             rel="apple-touch-icon"
             sizes="180x180"
-            href="/apple-touch-icon.png"
+            href={
+              (config.settings.prefixPath ? config.settings.prefixPath : '') +
+              '/apple-touch-icon.png'
+            }
           />
-          <link rel="manifest" href="/site.webmanifest" />
+          <link
+            rel="manifest"
+            href={
+              (config.settings.prefixPath ? config.settings.prefixPath : '') +
+              '/site.webmanifest'
+            }
+          />
           <meta name="generator" content="Plone 6 - https://plone.org" />
           <meta name="viewport" content="width=device-width, initial-scale=1" />
           <meta name="mobile-web-app-capable" content="yes" />

--- a/packages/volto/src/helpers/Url/Url.js
+++ b/packages/volto/src/helpers/Url/Url.js
@@ -259,6 +259,36 @@ export function isUrl(url) {
 }
 
 /**
+ * Add prefix path if set in settings
+ * @method addPrefixPath
+ * @param {string} src pathname
+ * @returns {string} prefixed pathname
+ */
+export function addPrefixPath(src) {
+  let url = src;
+  const { prefixPath } = config.settings;
+  if (isInternalURL(src) && prefixPath && !src.startsWith(prefixPath)) {
+    url = prefixPath + src; //add prefixPath to src if it's an internal url and not a static resource.
+  }
+  return url;
+}
+
+/**
+ * strip prefix path particulary from api calls
+ * @method stripPrefixPath
+ * @param {string} src pathname
+ * @returns {string} pathname
+ */
+export function stripPrefixPath(src) {
+  let url = src;
+  const { prefixPath } = config.settings;
+  if (prefixPath && src.match(new RegExp(`^${prefixPath}(/|$)`))) {
+    url = src.slice(prefixPath.length);
+  }
+  return url;
+}
+
+/**
  * Get field url
  * @method getFieldURL
  * @param {object} data

--- a/packages/volto/src/start-client.jsx
+++ b/packages/volto/src/start-client.jsx
@@ -18,7 +18,9 @@ import Api from '@plone/volto/helpers/Api/Api';
 import { persistAuthToken } from '@plone/volto/helpers/AuthToken/AuthToken';
 import ScrollToTop from '@plone/volto/helpers/ScrollToTop/ScrollToTop';
 
-export const history = createBrowserHistory();
+export const history = createBrowserHistory({
+  basename: config.settings.prefixPath ? config.settings.prefixPath : '/',
+});
 
 function reactIntlErrorHandler(error) {
   debug('i18n')(error);


### PR DESCRIPTION

Related PLIP #https://github.com/plone/volto/issues/4290

The idea is to use React-router basename which takes care of 90% of our tasks. The only caveat is how it handles the root path when basename is set. By default <Link to='/'/> will point to /prefix/ (with a trailing slash). RRv6 has a fix for this but its not backported to v5.x.
