### PR TITLE
Fixed a random failure in Cypress tests when using `getSlateEditorAndType` or `getSlateEditorSelectorAndType`

### DIFF
--- a/packages/volto/cypress/support/commands.js
+++ b/packages/volto/cypress/support/commands.js
@@ -833,23 +833,25 @@ function shouldVerifyContent(type) {
 }
 
 Cypress.Commands.add('getSlateEditorAndType', (type) => {
-  const el = cy.getSlate().focus().click().type(type);
+  cy.getSlate().focus().click().type(type);
 
   if (shouldVerifyContent(type)) {
-    return el.should('contain', type, { timeout: 5000 });
+    return cy.getSlate().should('contain', type, { timeout: 5000 });
   }
 
-  return el;
+  return cy.getSlate();
 });
 
 Cypress.Commands.add('getSlateEditorSelectorAndType', (selector, type) => {
-  const el = cy.getSlateSelector(selector).focus().click().type(type);
+  cy.getSlateSelector(selector).focus().click().type(type);
 
   if (shouldVerifyContent(type)) {
-    return el.should('contain', type, { timeout: 5000 });
+    return cy
+      .getSlateSelector(selector)
+      .should('contain', type, { timeout: 5000 });
   }
 
-  return el;
+  return cy.getSlateSelector(selector);
 });
 
 Cypress.Commands.add('setSlateCursor', (subject, query, endQuery) => {

--- a/packages/volto/news/7290.internal
+++ b/packages/volto/news/7290.internal
@@ -1,0 +1,1 @@
+Fixed a random failure in Cypress tests when using `getSlateEditorAndType` or `getSlateEditorSelectorAndType`. @wesleybl


### PR DESCRIPTION
Backport of #7290 to Volto 18

<!-- readthedocs-preview volto start -->
----
📚 Documentation preview 📚: https://volto--7296.org.readthedocs.build/

<!-- readthedocs-preview volto end -->