### PR TITLE
Fetch vocabularies and querystring config in the current context

### DIFF
--- a/packages/volto/news/3216.breaking
+++ b/packages/volto/news/3216.breaking
@@ -1,0 +1,5 @@
+The `getVocabulary` and `getQuerystring` actions now fetch vocabularies in
+the context of the current content item, using the vocabulary URLs provided
+by the backend.
+Previously they were always fetched at the Plone site root.
+@davisagli

--- a/packages/volto/src/actions/querystring/querystring.js
+++ b/packages/volto/src/actions/querystring/querystring.js
@@ -4,6 +4,7 @@
  */
 
 import { GET_QUERYSTRING } from '@plone/volto/constants/ActionTypes';
+import { flattenToAppURL } from '@plone/volto/helpers/Url/Url';
 
 /**
  * Get querystring.
@@ -11,11 +12,15 @@ import { GET_QUERYSTRING } from '@plone/volto/constants/ActionTypes';
  * @returns {Object} Get querystring action.
  */
 export function getQuerystring() {
-  return {
-    type: GET_QUERYSTRING,
-    request: {
-      op: 'get',
-      path: '/@querystring',
-    },
+  return (dispatch, getState) => {
+    const state = getState();
+    const path = flattenToAppURL(state.content?.data?.['@id'] || '');
+    dispatch({
+      type: GET_QUERYSTRING,
+      request: {
+        op: 'get',
+        path: `${path}/@querystring`,
+      },
+    });
   };
 }

--- a/packages/volto/src/actions/querystring/querystring.test.js
+++ b/packages/volto/src/actions/querystring/querystring.test.js
@@ -4,11 +4,32 @@ import { GET_QUERYSTRING } from '@plone/volto/constants/ActionTypes';
 describe('Querystring action', () => {
   describe('getQuerystring', () => {
     it('should create an action to get the querystring config', () => {
-      const action = getQuerystring();
-
-      expect(action.type).toEqual(GET_QUERYSTRING);
-      expect(action.request.op).toEqual('get');
-      expect(action.request.path).toEqual('/@querystring');
+      const getState = () => ({});
+      const dispatch = jest.fn();
+      getQuerystring()(dispatch, getState);
+      expect(dispatch).toHaveBeenCalledWith({
+        type: GET_QUERYSTRING,
+        request: {
+          op: 'get',
+          path: '/@querystring',
+        },
+      });
+    });
+    it('should get the querystring config in the current context', () => {
+      const getState = () => ({
+        content: {
+          data: { '@id': 'http://localhost:3000/some/content' },
+        },
+      });
+      const dispatch = jest.fn();
+      getQuerystring()(dispatch, getState);
+      expect(dispatch).toHaveBeenCalledWith({
+        type: GET_QUERYSTRING,
+        request: {
+          op: 'get',
+          path: '/some/content/@querystring',
+        },
+      });
     });
   });
 });

--- a/packages/volto/src/actions/vocabularies/vocabularies.js
+++ b/packages/volto/src/actions/vocabularies/vocabularies.js
@@ -8,6 +8,7 @@ import {
   GET_VOCABULARY_TOKEN_TITLE,
 } from '@plone/volto/constants/ActionTypes';
 import { getVocabName } from '@plone/volto/helpers/Vocabularies/Vocabularies';
+import { flattenToAppURL } from '@plone/volto/helpers/Url/Url';
 import qs from 'query-string';
 
 /**
@@ -27,7 +28,9 @@ export function getVocabulary({
   size,
   subrequest,
 }) {
-  const vocabulary = getVocabName(vocabNameOrURL);
+  const vocabPath = vocabNameOrURL.includes('/')
+    ? flattenToAppURL(vocabNameOrURL)
+    : `/@vocabularies/${vocabNameOrURL}`;
 
   let queryString = `b_start=${start}${size ? '&b_size=' + size : ''}`;
 
@@ -40,7 +43,7 @@ export function getVocabulary({
     start,
     request: {
       op: 'get',
-      path: `/@vocabularies/${vocabulary}?${queryString}`,
+      path: `${vocabPath}?${queryString}`,
     },
     subrequest,
   };

--- a/packages/volto/src/actions/vocabularies/vocabularies.test.js
+++ b/packages/volto/src/actions/vocabularies/vocabularies.test.js
@@ -17,7 +17,7 @@ describe('Vocabularies actions', () => {
     });
     it('should create an action to get a vocabulary if a URL is passed', () => {
       const vocabNameOrURL =
-        'http://localhost:8080/@vocabularies/plone.app.vocabularies.Keywords';
+        'http://localhost:3000/@vocabularies/plone.app.vocabularies.Keywords';
       const query = 'john';
       const action = getVocabulary({ vocabNameOrURL, query });
 
@@ -30,7 +30,7 @@ describe('Vocabularies actions', () => {
     });
     it('should create an action to get a vocabulary if a URL with path is passed', () => {
       const vocabNameOrURL =
-        'http://localhost:8080/de/foo/bar/@vocabularies/plone.app.vocabularies.Keywords';
+        'http://localhost:3000/de/foo/bar/@vocabularies/plone.app.vocabularies.Keywords';
       const query = 'john';
       const action = getVocabulary({ vocabNameOrURL, query });
 
@@ -38,19 +38,19 @@ describe('Vocabularies actions', () => {
       expect(action.vocabulary).toEqual(vocabNameOrURL);
       expect(action.request.op).toEqual('get');
       expect(action.request.path).toEqual(
-        `/@vocabularies/plone.app.vocabularies.Keywords?b_start=0&title=${query}`,
+        `/de/foo/bar/@vocabularies/plone.app.vocabularies.Keywords?b_start=0&title=${query}`,
       );
     });
     it('should create an action to get a vocabulary if an b_size=-1 is passed', () => {
       const vocabNameOrURL =
-        'http://localhost:8080/de/foo/bar/@vocabularies/plone.app.vocabularies.Keywords';
+        'http://localhost:3000/de/foo/bar/@vocabularies/plone.app.vocabularies.Keywords';
       const action = getVocabulary({ vocabNameOrURL, size: -1 });
 
       expect(action.type).toEqual(GET_VOCABULARY);
       expect(action.vocabulary).toEqual(vocabNameOrURL);
       expect(action.request.op).toEqual('get');
       expect(action.request.path).toEqual(
-        `/@vocabularies/plone.app.vocabularies.Keywords?b_start=0&b_size=-1`,
+        `/de/foo/bar/@vocabularies/plone.app.vocabularies.Keywords?b_start=0&b_size=-1`,
       );
     });
   });

--- a/packages/volto/src/components/manage/Widgets/IdWidget.test.jsx
+++ b/packages/volto/src/components/manage/Widgets/IdWidget.test.jsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import { Provider } from 'react-intl-redux';
 import { render, waitFor } from '@testing-library/react';
-import configureStore from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
 import config from '@plone/volto/registry';
 
 import IdWidget from './IdWidget';
 
-const mockStore = configureStore();
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
 
 describe('IdWidget', () => {
   test('renders an empty id widget component', async () => {


### PR DESCRIPTION
Fixes #3216 

- Always get a vocabulary from the URL that was specified in the schema by the backend.
- If the vocabulary doesn't include a /, assume it is a vocabulary name and handle it the way we did before, getting it from the root.
- Get the querystring config in the context of the current content item, to make sure the vocabularies it includes are also fetched in the right context.

This is based on #6236 and some customizations we have done for client projects. The big changes from #6236 are:
- There's no setting to configure which vocabularies are context-dependent. If some vocabularies should always be fetched in a particular context, the backend should provide the correct URL.
- This adds the change for the getQuerystring action