### PR TITLE
Fix public folder creation check path

### DIFF
--- a/packages/volto/razzle.config.js
+++ b/packages/volto/razzle.config.js
@@ -203,7 +203,7 @@ const defaultModify = ({
             if (fs.existsSync(path.join(p, 'public'))) {
               if (
                 !dev &&
-                fs.existsSync(path.join(paths.appBuildPublic, 'public'))
+                fs.existsSync(paths.appBuildPublic)
               ) {
                 mergeDirectories(path.join(p, 'public'), paths.appBuildPublic);
               }


### PR DESCRIPTION
It looks llike `public` does not have to be appended to the end of the variable, because that actually breaks the directory creation and causes production to break.

> [!CAUTION]
The Volto Team has suspended its review of new pull requests from first-time contributors until the [release of Plone 7](https://plone.org/download/release-schedule), which is preliminarily scheduled for the second quarter of 2026.
> [Read details](https://6.docs.plone.org/volto/contributing/index.html).

-----

- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't other open [pull requests](https://github.com/plone/volto/pulls) for the same change.
- [x] I followed the guidelines in [Contributing to Volto](https://6.docs.plone.org/volto/contributing/index.html).
- [x] I succesfully ran [code linting checks](https://6.docs.plone.org/volto/contributing/linting.html) on my changes locally.
- [x] I succesfully ran [unit tests](https://6.docs.plone.org/volto/contributing/testing.html) on my changes locally.
- [x] I succesfully ran [acceptance tests](https://6.docs.plone.org/volto/contributing/acceptance-tests.html) on my changes locally.
- [x] If needed, I added new tests for my changes.
- [x] If needed, I added [documentation](https://6.docs.plone.org/volto/contributing/documentation.html#narrative-documentation) for my changes, either in the Storybook or narrative documentation.
- [x] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

If your pull request closes an open issue, include the exact text below, immediately followed by the issue number. When your pull request gets merged, then that issue will close automatically.

Closes #
