### PR TITLE
Remove duplicate configuration item `html_title`

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -208,10 +208,6 @@ html_css_files = ["custom.css", ("print.css", {"media": "print"})]
 # If false, no index is generated.
 html_use_index = True
 
-# The name for this set of Sphinx documents.  If None, it defaults to
-# "<project> v<release> documentation".
-html_title = "%(project)s v%(release)s" % {"project": project, "release": release}
-
 html_extra_path = [
     "robots.txt",
 ]

--- a/packages/volto/news/6933.documentation
+++ b/packages/volto/news/6933.documentation
@@ -1,0 +1,1 @@
+Remove duplicate configuration item `html_title`. @stevepiercy


### PR DESCRIPTION


<!-- readthedocs-preview volto start -->
----
📚 Documentation preview 📚: https://volto--6933.org.readthedocs.build/

<!-- readthedocs-preview volto end -->