### PR TITLE
Fix getUtility when called with a utility type that hasn't been registered

### DIFF
--- a/packages/registry/news/7108.bugfix
+++ b/packages/registry/news/7108.bugfix
@@ -1,0 +1,1 @@
+`getUtility` returns an empty object if called with a utility type that has not been registered. @davisagli

--- a/packages/registry/src/index.ts
+++ b/packages/registry/src/index.ts
@@ -494,7 +494,7 @@ class Config {
 
     const utilityName = `${depsString ? `|${depsString}` : ''}${name}`;
 
-    return this._data.utilities[type][utilityName] || {};
+    return this._data.utilities[type]?.[utilityName] || {};
   }
 
   getUtilities(options: {

--- a/packages/registry/src/registry.test.tsx
+++ b/packages/registry/src/registry.test.tsx
@@ -1009,7 +1009,16 @@ describe('Utilities registry', () => {
     ).toEqual('this is a simple validator utility');
   });
 
-  it('trying to get a non-existent utility returns undefined', () => {
+  it('trying to get an unregistered utility type returns undefined', () => {
+    expect(config.getUtility({ name: 'Something', type: 'schema' })).toEqual(
+      {},
+    );
+    expect(
+      config.getUtility({ name: 'Something', type: 'schema' }).method,
+    ).toEqual(undefined);
+  });
+
+  it('trying to get an undefined utility name returns undefined', () => {
     expect(config.getUtility({ name: undefined, type: 'schema' })).toEqual({});
     expect(
       config.getUtility({ name: undefined, type: 'schema' }).method,
@@ -1102,6 +1111,10 @@ describe('Utilities registry', () => {
 
   it('trying to use getUtilities with no type returns an empty array', () => {
     expect(config.getUtilities({ type: undefined }).length).toEqual(0);
+  });
+
+  it('trying to use getUtilities with an unregistered type returns an empty array', () => {
+    expect(config.getUtilities({ type: 'Something' }).length).toEqual(0);
   });
 
   it('getUtilities - registers two utilities with the same dependencies and different names', () => {


### PR DESCRIPTION
Fixes https://github.com/plone/volto/issues/7108

@sneridagh Do you think this is the right way to handle it?

Instead we could raise a more explicit error that the utility hasn't been registered. That might make the problem more obvious if the developer misspelled the utility type. But it would mean the calling code has to explicitly catch the error if it's okay for the utility to be missing (like this case).

We could also add queryUtility like we have in the backend (getUtility raises if missing, queryUtility returns an empty object)