### PR TITLE
Fix rtd preview builds for Seven

### DIFF
--- a/.github/workflows/docs-rtd-pr-preview-volto.yml
+++ b/.github/workflows/docs-rtd-pr-preview-volto.yml
@@ -9,7 +9,7 @@ on:
     branches:
       - seven
     paths:
-      - "docs/source/**"
+      - "docs/**"
       - "packages/components/.storybook/**"
       - "packages/volto/.storybook/**"
       - .readthedocs.yaml

--- a/packages/volto/news/7066.documentation
+++ b/packages/volto/news/7066.documentation
@@ -1,0 +1,1 @@
+Fix the path in which to detect changes to documentation files in the `seven` branch. @stevepiercy


### PR DESCRIPTION
Fix the path in which to detect changes to documentation files for the `seven` branch.

<!-- readthedocs-preview volto start -->
----
📚 Documentation preview 📚: https://volto--7066.org.readthedocs.build/

<!-- readthedocs-preview volto end -->

<!-- readthedocs-preview plone-registry start -->
----
📚 Documentation preview 📚: https://plone-registry--7066.org.readthedocs.build/

<!-- readthedocs-preview plone-registry end -->