### PR TITLE
[NOT MAIN] Feature/fix subitemns messages logic

### DIFF
--- a/packages/volto/locales/pt_BR/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/pt_BR/LC_MESSAGES/volto.po
@@ -389,7 +389,7 @@ msgstr "Caminho da URL alternativa → caminho da URL de destino (data e hora da
 #. Default: "Another person edited this content, and it's currently displayed. Do you want to replace it with your autosaved content?"
 #: helpers/Utils/withSaveAsDraft
 msgid "Another person edited this content, and it's currently displayed. Do you want to replace it with your autosaved content?"
-msgstr ""
+msgstr "Outra pessoa editou este conteúdo e ele está sendo exibido atualmente. Você deseja substituir pelo seu conteúdo salvo automaticamente?"
 
 #. Default: "Applied to subfolders"
 #: components/manage/Rules/Rules
@@ -445,7 +445,7 @@ msgstr "Automaticamente"
 #. Default: "Autosaved content found"
 #: helpers/Utils/withSaveAsDraft
 msgid "Autosaved content found"
-msgstr ""
+msgstr "Conteúdo salvo automaticamente encontrado"
 
 #. Default: "Available"
 #: components/manage/Controlpanels/AddonsControlpanel
@@ -1018,7 +1018,7 @@ msgstr "Padrão"
 #. Default: "Default value"
 #: components/manage/Widgets/SchemaWidget
 msgid "Default value"
-msgstr ""
+msgstr "Valor padrão"
 
 #. Default: "Default view"
 #: config/Views
@@ -1098,7 +1098,7 @@ msgstr "Removida"
 #. Default: "Deleting this item will break {brokenReferences} {variation}."
 #: components/manage/Contents/ContentsDeleteModal
 msgid "Deleting this item will break {brokenReferences} {variation}."
-msgstr ""
+msgstr "Excluir este item irá quebrar {brokenReferences} {variation}."
 
 #. Default: "Depth"
 #: components/manage/Widgets/QuerystringWidget
@@ -1184,7 +1184,7 @@ msgstr "Você realmente quer excluir este item?"
 #. Default: "Do you want to restore your autosaved content?"
 #: helpers/Utils/withSaveAsDraft
 msgid "Do you want to restore your autosaved content?"
-msgstr ""
+msgstr "Você deseja restaurar seu conteúdo salvo automaticamente?"
 
 #. Default: "Document"
 #: components/manage/Multilingual/TranslationObject
@@ -1205,7 +1205,7 @@ msgstr "Baixar evento"
 #. Default: "Download file"
 #: components/theme/View/FileView
 msgid "Download file"
-msgstr ""
+msgstr "Baixar arquivo"
 
 #. Default: "Drag and drop files from your computer onto this area or click the “Browse” button."
 #: components/manage/Contents/ContentsUploadModal
@@ -1555,7 +1555,7 @@ msgstr "Arquivo"
 #. Default: "File is not of the accepted type {accept}"
 #: components/manage/Widgets/FileWidget
 msgid "File is not of the accepted type {accept}"
-msgstr ""
+msgstr "O arquivo não é do tipo aceito {accept}"
 
 #. Default: "File size"
 #: components/manage/Contents/ContentsUploadModal
@@ -1580,7 +1580,7 @@ msgstr "Arquivos carregados: {uploadedFiles}"
 #. Default: "Fills the value of the form field with the value supplied by a query parameter inside the URL with the given name."
 #: components/manage/Widgets/SchemaWidget
 msgid "Fills the value of the form field with the value supplied by a query parameter inside the URL with the given name."
-msgstr ""
+msgstr "Preenche o valor do campo do formulário com o valor fornecido por um parâmetro de consulta na URL com o nome fornecido."
 
 #. Default: "Filter"
 #: components/manage/Controlpanels/Aliases
@@ -3508,12 +3508,12 @@ msgstr "Pequeno"
 #. Default: "Some items are referenced by other contents. Deleting them will break {brokenReferences} {variation}."
 #: components/manage/Contents/ContentsDeleteModal
 msgid "Some items are referenced by other contents. Deleting them will break {brokenReferences} {variation}."
