### PR TITLE
Fix title to "Microsoft Writing Style Guide"

### DIFF
--- a/docs/source/contributing/documentation.md
+++ b/docs/source/contributing/documentation.md
@@ -110,7 +110,7 @@ Open `/docs/_build/linkcheck/output.txt` for a list of broken links.
 
 #### `docs-vale`
 
-`docs-vale` checks for American English spelling, grammar, syntax, and the Microsoft Developer Style Guide.
+`docs-vale` checks for American English spelling, grammar, and syntax, and follows the Microsoft Writing Style Guide.
 
 ```shell
 make docs-vale


### PR DESCRIPTION
- Minor grammar fix

No change log needed. Trivial maintenance.

<!-- readthedocs-preview volto start -->
----
📚 Documentation preview 📚: https://volto--7026.org.readthedocs.build/

<!-- readthedocs-preview volto end -->