### PR TITLE
Fix translations default of ContentsDeleteModal: 'linkintegrity: delete' -> 'delete' if no link to break. 

### DIFF
--- a/packages/volto/locales/ca/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ca/LC_MESSAGES/volto.po
@@ -4769,7 +4769,7 @@ msgstr "Camp d'imatge principal"
 
 #. Default: "Delete"
 #: components/manage/Contents/ContentsDeleteModal
-msgid "link-integrity: Delete"
+msgid "Delete"
 msgstr ""
 
 #. Default: "Delete item and break links"

--- a/packages/volto/locales/ca/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ca/LC_MESSAGES/volto.po
@@ -1017,6 +1017,7 @@ msgstr "Per defecte"
 
 #. Default: "Delete"
 #: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 #: components/manage/Contents/ContentsItem
 #: components/manage/Controlpanels/ContentTypesActions
 #: components/manage/Controlpanels/Groups/RenderGroups
@@ -4766,11 +4767,6 @@ msgstr "El meu nom d'usuari és"
 #: config/Blocks
 msgid "leadimage"
 msgstr "Camp d'imatge principal"
-
-#. Default: "Delete"
-#: components/manage/Contents/ContentsDeleteModal
-msgid "Delete"
-msgstr ""
 
 #. Default: "Delete item and break links"
 #: components/manage/Contents/ContentsDeleteModal

--- a/packages/volto/locales/de/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/de/LC_MESSAGES/volto.po
@@ -4769,7 +4769,7 @@ msgstr "Lead-Bild"
 #. Default: "Delete"
 #: components/manage/Contents/ContentsDeleteModal
 msgid "link-integrity: Delete"
-msgstr "Linkintegrität: Löschen"
+msgstr "Löschen"
 
 #. Default: "Delete item and break links"
 #: components/manage/Contents/ContentsDeleteModal

--- a/packages/volto/locales/de/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/de/LC_MESSAGES/volto.po
@@ -1016,6 +1016,7 @@ msgstr "Standard"
 
 #. Default: "Delete"
 #: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 #: components/manage/Contents/ContentsItem
 #: components/manage/Controlpanels/ContentTypesActions
 #: components/manage/Controlpanels/Groups/RenderGroups
@@ -4765,11 +4766,6 @@ msgstr "Mein Nutzername lautet"
 #: config/Blocks
 msgid "leadimage"
 msgstr "Lead-Bild"
-
-#. Default: "Delete"
-#: components/manage/Contents/ContentsDeleteModal
-msgid "Delete"
-msgstr "Löschen"
 
 #. Default: "Delete item and break links"
 #: components/manage/Contents/ContentsDeleteModal

--- a/packages/volto/locales/de/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/de/LC_MESSAGES/volto.po
@@ -4768,7 +4768,7 @@ msgstr "Lead-Bild"
 
 #. Default: "Delete"
 #: components/manage/Contents/ContentsDeleteModal
-msgid "link-integrity: Delete"
+msgid "Delete"
 msgstr "Löschen"
 
 #. Default: "Delete item and break links"

--- a/packages/volto/locales/en/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/en/LC_MESSAGES/volto.po
@@ -1011,6 +1011,7 @@ msgstr ""
 
 #. Default: "Delete"
 #: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 #: components/manage/Contents/ContentsItem
 #: components/manage/Controlpanels/ContentTypesActions
 #: components/manage/Controlpanels/Groups/RenderGroups
@@ -4759,11 +4760,6 @@ msgstr ""
 #. Default: "Lead Image Field"
 #: config/Blocks
 msgid "leadimage"
-msgstr ""
-
-#. Default: "Delete"
-#: components/manage/Contents/ContentsDeleteModal
-msgid "Delete"
 msgstr ""
 
 #. Default: "Delete item and break links"

--- a/packages/volto/locales/en/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/en/LC_MESSAGES/volto.po
@@ -4763,7 +4763,7 @@ msgstr ""
 
 #. Default: "Delete"
 #: components/manage/Contents/ContentsDeleteModal
-msgid "link-integrity: Delete"
+msgid "Delete"
 msgstr ""
 
 #. Default: "Delete item and break links"

--- a/packages/volto/locales/es/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/es/LC_MESSAGES/volto.po
@@ -4770,7 +4770,7 @@ msgstr "Imagen Principal"
 
 #. Default: "Delete"
 #: components/manage/Contents/ContentsDeleteModal
