### PR TITLE
Handle `youtube.com/embed/*` style URLs for the video block

### DIFF
--- a/packages/volto/news/7243.bugfix
+++ b/packages/volto/news/7243.bugfix
@@ -1,0 +1,1 @@
+Fixed the video block not supporting `youtube.com/embed/*` style links. @JeffersonBledsoe

--- a/packages/volto/src/components/manage/Blocks/Video/Body.jsx
+++ b/packages/volto/src/components/manage/Blocks/Video/Body.jsx
@@ -28,6 +28,8 @@ const getVideoIDAndPlaceholder = (url) => {
           'https://img.youtube.com/vi/' + thumbnailID + '/sddefault.jpg';
       } else if (url.match('live')) {
         videoID = url.match(/^.*\/live\/(.*)/)[1];
+      } else if (url.match('youtube.com/embed')) {
+        videoID = url.match('youtube.com/embed/(.*)')[1];
       } else if (url.match(/\.be\//)) {
         videoID = url.match(/^.*\.be\/(.*)/)[1];
       } else if (url.match(/\?v=/)) {

--- a/packages/volto/src/components/manage/Blocks/Video/Body.test.jsx
+++ b/packages/volto/src/components/manage/Blocks/Video/Body.test.jsx
@@ -56,6 +56,16 @@ test('extracts video details from a youtube video with ".be/" in its url', () =>
   });
 });
 
+test('extracts video details from a youtube video with a "youtube.com/embed" style URL', () => {
+  const url = 'https://www.youtube.com/embed/P9j-xYdWT28';
+  const videoDetails = getVideoIDAndPlaceholder(url);
+  expect(videoDetails).toEqual({
+    videoID: 'P9j-xYdWT28',
+    listID: null,
+    thumbnailURL: 'https://img.youtube.com/vi/P9j-xYdWT28/sddefault.jpg',
+  });
+});
+
 test('extracts video details from a youtube video with "?v=" in its url', () => {
   const url = 'https://www.youtube.com/watch?v=KUd6e105u_I';
   const videoDetails = getVideoIDAndPlaceholder(url);


### PR DESCRIPTION
> [!CAUTION]
The Volto Team has suspended its review of new pull requests from first-time contributors until the [release of Plone 7](https://plone.org/download/release-schedule), which is preliminarily scheduled for the second quarter of 2026.
> [Read details](https://6.docs.plone.org/volto/contributing/index.html).

-----

- [ ] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [ ] I verified there aren't other open [pull requests](https://github.com/plone/volto/pulls) for the same change.
- [ ] I followed the guidelines in [Contributing to Volto](https://6.docs.plone.org/volto/contributing/index.html).
- [ ] I succesfully ran [code linting checks](https://6.docs.plone.org/volto/contributing/linting.html) on my changes locally.
- [ ] I succesfully ran [unit tests](https://6.docs.plone.org/volto/contributing/testing.html) on my changes locally.
- [ ] I succesfully ran [acceptance tests](https://6.docs.plone.org/volto/contributing/acceptance-tests.html) on my changes locally.
- [ ] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/volto/contributing/documentation.html#narrative-documentation) for my changes, either in the Storybook or narrative documentation.
- [ ] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

If your pull request closes an open issue, include the exact text below, immediately followed by the issue number. When your pull request gets merged, then that issue will close automatically.

Closes #

-----

If your pull request includes changes to the documentation—either in narrative documentation, Storybook, or configuration—then a pull request preview will be generated and a link will populate in the description of your pull request below.
By clicking that link, you can use the visual diff menu in the upper right corner to navigate to pages that have changes, then display the diff by checking the `Show diff` checkbox.
