### PR TITLE
Prevent crash when selection points to deleted node

### DIFF
--- a/packages/volto-slate/src/editor/ui/Toolbar.jsx
+++ b/packages/volto-slate/src/editor/ui/Toolbar.jsx
@@ -3,9 +3,10 @@ import React, { useRef, useEffect } from 'react';
 import { useSlate } from 'slate-react';
 import Separator from './Separator';
 import BasicToolbar from './BasicToolbar';
-import { Editor, Node } from 'slate';
+import { Node } from 'slate';
 import { ReactEditor } from 'slate-react';
 import { createPortal } from 'react-dom';
+import { safeEditorNodes } from '../../utils/safe-nodes.js';
 
 const Toolbar = ({
   elementType,
@@ -45,7 +46,7 @@ const Toolbar = ({
     }
 
     if (elementType) {
-      const [element] = Editor.nodes(editor, {
+      const [element] = safeEditorNodes(editor, {
         at: editor.selection || editor.getSavedSelection(),
         match: (n) => n.type === elementType,
       });

--- a/packages/volto-slate/src/utils/blocks.js
+++ b/packages/volto-slate/src/utils/blocks.js
@@ -10,6 +10,7 @@ import includes from 'lodash/includes';
 import some from 'lodash/some';
 import first from 'lodash/first';
 import { makeEditor } from './editor';
+import { safeEditorNodes } from './safe-nodes.js';
 
 // case sensitive; first in an inner array is the default and preffered format
 // in that array of formats
@@ -140,7 +141,7 @@ export function createParagraph(text) {
 }
 
 export const isSingleBlockTypeActive = (editor, format) => {
-  const [match] = Editor.nodes(editor, {
+  const [match] = safeEditorNodes(editor, {
     match: (n) => n.type === format,
   });
 

--- a/packages/volto-slate/src/utils/safe-nodes.js
+++ b/packages/volto-slate/src/utils/safe-nodes.js
@@ -1,0 +1,16 @@
+// It's a wrapper around `Editor.nodes` that catches errors when the selection is invalid or out of bounds.
+import { Editor } from 'slate';
+
+export function safeEditorNodes(editor, options) {
+  try {
+    return Array.from(Editor.nodes(editor, options));
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.warn('safeEditorNodes: selection invalid or out of bounds:', {
+      options,
+      selection: editor.selection,
+      error: e,
+    });
+    return [];
+  }
+}


### PR DESCRIPTION
// ⚠️ Fix for "Cannot find a descendant at path [...]" error
// In certain cases (e.g., after merging blocks via Backspace),
// `editor.selection` may temporarily point to a path that no longer exists.
// This causes `Editor.nodes()` to throw an exception.
// Wrapping it in try/catch prevents crashes and hides the inline toolbar gracefully.
// Reproducible scenario: text block with bullet list → new text block → write a word → go to first position of letters → Backspace → crash.