### PR TITLE
feat: add getWidget and registerWidget methods in registry

### DIFF
--- a/packages/cmsui/components/Form/Field.tsx
+++ b/packages/cmsui/components/Form/Field.tsx
@@ -36,7 +36,6 @@ type FieldProps = {
 };
 
 const MODE_HIDDEN = 'hidden'; //hidden mode. If mode is hidden, field is not rendered
-
 /**
  * Get default widget
  */
@@ -49,7 +48,7 @@ const getWidgetDefault = (): React.ComponentType<any> =>
 const getWidgetByFieldId = (
   id: FieldProps['id'],
 ): React.ComponentType<any> | null =>
-  typeof id === 'string' ? config.widgets?.id?.[id] || null : null;
+  typeof id === 'string' ? (config.getWidget(id) ?? null) : null;
 
 /**
  * Get widget by factory attribute
@@ -57,7 +56,7 @@ const getWidgetByFieldId = (
 const getWidgetByFactory = (
   factory: FieldProps['factory'],
 ): React.ComponentType<any> | null =>
-  factory ? config.widgets?.factory?.[factory] || null : null;
+  factory ? (config.getWidget(factory) ?? null) : null;
 
 /**
  * Get widget by field's `widget` attribute
@@ -66,7 +65,7 @@ const getWidgetByName = (
   widget: FieldProps['widget'],
 ): React.ComponentType<any> | null =>
   typeof widget === 'string'
-    ? config.widgets?.widget?.[widget] || getWidgetDefault()
+    ? (config.getWidget(widget) ?? getWidgetDefault())
     : null;
 
 /**
@@ -85,7 +84,7 @@ const getWidgetFromTaggedValues = (widgetOptions?: {
   frontendOptions?: { widget: FieldProps['widget']; widgetProps: any };
 }): React.ComponentType<any> | null =>
   typeof widgetOptions?.frontendOptions?.widget === 'string'
-    ? config.widgets?.widget?.[widgetOptions.frontendOptions.widget]
+    ? (config.getWidget(widgetOptions.frontendOptions.widget) ?? null)
     : null;
 
 /**
@@ -102,7 +101,7 @@ directives.widget(
  */
 const getWidgetPropsFromTaggedValues = (widgetOptions?: {
   frontendOptions?: { widget: string; widgetProps: any };
-}): React.ComponentType<any> | null =>
+}): Record<string, any> | null =>
   typeof widgetOptions?.frontendOptions?.widgetProps === 'object'
     ? widgetOptions.frontendOptions.widgetProps
     : null;
