### PR TITLE
Fixes random error in Listing Block tests 2

### DIFF
--- a/packages/volto/cypress/tests/core/blocks/listing/blocks-listing.js
+++ b/packages/volto/cypress/tests/core/blocks/listing/blocks-listing.js
@@ -1042,6 +1042,7 @@ describe('Listing Block Tests', () => {
     cy.intercept('PATCH', '/**/my-page').as('save');
     cy.intercept('GET', '/**/my-page').as('content');
     cy.intercept('GET', '/**/@types/Document').as('schema');
+    cy.intercept('POST', '**/my-page/@querystring-search').as('querySearch');
 
     cy.createContent({
       contentType: 'Document',
@@ -1126,11 +1127,20 @@ describe('Listing Block Tests', () => {
     cy.url().should('not.include', '=3');
 
     cy.navigate('/my-page');
+    cy.wait('@content');
+    cy.wait('@querySearch');
+    cy.wait('@querySearch');
+    cy.get('.ui.small.indeterminate.text.loader').should('not.exist');
+    cy.wait(500);
     cy.get('.ui.pagination.menu a[value="2"]')
       .first()
       .should('be.visible')
       .as('paginationItem');
     cy.get('@paginationItem').click();
+    cy.wait('@querySearch');
+    cy.wait('@querySearch');
+    cy.get('.ui.small.indeterminate.text.loader').should('not.exist');
+    cy.wait(500);
     cy.get('.ui.pagination.menu a[value="3"]')
       .first()
       .should('be.visible')

--- a/packages/volto/news/7293.internal
+++ b/packages/volto/news/7293.internal
@@ -1,0 +1,1 @@
+Fixes random error in Listing Block tests 2. @wesleybl


### PR DESCRIPTION
Wait until the `querySearch` request finishes before clicking the pagination item. Also wait for the "Loading" to disappear from the screen.

This fixes:

```javascript
  1) Listing Block Tests
       Navigate to different pages on two different listings:
     CypressError: Timed out retrying after 4050ms: `cy.click()` failed because the page updated while this command was executing. Cypress tried to locate elements based on this query:

> cy.get(@paginationItem)
```

See: https://github.com/plone/volto/actions/runs/17345525928/job/49246764836#step:4:262