### PR TITLE
Backport: Fix consistent initialValue call on block insert (#6958)

### DIFF
--- a/packages/volto-slate/news/6952.bugfix
+++ b/packages/volto-slate/news/6952.bugfix
@@ -1,0 +1,1 @@
+Pass "null" instead of "{}" to blocksConfig for consistent execution of initialValue.@Abhishek-17h

--- a/packages/volto-slate/news/6952.bugfix
+++ b/packages/volto-slate/news/6952.bugfix
@@ -1,1 +1,1 @@
-Pass "null" instead of "{}" to blocksConfig for consistent execution of initialValue.@Abhishek-17h
+Call `initialValue` consistently by passing `null` instead of `{}` to `blocksConfig`. @Abhishek-17h

--- a/packages/volto-slate/src/utils/volto-blocks.js
+++ b/packages/volto-slate/src/utils/volto-blocks.js
@@ -128,7 +128,7 @@ export function createImageBlock(url, index, props, intl) {
   let id, newFormData;
 
   if (currBlockHasValue) {
-    [id, newFormData] = addBlock(properties, 'image', index + 1, {}, intl);
+    [id, newFormData] = addBlock(properties, 'image', index + 1, null, intl);
     newFormData = changeBlock(newFormData, id, { '@type': 'image', url });
   } else {
     [id, newFormData] = insertBlock(properties, currBlockId, {
@@ -153,7 +153,7 @@ export const createAndSelectNewBlockAfter = (editor, blockValue, intl) => {
     properties,
     'slate',
     index + 1,
-    {},
+    null,
     intl,
   );
 

--- a/packages/volto/news/6952.bugfix
+++ b/packages/volto/news/6952.bugfix
@@ -1,0 +1,1 @@
+Pass "null" instead of "{}" to blocksConfig for consistent execution of initialValue.@Abhishek-17h

--- a/packages/volto/news/6952.bugfix
+++ b/packages/volto/news/6952.bugfix
@@ -1,1 +1,1 @@
-Pass "null" instead of "{}" to blocksConfig for consistent execution of initialValue.@Abhishek-17h
+Call `initialValue` consistently by passing `null` instead of `{}` to `blocksConfig`. @Abhishek-17h

--- a/packages/volto/src/components/manage/Blocks/Block/BlocksForm.jsx
+++ b/packages/volto/src/components/manage/Blocks/Block/BlocksForm.jsx
@@ -142,7 +142,7 @@ const BlocksForm = (props) => {
   };
 
   const onMutateBlock = (id, value) => {
-    const newFormData = mutateBlock(properties, id, value, {}, intl);
+    const newFormData = mutateBlock(properties, id, value, null, intl);
     onChangeFormData(newFormData);
   };
 
@@ -153,7 +153,7 @@ const BlocksForm = (props) => {
       value,
       current,
       config.experimental.addBlockButton.enabled ? 1 : 0,
-      {},
+      null,
       intl,
     );
 
@@ -172,7 +172,7 @@ const BlocksForm = (props) => {
 
   const onAddBlock = (type, index) => {
     if (editable) {
-      const [id, newFormData] = addBlock(properties, type, index, {}, intl);
+      const [id, newFormData] = addBlock(properties, type, index, null, intl);
       const blocksFieldname = getBlocksFieldname(newFormData);
       const blockData = newFormData[blocksFieldname][id];
       newFormData[blocksFieldname][id] = applyBlockDefaults({

--- a/packages/volto/src/helpers/Blocks/Blocks.js
+++ b/packages/volto/src/helpers/Blocks/Blocks.js
@@ -140,7 +140,7 @@ export function deleteBlock(formData, blockId, intl) {
       newFormData,
       config.settings.defaultBlockType,
       0,
-      {},
+      null,
       intl,
     );
   }


### PR DESCRIPTION
> [!CAUTION]
The Volto Team has suspended its review of new pull requests from first-time contributors until the [release of Plone 7](https://plone.org/download/release-schedule), which is preliminarily scheduled for the second quarter of 2026.
> [Read details](https://6.docs.plone.org/volto/contributing/index.html).

-----

- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't other open [pull requests](https://github.com/plone/volto/pulls) for the same change.
- [x] I followed the guidelines in [Contributing to Volto](https://6.docs.plone.org/volto/contributing/index.html).
- [x] I succesfully ran [code linting checks](https://6.docs.plone.org/volto/contributing/linting.html) on my changes locally.
- [x] I succesfully ran [unit tests](https://6.docs.plone.org/volto/contributing/testing.html) on my changes locally.
- [x] I succesfully ran [acceptance tests](https://6.docs.plone.org/volto/contributing/acceptance-tests.html) on my changes locally.
- [ ] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/volto/contributing/documentation.html#narrative-documentation) for my changes, either in the Storybook or narrative documentation.
- [x] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

If your pull request closes an open issue, include the exact text below, immediately followed by the issue number. When your pull request gets merged, then that issue will close automatically.

Closes #