@@ -112,50 +111,34 @@ const getWidgetPropsFromTaggedValues = (widgetOptions?: {
  */
 const getWidgetByVocabulary = (
   vocabulary: FieldProps['vocabulary'],
-): React.ComponentType<any> | null =>
-  vocabulary && vocabulary['@id']
-    ? config.widgets?.vocabulary?.[
-        vocabulary['@id'].replace(
-          /^.*\/@vocabularies\//,
-          '',
-        ) as keyof WidgetsConfigByVocabulary
-      ]
-    : null;
+): React.ComponentType<any> | null => {
+  const vocabId = vocabulary?.['@id'];
+  if (!vocabId) return null;
+
+  const key = vocabId.replace(/^.*\/@vocabularies\//, '');
+  return config.getWidget(key) ?? null;
+};
 
 /**
  * Get widget by field's hints `vocabulary` attribute in widgetOptions
  */
 const getWidgetByVocabularyFromHint = (
   props: FieldProps,
-): React.ComponentType<any> | null =>
-  props.widgetOptions && props.widgetOptions.vocabulary
-    ? config.widgets?.vocabulary?.[
-        props.widgetOptions.vocabulary['@id'].replace(
-          /^.*\/@vocabularies\//,
-          '',
-        ) as keyof WidgetsConfigByVocabulary
-      ]
-    : null;
+): React.ComponentType<any> | null => {
+  const vocabId = props.widgetOptions?.vocabulary?.['@id'];
+  if (!vocabId) return null;
+
+  const key = vocabId.replace(/^.*\/@vocabularies\//, '');
+  return config.getWidget(key) ?? null;
+};
 
 /**
  * Get widget by field's `choices` attribute
  */
 const getWidgetByChoices = (
   props: FieldProps,
-): React.ComponentType<any> | null => {
-  if (props.choices) {
-    return config.widgets?.choices;
-  }
-
-  if (props.vocabulary) {
-    // If vocabulary exists, then it means it's a choice field in disguise with
-    // no widget specified that probably contains a string then we force it
-    // to be a select widget instead
-    return config.widgets?.choices;
-  }
-
-  return null;
-};
+): React.ComponentType<any> | null =>
+  props.choices || props.vocabulary ? (config.widgets?.choices ?? null) : null;
 
 /**
  * Get widget by field's `type` attribute
@@ -163,7 +146,7 @@ const getWidgetByChoices = (
 const getWidgetByType = (
   type: FieldProps['type'],
 ): React.ComponentType<any> | null =>
-  type ? config.widgets?.type?.[type] || null : null;
+  type ? (config.getWidget(type) ?? null) : null;
 
 const Field = (props: FieldProps) => {
   const Widget =

--- a/packages/cmsui/components/TextField/TextField.stories.tsx
+++ b/packages/cmsui/components/TextField/TextField.stories.tsx
@@ -80,7 +80,7 @@ export const Example = (args: any) => <TextField {...args} />;
 export const Validation = (args: any) => (
   <Form className="flex flex-col items-start gap-2">
     <TextField {...args} />
-    <Button type="submit" variant="secondary">
+    <Button type="submit" variant="primary">
       Submit
     </Button>
   </Form>

--- a/packages/cmsui/config/widgets.ts
+++ b/packages/cmsui/config/widgets.ts
@@ -2,7 +2,6 @@ import type { ConfigType } from '@plone/registry';
 import { TextField } from '../components/TextField/TextField';
 
 export default function install(config: ConfigType) {
-  config.widgets.default = TextField;
-
+  config.registerWidget({ key: 'default', definition: TextField });
   return config;
 }

--- a/packages/cmsui/news/7141.feature
+++ b/packages/cmsui/news/7141.feature
@@ -1,0 +1,1 @@
+Update widget registration and getting widgets from config with new methods. @deodorhunter

--- a/packages/registry/news/7141.feature
+++ b/packages/registry/news/7141.feature
@@ -1,0 +1,1 @@
+Add widget registration and getting widgets from config with new methods. @deodorhunter

--- a/packages/registry/src/registry.test.tsx
+++ b/packages/registry/src/registry.test.tsx
@@ -2,6 +2,11 @@ import React from 'react';
 import config from './index';
 import { describe, expect, it, afterEach, beforeEach } from 'vitest';
 
+const MockDefaultWidget = () => <div data-testid="default-widget">Default</div>;
+const MockTextWidget = () => <input type="text" data-testid="text-widget" />;
+const MockChoiceWidget = () => <select data-testid="choice-widget" />;
+const MockVocabWidget = () => <div data-testid="vocab-widget">Vocab</div>;
+
 beforeEach(() => {
   config.set('components', {
     Toolbar: { component: 'this is the Toolbar component' },
@@ -10,6 +15,22 @@ beforeEach(() => {
   });
   config.set('slots', {});
   config.set('utilities', {});
+  config.set('widgets', {
+    default: MockDefaultWidget,
+    id: {
+      title: MockTextWidget,
+    },
+    widget: {
+      special: MockChoiceWidget,
+    },
+    vocabulary: {
+      my_vocab: MockVocabWidget,
+    },
+    factory: {},
+    type: {},
+    choices: MockChoiceWidget,
+    views: {},
+  });
 });
 
 describe('Component registry', () => {
@@ -1246,5 +1267,173 @@ describe('Routes registry', () => {
         file: 'logout.tsx',
       },
     ]);
+  });
+});
+describe('registerWidget', () => {
+  const DummyWidget = () => <div>Dummy Widget</div>;
+  const AnotherWidget = () => <div>Another Widget</div>;
+
+  beforeEach(() => {
+    config._data.widgets = {}; // reset registry for a clean test state
+  });
+
+  it('registers a default widget', () => {
+    config.registerWidget({
+      key: 'default',
+      definition: DummyWidget,
+    });
+
+    expect(config.widgets?.default).toBe(DummyWidget);
+  });
+
+  it('registers a widget in the "widget" group', () => {
+    config.registerWidget({
+      key: 'widget',
+      definition: {
+        special: DummyWidget,
+      },
+    });
+
+    expect(config.widgets?.widget?.special).toBe(DummyWidget);
+  });
+
+  it('registers a widget in the "factory" group', () => {
+    config.registerWidget({
+      key: 'factory',
+      definition: {
+        'my.custom.Factory': DummyWidget,
+      },
+    });
+
+    expect(config.widgets?.factory?.['my.custom.Factory']).toBe(DummyWidget);
+  });
+
+  it('overwrites existing widgets of the same key', () => {
+    config.registerWidget({
+      key: 'default',
+      definition: DummyWidget,
+    });
+
+    config.registerWidget({
+      key: 'default',
+      definition: AnotherWidget,
+    });
+
+    expect(config.widgets?.default).toBe(AnotherWidget);
+  });
+
+  it('preserves unrelated widget keys', () => {
+    config.registerWidget({
+      key: 'default',
+      definition: DummyWidget,
+    });
+
+    config.registerWidget({
+      key: 'widget',
+      definition: {
+        special: AnotherWidget,
+      },
+    });
+
+    expect(config.widgets?.default).toBe(DummyWidget);
+    expect(config.widgets?.widget?.special).toBe(AnotherWidget);
+  });
+});
+
+describe('Widgets registry: registerWidget', () => {
+  const DummyWidget = () => <div>Dummy Widget</div>;
+  const AnotherWidget = () => <div>Another Widget</div>;
+
+  beforeEach(() => {
+    config._data.widgets = {}; // reset registry for a clean test state
+  });
+
+  it('registers a default widget', () => {
+    config.registerWidget({
+      key: 'default',
+      definition: DummyWidget,
+    });
+
+    expect(config.widgets?.default).toBe(DummyWidget);
+  });
+
+  it('registers a widget in the "widget" group', () => {
+    config.registerWidget({
+      key: 'widget',
+      definition: {
+        special: DummyWidget,
+      },
+    });
+
+    expect(config.widgets?.widget?.special).toBe(DummyWidget);
+  });
+
+  it('registers a widget in the "factory" group', () => {
+    config.registerWidget({
+      key: 'factory',
+      definition: {
+        'my.custom.Factory': DummyWidget,
+      },
+    });
+
+    expect(config.widgets?.factory?.['my.custom.Factory']).toBe(DummyWidget);
+  });
+
+  it('overwrites existing widgets of the same key', () => {
+    config.registerWidget({
+      key: 'default',
+      definition: DummyWidget,
+    });
+
+    config.registerWidget({
+      key: 'default',
+      definition: AnotherWidget,
+    });
+
+    expect(config.widgets?.default).toBe(AnotherWidget);
+  });
+
+  it('preserves unrelated widget keys', () => {
+    config.registerWidget({
+      key: 'default',
+      definition: DummyWidget,
+    });
+
+    config.registerWidget({
+      key: 'widget',
+      definition: {
+        special: AnotherWidget,
+      },
+    });
+
+    expect(config.widgets?.default).toBe(DummyWidget);
+    expect(config.widgets?.widget?.special).toBe(AnotherWidget);
+  });
+});
+
+describe('Widgets registry: getWidget', () => {
+  it('gets widget by id', () => {
+    const Widget = config.getWidget('title');
+    expect(Widget).toBe(config.widgets.id.title);
+  });
+
+  it('gets widget by widget key', () => {
+    const Widget = config.getWidget('special');
+    expect(Widget).toBe(config.widgets.widget.special);
+  });
+
+  it('gets widget by vocabulary', () => {
+    const Widget = config.getWidget('my_vocab');
+    expect(Widget).toBe(config.widgets.vocabulary.my_vocab);
+  });
+
+  it('returns undefined if not found', () => {
+    const Widget = config.getWidget('nonexistent');
+    expect(Widget).toBeUndefined();
+  });
+
+  it('does NOT return widgets.default', () => {
+    const Widget = config.getWidget('default');
+    expect(Widget).not.toBe(config.widgets.default);
   });
 });

--- a/packages/types/news/7141.bugfix
+++ b/packages/types/news/7141.bugfix
@@ -1,0 +1,1 @@
+Update widget config typings for better inference. @deodorhunter

--- a/packages/types/src/config/Widgets.d.ts
+++ b/packages/types/src/config/Widgets.d.ts
@@ -1,119 +1,182 @@
-export interface WidgetsConfigById {
-  schema: React.ComponentType;
-  subjects: React.ComponentType;
-  query: React.ComponentType;
-  recurrence: React.ComponentType;
-  remoteUrl: React.ComponentType;
-  id: React.ComponentType;
-  site_logo: React.ComponentType;
-  preview_image_link: React.ComponentType;
-}
+export type WidgetIdsTypes =
+  | (string & {})
+  | 'schema'
+  | 'subjects'
+  | 'query'
+  | 'recurrence'
+  | 'remoteUrl'
+  | 'id'
+  | 'site_logo'
+  | 'preview_image_link';
 
-export interface WidgetsConfigByWidget {
-  textarea: React.ComponentType;
-  datetime: React.ComponentType;
-  date: React.ComponentType;
-  password: React.ComponentType;
-  file: React.ComponentType;
-  image: React.ComponentType;
-  align: React.ComponentType;
-  buttons: React.ComponentType;
-  url: React.ComponentType;
-  internal_url: React.ComponentType;
-  email: React.ComponentType;
-  array: React.ComponentType;
-  token: React.ComponentType;
-  query: React.ComponentType;
-  query_sort_on: React.ComponentType;
-  querystring: React.ComponentType;
-  object_browser: React.ComponentType;
-  object: React.ComponentType;
-  object_list: React.ComponentType;
-  vocabularyterms: React.ComponentType;
-  image_size: React.ComponentType;
-  select_querystring_field: React.ComponentType;
-  autocomplete: React.ComponentType;
-  color_picker: React.ComponentType;
-  select: React.ComponentType;
-  schema: React.ComponentType;
-  static_text: React.ComponentType;
-  hidden: React.ComponentType;
-  radio_group: React.ComponentType;
-  checkbox_group: React.ComponentType;
-}
+export type WidgetsConfigById<
+  K extends WidgetIdsTypes = WidgetIdsTypes,
+  P = any,
+> = Partial<{
+  [id in K]: React.ComponentType<P>;
+}> & {
+  [custom: string]: React.ComponentType<P>;
+};
 
-export interface WidgetsConfigByVocabulary {
-  'plone.app.vocabularies.Catalog': React.ComponentType;
-}
+export type WidgetByWidgetTypes =
+  | (string & {})
+  | 'textarea'
+  | 'datetime'
+  | 'date'
+  | 'password'
+  | 'file'
+  | 'image'
+  | 'align'
+  | 'buttons'
+  | 'url'
+  | 'internal_url'
+  | 'email'
+  | 'array'
+  | 'token'
+  | 'query'
+  | 'query_sort_on'
+  | 'querystring'
+  | 'object_browser'
+  | 'object'
+  | 'object_list'
+  | 'vocabularyterms'
+  | 'image_size'
+  | 'select_querystring_field'
+  | 'autocomplete'
+  | 'color_picker'
+  | 'select'
+  | 'schema'
+  | 'static_text'
+  | 'hidden'
+  | 'radio_group'
+  | 'checkbox_group';
 
-export interface WidgetsConfigByFactory {
-  'Relation List': React.ComponentType;
-  'Relation Choice': React.ComponentType;
-}
+export type WidgetsConfigByWidget<
+  K extends WidgetByWidgetTypes = WidgetByWidgetTypes,
+  P = any,
+> = Partial<{
+  [widgetType in K]: React.ComponentType<P>;
+}>;
 
-export interface WidgetsConfigByType {
-  boolean: React.ComponentType;
-  array: React.ComponentType;
-  object: React.ComponentType;
-  datetime: React.ComponentType;
-  date: React.ComponentType;
-  password: React.ComponentType;
-  number: React.ComponentType;
-  integer: React.ComponentType;
-  id: React.ComponentType;
-}
+export type WidgetVocabularyTypes =
+  | (string & {})
+  | 'plone.app.vocabularies.Catalog';
 
-export interface WidgetsConfigViewById {
-  file: React.ComponentType;
-  image: React.ComponentType;
-  relatedItems: React.ComponentType;
-  subjects: React.ComponentType;
-}
+export type WidgetsConfigByVocabulary<
+  K extends WidgetVocabularyTypes = WidgetVocabularyTypes,
+  P = any,
+> = Partial<{
+  [vocabularyName in K]: React.ComponentType<P>;
+}>;
 
-export interface WidgetsConfigViewByWidget {
-  array: React.ComponentType;
-  boolean: React.ComponentType;
-  choices: React.ComponentType;
-  date: React.ComponentType;
-  datetime: React.ComponentType;
-  description: React.ComponentType;
-  email: React.ComponentType;
-  file: React.ComponentType;
-  image: React.ComponentType;
-  password: React.ComponentType;
-  relation: React.ComponentType;
-  richtext: React.ComponentType;
-  string: React.ComponentType;
-  tags: React.ComponentType;
-  textarea: React.ComponentType;
-  title: React.ComponentType;
-  url: React.ComponentType;
-  internal_url: React.ComponentType;
-  object: React.ComponentType;
-}
+export type WidgetFactortTypes =
+  | (string & {})
+  | 'Relation List'
+  | 'Relation Choice';
 
-export interface WidgetsConfigViewByType {
-  array: React.ComponentType;
-  boolean: React.ComponentType;
-}
+export type WidgetsConfigByFactory<
+  K extends WidgetFactortTypes = WidgetFactortTypes,
+  P = any,
+> = Partial<{
+  [factoryName in K]: React.ComponentType<P>;
+}>;
 
-export interface WidgetsConfigViews {
-  getWidget: React.ComponentType;
-  default: React.ComponentType;
+export type WidgetByTypeTypes =
+  | (string & {})
+  | 'boolean'
+  | 'array'
+  | 'object'
+  | 'date'
+  | 'datetime'
+  | 'password'
+  | 'number'
+  | 'integer'
+  | 'id';
+
+export type WidgetsConfigByType<
+  K extends WidgetByTypeTypes = WidgetByTypeTypes,
+  P = any,
+> = Partial<{
+  [widgetType in K]: React.ComponentType<P>;
+}>;
+export type WidgetViewsIdTypes =
+  | (string & {})
+  | 'file'
+  | 'image'
+  | 'relatedItems'
+  | 'subjects';
+
+export type WidgetsConfigViewById<
+  K extends WidgetViewsIdTypes = WidgetViewsIdTypes,
+  P = any,
+> = Partial<{
+  [viewId in K]: React.ComponentType<P>;
+}>;
+
+export type WidgetByViewTypes =
+  | (string & {})
+  | 'array'
+  | 'boolean'
+  | 'choices'
+  | 'date'
+  | 'datetime'
+  | 'password'
+  | 'description'
+  | 'email'
+  | 'file'
+  | 'image'
+  | 'password'
+  | 'relation'
+  | 'richtext'
+  | 'string'
+  | 'tags'
+  | 'textarea'
+  | 'title'
+  | 'url'
+  | 'internal_url'
+  | 'object';
+
+export type WidgetsConfigViewByWidget<
+  K extends WidgetByViewTypes = WidgetByViewTypes,
+  P = any,
+> = Partial<{
+  [widgetTypeByView in K]: React.ComponentType<P>;
+}>;
+
+export type WidgetViewByTypeTypes = (string & {}) | 'array' | 'boolean';
+
+export type WidgetsConfigViewByType<
+  K extends WidgetViewByTypeTypes = WidgetViewByTypeTypes,
+  P = any,
+> = Partial<{
+  [viewByType in K]: React.ComponentType<P>;
+}>;
+
+export interface WidgetsConfigViews<P = any> {
+  getWidget: React.ComponentType<P>;
+  default: React.ComponentType<P>;
   id: WidgetsConfigViewById;
   widget: WidgetsConfigViewByWidget;
   vocabulary: {};
-  choices: React.ComponentType;
+  choices: React.ComponentType<P>;
   type: WidgetsConfigViewByType;
 }
 
 export interface WidgetsConfig {
-  default: React.ComponentType;
+  default: React.ComponentType<any>;
   id: WidgetsConfigById;
   widget: WidgetsConfigByWidget;
   vocabulary: WidgetsConfigByVocabulary;
   factory: WidgetsConfigByFactory;
-  choices: React.ComponentType;
+  choices: React.ComponentType<any>;
   type: WidgetsConfigByType;
   views: WidgetsConfigViews;
 }
+
+export type NestedKeys<T> = {
+  [K in keyof T]: T[K] extends Record<string, React.ComponentType<any>>
+    ? K
+    : never;
+}[keyof T];
+
+export type WidgetKey = NestedKeys<WidgetsConfig>;


### PR DESCRIPTION
This PR adds getWidget and registerWidget methods in registry, and updates Field component and widgets config in cmsui.
Widget registration is now done by calling registerWidget method
```
config.registerWidget({ key: 'default', definition: TextField });
```
You can get a widget from config by using getWidget
```
(method) Config.getWidget(key: string): React.ComponentType<any> | undefined
```
Both methods provide intellisense via Typescript, docstrings are
```
(method) Config.getWidget(key: string): React.ComponentType<any> | undefined
```

```
@param key — A key from the WidgetsConfig interface.

(method) Config.registerWidget<"default">(options: {
    key: "default";
    definition: ComponentType<any>;
}): void
Registers a widget configuration into the registry.

@template K — A key from the WidgetsConfig interface.

@param options — An object containing the widget key and its corresponding implementation.

@param options.key — The name of the widget configuration key (e.g., 'default', 'factory').

@param options.definition — The actual widget configuration, which must match the expected structure of WidgetsConfig[K].
```