### PR TITLE
Fixed a random failure in Cypress tests when using `getSlateEditorAndType` or `getSlateEditorSelectorAndType`

### DIFF
--- a/packages/volto/cypress/support/commands.js
+++ b/packages/volto/cypress/support/commands.js
@@ -833,23 +833,25 @@ function shouldVerifyContent(type) {
 }
 
 Cypress.Commands.add('getSlateEditorAndType', (type) => {
-  const el = cy.getSlate().focus().click().type(type);
+  cy.getSlate().focus().click().type(type);
 
   if (shouldVerifyContent(type)) {
-    return el.should('contain', type, { timeout: 5000 });
+    return cy.getSlate().should('contain', type, { timeout: 5000 });
   }
 
-  return el;
+  return cy.getSlate();
 });
 
 Cypress.Commands.add('getSlateEditorSelectorAndType', (selector, type) => {
-  const el = cy.getSlateSelector(selector).focus().click().type(type);
+  cy.getSlateSelector(selector).focus().click().type(type);
 
   if (shouldVerifyContent(type)) {
-    return el.should('contain', type, { timeout: 5000 });
+    return cy
+      .getSlateSelector(selector)
+      .should('contain', type, { timeout: 5000 });
   }
 
-  return el;
+  return cy.getSlateSelector(selector);
 });
 
 Cypress.Commands.add('setSlateCursor', (subject, query, endQuery) => {

--- a/packages/volto/news/7290.internal
+++ b/packages/volto/news/7290.internal
@@ -1,0 +1,1 @@
+Fixed a random failure in Cypress tests when using `getSlateEditorAndType` or `getSlateEditorSelectorAndType`. @wesleybl


### PR DESCRIPTION
The text was entered into the editor, but a re-render caused the editor reference to become stale when verifying whether the text was present. We now re-fetch the editor to ensure we always have an up-to-date reference.

This fixes the error:

```javascript
1) Block Tests: Basic text format
       Heading (h2):
     AssertionError: Timed out retrying after 4430ms: expected '<div>' to contain 'Colorless green ideas sleep furiously.'
      at Context.eval (webpack://@plone/volto/./cypress/support/commands.js:839:14)
```

See: https://github.com/plone/volto/actions/runs/17314600477/job/49155144015#step:4:402