### PR TITLE
Fix test storeProtectLoadUtils.test.js > storeProtectLoadUtils > loadProtector store > pass when not counting

### DIFF
--- a/packages/volto/news/7287.internal
+++ b/packages/volto/news/7287.internal
@@ -1,0 +1,1 @@
+Fix test storeProtectLoadUtils.test.js > storeProtectLoadUtils > loadProtector store > pass when not counting. @wesleybl

--- a/packages/volto/src/middleware/storeProtectLoadUtils.test.js
+++ b/packages/volto/src/middleware/storeProtectLoadUtils.test.js
@@ -445,9 +445,9 @@ describe('storeProtectLoadUtils', () => {
           isCounting: false,
         });
       };
-      test('pending', expectPass({ type: 'ANY_PENDING' }), 2);
-      test('success', expectPass({ type: 'ANY_SUCCESS' }), 2);
-      test('failure', expectPass({ type: 'ANY_FAIL' }), 2);
+      test('pending', expectPass({ type: 'ANY_PENDING' }, 2));
+      test('success', expectPass({ type: 'ANY_SUCCESS' }, 2));
+      test('failure', expectPass({ type: 'ANY_FAIL' }, 2));
     });
     describe('counting', () => {
       const expectCount = (action, from, to) => () => {


### PR DESCRIPTION
Backport of #7287 to Volto 18