### PR TITLE
Move includes from `plone/documentation` to `plone/volto`

### DIFF
--- a/docs/source/_inc/_branch-policy.md
+++ b/docs/source/_inc/_branch-policy.md
@@ -47,7 +47,7 @@ legacy
 :   `17.x.x` is no longer supported and became _legacy_ (see above definition) when Volto 18 was released.
     You should upgrade to the latest released version of Volto 18.
     You can use Cookieplone to generate a new Volto 18 project, then copy-paste over the relevant parts from your existing project into the new one.
-    See {ref}`volto-upgrade-guide-18.x.x`.
+    See {ref}`upgrading-to-volto-18-x-x`.
     If you need a bug fix, please create an issue to discuss with the Volto Team.
     For security issues, please contact the Plone Security Team by sending email to security@plone.org.
 

--- a/docs/source/_inc/_install-nodejs.md
+++ b/docs/source/_inc/_install-nodejs.md
@@ -10,3 +10,9 @@
     ```shell
     node -v
     ```
+
+3.  Enable {term}`corepack` so that Node.js will install {term}`pnpm` as a package manager.
+
+    ```shell
+    npm i -g corepack@latest && corepack enable
+    ```

--- a/docs/source/_inc/_install-uv.md
+++ b/docs/source/_inc/_install-uv.md
@@ -1,0 +1,21 @@
+Install {term}`uv`.
+Carefully read the console output for further instructions, and follow them, if needed.
+
+`````{tab-set}
+
+````{tab-item} macOS, Linux, and Windows with WSL
+```shell
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+````
+
+````{tab-item} Windows
+```shell
+powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+```
+````
+`````
+
+```{seealso}
+-   [Other {term}`uv` installation methods](https://docs.astral.sh/uv/getting-started/installation/)
+```

--- a/docs/source/contributing/developing-core.md
+++ b/docs/source/contributing/developing-core.md
@@ -97,9 +97,6 @@ When developing a project using Plone, Yarn or other package managers may be use
 
 ### Node.js
 
-We recommend that you install Node.js using nvm.
-Alternatively you can install Node.js using Homebrew or other package installer.
-
 ```{include} ../_inc/_install-nodejs.md
 ```
 

--- a/docs/source/upgrade-guide/index.md
+++ b/docs/source/upgrade-guide/index.md
@@ -65,7 +65,7 @@ These packages have been removed from the Volto repository as they are no longer
 - `@plone/volto-testing`: Testing functionality is now integrated directly in Volto core
 
 
-(upgrade-18-label)=
+(upgrading-to-volto-18-x-x)=
 
 ## Upgrading to Volto 18.x.x
 

--- a/packages/volto/news/6917.documentation
+++ b/packages/volto/news/6917.documentation
@@ -1,0 +1,1 @@
+Move includes from `plone/documentation` to `plone/volto`. @stevepiercy


### PR DESCRIPTION
- Also fix cross-references

This PR must be merged before https://github.com/plone/documentation/pull/1929.

<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚:

- https://volto--6917.org.readthedocs.build/6917/contributing/index.html#branch-policy
- https://volto--6917.org.readthedocs.build/6917/contributing/version-policy.html#branch-policy
- https://volto--6917.org.readthedocs.build/6917/upgrade-guide/index.html#upgrading-to-volto-18-x-x
- https://volto--6917.org.readthedocs.build/6917/contributing/developing-core.html#node-js

<!-- readthedocs-preview plone6 end -->


