### PR TITLE
Fixes Cypress "Index Text Block" test

### DIFF
--- a/packages/volto/cypress/tests/core/blocks/blocks-indexing.js
+++ b/packages/volto/cypress/tests/core/blocks/blocks-indexing.js
@@ -22,7 +22,10 @@ describe('Block Indexing Tests', () => {
     cy.get('#toolbar-save').click();
 
     // WHEN: I search for Avram
-    cy.get('input[name="SearchableText"]').clear().type('Avram');
+    cy.get('input[name="SearchableText"]')
+      .should('not.be.disabled')
+      .clear()
+      .type('Avram');
     cy.get('button[aria-label="Search"]').click();
 
     // THEN: The search results should contain the page 'Noam Avram Chomsky'

--- a/packages/volto/news/6965.internal
+++ b/packages/volto/news/6965.internal
@@ -1,0 +1,1 @@
+Fixes Cypress "Index Text Block" test. @wesleybl


### PR DESCRIPTION
Wait for the search field to be enabled before trying to enter something.

Fix the error:

```
1) Block Indexing Tests
       Index Text Block:
     CypressError: `cy.type()` failed because it targeted a disabled element.
```

See: https://github.com/plone/volto/actions/runs/14365190416/job/40276279370#step:4:457

> [!CAUTION]
The Volto Team has suspended its review of new pull requests from first-time contributors until the [release of Plone 7](https://plone.org/download/release-schedule), which is preliminarily scheduled for the second quarter of 2026.
> [Read details](https://6.docs.plone.org/volto/contributing/index.html).

-----

- [ ] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [ ] I verified there aren't other open [pull requests](https://github.com/plone/volto/pulls) for the same change.
- [ ] I followed the guidelines in [Contributing to Volto](https://6.docs.plone.org/volto/contributing/index.html).
- [ ] I succesfully ran [code linting checks](https://6.docs.plone.org/volto/contributing/linting.html) on my changes locally.
- [ ] I succesfully ran [unit tests](https://6.docs.plone.org/volto/contributing/testing.html) on my changes locally.
- [ ] I succesfully ran [acceptance tests](https://6.docs.plone.org/volto/contributing/acceptance-tests.html) on my changes locally.
- [ ] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/volto/contributing/documentation.html#narrative-documentation) for my changes, either in the Storybook or narrative documentation.
- [ ] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

If your pull request closes an open issue, include the exact text below, immediately followed by the issue number. When your pull request gets merged, then that issue will close automatically.

Closes #
