### PR TITLE
Remove styles related to volto-slate-metadata-mentions from volto-slate #7181

### DIFF
--- a/packages/volto-slate/src/widgets/style.css
+++ b/packages/volto-slate/src/widgets/style.css
@@ -3,18 +3,6 @@
   border-bottom: 1px solid #c7d5d8;
 }
 
-.metadata.mention.slate.widget {
-  display: inline;
-}
-
-.metadata.mention.slate.widget > :first-child {
-  display: inline;
-}
-
-.metadata.mention.slate.widget > :last-child {
-  display: inline;
-}
-
 .slate.error {
   color: #f00;
   white-space: normal;


### PR DESCRIPTION
"Fixes #7181 - Removed CSS rules for metadata mentions as they belong in the separate volto-slate-metadata-mentions package