### PR TITLE
Added current evaluated `querystring` as a parameter in expander `querystring` key when it is a function

### DIFF
--- a/docs/source/configuration/expanders.md
+++ b/docs/source/configuration/expanders.md
@@ -38,8 +38,8 @@ export default function applyConfig (config) {
 }
 ```
 
-The config accepts a list of matchers with the ability to filter by request path and action type, for maximum flexibility.
-It also accepts a `querystring` object that allows to configure the expandeders via querystring params (eg. the navigation expander).
+`config` accepts a list of matchers to filter by request path and action type for maximum flexibility.
+It also accepts a `querystring` object that allows to configure the expanders via querystring parameters, for example, the navigation expander.
 The `querystring` object accepts a querystring object or a function that returns a querystring object.
 The function receives the current `config` and the current evaluated `querystring` as parameters, so you can use it to pass dynamic values to the querystring.
 

--- a/docs/source/configuration/expanders.md
+++ b/docs/source/configuration/expanders.md
@@ -41,6 +41,7 @@ export default function applyConfig (config) {
 The config accepts a list of matchers with the ability to filter by request path and action type, for maximum flexibility.
 It also accepts a `querystring` object that allows to configure the expandeders via querystring params (eg. the navigation expander).
 The `querystring` object accepts a querystring object or a function that returns a querystring object.
+The function receives the current `config` and the current evaluated `querystring` as parameters, so you can use it to pass dynamic values to the querystring.
 
 ```js
 export default function applyConfig (config) {
@@ -57,7 +58,7 @@ export default function applyConfig (config) {
       {
         match: '/de',
         GET_CONTENT: ['navigation'],
-        querystring: (config) => ({
+        querystring: (config, querystring) => ({
           'expand.navigation.depth': config.settings.navDepth,
         }),
       }

--- a/docs/source/configuration/settings-reference.md
+++ b/docs/source/configuration/settings-reference.md
@@ -356,8 +356,8 @@ apiExpanders
       },
     ],
     ```
-    The configuration accepts a list of matchers, with the ability to filter by the request path and action type for maximum flexibility.
-    It also accepts a `querystring` object that allows configuring the expanders via query string parameters, such as the navigation expander.
+    `config` accepts a list of matchers to filter by request path and action type for maximum flexibility.
+    It also accepts a `querystring` object that allows to configure the expanders via querystring parameters, for example, the navigation expander.
     The `querystring` object accepts a querystring object or a function that returns a querystring object.
     The function receives the current `config` and the current evaluated `querystring` as parameters, so you can use it to pass dynamic values to the querystring.
 

--- a/docs/source/configuration/settings-reference.md
+++ b/docs/source/configuration/settings-reference.md
@@ -359,6 +359,7 @@ apiExpanders
     The configuration accepts a list of matchers, with the ability to filter by the request path and action type for maximum flexibility.
     It also accepts a `querystring` object that allows configuring the expanders via query string parameters, such as the navigation expander.
     The `querystring` object accepts a querystring object or a function that returns a querystring object.
+    The function receives the current `config` and the current evaluated `querystring` as parameters, so you can use it to pass dynamic values to the querystring.
 
     ```js
     export default function applyConfig (config) {
@@ -375,7 +376,7 @@ apiExpanders
           {
             match: '/de',
             GET_CONTENT: ['navigation'],
-            querystring: (config) => ({
+            querystring: (config, querystring) => ({
               'expand.navigation.depth': config.settings.navDepth,
             }),
           }

--- a/packages/volto/news/7012.feature
+++ b/packages/volto/news/7012.feature
@@ -1,0 +1,1 @@
+Added current evaluated `querystring` as a parameter in expander's `querystring` key when it's a function. @sneridagh

--- a/packages/volto/src/middleware/Api.test.js
+++ b/packages/volto/src/middleware/Api.test.js
@@ -282,4 +282,51 @@ describe('api middleware helpers', () => {
       '/de/mypage?expand=navigation&expand.navigation.coolness=1&expand.navigation.depth=3&someotherquery=1&someotherquery=2',
     );
   });
+
+  it('addExpandersToPath - inherit expander merged using querystring as a function', () => {
+    config.settings.apiExpanders = [
+      {
+        match: '/',
+        GET_CONTENT: ['navigation'],
+        querystring: {
+          'expand.navigation.depth': 3,
+          'expand.navigation.coolness': 1,
+        },
+      },
+      {
+        match: '/',
+        GET_CONTENT: ['inherit'],
+        querystring: {
+          'expand.inherit.behaviors':
+            'voltolighttheme.header,voltolighttheme.theme,voltolighttheme.footer',
+        },
+      },
+      {
+        match: '/',
+        GET_CONTENT: ['inherit'],
+        querystring: (config, querystring) => {
+          if (querystring['expand.inherit.behaviors']) {
+            return {
+              'expand.inherit.behaviors': querystring[
+                'expand.inherit.behaviors'
+              ].concat(',', 'plonegovbr.socialmedia.settings'),
+            };
+          } else {
+            return {
+              'expand.inherit.behaviors': 'plonegovbr.socialmedia.settings',
+            };
+          }
+        },
+      },
+    ];
+
+    const result = addExpandersToPath(
+      '/de/mypage?someotherquery=1&someotherquery=2',
+      GET_CONTENT,
+    );
+
+    expect(result).toEqual(
+      '/de/mypage?expand=navigation,inherit&expand.inherit.behaviors=voltolighttheme.header,voltolighttheme.theme,voltolighttheme.footer,plonegovbr.socialmedia.settings&expand.navigation.coolness=1&expand.navigation.depth=3&someotherquery=1&someotherquery=2',
+    );
+  });
 });

--- a/packages/volto/src/middleware/api.js
+++ b/packages/volto/src/middleware/api.js
@@ -75,7 +75,7 @@ export function addExpandersToPath(path, type, isAnonymous) {
       // The querystring accepts being a function to be able to take other
       // config parameters
       if (typeof querystring === 'function') {
-        querystring = querystring(config);
+        querystring = querystring(config, acc);
       }
       return { ...acc, ...querystring };
     }, {});


### PR DESCRIPTION


<!-- readthedocs-preview volto start -->
----
📚 Documentation preview 📚: https://volto--7012.org.readthedocs.build/

<!-- readthedocs-preview volto end -->