### PR TITLE
Use schema title in Helmet for `Add` page component.

### DIFF
--- a/packages/volto/news/7048.feature
+++ b/packages/volto/news/7048.feature
@@ -1,0 +1,1 @@
+Use translated schema title in Helmet for `Add` component page. @alexandreIFB

--- a/packages/volto/src/components/manage/Add/Add.jsx
+++ b/packages/volto/src/components/manage/Add/Add.jsx
@@ -348,7 +348,7 @@ class Add extends Component {
         <div id="page-add">
           <Helmet
             title={this.props.intl.formatMessage(messages.add, {
-              type: this.props.type,
+              type: this.props?.schema?.title || this.props.type,
             })}
           />
           <Form


### PR DESCRIPTION
 This PR updates the `Add` page component to use the schema title (`this.props.schema.title`) in the `Helmet` title instead of the technical identifier (`props.type`). This change ensures that the browser title is more user-friendly and descriptive, improving the overall user experience.


- Fallback to `props.type` remains in place to ensure compatibility.
- Aligns with other parts of the system that already use the schema title.  
- Ability to translate the schema title.


#### Testing  
1. Navigate to the page for creating new content (e.g., `Page`).  
2. Verify that the browser title now displays the schema title (e.g., "Add Page") instead of the technical identifier.  
3. Confirm that the fallback to `props.type` works if `schema.title` is unavailable.

#### No Negative Impact
Retains the current behavior as a fallback.

#### Related Issue  
Closes #7048