### PR TITLE
feat: add custom drag layer for enhanced drag-and-drop experience in editor

### DIFF
--- a/packages/editor/components/editor/custom-drag-layer.tsx
+++ b/packages/editor/components/editor/custom-drag-layer.tsx
@@ -1,0 +1,90 @@
+import { useDragLayer } from 'react-dnd';
+
+export function CustomDragLayer() {
+  const { isDragging, item, currentOffset, itemType } = useDragLayer(
+    (monitor) => ({
+      isDragging: monitor.isDragging(),
+      item: monitor.getItem() as {
+        element?: {
+          type?: string;
+          children?: Array<
+            { type?: string; children?: any[]; text?: string } | string
+          >;
+        };
+        width?: number;
+        height?: number;
+      } | null,
+      itemType: monitor.getItemType(),
+      currentOffset: monitor.getSourceClientOffset(),
+    }),
+  );
+
+  if (!isDragging || !currentOffset || !item) return null;
+
+  const style: React.CSSProperties = {
+    position: 'fixed',
+    top: currentOffset.y - 48,
+    left: currentOffset.x - 62,
+    transform: 'none',
+    pointerEvents: 'none',
+    zIndex: 1000,
+    border: '2px solid #c4c4c4',
+    borderRadius: '4px',
+    padding: '8px',
+    boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15)',
+    background: 'white',
+  };
+
+  function renderElement(element: any): React.ReactNode {
+    if (!element) return null;
+
+    if (typeof element.text === 'string') {
+      let content: React.ReactNode = element.text;
+      if (element.bold) content = <strong>{content}</strong>;
+      if (element.italic) content = <em>{content}</em>;
+      if (element.underline) content = <u>{content}</u>;
+      if (element.code)
+        content = <code className="rounded bg-gray-100 px-1">{content}</code>;
+      return content;
+    }
+
+    const children = (element.children || []).map((child: any, i: number) =>
+      renderElement(child),
+    );
+
+    switch (element.type) {
+      case 'h1':
+      case 'title':
+        return <h1 className="m-0 p-0 text-3xl font-bold">{children}</h1>;
+      case 'h2':
+        return <h2 className="m-0 p-0 text-2xl font-semibold">{children}</h2>;
+      case 'h3':
+        return <h3 className="m-0 p-0 text-xl font-semibold">{children}</h3>;
+      case 'ul':
+        return <ul className="m-0 list-disc p-0 pl-6">{children}</ul>;
+      case 'ol':
+        return <ol className="m-0 list-decimal p-0 pl-6">{children}</ol>;
+      case 'li':
+        return <li>{children}</li>;
+      case 'blockquote':
+        return (
+          <blockquote className="m-0 border-l-4 p-0 pl-4 text-gray-600 italic">
+            {children}
+          </blockquote>
+        );
+      case 'p':
+      default:
+        return <p className="m-0 p-0">{children}</p>;
+    }
+  }
+
+  return (
+    <div style={style}>
+      {item && item.element ? (
+        renderElement(item.element)
+      ) : (
+        <span>Moving element...</span>
+      )}
+    </div>
+  );
+}

--- a/packages/editor/components/editor/plate-editor.tsx
+++ b/packages/editor/components/editor/plate-editor.tsx
@@ -4,15 +4,18 @@ import { HTML5Backend } from 'react-dnd-html5-backend';
 
 import { Plate } from '@udecode/plate/react';
 import type { Value } from '@udecode/plate';
+import type { EmblaCarouselType } from 'embla-carousel';
 
-import { useCreateEditor } from '@/components/editor/use-create-editor';
-import { Editor, EditorContainer } from '@/components/plate-ui/editor';
-import { editorAtom } from '@/routes/editor';
 import { useSetAtom } from 'jotai';
