### PR TITLE
Use Image from @plone/volto/components/theme/Image/Image instead of semantic-ui-react in ContentsUploadModal

### DIFF
--- a/packages/volto/news/6982.internal
+++ b/packages/volto/news/6982.internal
@@ -1,0 +1,1 @@
+Use `Image` from `@plone/volto/components/theme/Image/Image` instead of `semantic-ui-react` in `ContentsUploadModal`. @wesleybl

--- a/packages/volto/src/components/manage/Contents/ContentsUploadModal.jsx
+++ b/packages/volto/src/components/manage/Contents/ContentsUploadModal.jsx
@@ -6,7 +6,6 @@ import {
   Dimmer,
   Header,
   Icon,
-  Image,
   Modal,
   Table,
   Segment,
@@ -24,6 +23,7 @@ import FormattedRelativeDate from '@plone/volto/components/theme/FormattedDate/F
 import { createContent } from '@plone/volto/actions/content/content';
 import { validateFileUploadSize } from '@plone/volto/helpers/FormValidation/FormValidation';
 import { usePrevious } from '@plone/volto/helpers/Utils/usePrevious';
+import Image from '@plone/volto/components/theme/Image/Image';
 
 const Dropzone = loadable(() => import('react-dropzone'));
 
@@ -259,7 +259,11 @@ const ContentsUploadModal = (props) => {
                     <Table.Cell>{filesize(file.size, { round: 0 })}</Table.Cell>
                     <Table.Cell>
                       {file.type.split('/')[0] === 'image' && (
-                        <Image src={file.preview} height={60} />
+                        <Image
+                          src={file.preview}
+                          height={60}
+                          className="ui image"
+                        />
                       )}
                     </Table.Cell>
                     <Table.Cell>


### PR DESCRIPTION
> [!CAUTION]
The Volto Team has suspended its review of new pull requests from first-time contributors until the [release of Plone 7](https://plone.org/download/release-schedule), which is preliminarily scheduled for the second quarter of 2026.
> [Read details](https://6.docs.plone.org/volto/contributing/index.html).

-----

- [ ] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [ ] I verified there aren't other open [pull requests](https://github.com/plone/volto/pulls) for the same change.
- [ ] I followed the guidelines in [Contributing to Volto](https://6.docs.plone.org/volto/contributing/index.html).
- [ ] I succesfully ran [code linting checks](https://6.docs.plone.org/volto/contributing/linting.html) on my changes locally.
- [ ] I succesfully ran [unit tests](https://6.docs.plone.org/volto/contributing/testing.html) on my changes locally.
- [ ] I succesfully ran [acceptance tests](https://6.docs.plone.org/volto/contributing/acceptance-tests.html) on my changes locally.
- [ ] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/volto/contributing/documentation.html#narrative-documentation) for my changes, either in the Storybook or narrative documentation.
- [ ] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

If your pull request closes an open issue, include the exact text below, immediately followed by the issue number. When your pull request gets merged, then that issue will close automatically.

Closes #
