### PR TITLE
Enable pull request previews on Read the Docs

### DIFF
--- a/.github/workflows/docs-rtd-pr-preview-volto.yml
+++ b/.github/workflows/docs-rtd-pr-preview-volto.yml
@@ -7,9 +7,10 @@ on:
     # Execute this action only on PRs that touch
     # documentation files for Volto.
     branches:
-      - main
+      - seven
     paths:
       - "docs/source/**"
+      - "packages/components/.storybook/**"
       - "packages/volto/.storybook/**"
       - .readthedocs.yaml
       - requirements-docs.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,7 +19,8 @@ build:
     # If there are no changes (git diff exits with 0) we force the command to return with 183.
     # This is a special exit code on Read the Docs that will cancel the build immediately.
     - |
-      if [ "$READTHEDOCS_VERSION_TYPE" = "external" ] && git diff --quiet origin/main -- docs/ .readthedocs.yaml requirements-docs.txt;
+      if [ "$READTHEDOCS_VERSION_TYPE" = "external" ] && git diff --quiet origin/seven -- docs/ .readthedocs.yaml requirements-docs.txt \
+          packages/components/.storybook/ packages/volto/.storybook/;
       then
         exit 183;
       fi

--- a/packages/volto/news/6950.documentation
+++ b/packages/volto/news/6950.documentation
@@ -1,0 +1,1 @@
+Enable pull request previews on Read the Docs for Seven. @stevepiercy


### PR DESCRIPTION
This time with the correct base to see if it triggers RTD PR preview builds.

https://volto--6950.org.readthedocs.build/6950/

Well, I goofed. PR previews build. It's just a matter of opening up a PR against `seven` with changes to docs, and it should add the link of the preview to the description.