### PR TITLE
updated docs for vitest in bundle-size-optimiazation

### DIFF
--- a/docs/source/contributing/bundle-size-optimization.md
+++ b/docs/source/contributing/bundle-size-optimization.md
@@ -34,9 +34,13 @@ This should also help to reduce circular dependencies, and help the overall buil
 
 If you import a component from a lazy loaded index, you can have issues with rendering these in unit tests.
 Mocks are provided for lazy loaded components and are available for you to use.
-This can be done by using the `jest.mock` function to mock the specific component index.
+This can be done by using the `vi.mock` function to mock the specific component index.
 For example, to mock the `Form` component and all other components in the `Form`-specific index, you can use the following code in your test file:
 
 ```javascript
-jest.mock('@plone/volto/components/manage/Form');
+vi.mock('@plone/volto/components/manage/Form', async () => {
+  return await import(
+    '@plone/volto/components/manage/Form/__mocks__/index.vitest.tsx'
+  );
+});
 ```

--- a/packages/volto/news/7024.documentation
+++ b/packages/volto/news/7024.documentation
@@ -1,1 +1,1 @@
-Updated "bundle-size-optimization" to support Vitest documentation.@Abhishek-17h
+Updated "bundle-size-optimization" documentation according to Vitest testing.@Abhishek-17h

--- a/packages/volto/news/7024.documentation
+++ b/packages/volto/news/7024.documentation
@@ -1,0 +1,1 @@
+Updated "bundle-size-optimization" to support Vitest documentation.@Abhishek-17h

--- a/packages/volto/news/7024.documentation
+++ b/packages/volto/news/7024.documentation
@@ -1,1 +1,1 @@
-Updated "bundle-size-optimization" documentation according to Vitest testing.@Abhishek-17h
+Updated documentation code example from Jest to Vitest in the "Bundle size optimization" chapter. @Abhishek-17h


### PR DESCRIPTION
> [!CAUTION]
The Volto Team has suspended its review of new pull requests from first-time contributors until the [release of Plone 7](https://plone.org/download/release-schedule), which is preliminarily scheduled for the second quarter of 2026.
> [Read details](https://6.docs.plone.org/volto/contributing/index.html).

-----

- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't other open [pull requests](https://github.com/plone/volto/pulls) for the same change.
- [x] I followed the guidelines in [Contributing to Volto](https://6.docs.plone.org/volto/contributing/index.html).
- [x] I succesfully ran [code linting checks](https://6.docs.plone.org/volto/contributing/linting.html) on my changes locally.
- [x] I succesfully ran [unit tests](https://6.docs.plone.org/volto/contributing/testing.html) on my changes locally.
- [x] I succesfully ran [acceptance tests](https://6.docs.plone.org/volto/contributing/acceptance-tests.html) on my changes locally.
- [ ] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/volto/contributing/documentation.html#narrative-documentation) for my changes, either in the Storybook or narrative documentation.
- [x] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

If your pull request closes an open issue, include the exact text below, immediately followed by the issue number. When your pull request gets merged, then that issue will close automatically.

Closes #7024 


<!-- readthedocs-preview volto start -->
----
📚 Documentation preview 📚: https://volto--7025.org.readthedocs.build/

<!-- readthedocs-preview volto end -->