### PR TITLE
Issue #6805 sloved, with additional bug fixes.

### DIFF
--- a/packages/volto-slate/news/6805.bugfix
+++ b/packages/volto-slate/news/6805.bugfix
@@ -1,0 +1,1 @@
+These changes will ensure that slate text blocks do not behave weirdly when using the 'backspace' or 'delete' keys. @ManojaD2004


### PR DESCRIPTION
Fixed open issue #6805 (reopened after #6814)

Additional bugs that I faced:

1. When the cursor is at the beginning of the slate text editor and the 'backspace' key is pressed, it would append the content of the previous slate text block.
2. When we were at the end of the slate text editor and the 'delete' key is pressed, it would append the content of the next slate text block.

**Note:**

> We need to make sure the slate text editor is removed and focused on the previous slate text block only when it has no content in the current slate text editor. 

**Bug Fix:**
- To handle this weird behavior, I created a function and checked these two edge cases. This pull request has fixed the main bug mentioned in the open issue and also fixed the additional bugs mentioned above.

**Test the bug:**
1. Add a new page.
2. Add three slate blocks with some text in them.
3. Be at the second slate block, make sure your cursor is at the beginning of the second slate block, and press 'backspace'. (Notice the weird behaviour.)
4. Again, be at the second slate block, make sure your cursor is at the end of the second slate block, and press 'delete'. 

**Bug screenshot:**
![Screenshot 2025-03-07 193148](https://github.com/user-attachments/assets/c1b10f31-7ff0-4633-8027-d239ff690fa9)
![Screenshot 2025-03-07 193215](https://github.com/user-attachments/assets/b577901b-bab9-4e89-9b83-42279f16aaeb)

> [!CAUTION]
The Volto Team has suspended its review of new pull requests from first-time contributors until the [release of Plone 7](https://plone.org/download/release-schedule), which is preliminarily scheduled for the second quarter of 2026.
> [Read details](https://6.docs.plone.org/volto/contributing/index.html).

-----

- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't other open [pull requests](https://github.com/plone/volto/pulls) for the same change.
- [x] I followed the guidelines in [Contributing to Volto](https://6.docs.plone.org/volto/contributing/index.html).
- [x] I succesfully ran [code linting checks](https://6.docs.plone.org/volto/contributing/linting.html) on my changes locally.
- [x] I succesfully ran [unit tests](https://6.docs.plone.org/volto/contributing/testing.html) on my changes locally.
- [x] I succesfully ran [acceptance tests](https://6.docs.plone.org/volto/contributing/acceptance-tests.html) on my changes locally.
- [x] If needed, I added new tests for my changes.
- [x] If needed, I added [documentation](https://6.docs.plone.org/volto/contributing/documentation.html#narrative-documentation) for my changes, either in the Storybook or narrative documentation.
- [x] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

If your pull request closes an open issue, include the exact text below, immediately followed by the issue number. When your pull request gets merged, then that issue will close automatically.

Closes #6805

