### PR TITLE
fix ImageWidget state handling in upload and drag-and-drop functional.

### DIFF
--- a/packages/volto/news/7045.bugfix
+++ b/packages/volto/news/7045.bugfix
@@ -1,0 +1,1 @@
+Fixed stuck states in the Image Upload Widget by resetting uploading after failed size validation and dragging after image deletion or drag events, ensuring proper functionality and user feedback.

--- a/packages/volto/src/components/manage/Widgets/ImageWidget.jsx
+++ b/packages/volto/src/components/manage/Widgets/ImageWidget.jsx
@@ -131,7 +131,10 @@ const UnconnectedImageInput = (props) => {
       const file = eventOrFile.target
         ? eventOrFile.target.files[0]
         : eventOrFile[0];
-      if (!validateFileUploadSize(file, intl.formatMessage)) return;
+      if (!validateFileUploadSize(file, intl.formatMessage)) {
+        setUploading(false);
+        return;
+      }
       readAsDataURL(file).then((fileData) => {
         const fields = fileData.match(/^data:(.*);(.*),(.*)$/);
         dispatch(
@@ -196,10 +199,10 @@ const UnconnectedImageInput = (props) => {
         noClick
         accept="image/*"
         onDrop={(acceptedFiles) => {
+          setDragging(false);
           if (acceptedFiles.length > 0) {
             handleUpload(acceptedFiles);
           } else {
-            setDragging(false);
             toast.error(
               <Toast
                 error


### PR DESCRIPTION
### Implementation Details for Fixing Issues in the Image Upload Widget

This merge request addresses two key issues in the Image Upload Widget: the `uploading` state remaining stuck when an oversized image is uploaded, and the `dragging` state persisting after an image is deleted or a drag event ends. Below is a detailed explanation of the changes made to resolve these problems.

---

#### **Issue 1: Uploading State Stuck When Uploading an Oversized Image**

**Problem:**
When a user uploads an image that exceeds the allowed size limit, the `uploading` state remains `true`, causing the loading CSS (`Dimmer` active) to stay visible. This prevents the user from interacting with the widget further.

**Solution:**
The `handleUpload` function was updated to explicitly reset the `uploading` state to `false` when the size validation fails. This ensures that the loading state is cleared, and the user can retry the upload.

**Changes Made:**
- Added a `setUploading(false)` call in the `handleUpload` function when the file size validation fails.

**Code Snippet:**
```jsx
if (!validateFileUploadSize(file, intl.formatMessage)) {
  setUploading(false); // Reset uploading state if validation fails
  return;
}
```

---

#### **Issue 2: Dragging State Stuck After Deleting an Image**

**Problem:**
When a user drags an image into the widget and then deletes it, the `dragging` state remains `true`. This causes the drag CSS (`Dimmer` active) to stay visible, even though the user is no longer interacting with the widget.

**Solution:**
The `dragging` state is now explicitly reset to `false` in the following scenarios:
1. When the `onDrop` event is triggered.

**Changes Made:**
- Updated the `onDrop` handler to reset the `dragging` state to `false` after a file is dropped.

**Code Snippets:**

*Resetting `dragging` in `onDrop`:*
```jsx
onDrop={(acceptedFiles) => {
  setDragging(false); // Reset dragging state
  if (acceptedFiles.length > 0) {
    handleUpload(acceptedFiles);
  } else {
    toast.error(
      <Toast
        error
        title={intl.formatMessage(messages.Error)}
        content={intl.formatMessage(messages.imageUploadErrorMessage)}
      />,
    );
  }
}}
```
---

### Summary of Changes
1. **Uploading State Fix:**
   - Reset the `uploading` state to `false` when file size validation fails.

2. **Dragging State Fix:**
   - Reset the `dragging` state to `false` in the `onDrop`.

---

### Testing
- **Uploading State:**
  - Attempted to upload an oversized image and verified that the loading state (`Dimmer`) is cleared after the error message is displayed.
  - Successfully uploaded valid images to ensure no regressions.

- **Dragging State:**
  - Dragged an image into the widget and deleted it, confirming that the drag CSS is cleared.
  - Tested leaving the drag area to ensure the `dragging` state is reset.

---

These changes ensure a smoother user experience by preventing stuck states in the Image Upload Widget.

Closes #7045 