### PR TITLE
Fix random failure in 'renders a file widget component with value' test of RegistryImageWidget

### DIFF
--- a/packages/volto/news/7292.internal
+++ b/packages/volto/news/7292.internal
@@ -1,0 +1,1 @@
+Fix random failure in 'renders a file widget component with value' test of RegistryImageWidget. @wesleybl

--- a/packages/volto/src/components/manage/Widgets/RegistryImageWidget.test.jsx
+++ b/packages/volto/src/components/manage/Widgets/RegistryImageWidget.test.jsx
@@ -82,8 +82,9 @@ describe('RegistryImageWidget', () => {
         const dropzone = container.querySelector('.file-widget-dropzone');
         const preview = container.querySelector('.image-preview');
         const filename = container.querySelector('.field-file-name');
+        const img = container.querySelector('img[src*="logo"]');
 
-        return dropzone && preview && filename;
+        return dropzone && preview && filename && img && img.complete;
       },
       { timeout: 2000 },
     );


### PR DESCRIPTION
Wait for a more consistent state, where the image has the correct src

This fixes the error:

```javascript
Error: Error: Snapshot `RegistryImageWidget > renders a file widget component with value 1` mismatched

- Expected
+ Received

@@ -24,36 +24,10 @@
          </div>
          <div
            class="eight wide column"
          >
            <div
-             class="file-widget-dropzone"
-             tabindex="0"
-           >
-             <img
-               alt=""
-               class="image-preview small ui image"
-               fetchpriority="high"
-               id="field-my-field-image"
-               src="http://localhost:3000/@@site-logo/logo.cab945d8.svg"
-             />
-             <label
-               class="label-file-widget-input"
-             >
-               Replace existing file
-             </label>
-             <input
-               autocomplete="off"
-               id="field-my-field"
-               multiple=""
-               name="my-field"
-               style="display: none;"
-               tabindex="-1"
-               type="file"
-             />
-           </div>
-           <div
              class="field-file-name"
            >
              <button
                aria-label="delete file"
                class="ui basic icon button delete-button"

 ❯ src/components/manage/Widgets/RegistryImageWidget.test.jsx:91:23
```

See: https://github.com/plone/volto/actions/runs/17339260771/job/49230844220#step:5:1042