-msgid "link-integrity: Delete"
+msgid "Delete"
 msgstr ""
 
 #. Default: "Delete item and break links"

--- a/packages/volto/locales/es/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/es/LC_MESSAGES/volto.po
@@ -1018,6 +1018,7 @@ msgstr "Vista por defecto"
 
 #. Default: "Delete"
 #: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 #: components/manage/Contents/ContentsItem
 #: components/manage/Controlpanels/ContentTypesActions
 #: components/manage/Controlpanels/Groups/RenderGroups
@@ -4767,11 +4768,6 @@ msgstr "Mi nombre de usuario es"
 #: config/Blocks
 msgid "leadimage"
 msgstr "Imagen Principal"
-
-#. Default: "Delete"
-#: components/manage/Contents/ContentsDeleteModal
-msgid "Delete"
-msgstr ""
 
 #. Default: "Delete item and break links"
 #: components/manage/Contents/ContentsDeleteModal

--- a/packages/volto/locales/eu/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/eu/LC_MESSAGES/volto.po
@@ -1018,6 +1018,7 @@ msgstr "Defektuzko bista"
 
 #. Default: "Delete"
 #: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 #: components/manage/Contents/ContentsItem
 #: components/manage/Controlpanels/ContentTypesActions
 #: components/manage/Controlpanels/Groups/RenderGroups
@@ -4767,11 +4768,6 @@ msgstr "Nire erabiltzaile izena da"
 #: config/Blocks
 msgid "leadimage"
 msgstr "Irudi nagusiaren eremua"
-
-#. Default: "Delete"
-#: components/manage/Contents/ContentsDeleteModal
-msgid "Delete"
-msgstr ""
 
 #. Default: "Delete item and break links"
 #: components/manage/Contents/ContentsDeleteModal

--- a/packages/volto/locales/eu/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/eu/LC_MESSAGES/volto.po
@@ -4770,7 +4770,7 @@ msgstr "Irudi nagusiaren eremua"
 
 #. Default: "Delete"
 #: components/manage/Contents/ContentsDeleteModal
-msgid "link-integrity: Delete"
+msgid "Delete"
 msgstr ""
 
 #. Default: "Delete item and break links"

--- a/packages/volto/locales/fi/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/fi/LC_MESSAGES/volto.po
@@ -1016,6 +1016,7 @@ msgstr "Oletusnäkymä"
 
 #. Default: "Delete"
 #: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 #: components/manage/Contents/ContentsItem
 #: components/manage/Controlpanels/ContentTypesActions
 #: components/manage/Controlpanels/Groups/RenderGroups
@@ -4765,11 +4766,6 @@ msgstr "Käyttäjätunnukseni"
 #: config/Blocks
 msgid "leadimage"
 msgstr "nostokuva"
-
-#. Default: "Delete"
-#: components/manage/Contents/ContentsDeleteModal
-msgid "Delete"
-msgstr ""
 
 #. Default: "Delete item and break links"
 #: components/manage/Contents/ContentsDeleteModal

--- a/packages/volto/locales/fi/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/fi/LC_MESSAGES/volto.po
@@ -4768,7 +4768,7 @@ msgstr "nostokuva"
 
 #. Default: "Delete"
 #: components/manage/Contents/ContentsDeleteModal
-msgid "link-integrity: Delete"
+msgid "Delete"
 msgstr ""
 
 #. Default: "Delete item and break links"

--- a/packages/volto/locales/fr/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/fr/LC_MESSAGES/volto.po
@@ -4770,7 +4770,7 @@ msgstr "image de garde"
 
 #. Default: "Delete"
 #: components/manage/Contents/ContentsDeleteModal
-msgid "link-integrity: Delete"
+msgid "Delete"
 msgstr ""
 
 #. Default: "Delete item and break links"

--- a/packages/volto/locales/fr/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/fr/LC_MESSAGES/volto.po
@@ -1018,6 +1018,7 @@ msgstr "Vue par défaut"
 
 #. Default: "Delete"
 #: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 #: components/manage/Contents/ContentsItem
 #: components/manage/Controlpanels/ContentTypesActions
 #: components/manage/Controlpanels/Groups/RenderGroups
@@ -4767,11 +4768,6 @@ msgstr "Mon nom d'utilisateur est"
 #: config/Blocks
 msgid "leadimage"
 msgstr "image de garde"
-
-#. Default: "Delete"
-#: components/manage/Contents/ContentsDeleteModal
-msgid "Delete"
-msgstr ""
 
 #. Default: "Delete item and break links"
 #: components/manage/Contents/ContentsDeleteModal

