### PR TITLE
Add isClearable prop to SelectWidget component

### DIFF
--- a/packages/volto/news/7083.feature
+++ b/packages/volto/news/7083.feature
@@ -1,0 +1,1 @@
+add isClearable prop to `SelectWidget`, allowing configuration of whether the select input can be cleared by the user. @alexandreIFB

--- a/packages/volto/news/7083.feature
+++ b/packages/volto/news/7083.feature
@@ -1,1 +1,1 @@
-add isClearable prop to `SelectWidget`, allowing configuration of whether the select input can be cleared by the user. @alexandreIFB
+Add isClearable prop to `SelectWidget`, allowing configuration of whether the select input can be cleared by the user. @alexandreIFB

--- a/packages/volto/news/7083.feature
+++ b/packages/volto/news/7083.feature
@@ -1,1 +1,1 @@
-Add isClearable prop to `SelectWidget`, allowing configuration of whether the select input can be cleared by the user. @alexandreIFB
+Add `isClearable` prop to `SelectWidget`, allowing configuration of whether the select input can be cleared by the user. @alexandreIFB

--- a/packages/volto/src/components/manage/Widgets/SelectWidget.jsx
+++ b/packages/volto/src/components/manage/Widgets/SelectWidget.jsx
@@ -128,6 +128,7 @@ class SelectWidget extends Component {
     isMulti: PropTypes.bool,
     placeholder: PropTypes.string,
     sort: PropTypes.bool,
+    isClearable: PropTypes.bool,
   };
 
   /**
@@ -156,6 +157,7 @@ class SelectWidget extends Component {
     noValueOption: true,
     customOptionStyling: null,
     sort: false,
+    isClearable: true,
   };
 
   /**
@@ -302,7 +304,7 @@ class SelectWidget extends Component {
                 : undefined,
             );
           }}
-          isClearable
+          isClearable={this.props.isClearable}
         />
       </FormFieldWrapper>
     );


### PR DESCRIPTION
This PR adds the `isClearable` prop to the `SelectWidget` component, allowing configuration of whether the select input can be cleared by the user. By default, the select remains clearable for backward compatibility, but now it can be set to `false` when needed. This makes the widget more flexible and suitable for different form requirements.

Closes #7083