### PR TITLE
Fix InlineForm to always pass error as array to prevent prop type errors

### DIFF
--- a/packages/volto/news/7267.bugfix
+++ b/packages/volto/news/7267.bugfix
@@ -1,0 +1,1 @@
+Fix `InlineForm` to always pass the error prop as an array, preventing prop type errors in widgets that use `InlineForm`. @alexandreIFB

--- a/packages/volto/src/components/manage/Form/InlineForm.jsx
+++ b/packages/volto/src/components/manage/Form/InlineForm.jsx
@@ -158,7 +158,7 @@ const InlineForm = (props) => {
                 onChangeField(id, value, itemInfo);
               }}
               key={field}
-              error={errors?.[block]?.[field] || {}}
+              error={errors?.[block]?.[field] || []}
               block={block}
             />
           ))}
@@ -199,7 +199,7 @@ const InlineForm = (props) => {
                         onChangeField(id, value);
                       }}
                       key={field}
-                      error={errors?.[block]?.[field] || {}}
+                      error={errors?.[block]?.[field] || []}
                       block={block}
                     />
                   ))}


### PR DESCRIPTION
This PR fixes an issue where the `InlineForm` component would pass the `error` prop as an object instead of an array, causing prop type errors and warnings in widgets that use `FormFieldWrapper`, such as Checkbox.

**How to test:**
1. Add a Teaser block to the page.
2. Check the browser console and confirm that prop type errors related to the error prop are no longer present.

Closes #7267 