--- a/packages/volto/locales/hi/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/hi/LC_MESSAGES/volto.po
@@ -4763,7 +4763,7 @@ msgstr "प्रमुख छवि फ़ील्ड"
 
 #. Default: "Delete"
 #: components/manage/Contents/ContentsDeleteModal
-msgid "link-integrity: Delete"
+msgid "Delete"
 msgstr ""
 
 #. Default: "Delete item and break links"

--- a/packages/volto/locales/hi/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/hi/LC_MESSAGES/volto.po
@@ -1011,6 +1011,7 @@ msgstr "डिफ़ॉल्ट दृश्य"
 
 #. Default: "Delete"
 #: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 #: components/manage/Contents/ContentsItem
 #: components/manage/Controlpanels/ContentTypesActions
 #: components/manage/Controlpanels/Groups/RenderGroups
@@ -4760,11 +4761,6 @@ msgstr "मेरा उपयोगकर्ता नाम है"
 #: config/Blocks
 msgid "leadimage"
 msgstr "प्रमुख छवि फ़ील्ड"
-
-#. Default: "Delete"
-#: components/manage/Contents/ContentsDeleteModal
-msgid "Delete"
-msgstr ""
 
 #. Default: "Delete item and break links"
 #: components/manage/Contents/ContentsDeleteModal

--- a/packages/volto/locales/it/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/it/LC_MESSAGES/volto.po
@@ -1011,6 +1011,7 @@ msgstr "Vista default"
 
 #. Default: "Delete"
 #: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 #: components/manage/Contents/ContentsItem
 #: components/manage/Controlpanels/ContentTypesActions
 #: components/manage/Controlpanels/Groups/RenderGroups
@@ -4760,11 +4761,6 @@ msgstr "Il mio nome utente è"
 #: config/Blocks
 msgid "leadimage"
 msgstr "Immagine di testata"
-
-#. Default: "Delete"
-#: components/manage/Contents/ContentsDeleteModal
-msgid "Delete"
-msgstr "Elimina"
 
 #. Default: "Delete item and break links"
 #: components/manage/Contents/ContentsDeleteModal

--- a/packages/volto/locales/it/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/it/LC_MESSAGES/volto.po
@@ -4763,7 +4763,7 @@ msgstr "Immagine di testata"
 
 #. Default: "Delete"
 #: components/manage/Contents/ContentsDeleteModal
-msgid "link-integrity: Delete"
+msgid "Delete"
 msgstr "Elimina"
 
 #. Default: "Delete item and break links"

--- a/packages/volto/locales/ja/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ja/LC_MESSAGES/volto.po
@@ -4768,7 +4768,7 @@ msgstr "リード画像"
 
 #. Default: "Delete"
 #: components/manage/Contents/ContentsDeleteModal
-msgid "link-integrity: Delete"
+msgid "Delete"
 msgstr ""
 
 #. Default: "Delete item and break links"

--- a/packages/volto/locales/ja/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ja/LC_MESSAGES/volto.po
@@ -1016,6 +1016,7 @@ msgstr ""
 
 #. Default: "Delete"
 #: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 #: components/manage/Contents/ContentsItem
 #: components/manage/Controlpanels/ContentTypesActions
 #: components/manage/Controlpanels/Groups/RenderGroups
@@ -4765,11 +4766,6 @@ msgstr "私のユーザー名は"
 #: config/Blocks
 msgid "leadimage"
 msgstr "リード画像"
-
-#. Default: "Delete"
-#: components/manage/Contents/ContentsDeleteModal
-msgid "Delete"
-msgstr ""
 
 #. Default: "Delete item and break links"
 #: components/manage/Contents/ContentsDeleteModal

--- a/packages/volto/locales/nl/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/nl/LC_MESSAGES/volto.po
@@ -1015,6 +1015,7 @@ msgstr "Standaard weergave"
 
 #. Default: "Delete"
 #: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 #: components/manage/Contents/ContentsItem
 #: components/manage/Controlpanels/ContentTypesActions
 #: components/manage/Controlpanels/Groups/RenderGroups
@@ -4764,11 +4765,6 @@ msgstr "Mijn gebruikersnaam is"
 #: config/Blocks
 msgid "leadimage"
 msgstr "Veld leidende afbeelding"
-
-#. Default: "Delete"
-#: components/manage/Contents/ContentsDeleteModal
-msgid "Delete"
-msgstr ""
 
 #. Default: "Delete item and break links"
 #: components/manage/Contents/ContentsDeleteModal