+import { CustomDragLayer } from './custom-drag-layer';
+import { useCreateEditor } from './use-create-editor';
+import { Editor, EditorContainer } from '../plate-ui/editor';
+import { editorAtom } from '../../routes/editor';
 
 export function PlateEditor(props: {
   value?: Value;
   onChange?: (value: Value) => void;
+  emblaApi?: EmblaCarouselType;
 }) {
   const editor = useCreateEditor({ value: props.value });
   const setEditorState = useSetAtom(editorAtom);
@@ -32,6 +35,7 @@ export function PlateEditor(props: {
             <Editor variant="demo" />
           </EditorContainer>
         </Plate>
+        <CustomDragLayer />
       </DndProvider>
     </>
   );

--- a/packages/editor/components/plate-ui/draggable.tsx
+++ b/packages/editor/components/plate-ui/draggable.tsx
@@ -35,7 +35,7 @@ import {
 import { useReadOnly, useSelected } from '@udecode/plate/react';
 import { GripVertical } from 'lucide-react';
 
-import { STRUCTURAL_TYPES } from '@/components/editor/transforms';
+import { STRUCTURAL_TYPES } from '../editor/transforms';
 
 import { TooltipButton } from './tooltip';
 
@@ -84,7 +84,11 @@ export const DraggableAboveNodes: RenderNodeWrapper = (props) => {
 
   if (!enabled) return;
 
-  return (props) => <Draggable {...props} />;
+  const DraggableWrapper = (props: PlateRenderElementProps) => (
+    <Draggable {...props} />
+  );
+  DraggableWrapper.displayName = 'DraggableWrapper';
+  return DraggableWrapper;
 };
 
 export const Draggable = withRef<'div', PlateRenderElementProps>(
@@ -100,6 +104,9 @@ export const Draggable = withRef<'div', PlateRenderElementProps>(
         if (blockSelectionApi && id) {
           blockSelectionApi.set(id);
         }
+      },
+      preview: {
+        disable: typeof window !== 'undefined',
       },
     });
 
@@ -222,7 +229,7 @@ const DragHandle = React.memo(() => {
   return (
     <TooltipButton
       variant="ghost"
-      className="h-6 w-4.5 p-0"
+      className="flex h-6 w-4.5 p-0"
       onClick={() => {
         editor
           .getApi(BlockSelectionPlugin)
@@ -236,27 +243,28 @@ const DragHandle = React.memo(() => {
   );
 });
 
-const DropLine = React.memo(
-  React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-    ({ className, ...props }, ref) => {
-      const { dropLine } = useDropLine();
+const DropLine = withRef<'div'>(({ className, ...props }, ref) => {
+  const { dropLine } = useDropLine();
 
-      if (!dropLine) return null;
+  if (!dropLine) return null;
 
-      return (
-        <div
-          ref={ref}
-          {...props}
-          className={cn(
-            'slate-dropLine',
-            'absolute inset-x-0 h-0.5 opacity-100 transition-opacity',
-            'bg-brand/50',
-            dropLine === 'top' && '-top-px',
-            dropLine === 'bottom' && '-bottom-px',
-            className,
-          )}
-        />
-      );
-    },
-  ),
-);
+  return (
+    <div
+      ref={ref}
+      {...props}
+      className={cn(
+        'slate-dropLine',
+        'absolute inset-x-0 h-0.5 opacity-100 transition-opacity',
+        'bg-quanta-cobalt',
+        'w-4/5',
+        dropLine === 'top' && '-top-px',
+        dropLine === 'bottom' && '-bottom-px',
+        className,
+      )}
+    />
+  );
+});
+
+Gutter.displayName = 'Gutter';
+DragHandle.displayName = 'DragHandle';
+DropLine.displayName = 'DropLine';

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -161,6 +161,7 @@
     "@types/node": "^20",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
+    "embla-carousel": "^8.6.0",
     "eslint-plugin-storybook": "^0.11.2",
     "jest-axe": "^8.0.0",
     "jotai-devtools": "^0.11.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1005,6 +1005,9 @@ importers:
       '@types/react-dom':
         specifier: 'catalog:'
         version: 19.1.5(@types/react@19.1.6)
+      embla-carousel:
+        specifier: ^8.6.0
+        version: 8.6.0
       eslint-plugin-storybook:
         specifier: ^0.11.2
         version: 0.11.2(eslint@9.20.1(jiti@2.4.2))(typescript@5.7.3)
@@ -1919,12 +1922,6 @@ packages:
 
   '@babel/plugin-syntax-top-level-await@7.14.5':
     resolution: {integrity: sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-syntax-typescript@7.25.9':
-    resolution: {integrity: sha512-hjMgRy5hb8uJJjUcdWunWVcoi9bGpJp8p5Ol1229PoN6aytsLwNMgmdftO23wnCLMfVmTwZDWMPNq/D1SY60JQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -13064,19 +13061,19 @@ snapshots:
   '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.27.1
     optional: true
 
   '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.27.1
     optional: true
 
   '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.27.1
     optional: true
 
   '@babel/plugin-syntax-decorators@7.25.9(@babel/core@7.26.9)':
@@ -13087,13 +13084,13 @@ snapshots:
   '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.27.1
     optional: true
 
   '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.27.1
     optional: true
 
   '@babel/plugin-syntax-jsx@7.25.9(@babel/core@7.26.9)':
@@ -13109,49 +13106,43 @@ snapshots:
   '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.27.1
     optional: true
 
   '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.27.1
     optional: true
 
   '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.27.1
     optional: true
 
   '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.27.1
     optional: true
 
   '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.27.1
     optional: true
 
   '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.27.1
     optional: true
 
   '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
-      '@babel/helper-plugin-utils': 7.26.5
-    optional: true
-
-  '@babel/plugin-syntax-typescript@7.25.9(@babel/core@7.26.9)':
-    dependencies:
-      '@babel/core': 7.26.9
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.27.1
     optional: true
 
   '@babel/plugin-syntax-typescript@7.27.1(@babel/core@7.26.9)':
@@ -18739,7 +18730,7 @@ snapshots:
 
   babel-plugin-istanbul@6.1.1:
     dependencies:
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.27.1
       '@istanbuljs/load-nyc-config': 1.1.0
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-instrument: 5.2.1
@@ -18750,8 +18741,8 @@ snapshots:
 
   babel-plugin-jest-hoist@29.6.3:
     dependencies:
-      '@babel/template': 7.26.9
-      '@babel/types': 7.26.9
+      '@babel/template': 7.27.2
+      '@babel/types': 7.27.3
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.20.6
     optional: true
@@ -21574,7 +21565,7 @@ snapshots:
   istanbul-lib-instrument@5.2.1:
     dependencies:
       '@babel/core': 7.26.9
-      '@babel/parser': 7.26.9
+      '@babel/parser': 7.27.3
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 6.3.1
@@ -21585,7 +21576,7 @@ snapshots:
   istanbul-lib-instrument@6.0.3:
     dependencies:
       '@babel/core': 7.26.9
-      '@babel/parser': 7.26.9
+      '@babel/parser': 7.27.3
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 7.7.1
@@ -21968,10 +21959,10 @@ snapshots:
   jest-snapshot@29.7.0:
     dependencies:
       '@babel/core': 7.26.9
-      '@babel/generator': 7.26.9
-      '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.26.9)
-      '@babel/plugin-syntax-typescript': 7.25.9(@babel/core@7.26.9)
-      '@babel/types': 7.26.9
+      '@babel/generator': 7.27.3
+      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.26.9)
+      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.26.9)
+      '@babel/types': 7.27.3
       '@jest/expect-utils': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3


### PR DESCRIPTION


> [!CAUTION]
The Volto Team has suspended its review of new pull requests from first-time contributors until the [release of Plone 7](https://plone.org/download/release-schedule), which is preliminarily scheduled for the second quarter of 2026.
> [Read details](https://6.docs.plone.org/volto/contributing/index.html).

-----

- [ ] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [ ] I verified there aren't other open [pull requests](https://github.com/plone/volto/pulls) for the same change.
- [ ] I followed the guidelines in [Contributing to Volto](https://6.docs.plone.org/volto/contributing/index.html).
- [ ] I succesfully ran [code linting checks](https://6.docs.plone.org/volto/contributing/linting.html) on my changes locally.
- [ ] I succesfully ran [unit tests](https://6.docs.plone.org/volto/contributing/testing.html) on my changes locally.
- [ ] I succesfully ran [acceptance tests](https://6.docs.plone.org/volto/contributing/acceptance-tests.html) on my changes locally.
- [ ] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/volto/contributing/documentation.html#narrative-documentation) for my changes, either in the Storybook or narrative documentation.
- [ ] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

If your pull request closes an open issue, include the exact text below, immediately followed by the issue number. When your pull request gets merged, then that issue will close automatically.

Closes #


-----

Notes: 

- Introduced `CustomDragLayer` component to visually represent items being dragged.
- Integrated `CustomDragLayer` into `PlateEditor` for improved user feedback during drag operations.
- Updated `Draggable` component to support drag previews and adjusted styles for better UI consistency.

The CustomDragLayer component currently renders only a text-element preview, just to show how we can override the browser’s default drag-and-drop preview.
If you want the preview to show the actual content being dragged, you can:

Give the element a type prop when you render it in the editor.

Inside CustomDragLayer, read that type and render the same (or any other) component accordingly.

References
Assign a type to the element you’re rendering

https://platejs.org/docs/dnd#usedraggable-opt-type

Read the type in the drag layer to decide what to render in the preview `monitor.getItemType()`:

```
const { isDragging, item, itemType, currentOffset } = useDragLayer((monitor) => ({
  item: monitor.getItem(),
  itemType: monitor.getItemType(),
  isDragging: monitor.isDragging(),
  currentOffset: monitor.getClientOffset(),
}));
```

