### PR TITLE
fix switch sidebar to Blocks tab on block selection from Order tab

### DIFF
--- a/packages/volto/news/7004.bugfix
+++ b/packages/volto/news/7004.bugfix
@@ -1,1 +1,1 @@
-Selecting a block in the main editing area now correctly switches the sidebar tab from "Order" to "Block".@Abhishek-17h
+Selecting a block in the main editing area now correctly switches the sidebar tab from "Order" to "Block". @Abhishek-17h

--- a/packages/volto/news/7004.bugfix
+++ b/packages/volto/news/7004.bugfix
@@ -1,0 +1,1 @@
+Selecting a block in the main editing area now correctly switches the sidebar tab from "Order" to "Block".@Abhishek-17h

--- a/packages/volto/src/components/manage/Blocks/Block/Edit.jsx
+++ b/packages/volto/src/components/manage/Blocks/Block/Edit.jsx
@@ -77,11 +77,7 @@ export class Edit extends Component {
       this.blockNode.current.focus();
     }
     const tab = this.props.manage ? 1 : blocksConfig?.[type]?.sidebarTab || 0;
-    if (
-      this.props.selected &&
-      this.props.editable &&
-      this.props.sidebarTab !== 2
-    ) {
+    if (this.props.selected && this.props.editable) {
       this.props.setSidebarTab(tab);
     }
   }
@@ -107,9 +103,7 @@ export class Edit extends Component {
       const tab = this.props.manage
         ? 1
         : blocksConfig?.[nextProps.type]?.sidebarTab || 0;
-      if (this.props.sidebarTab !== 2) {
-        this.props.setSidebarTab(tab);
-      }
+      this.props.setSidebarTab(tab);
     }
   }
 


### PR DESCRIPTION
> [!CAUTION]
The Volto Team has suspended its review of new pull requests from first-time contributors until the [release of Plone 7](https://plone.org/download/release-schedule), which is preliminarily scheduled for the second quarter of 2026.
> [Read details](https://6.docs.plone.org/volto/contributing/index.html).

-----

- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't other open [pull requests](https://github.com/plone/volto/pulls) for the same change.
- [x] I followed the guidelines in [Contributing to Volto](https://6.docs.plone.org/volto/contributing/index.html).
- [x] I succesfully ran [code linting checks](https://6.docs.plone.org/volto/contributing/linting.html) on my changes locally.
- [x] I succesfully ran [unit tests](https://6.docs.plone.org/volto/contributing/testing.html) on my changes locally.
- [] I succesfully ran [acceptance tests](https://6.docs.plone.org/volto/contributing/acceptance-tests.html) on my changes locally.
- [ ] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/volto/contributing/documentation.html#narrative-documentation) for my changes, either in the Storybook or narrative documentation.
- [x] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

If your pull request closes an open issue, include the exact text below, immediately followed by the issue number. When your pull request gets merged, then that issue will close automatically.

Closes #7004 