--- a/packages/volto/locales/nl/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/nl/LC_MESSAGES/volto.po
@@ -4767,7 +4767,7 @@ msgstr "Veld leidende afbeelding"
 
 #. Default: "Delete"
 #: components/manage/Contents/ContentsDeleteModal
-msgid "link-integrity: Delete"
+msgid "Delete"
 msgstr ""
 
 #. Default: "Delete item and break links"

--- a/packages/volto/locales/pt/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/pt/LC_MESSAGES/volto.po
@@ -1016,6 +1016,7 @@ msgstr ""
 
 #. Default: "Delete"
 #: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 #: components/manage/Contents/ContentsItem
 #: components/manage/Controlpanels/ContentTypesActions
 #: components/manage/Controlpanels/Groups/RenderGroups
@@ -4764,11 +4765,6 @@ msgstr "Meu nome de usuário é"
 #. Default: "Lead Image Field"
 #: config/Blocks
 msgid "leadimage"
-msgstr ""
-
-#. Default: "Delete"
-#: components/manage/Contents/ContentsDeleteModal
-msgid "Delete"
 msgstr ""
 
 #. Default: "Delete item and break links"

--- a/packages/volto/locales/pt/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/pt/LC_MESSAGES/volto.po
@@ -4768,7 +4768,7 @@ msgstr ""
 
 #. Default: "Delete"
 #: components/manage/Contents/ContentsDeleteModal
-msgid "link-integrity: Delete"
+msgid "Delete"
 msgstr ""
 
 #. Default: "Delete item and break links"

--- a/packages/volto/locales/pt_BR/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/pt_BR/LC_MESSAGES/volto.po
@@ -4769,7 +4769,7 @@ msgstr "Imagem principal"
 
 #. Default: "Delete"
 #: components/manage/Contents/ContentsDeleteModal
-msgid "link-integrity: Delete"
+msgid "Delete"
 msgstr ""
 
 #. Default: "Delete item and break links"

--- a/packages/volto/locales/pt_BR/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/pt_BR/LC_MESSAGES/volto.po
@@ -1017,6 +1017,7 @@ msgstr "Visão padrão"
 
 #. Default: "Delete"
 #: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 #: components/manage/Contents/ContentsItem
 #: components/manage/Controlpanels/ContentTypesActions
 #: components/manage/Controlpanels/Groups/RenderGroups
@@ -4766,11 +4767,6 @@ msgstr "Meu nome de usuário é "
 #: config/Blocks
 msgid "leadimage"
 msgstr "Imagem principal"
-
-#. Default: "Delete"
-#: components/manage/Contents/ContentsDeleteModal
-msgid "Delete"
-msgstr ""
 
 #. Default: "Delete item and break links"
 #: components/manage/Contents/ContentsDeleteModal

--- a/packages/volto/locales/ro/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ro/LC_MESSAGES/volto.po
@@ -4769,7 +4769,7 @@ msgstr "Imagine (copertă)"
 
 #. Default: "Delete"
 #: components/manage/Contents/ContentsDeleteModal
-msgid "link-integrity: Delete"
+msgid "Delete"
 msgstr ""
 
 #. Default: "Delete item and break links"

--- a/packages/volto/locales/ro/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ro/LC_MESSAGES/volto.po
@@ -1017,6 +1017,7 @@ msgstr "Vizualizare implicită"
 
 #. Default: "Delete"
 #: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 #: components/manage/Contents/ContentsItem
 #: components/manage/Controlpanels/ContentTypesActions
 #: components/manage/Controlpanels/Groups/RenderGroups
@@ -4766,11 +4767,6 @@ msgstr "Numele meu de utilizator este"
 #: config/Blocks
 msgid "leadimage"
 msgstr "Imagine (copertă)"
-
-#. Default: "Delete"
-#: components/manage/Contents/ContentsDeleteModal
-msgid "Delete"
-msgstr ""
 
 #. Default: "Delete item and break links"
 #: components/manage/Contents/ContentsDeleteModal

--- a/packages/volto/locales/ru/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ru/LC_MESSAGES/volto.po
@@ -4768,7 +4768,7 @@ msgstr "Поле главного изображения"
 
 #. Default: "Delete"
 #: components/manage/Contents/ContentsDeleteModal
-msgid "link-integrity: Delete"
+msgid "Delete"
 msgstr "Удалить"
 
 #. Default: "Delete item and break links"

