### PR TITLE
Remove unused description prop from TextWidget to fix typing errors (#7265)

### DIFF
--- a/packages/volto/news/7265.bugfix
+++ b/packages/volto/news/7265.bugfix
@@ -1,0 +1,1 @@
+Removed the unused description prop from the TextWidget to prevent typing errors. @alexandreIFB

--- a/packages/volto/src/components/manage/Widgets/TextWidget.jsx
+++ b/packages/volto/src/components/manage/Widgets/TextWidget.jsx
@@ -64,7 +64,6 @@ export default TextWidget;
 TextWidget.propTypes = {
   id: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
-  description: PropTypes.string,
   required: PropTypes.bool,
   error: PropTypes.arrayOf(PropTypes.string),
   value: PropTypes.string,
@@ -87,7 +86,6 @@ TextWidget.propTypes = {
 };
 
 TextWidget.defaultProps = {
-  description: null,
   required: false,
   error: [],
   value: null,


### PR DESCRIPTION
When defining a description property of type element in a schema that uses TextWidget, a typing error occurs. The description prop is passed to TextWidget, but it is not used anywhere in the component. If a description were to be used, it would likely have a different name or be handled differently.

**What was done:**
- Removed the unused description prop from the TextWidget to prevent typing errors and confusion.

**How to test:**
1. Define a field in the schema using the with type: "string" and add the description property as a React element (e.g., an `<a>` link), 
2. Confirm that no typing error is raised and the prop is no longer passed unnecessarily.

Closes #7265.
