### PR TITLE
Makes the cypress getSlateEditorAndType and getSlateEditorSelectorAndType commands more robust

### DIFF
--- a/packages/volto/cypress/support/commands.js
+++ b/packages/volto/cypress/support/commands.js
@@ -822,12 +822,29 @@ Cypress.Commands.add(
   },
 );
 
+// Helper function to check if it is normal text or special command
+function shouldVerifyContent(type) {
+  return !type.includes('{');
+}
+
 Cypress.Commands.add('getSlateEditorAndType', (type) => {
-  cy.getSlate().focus().click().type(type);
+  const el = cy.getSlate().focus().click().type(type);
+
+  if (shouldVerifyContent(type)) {
+    return el.should('contain', type, { timeout: 5000 });
+  }
+
+  return el;
 });
 
 Cypress.Commands.add('getSlateEditorSelectorAndType', (selector, type) => {
-  cy.getSlateSelector(selector).focus().click().type(type);
+  const el = cy.getSlateSelector(selector).focus().click().type(type);
+
+  if (shouldVerifyContent(type)) {
+    return el.should('contain', type, { timeout: 5000 });
+  }
+
+  return el;
 });
 
 Cypress.Commands.add('setSlateCursor', (subject, query, endQuery) => {

--- a/packages/volto/news/6957.internal
+++ b/packages/volto/news/6957.internal
@@ -1,1 +1,1 @@
-Makes the cypress `getSlateEditorAndType` and `getSlateEditorSelectorAndType` commands more robust. @wesleybl
+Make the Cypress `getSlateEditorAndType` and `getSlateEditorSelectorAndType` commands more robust, avoiding timeouts. @wesleybl

--- a/packages/volto/news/6957.internal
+++ b/packages/volto/news/6957.internal
@@ -1,0 +1,1 @@
+Makes the cypress `getSlateEditorAndType` and `getSlateEditorSelectorAndType` commands more robust. @wesleybl


### PR DESCRIPTION
Locally and I had the error:

```
As editor I can add a page with a text block:
     AssertionError: Timed out retrying after 4000ms: Expected to find content: 'This is the text' within the element: <div> but never did.
```

This error occurred on the line:

https://github.com/plone/volto/blob/81d0369e1628b3072f9e47d14831a2618d2633b6/packages/volto/cypress/tests/core/content/content.js#L53

This PR's change waits until text is entered in `getSlateEditorAndType` and `getSlateEditorSelectorAndType` before testing continues.

There are situations where cypress commands are entered and we cannot verify the text. For example:

https://github.com/plone/volto/blob/c2c4f0f2db89eeb9ea8c1846cdafe3258581842c/packages/volto/cypress/tests/core/volto-slate/06-block-slate-format-link.js#L64-L66

> [!CAUTION]
The Volto Team has suspended its review of new pull requests from first-time contributors until the [release of Plone 7](https://plone.org/download/release-schedule), which is preliminarily scheduled for the second quarter of 2026.
> [Read details](https://6.docs.plone.org/volto/contributing/index.html).

-----

- [ ] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [ ] I verified there aren't other open [pull requests](https://github.com/plone/volto/pulls) for the same change.
- [ ] I followed the guidelines in [Contributing to Volto](https://6.docs.plone.org/volto/contributing/index.html).
- [ ] I succesfully ran [code linting checks](https://6.docs.plone.org/volto/contributing/linting.html) on my changes locally.
- [ ] I succesfully ran [unit tests](https://6.docs.plone.org/volto/contributing/testing.html) on my changes locally.
- [ ] I succesfully ran [acceptance tests](https://6.docs.plone.org/volto/contributing/acceptance-tests.html) on my changes locally.
- [ ] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/volto/contributing/documentation.html#narrative-documentation) for my changes, either in the Storybook or narrative documentation.
- [ ] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

If your pull request closes an open issue, include the exact text below, immediately followed by the issue number. When your pull request gets merged, then that issue will close automatically.

Closes #