--- a/packages/volto/locales/ru/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ru/LC_MESSAGES/volto.po
@@ -1016,6 +1016,7 @@ msgstr "Вид по умолчанию"
 
 #. Default: "Delete"
 #: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 #: components/manage/Contents/ContentsItem
 #: components/manage/Controlpanels/ContentTypesActions
 #: components/manage/Controlpanels/Groups/RenderGroups
@@ -4765,11 +4766,6 @@ msgstr "Мое имя пользователя"
 #: config/Blocks
 msgid "leadimage"
 msgstr "Поле главного изображения"
-
-#. Default: "Delete"
-#: components/manage/Contents/ContentsDeleteModal
-msgid "Delete"
-msgstr "Удалить"
 
 #. Default: "Delete item and break links"
 #: components/manage/Contents/ContentsDeleteModal

--- a/packages/volto/locales/volto.pot
+++ b/packages/volto/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2025-04-03T14:23:15.314Z\n"
+"POT-Creation-Date: 2025-04-09T19:53:50.699Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Content-Type: text/plain; charset=utf-8\n"
@@ -1013,6 +1013,7 @@ msgstr ""
 
 #. Default: "Delete"
 #: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 #: components/manage/Contents/ContentsItem
 #: components/manage/Controlpanels/ContentTypesActions
 #: components/manage/Controlpanels/Groups/RenderGroups
@@ -4761,11 +4762,6 @@ msgstr ""
 #. Default: "Lead Image Field"
 #: config/Blocks
 msgid "leadimage"
-msgstr ""
-
-#. Default: "Delete"
-#: components/manage/Contents/ContentsDeleteModal
-msgid "Delete"
 msgstr ""
 
 #. Default: "Delete item and break links"

--- a/packages/volto/locales/volto.pot
+++ b/packages/volto/locales/volto.pot
@@ -4765,7 +4765,7 @@ msgstr ""
 
 #. Default: "Delete"
 #: components/manage/Contents/ContentsDeleteModal
-msgid "link-integrity: Delete"
+msgid "Delete"
 msgstr ""
 
 #. Default: "Delete item and break links"

--- a/packages/volto/locales/zh_CN/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/zh_CN/LC_MESSAGES/volto.po
@@ -4769,7 +4769,7 @@ msgstr ""
 
 #. Default: "Delete"
 #: components/manage/Contents/ContentsDeleteModal
-msgid "link-integrity: Delete"
+msgid "Delete"
 msgstr ""
 
 #. Default: "Delete item and break links"

--- a/packages/volto/locales/zh_CN/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/zh_CN/LC_MESSAGES/volto.po
@@ -1017,6 +1017,7 @@ msgstr "默认视图"
 
 #. Default: "Delete"
 #: components/manage/Contents/Contents
+#: components/manage/Contents/ContentsDeleteModal
 #: components/manage/Contents/ContentsItem
 #: components/manage/Controlpanels/ContentTypesActions
 #: components/manage/Controlpanels/Groups/RenderGroups
@@ -4765,11 +4766,6 @@ msgstr "我的用户名是"
 #. Default: "Lead Image Field"
 #: config/Blocks
 msgid "leadimage"
-msgstr ""
-
-#. Default: "Delete"
-#: components/manage/Contents/ContentsDeleteModal
-msgid "Delete"
 msgstr ""
 
 #. Default: "Delete item and break links"

--- a/packages/volto/news/6964.feature
+++ b/packages/volto/news/6964.feature
@@ -1,0 +1,1 @@
+Improve german translation. @ksuess

--- a/packages/volto/news/6964.feature
+++ b/packages/volto/news/6964.feature
@@ -1,1 +1,1 @@
-Improve german translation. @ksuess
+Fix translations default of ContentsDeleteModal: 'linkintegrity: delete' -> 'delete' if no link to break. @ksuess

--- a/packages/volto/src/components/manage/Contents/ContentsDeleteModal.jsx
+++ b/packages/volto/src/components/manage/Contents/ContentsDeleteModal.jsx
@@ -28,7 +28,7 @@ const messages = defineMessages({
     defaultMessage: 'Checking references...',
   },
   delete: {
-    id: 'link-integrity: Delete',
+    id: 'Delete',
     defaultMessage: 'Delete',
   },
   delete_and_broken_links: {


### PR DESCRIPTION
![grafik](https://github.com/user-attachments/assets/43e81f49-ee6e-47a4-bdbe-2e248924a88b)