### PR TITLE
Fixes random error in Listing Block tests

### DIFF
--- a/packages/volto/cypress/tests/core/blocks/listing/blocks-listing.js
+++ b/packages/volto/cypress/tests/core/blocks/listing/blocks-listing.js
@@ -862,7 +862,11 @@ describe('Listing Block Tests', () => {
 
     cy.get('#field-limit-3-querystring').click().clear().type('0');
     cy.get('#field-b_size-4-querystring').click().type('2');
-    cy.get('.ui.pagination.menu a[value="2"]').first().click();
+    cy.get('.ui.pagination.menu a[value="2"]')
+      .first()
+      .should('be.visible')
+      .as('paginationItem');
+    cy.get('@paginationItem').click();
 
     cy.get('.listing-item h3').first().contains('My Folder 3');
   });
@@ -920,8 +924,16 @@ describe('Listing Block Tests', () => {
 
     cy.get('.ui.pagination.menu a[value="1"][type="pageItem"]')
       .first()
-      .click({ force: true });
-    cy.get('.ui.pagination.menu a[value="2"]').first().click({ force: true });
+      .should('be.visible')
+      .as('paginationItem');
+    cy.get('@paginationItem').click();
+
+    cy.get('.ui.pagination.menu a[value="2"]')
+      .first()
+      .should('be.visible')
+      .as('paginationItem');
+    cy.get('@paginationItem').click();
+
     cy.wait(1000);
     cy.url().should('include', '?page=2');
     cy.isInHTML({ parent: '.listing-item', content: 'My Folder 3' });
@@ -1001,14 +1013,22 @@ describe('Listing Block Tests', () => {
 
     cy.get('#field-limit-3-querystring').click().clear().type('0');
     cy.get('#field-b_size-4-querystring').click().type('2');
-    cy.get('.ui.pagination.menu a[value="2"]').first().click();
+    cy.get('.ui.pagination.menu a[value="2"]')
+      .first()
+      .should('be.visible')
+      .as('paginationItem');
+    cy.get('@paginationItem').click();
 
     cy.get('.listing-item h3').first().contains('My Folder 3');
     cy.get('#toolbar-save').click();
     cy.wait('@save');
     cy.wait('@content');
     //test second pagination click
-    cy.get('.ui.pagination.menu a[value="2"]').first().click();
+    cy.get('.ui.pagination.menu a[value="2"]')
+      .first()
+      .should('be.visible')
+      .as('paginationItem');
+    cy.get('@paginationItem').click();
 
     cy.isInHTML({ parent: '.listing-item', content: 'My Folder 3' });
     //test f5
@@ -1080,7 +1100,9 @@ describe('Listing Block Tests', () => {
     cy.get('.ui.pagination.menu a[value="2"]')
       .first()
       .should('be.visible')
-      .click();
+      .as('paginationItem');
+    cy.get('@paginationItem').click();
+
     //test f5
     cy.reload();
     cy.isInHTML({ parent: '.listing-item', content: 'My Folder 3' });
@@ -1090,7 +1112,9 @@ describe('Listing Block Tests', () => {
     cy.get('.ui.pagination.menu a[value="3"]')
       .first()
       .should('be.visible')
-      .click();
+      .as('paginationItem');
+    cy.get('@paginationItem').click();
+
     //test f5
     cy.reload();
     cy.isInHTML({ parent: '.listing-item', content: 'My Folder 3' });
@@ -1105,11 +1129,13 @@ describe('Listing Block Tests', () => {
     cy.get('.ui.pagination.menu a[value="2"]')
       .first()
       .should('be.visible')
-      .click({ force: true });
+      .as('paginationItem');
+    cy.get('@paginationItem').click();
     cy.get('.ui.pagination.menu a[value="3"]')
       .first()
       .should('be.visible')
-      .click({ force: true });
+      .as('paginationItem');
+    cy.get('@paginationItem').click();
     cy.go(-1);
     cy.wait('@content');
     cy.isInHTML({ parent: '.listing-item', content: 'My Folder 3' });

--- a/packages/volto/news/7286.internal
+++ b/packages/volto/news/7286.internal
@@ -1,0 +1,1 @@
+Fix random error in Listing Block tests. @wesleybl


### PR DESCRIPTION
Improve pagination click checks in Listing Block tests

This makes Cypress to re-search the pagination item instead of clicking on the old reference. This prevents errors from clicking on an item that has been re-rendered.

This attempts to fix the error:

```bash
1) Listing Block Tests
       Navigate to different pages on two different listings:
     CypressError: Timed out retrying after 4050ms: `cy.click()` failed because the page updated while this command was executing. Cypress tried to locate elements based on this query:

> <a.item>
```

See: https://github.com/plone/volto/actions/runs/17285679025/job/49062413145#step:4:270

The fix was based on the error hint itself: https://github.com/plone/volto/actions/runs/17285679025/job/49062413145#step:4:278