-msgstr ""
+msgstr "Alguns itens são referenciados por outros conteúdos. Excluí-los irá quebrar {brokenReferences} {variation}."
 
 #. Default: "Some items contain subitems. Deleting them will also delete their {containedItemsToDelete} {variation} inside."
 #: components/manage/Contents/ContentsDeleteModal
 msgid "Some items contain subitems. Deleting them will also delete their {containedItemsToDelete} {variation} inside."
-msgstr ""
+msgstr "Alguns itens contêm subitens. Excluí-los também irá excluir seus {containedItemsToDelete} {variation} internos."
 
 #. Default: "Some relations are broken. Please fix."
 #: components/manage/Controlpanels/Relations/Relations
@@ -3922,7 +3922,7 @@ msgstr "Esta é uma cópia de trabalho de {title}"
 #. Default: "This item contains subitems. Deleting it will also delete its {containedItemsToDelete} {variation} inside."
 #: components/manage/Contents/ContentsDeleteModal
 msgid "This item contains subitems. Deleting it will also delete its {containedItemsToDelete} {variation} inside."
-msgstr ""
+msgstr "Este item contém subitens. Excluí-lo também irá excluir seus {containedItemsToDelete} {variation} internos."
 
 #. Default: "This item was locked by {creator} on {date}"
 #: components/manage/LockingToastsFactory/LockingToastsFactory
@@ -4480,7 +4480,7 @@ msgstr "Sim"
 #. Default: "You are about to delete all items and all its subitems."
 #: components/manage/Contents/ContentsDeleteModal
 msgid "You are about to delete all items and all its subitems."
-msgstr ""
+msgstr "Você está prestes a excluir todos os itens e todos os seus subitens."
 
 #. Default: "You are about to delete all items in the current pagination of this folder."
 #: components/manage/Contents/ContentsDeleteModal

--- a/packages/volto/src/components/manage/Contents/ContentsDeleteModal.jsx
+++ b/packages/volto/src/components/manage/Contents/ContentsDeleteModal.jsx
@@ -187,7 +187,7 @@ const ContentsDeleteModal = (props) => {
   const loading = useSelector((state) => state.linkIntegrity?.loading);
 
   const [brokenReferences, setBrokenReferences] = useState(0);
-  const [containedItemsToDelete, setContainedItemsToDelete] = useState([]);
+  const [containedItemsToDelete, setContainedItemsToDelete] = useState(0);
   const [breaches, setBreaches] = useState([]);
 
   const [linksAndReferencesViewLink, setLinkAndReferencesViewLink] =
@@ -220,10 +220,11 @@ const ContentsDeleteModal = (props) => {
 
   useEffect(() => {
     if (linkintegrityInfo) {
-      // total number of contained items in the items to be deleted
+      // Always set the total number of contained items, regardless of breaches
       const totalContainedItems = linkintegrityInfo
         .map((result) => result.items_total ?? 0)
         .reduce((acc, value) => acc + value, 0);
+      setContainedItemsToDelete(totalContainedItems); // <-- always set
       const breaches = linkintegrityInfo.flatMap((result) =>
         result.breaches.map((source) => ({
           source: source,
@@ -237,7 +238,6 @@ const ContentsDeleteModal = (props) => {
       );
       // If no breaches are found, return early
       if (filteredBreaches.length === 0) {
-        setContainedItemsToDelete(0);
         setBrokenReferences(0);
         setLinkAndReferencesViewLink(null);
         setBreaches([]);
@@ -255,7 +255,6 @@ const ContentsDeleteModal = (props) => {
         return acc;
       }, new Map());
 
-      setContainedItemsToDelete(totalContainedItems);
       setBrokenReferences(by_source.size);
       setLinkAndReferencesViewLink(
         linkintegrityInfo.length


### PR DESCRIPTION
Before the code update, the subitems deletion message was always displayed when `containedItemsToDelete > 0`, regardless of broken references. After the update, this behavior was lost because the state responsible for counting subitems (`containedItemsToDelete`) was being reset together with the broken references state (`brokenReferences`). This meant that when there were no broken references, the subitems count was also set to zero, and the subitems message did not appear even when it should.

The applied fix ensures that the subitems count is always maintained correctly, regardless of broken references. Now, the message is shown whenever there are subitems to be deleted, just like before the update.

Additionally, I added the corresponding translations.

You can also copy these changes directly from my branch (link below).