### PR TITLE
[Seven] Change default script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,17 +56,17 @@ help: ## This help message
 start: ## Starts Seven in development mode
 	pnpm start
 
-.PHONY: start-cmsui
-start-cmsui: ## Starts Seven with CMSUI in development mode
-	pnpm start:cmsui
+.PHONY: start-publicui
+start-publicui: ## Starts Seven in development mode (Public UI only)
+	pnpm start:publicui
 
 .PHONY: build
 build: ## Build a production bundle for distribution
 	pnpm build
 
-.PHONY: build-cmsui
-build-cmsui: ## Build a production bundle for distribution with CMSUI
-	pnpm build:cmsui
+.PHONY: build-publicui
+build-publicui: ## Build a production bundle for distribution (Public UI only)
+	pnpm build:publicui
 
 .PHONY: test
 test: ## Run unit tests

--- a/apps/seven/news/6913.internal
+++ b/apps/seven/news/6913.internal
@@ -1,0 +1,1 @@
+Set the full Seven app with CMSUI as the default app and the Public UI only as opt-in. @pnicolli

--- a/apps/seven/package.json
+++ b/apps/seven/package.json
@@ -5,10 +5,10 @@
   "type": "module",
   "scripts": {
     "dev": "react-router dev",
-    "dev:cmsui": "REGISTRYCONFIG=registry-cmsui.config.ts react-router dev",
+    "dev:publicui": "REGISTRYCONFIG=registry-publicui.config.ts react-router dev",
     "start": "react-router dev",
     "build": "pnpm exec init-loaders && react-router build",
-    "build:cmsui": "pnpm exec init-loaders && REGISTRYCONFIG=registry-cmsui.config.ts react-router build",
+    "build:publicui": "pnpm exec init-loaders && REGISTRYCONFIG=registry-publicui.config.ts react-router build",
     "start:prod": "react-router-serve ./build/server/index.js",
     "typecheck": "react-router typegen && tsc",
     "typegen": "react-router typegen",

--- a/apps/seven/registry-publicui.config.ts
+++ b/apps/seven/registry-publicui.config.ts
@@ -2,7 +2,6 @@ const addons = [
   '@plone/theming',
   '@plone/blocks',
   '@plone/slots',
-  '@plone/cmsui',
   '@plone/publicui',
 ];
 const theme = '';

--- a/apps/seven/registry.config.ts
+++ b/apps/seven/registry.config.ts
@@ -2,6 +2,7 @@ const addons = [
   '@plone/theming',
   '@plone/blocks',
   '@plone/slots',
+  '@plone/cmsui',
   '@plone/publicui',
 ];
 const theme = '';


### PR DESCRIPTION
This sets the full application with CMSUI as the default one, while the extra option that has just the publicui is the one people have to opt-in. Even if the latter is the most complete at this time, I feel this will make it easier to jump in into working towards Seven.