### PR TITLE
Fallback for className if listing in grid has only one variation.

### DIFF
--- a/packages/volto/news/7206.bugfix
+++ b/packages/volto/news/7206.bugfix
@@ -1,0 +1,1 @@
+Fallback for className if listing in grid has only one variation. @ksuess

--- a/packages/volto/src/components/manage/Blocks/Listing/View.jsx
+++ b/packages/volto/src/components/manage/Blocks/Listing/View.jsx
@@ -10,7 +10,11 @@ const View = (props) => {
 
   return (
     <div
-      className={cx('block listing', data.variation || 'default', className)}
+      className={cx(
+        'block listing',
+        data.variation || props.variation?.id || 'default',
+        className,
+      )}
       style={style}
     >
       <ListingBody {...props} path={path ?? pathname} />


### PR DESCRIPTION
closes #7206 