### PR TITLE
Fix random failure in 'renders a file widget component with value' test of RegistryImageWidget

### DIFF
--- a/packages/volto/news/7292.internal
+++ b/packages/volto/news/7292.internal
@@ -1,0 +1,1 @@
+Fix random failure in 'renders a file widget component with value' test of RegistryImageWidget. @wesleybl

--- a/packages/volto/src/components/manage/Widgets/RegistryImageWidget.test.jsx
+++ b/packages/volto/src/components/manage/Widgets/RegistryImageWidget.test.jsx
@@ -82,8 +82,9 @@ describe('RegistryImageWidget', () => {
         const dropzone = container.querySelector('.file-widget-dropzone');
         const preview = container.querySelector('.image-preview');
         const filename = container.querySelector('.field-file-name');
+        const img = container.querySelector('img[src*="logo"]');
 
-        return dropzone && preview && filename;
+        return dropzone && preview && filename && img && img.complete;
       },
       { timeout: 2000 },
     );


### PR DESCRIPTION
Backport of #7292 to Voto 18