### PR TITLE
2021.ploneconf.org is no longer a Volto site, but just a redirect to …

### DIFF
--- a/.github/workflows/readme-link-check.yml
+++ b/.github/workflows/readme-link-check.yml
@@ -19,4 +19,4 @@ jobs:
       - name: Check links in README.md with awesome_bot
         run: |
           gem install awesome_bot
-          awesome_bot --request-delay 1 --allow-dupe --white-list http://localhost:8080/Plone,http://localhost:8080,http://localhost:3000,https://github.com/kitconcept/volto-blocks-grid.git,https://my-server-DNS-name.tld/api,2021.ploneconf.org --files PACKAGES.md,README.md,packages/blocks/README.md,packages/client/README.md,packages/components/README.md,packages/registry/README.md,packages/scripts/README.md,packages/tsconfig/README.md,packages/types/README.md,packages/volto-slate/README.md,apps/nextjs/README.md
+          awesome_bot --request-delay 1 --allow-dupe --white-list http://localhost:8080/Plone,http://localhost:8080,http://localhost:3000,https://github.com/kitconcept/volto-blocks-grid.git,https://my-server-DNS-name.tld/api --files PACKAGES.md,README.md,packages/blocks/README.md,packages/client/README.md,packages/components/README.md,packages/registry/README.md,packages/scripts/README.md,packages/tsconfig/README.md,packages/types/README.md,packages/volto-slate/README.md,apps/nextjs/README.md

--- a/README.md
+++ b/README.md
@@ -180,7 +180,6 @@ You should check the dependencies in their `package.json` for more details.
 - [EEA Main Website frontend](https://github.com/eea/eea-website-frontend) - Plone 6 Volto frontend for [European Environment Agency](https://www.eea.europa.eu/en)
 - [volto-bise](https://github.com/eea/volto-bise) - A Volto project packaged as an addon. It provides Theming using a razzle.extend.js provided alias.
 - [design-volto-theme](https://github.com/RedTurtle/design-volto-theme) Volto theme for Italian Public Administration
-- [2021.ploneconf.org](https://github.com/plone/ploneconf.org/tree/2021) - Volto project for [Plone Conference 2021 site](https://2021.ploneconf.org)
 - [2022.ploneconf.org](https://github.com/plone/ploneconf.org/tree/2022) - Volto project for [Plone Conference 2022 site](https://2022.ploneconf.org)
 - [2023.ploneconf.org](https://github.com/plone/ploneconf.org/tree/2023) - Volto project for [Plone Conference 2023 site](https://2023.ploneconf.org)
 - [plone.org.br](https://github.com/plonegovbr/plone.org.br) - Volto project for the [Brazilian Plone Community](https://plone.org.br)

--- a/docs/source/development/environment-variables.md
+++ b/docs/source/development/environment-variables.md
@@ -55,7 +55,7 @@ This is an advanced feature, and needs understanding of what you are doing and w
 Let's say you want to debug a deployed site in production, but the build does not allow you to look deeper into the tracebacks. You could bootstrap a frontend in your machine, and point it to the production server, combining environment variables like:
 
 ```
-RAZZLE_DEV_PROXY_API_PATH=https://2021.ploneconf.org RAZZLE_PROXY_REWRITE_TARGET=https://2021.ploneconf.org/++api++ pnpm start
+RAZZLE_DEV_PROXY_API_PATH=https://2022.ploneconf.org RAZZLE_PROXY_REWRITE_TARGET=https://2022.ploneconf.org/++api++ pnpm start
 ```
 
 This has the drawback that could be that the proxy does not work well with the proxied SSL connection.
@@ -63,7 +63,7 @@ This has the drawback that could be that the proxy does not work well with the p
 If you have access (via tunnel) to the port of the deployed backend is even more easier:
 
 ```
-RAZZLE_DEV_PROXY_API_PATH=http://2021.ploneconf.org:8080/Plone pnpm start
+RAZZLE_DEV_PROXY_API_PATH=http://2022.ploneconf.org:8080/Plone pnpm start
 ```
 
 This will use the internal proxy to access the backend, bypassing CORS.

--- a/packages/volto/README.md
+++ b/packages/volto/README.md
@@ -181,7 +181,6 @@ You should check the dependencies in their `package.json` for more details.
 - [EEA Main Website frontend](https://github.com/eea/eea-website-frontend) - Plone 6 Volto frontend for [European Environment Agency](https://www.eea.europa.eu/en)
 - [volto-bise](https://github.com/eea/volto-bise) - A Volto project packaged as an addon. It provides Theming using a razzle.extend.js provided alias.
 - [design-volto-theme](https://github.com/RedTurtle/design-volto-theme) Volto theme for Italian Public Administration
-- [2021.ploneconf.org](https://github.com/plone/ploneconf.org/tree/2021) - Volto project for [Plone Conference 2021 site](https://2021.ploneconf.org)
 - [2022.ploneconf.org](https://github.com/plone/ploneconf.org/tree/2022) - Volto project for [Plone Conference 2022 site](https://2022.ploneconf.org)
 - [2023.ploneconf.org](https://github.com/plone/ploneconf.org/tree/2023) - Volto project for [Plone Conference 2023 site](https://2023.ploneconf.org)
 - [plone.org.br](https://github.com/plonegovbr/plone.org.br) - Volto project for the [Brazilian Plone Community](https://plone.org.br)

--- a/packages/volto/news/7314.internal
+++ b/packages/volto/news/7314.internal
@@ -1,0 +1,1 @@
+2021.ploneconf.org is no longer a Volto site, but just a redirect to YouTube. Also reverts #6627 and replaces code examples with `2022.ploneconf.org`. @stevepiercy


### PR DESCRIPTION
…YouTube

- Also replace mention of it in code examples to 2022.ploneconf.org
- Reverts #6627

These changes need to be backported to `18.x.x`. See https://github.com/plone/volto/pull/6870

<!-- readthedocs-preview volto start -->
----
📚 Documentation preview 📚: https://volto--7314.org.readthedocs.build/

<!-- readthedocs-preview volto end -->