### PR TITLE
Add detailed list with links to contents delete modal

### DIFF
--- a/packages/volto/news/7054.feature
+++ b/packages/volto/news/7054.feature
@@ -1,0 +1,1 @@
+Improved the ContentsDeleteModal by displaying a detailed list of selected items with clickable links for better clarity and usability. @alexandreIFB

--- a/packages/volto/src/components/manage/Contents/ContentsDeleteModal.jsx
+++ b/packages/volto/src/components/manage/Contents/ContentsDeleteModal.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
@@ -54,6 +54,16 @@ const ContentsDeleteModal = (props) => {
 
   const [linksAndReferencesViewLink, setLinkAndReferencesViewLink] =
     useState(null);
+
+  const titlesToDelete = useMemo(
+    () =>
+      itemsToDelete.reduce((acc, id) => {
+        const item = items.find((item) => item['@id'] === id);
+        acc[id] = item ? item.Title : null;
+        return acc;
+      }, {}),
+    [itemsToDelete, items],
+  );
 
   useEffect(() => {
     const getFieldById = (id, field) => {
@@ -136,6 +146,22 @@ const ContentsDeleteModal = (props) => {
                 {intl.formatMessage(messages.loading)}
               </Loader>
             </Dimmer>
+
+            <ul>
+              {itemsToDelete.map((id) => {
+                return (
+                  <li key={id}>
+                    <Link
+                      to={flattenToAppURL(id)}
+                      title={intl.formatMessage(messages.navigate_to_this_item)}
+                      target="_blank"
+                    >
+                      {titlesToDelete[id] || id}
+                    </Link>
+                  </li>
+                );
+              })}
+            </ul>
 
             {itemsToDelete.length > 1 ? (
               containedItemsToDelete > 0 ? (


### PR DESCRIPTION
This PR enhances the `ContentsDeleteModal` by adding a detailed list of selected items for deletion. Each item in the list includes:  
- The title of the item.  
- A clickable link  to the item's path for easy navigation and verification.  

These changes aim to improve usability, reduce accidental deletions, and increase user confidence when performing critical actions.

**Changes Made:**

- Added a detailed list of selected items in the modal.
- Made each item clickable with a link to its corresponding path.

![image](https://github.com/user-attachments/assets/5046cc8d-b68e-4a00-9d2c-7521393290c4) 
![image](https://github.com/user-attachments/assets/49f19e8a-02e2-4fa1-98b8-26323cf6051e)


**How to Test:**

1. Enter content management mode (/contents).  
2. Select one or more items for deletion.  
3. Open the delete modal and verify:  
   - The list of selected items is displayed.  
   - Each item has a clickable link that redirects to the correct path.  
4. Confirm or cancel the deletion to ensure functionality remains intact.


**Notes:**  
This change is backward-compatible and does not affect other functionalities.

Closes #7054