### PR TITLE
Serve Volto on a subpath

### DIFF
--- a/packages/volto/Makefile
+++ b/packages/volto/Makefile
@@ -107,7 +107,7 @@ release-notes-copy-to-docs: ## Copy release notes into documentation
 
 .PHONY: backend-docker-start
 backend-docker-start: ## Starts a Docker-based backend for development
-	docker run -it --rm --name=backend -p 8080:8080 -v volto-backend-data:/data -e SITE=Plone -e ADDONS='$(KGS)' -e SITE_DEFAULT_LANGUAGE='$(SITE_DEFAULT_LANGUAGE)' $(DOCKER_IMAGE)
+	docker run -it --rm --name=backend -p 8080:8080 -v volto-backend-data:/data -e SITE=Plone -e ADDONS='$(KGS)' -e SITE_DEFAULT_LANGUAGE='$(SITE_DEFAULT_LANGUAGE)' -e CORS_ENABLE=1 $(DOCKER_IMAGE)
 
 .PHONY: frontend-docker-start
 frontend-docker-start: ## Starts a Docker-based frontend for development

--- a/packages/volto/locales/ca/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ca/LC_MESSAGES/volto.po
@@ -2464,7 +2464,7 @@ msgstr ""
 msgid "No broken relations found."
 msgstr ""
 
-#. Default: "There is no connection to the server, due to a timeout o no network connection."
+#. Default: "There is no connection to the server, due to a timeout or no network connection."
 #: components/theme/RequestTimeout/RequestTimeout
 msgid "No connection to the server"
 msgstr ""

--- a/packages/volto/locales/de/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/de/LC_MESSAGES/volto.po
@@ -2463,7 +2463,7 @@ msgstr "Keine Add-ons installiert."
 msgid "No broken relations found."
 msgstr "Alle Relationen sind OK."
 
-#. Default: "There is no connection to the server, due to a timeout o no network connection."
+#. Default: "There is no connection to the server, due to a timeout or no network connection."
 #: components/theme/RequestTimeout/RequestTimeout
 msgid "No connection to the server"
 msgstr "Keine Verbindung zum Server"

--- a/packages/volto/locales/en/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/en/LC_MESSAGES/volto.po
@@ -2458,7 +2458,7 @@ msgstr ""
 msgid "No broken relations found."
 msgstr ""
 
-#. Default: "There is no connection to the server, due to a timeout o no network connection."
+#. Default: "There is no connection to the server, due to a timeout or no network connection."
 #: components/theme/RequestTimeout/RequestTimeout
 msgid "No connection to the server"
 msgstr ""

--- a/packages/volto/locales/es/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/es/LC_MESSAGES/volto.po
@@ -2465,7 +2465,7 @@ msgstr "No se han encontrado complementos"
 msgid "No broken relations found."
 msgstr "No se encontraron relaciones rotas."
 
-#. Default: "There is no connection to the server, due to a timeout o no network connection."
+#. Default: "There is no connection to the server, due to a timeout or no network connection."
 #: components/theme/RequestTimeout/RequestTimeout
 msgid "No connection to the server"
 msgstr "No hay conexión con el servidor"

--- a/packages/volto/locales/eu/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/eu/LC_MESSAGES/volto.po
@@ -2465,7 +2465,7 @@ msgstr "Ez da gehigarririk aurkitu"
 msgid "No broken relations found."
 msgstr ""
 
-#. Default: "There is no connection to the server, due to a timeout o no network connection."
+#. Default: "There is no connection to the server, due to a timeout or no network connection."
 #: components/theme/RequestTimeout/RequestTimeout
 msgid "No connection to the server"
 msgstr "Ez dago konexiorik zerbitzariarekin"

--- a/packages/volto/locales/fi/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/fi/LC_MESSAGES/volto.po
@@ -2463,7 +2463,7 @@ msgstr "Lisäosia ei löytynyt"
 msgid "No broken relations found."
 msgstr ""
 
-#. Default: "There is no connection to the server, due to a timeout o no network connection."
+#. Default: "There is no connection to the server, due to a timeout or no network connection."
 #: components/theme/RequestTimeout/RequestTimeout
 msgid "No connection to the server"
 msgstr "Ei yhteyttä palvelimeen"

--- a/packages/volto/locales/fr/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/fr/LC_MESSAGES/volto.po
@@ -2465,7 +2465,7 @@ msgstr "Aucun module trouvé"
 msgid "No broken relations found."
 msgstr ""
 
-#. Default: "There is no connection to the server, due to a timeout o no network connection."
+#. Default: "There is no connection to the server, due to a timeout or no network connection."
 #: components/theme/RequestTimeout/RequestTimeout
 msgid "No connection to the server"
 msgstr "Aucune connexion avec le serveur"

--- a/packages/volto/locales/hi/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/hi/LC_MESSAGES/volto.po
@@ -2458,7 +2458,7 @@ msgstr "कोई ऐड-ऑन नहीं मिला"
 msgid "No broken relations found."
 msgstr "कोई टूटी हुई संबंध नहीं मिला।"
 
-#. Default: "There is no connection to the server, due to a timeout o no network connection."
+#. Default: "There is no connection to the server, due to a timeout or no network connection."
 #: components/theme/RequestTimeout/RequestTimeout
 msgid "No connection to the server"
 msgstr "सर्वर से कोई कनेक्शन नहीं है"

--- a/packages/volto/locales/it/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/it/LC_MESSAGES/volto.po
@@ -2458,7 +2458,7 @@ msgstr "Nessun addon trovato"
 msgid "No broken relations found."
 msgstr "Nessuna relazione corrotta trovata."
 
-#. Default: "There is no connection to the server, due to a timeout o no network connection."
+#. Default: "There is no connection to the server, due to a timeout or no network connection."
 #: components/theme/RequestTimeout/RequestTimeout
 msgid "No connection to the server"
 msgstr "Non c'è connessione con il server, a causa di un timeout o di problemi di connessione di rete del tuo dispositivo."

--- a/packages/volto/locales/ja/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ja/LC_MESSAGES/volto.po
@@ -2463,7 +2463,7 @@ msgstr ""
 msgid "No broken relations found."
 msgstr ""
 
-#. Default: "There is no connection to the server, due to a timeout o no network connection."
+#. Default: "There is no connection to the server, due to a timeout or no network connection."
 #: components/theme/RequestTimeout/RequestTimeout
 msgid "No connection to the server"
 msgstr ""

--- a/packages/volto/locales/nl/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/nl/LC_MESSAGES/volto.po
@@ -2462,7 +2462,7 @@ msgstr "Geen modules gevonden"
 msgid "No broken relations found."
 msgstr "Geen gebroken relaties gevonden."
 
-#. Default: "There is no connection to the server, due to a timeout o no network connection."
+#. Default: "There is no connection to the server, due to a timeout or no network connection."
 #: components/theme/RequestTimeout/RequestTimeout
 msgid "No connection to the server"
 msgstr "Er is geen verbinding naar de server, wegens een timeout of geen netwerkverbinding."

--- a/packages/volto/locales/pt/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/pt/LC_MESSAGES/volto.po
@@ -2463,7 +2463,7 @@ msgstr ""
 msgid "No broken relations found."
 msgstr ""
 
-#. Default: "There is no connection to the server, due to a timeout o no network connection."
+#. Default: "There is no connection to the server, due to a timeout or no network connection."
 #: components/theme/RequestTimeout/RequestTimeout
 msgid "No connection to the server"
 msgstr ""

--- a/packages/volto/locales/pt_BR/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/pt_BR/LC_MESSAGES/volto.po
@@ -2464,7 +2464,7 @@ msgstr "Nenhum complemento encontrado"
 msgid "No broken relations found."
 msgstr "Nenhum relacionamento rompido foi encontrado"
 
-#. Default: "There is no connection to the server, due to a timeout o no network connection."
+#. Default: "There is no connection to the server, due to a timeout or no network connection."
 #: components/theme/RequestTimeout/RequestTimeout
 msgid "No connection to the server"
 msgstr "Sem conexão ao servidor"

--- a/packages/volto/locales/ro/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ro/LC_MESSAGES/volto.po
@@ -2464,7 +2464,7 @@ msgstr "Nu s-au găsit addons"
 msgid "No broken relations found."
 msgstr "Nu s-au găsit relații rupte."
 
-#. Default: "There is no connection to the server, due to a timeout o no network connection."
+#. Default: "There is no connection to the server, due to a timeout or no network connection."
 #: components/theme/RequestTimeout/RequestTimeout
 msgid "No connection to the server"
 msgstr "Nu există conexiunea la server, din cauza unui timeout sau a unei conexiuni întrerupte."

--- a/packages/volto/locales/ru/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ru/LC_MESSAGES/volto.po
@@ -2463,7 +2463,7 @@ msgstr "Дополнения не найдены"
 msgid "No broken relations found."
 msgstr "Нарушенные связи не выявлены."
 
-#. Default: "There is no connection to the server, due to a timeout o no network connection."
+#. Default: "There is no connection to the server, due to a timeout or no network connection."
 #: components/theme/RequestTimeout/RequestTimeout
 msgid "No connection to the server"
 msgstr "Нет соединения с сервером"

--- a/packages/volto/locales/volto.pot
+++ b/packages/volto/locales/volto.pot
@@ -2460,7 +2460,7 @@ msgstr ""
 msgid "No broken relations found."
 msgstr ""
 
-#. Default: "There is no connection to the server, due to a timeout o no network connection."
+#. Default: "There is no connection to the server, due to a timeout or no network connection."
 #: components/theme/RequestTimeout/RequestTimeout
 msgid "No connection to the server"
 msgstr ""

--- a/packages/volto/locales/zh_CN/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/zh_CN/LC_MESSAGES/volto.po
@@ -2464,7 +2464,7 @@ msgstr "没有找到附件"
 msgid "No broken relations found."
 msgstr ""
 
-#. Default: "There is no connection to the server, due to a timeout o no network connection."
+#. Default: "There is no connection to the server, due to a timeout or no network connection."
 #: components/theme/RequestTimeout/RequestTimeout
 msgid "No connection to the server"
 msgstr "与服务器无连接"

--- a/packages/volto/news/7326.feature
+++ b/packages/volto/news/7326.feature
@@ -1,0 +1,1 @@
+Serve API requests from prefixpath @davisagli

--- a/packages/volto/razzle.config.js
+++ b/packages/volto/razzle.config.js
@@ -414,17 +414,21 @@ const defaultModify = ({
         ]
       : [];
 
-  //prefix-path
+  // If Volto is served under a prefix path,
+  // we have to adjust where Webpack assets are served too.
   const prefixPath = process.env.RAZZLE_PREFIX_PATH || '';
   if (prefixPath) {
     if (target === 'web' && dev) {
-      if (config.devServer.devMiddleware)
+      if (config.devServer.devMiddleware) {
         config.devServer.devMiddleware.publicPath = prefixPath;
-      else config.devServer.publicPath += `${prefixPath.slice(1)}/`;
+      } else {
+        config.devServer.publicPath += `${prefixPath.slice(1)}/`;
+      }
     }
     const publicPath = config.output.publicPath;
-    if (publicPath.indexOf(prefixPath) === -1)
+    if (publicPath.indexOf(prefixPath) === -1) {
       config.output.publicPath = `${publicPath}${prefixPath.slice(1)}/`;
+    }
   }
   return config;
 };

--- a/packages/volto/src/components/theme/RequestTimeout/RequestTimeout.jsx
+++ b/packages/volto/src/components/theme/RequestTimeout/RequestTimeout.jsx
@@ -29,7 +29,7 @@ const RequestTimeout = () => (
         <h1 style={{ textAlign: 'center', lineHeight: '40px' }}>
           <FormattedMessage
             id="No connection to the server"
-            defaultMessage="There is no connection to the server, due to a timeout o no network connection."
+            defaultMessage="There is no connection to the server, due to a timeout or no network connection."
           />
           <br />
           <a href={config.settings.apiPath}>{config.settings.apiPath}</a>

--- a/packages/volto/src/components/theme/RequestTimeout/__snapshots__/RequestTimeout.test.jsx.snap
+++ b/packages/volto/src/components/theme/RequestTimeout/__snapshots__/RequestTimeout.test.jsx.snap
@@ -22,7 +22,7 @@ exports[`RequestTimeout > renders a request timeout or no connection component 1
       }
     }
   >
-    There is no connection to the server, due to a timeout o no network connection.
+    There is no connection to the server, due to a timeout or no network connection.
     <br />
     <a
       href="http://localhost:8080/Plone"

--- a/packages/volto/src/config/index.js
+++ b/packages/volto/src/config/index.js
@@ -30,10 +30,6 @@ import languages from '@plone/volto/constants/Languages.cjs';
 const host = process.env.HOST || 'localhost';
 const port = process.env.PORT || '3000';
 
-const apiPath =
-  process.env.RAZZLE_API_PATH ||
-  (__DEVELOPMENT__ ? `http://${host}:${port}` : '');
-
 const getServerURL = (url) => {
   if (!url) return;
   const apiPathURL = parseUrl(url);
@@ -46,12 +42,14 @@ const getServerURL = (url) => {
 // if RAZZLE_PUBLIC_URL is present, use it
 // if in DEV, use the host/port combination by default
 // if in PROD, assume it's RAZZLE_API_PATH server name (no /api or alikes) or fallback
-// to DEV settings if RAZZLE_API_PATH is not present
+// to DEV settings if RAZZLE_API_PATH is not present.
+// Finally, add the prefix path, if there is one.
 const publicURL =
-  process.env.RAZZLE_PUBLIC_URL ||
-  (__DEVELOPMENT__
-    ? `http://${host}:${port}`
-    : getServerURL(process.env.RAZZLE_API_PATH) || `http://${host}:${port}`);
+  (process.env.RAZZLE_PUBLIC_URL ||
+    (__DEVELOPMENT__
+      ? `http://${host}:${port}`
+      : getServerURL(process.env.RAZZLE_API_PATH) ||
+        `http://${host}:${port}`)) + (process.env.RAZZLE_PREFIX_PATH || '');
 
 const serverConfig =
   typeof __SERVER__ !== 'undefined' && __SERVER__
@@ -65,7 +63,10 @@ let config = {
     // The URL Volto is going to be served (see sensible defaults above)
     publicURL,
     okRoute: '/ok',
-    apiPath,
+    // Base URL for API requests from the browser.
+    // If not explicitly set, use the publicURL (seamless mode) --
+    // but in that case it will be updated in server.jsx for each request.
+    apiPath: process.env.RAZZLE_API_PATH || publicURL,
     apiExpanders: [
       // Added here for documentation purposes, added at the end because it
       // depends on a value of this object.
@@ -98,7 +99,8 @@ let config = {
     // apiPath: process.env.RAZZLE_API_PATH || 'http://localhost:8000', // for Volto reference
     // apiPath: process.env.RAZZLE_API_PATH || 'http://localhost:8081/db/web', // for guillotina
     actions_raising_api_errors: ['GET_CONTENT', 'UPDATE_CONTENT'],
-    internalApiPath: process.env.RAZZLE_INTERNAL_API_PATH || undefined,
+    internalApiPath:
+      process.env.RAZZLE_INTERNAL_API_PATH || 'http://localhost:8080/Plone',
     prefixPath: process.env.RAZZLE_PREFIX_PATH || '',
     websockets: process.env.RAZZLE_WEBSOCKETS || false,
     // TODO: legacyTraverse to be removed when the use of the legacy traverse is deprecated.

--- a/packages/volto/src/config/index.js
+++ b/packages/volto/src/config/index.js
@@ -99,8 +99,7 @@ let config = {
     // apiPath: process.env.RAZZLE_API_PATH || 'http://localhost:8000', // for Volto reference
     // apiPath: process.env.RAZZLE_API_PATH || 'http://localhost:8081/db/web', // for guillotina
     actions_raising_api_errors: ['GET_CONTENT', 'UPDATE_CONTENT'],
-    internalApiPath:
-      process.env.RAZZLE_INTERNAL_API_PATH || 'http://localhost:8080/Plone',
+    internalApiPath: process.env.RAZZLE_INTERNAL_API_PATH || undefined,
     prefixPath: process.env.RAZZLE_PREFIX_PATH || '',
     websockets: process.env.RAZZLE_WEBSOCKETS || false,
     // TODO: legacyTraverse to be removed when the use of the legacy traverse is deprecated.

--- a/packages/volto/src/express-middleware/devproxy.js
+++ b/packages/volto/src/express-middleware/devproxy.js
@@ -13,7 +13,10 @@ const filter = function (pathname, req) {
   // Check if pathname is defined, there are some corner cases that pathname is null
   if (pathname) {
     // This is the proxy to the API in case the accept header is 'application/json'
-    return config.settings.devProxyToApiPath && pathname.startsWith('/++api++');
+    return (
+      config.settings.devProxyToApiPath &&
+      pathname.startsWith(`${config.settings.prefixPath}/++api++`)
+    );
   } else {
     return false;
   }
@@ -82,13 +85,13 @@ export default function devProxyMiddleware() {
         config.settings.proxyRewriteTarget ||
         `/VirtualHostBase/${apiPathURL.protocol.slice(0, -1)}/${
           apiPathURL.hostname
-        }:${apiPathURL.port}${instancePath}/++api++/VirtualHostRoot`;
+        }:${apiPathURL.port}${instancePath}/++api++/VirtualHostRoot${config.settings.prefixPath ? '/_vh_' + config.settings.prefixPath.slice(1) : ''}`;
 
-      return `${target}${path.replace('/++api++', '')}`;
+      return `${target}${path.replace(`${config.settings.prefixPath}/++api++`, '')}`;
     },
+    changeOrigin: true,
     logLevel: process.env.DEBUG_HPM ? 'debug' : 'silent',
     ...(process.env.RAZZLE_DEV_PROXY_INSECURE && {
-      changeOrigin: true,
       secure: false,
     }),
   });

--- a/packages/volto/src/helpers/Api/APIResourceWithAuth.js
+++ b/packages/volto/src/helpers/Api/APIResourceWithAuth.js
@@ -17,7 +17,7 @@ import { stripPrefixPath } from '@plone/volto/helpers/Url/Url';
 export const getAPIResourceWithAuth = (req) =>
   new Promise((resolve, reject) => {
     const { settings } = config;
-    const APISUFIX = settings.legacyTraverse ? '' : '/++api++';
+    const apiSuffix = settings.legacyTraverse ? '' : '/++api++';
     let apiPath = '';
 
     if (settings.internalApiPath && __SERVER__) {
@@ -28,12 +28,11 @@ export const getAPIResourceWithAuth = (req) =>
       apiPath = settings.apiPath;
     }
 
-    let path = req.path;
     //strip prefix if any
-    path = stripPrefixPath(path);
+    const contentPath = stripPrefixPath(req.path);
 
     const request = superagent
-      .get(`${apiPath}${__DEVELOPMENT__ ? '' : APISUFIX}${path}`)
+      .get(`${apiPath}${__DEVELOPMENT__ ? '' : apiSuffix}${contentPath}`)
       .maxResponseSize(settings.maxResponseSize)
       .responseType('blob');
     const authToken = req.universalCookies.get('auth_token');

--- a/packages/volto/src/helpers/Api/Api.js
+++ b/packages/volto/src/helpers/Api/Api.js
@@ -22,7 +22,7 @@ const methods = ['get', 'post', 'put', 'patch', 'del'];
  */
 export function formatUrl(path) {
   const { settings } = config;
-  const APISUFIX = settings.legacyTraverse ? '' : '/++api++';
+  const apiSuffix = settings.legacyTraverse ? '' : '/++api++';
 
   if (path.startsWith('http://') || path.startsWith('https://')) return path;
 
@@ -33,10 +33,8 @@ export function formatUrl(path) {
     apiPath = settings.apiPath;
   }
 
-  let adjustedPath = path[0] !== '/' ? `/${path}` : path;
-  adjustedPath = stripPrefixPath(adjustedPath);
-
-  return `${apiPath}${APISUFIX}${adjustedPath}`;
+  const contentPath = stripPrefixPath(path[0] !== '/' ? `/${path}` : path);
+  return `${apiPath}${apiSuffix}${contentPath}`;
 }
 
 /**

--- a/packages/volto/src/helpers/Html/Html.jsx
+++ b/packages/volto/src/helpers/Html/Html.jsx
@@ -9,6 +9,7 @@ import Helmet from '@plone/volto/helpers/Helmet/Helmet';
 import serialize from 'serialize-javascript';
 import join from 'lodash/join';
 import BodyClass from '@plone/volto/helpers/BodyClass/BodyClass';
+import { addPrefixPath } from '@plone/volto/helpers/Url/Url';
 import { runtimeConfig } from '@plone/volto/runtime_config';
 import config from '@plone/volto/registry';
 import { bulkFlattenToAppURL } from '../Url/bulkFlattenToAppURL';
@@ -127,37 +128,18 @@ class Html extends Component {
             }}
           />
 
+          <link rel="icon" href={addPrefixPath('/favicon.ico')} sizes="any" />
           <link
             rel="icon"
-            href={
-              (config.settings.prefixPath ? config.settings.prefixPath : '') +
-              '/favicon.ico'
-            }
-            sizes="any"
-          />
-          <link
-            rel="icon"
-            href={
-              (config.settings.prefixPath ? config.settings.prefixPath : '') +
-              '/icon.svg'
-            }
+            href={addPrefixPath('/icon.svg')}
             type="image/svg+xml"
           />
           <link
             rel="apple-touch-icon"
             sizes="180x180"
-            href={
-              (config.settings.prefixPath ? config.settings.prefixPath : '') +
-              '/apple-touch-icon.png'
-            }
+            href={addPrefixPath('/apple-touch-icon.png')}
           />
-          <link
-            rel="manifest"
-            href={
-              (config.settings.prefixPath ? config.settings.prefixPath : '') +
-              '/site.webmanifest'
-            }
-          />
+          <link rel="manifest" href={addPrefixPath('/site.webmanifest')} />
           <meta name="generator" content="Plone 6 - https://plone.org" />
           <meta name="viewport" content="width=device-width, initial-scale=1" />
           <meta name="mobile-web-app-capable" content="yes" />

--- a/packages/volto/src/helpers/Sitemap/Sitemap.js
+++ b/packages/volto/src/helpers/Sitemap/Sitemap.js
@@ -22,10 +22,10 @@ export const SITEMAP_BATCH_SIZE = 5000;
 export const generateSitemap = (_req, start = 0, size = undefined) =>
   new Promise((resolve) => {
     const { settings } = config;
-    const APISUFIX = settings.legacyTraverse ? '' : '/++api++';
+    const apiSuffix = settings.legacyTraverse ? '' : '/++api++';
     const apiPath = settings.internalApiPath ?? settings.apiPath;
     const request = superagent.get(
-      `${apiPath}${APISUFIX}/@search?metadata_fields=modified&b_start=${start}&b_size=${
+      `${apiPath}${apiSuffix}/@search?metadata_fields=modified&b_start=${start}&b_size=${
         size !== undefined ? size : 100000000
       }&use_site_search_settings=1`,
     );
@@ -64,10 +64,10 @@ export const generateSitemap = (_req, start = 0, size = undefined) =>
 export const generateSitemapIndex = (_req, gzip = false) =>
   new Promise((resolve) => {
     const { settings } = config;
-    const APISUFIX = settings.legacyTraverse ? '' : '/++api++';
+    const apiSuffix = settings.legacyTraverse ? '' : '/++api++';
     const apiPath = settings.internalApiPath ?? settings.apiPath;
     const request = superagent.get(
-      `${apiPath}${APISUFIX}/@search?metadata_fields=modified&b_size=0&use_site_search_settings=1`,
+      `${apiPath}${apiSuffix}/@search?metadata_fields=modified&b_size=0&use_site_search_settings=1`,
     );
     request.set('Accept', 'application/json');
     const authToken = _req.universalCookies.get('auth_token');

--- a/packages/volto/src/helpers/Url/Url.js
+++ b/packages/volto/src/helpers/Url/Url.js
@@ -193,7 +193,7 @@ export function addAppURL(url) {
  */
 export function expandToBackendURL(path) {
   const { settings } = config;
-  const APISUFIX = settings.legacyTraverse ? '' : '/++api++';
+  const apiSuffix = settings.legacyTraverse ? '' : '/++api++';
   let adjustedPath;
   if (path.startsWith('http://') || path.startsWith('https://')) {
     // flattenToAppURL first if we get a full URL
@@ -210,7 +210,7 @@ export function expandToBackendURL(path) {
     apiPath = settings.apiPath;
   }
 
-  return `${apiPath}${APISUFIX}${adjustedPath}`;
+  return `${apiPath}${apiSuffix}${adjustedPath}`;
 }
 
 /**

--- a/packages/volto/src/server.jsx
+++ b/packages/volto/src/server.jsx
@@ -179,8 +179,10 @@ function setupServer(req, res, next) {
     res.locals.detectedHost = `${
       req.headers['x-forwarded-proto'] || req.protocol
     }://${req.headers.host}`;
-    config.settings.apiPath = res.locals.detectedHost;
-    config.settings.publicURL = res.locals.detectedHost;
+    config.settings.apiPath =
+      res.locals.detectedHost + config.settings.prefixPath;
+    config.settings.publicURL =
+      res.locals.detectedHost + config.settings.prefixPath;
   }
 
   res.locals = {
@@ -313,8 +315,8 @@ server.get('/*', (req, res) => {
             markup={markup}
             store={store}
             criticalCss={readCriticalCss(req)}
-            apiPath={res.locals.detectedHost || config.settings.apiPath}
-            publicURL={res.locals.detectedHost || config.settings.publicURL}
+            apiPath={config.settings.apiPath}
+            publicURL={config.settings.publicURL}
           />,
         )}
       `,
@@ -357,6 +359,8 @@ export const defaultReadCriticalCss = () => {
 
 // Exposed for the console bootstrap info messages
 server.apiPath = config.settings.apiPath;
+server.internalApiPath = config.settings.internalApiPath;
+server.prefixPath = config.settings.prefixPath;
 server.devProxyToApiPath = config.settings.devProxyToApiPath;
 server.proxyRewriteTarget = config.settings.proxyRewriteTarget;
 server.publicURL = config.settings.publicURL;

--- a/packages/volto/src/server.jsx
+++ b/packages/volto/src/server.jsx
@@ -72,9 +72,12 @@ const server = express()
   })
   .use(cookiesMiddleware());
 
-if (process.env.RAZZLE_PREFIX_PATH) {
+// If Volto is being served under a prefix,
+// make sure the static files are available there too.
+// (The static middleware loads too early to access the config.)
+if (config.settings.prefixPath) {
   server.use(
-    process.env.RAZZLE_PREFIX_PATH,
+    config.settings.prefixPath,
     express.static(
       process.env.BUILD_DIR
         ? path.join(process.env.BUILD_DIR, 'public')
@@ -277,7 +280,7 @@ server.get('/*', (req, res) => {
               <StaticRouter
                 context={context}
                 location={req.url}
-                basename={process.env.RAZZLE_PREFIX_PATH}
+                basename={config.settings.prefixPath}
               >
                 <ReduxAsyncConnect routes={routes} helpers={api} />
               </StaticRouter>

--- a/packages/volto/src/start-client.jsx
+++ b/packages/volto/src/start-client.jsx
@@ -18,16 +18,19 @@ import Api from '@plone/volto/helpers/Api/Api';
 import { persistAuthToken } from '@plone/volto/helpers/AuthToken/AuthToken';
 import ScrollToTop from '@plone/volto/helpers/ScrollToTop/ScrollToTop';
 
-export const history = createBrowserHistory({
-  basename: config.settings.prefixPath ? config.settings.prefixPath : '/',
-});
-
 function reactIntlErrorHandler(error) {
   debug('i18n')(error);
 }
 
 export default function client() {
   const api = new Api();
+
+  if (window.env.RAZZLE_PREFIX_PATH) {
+    config.settings.prefixPath = window.env.RAZZLE_PREFIX_PATH;
+  }
+  const history = createBrowserHistory({
+    basename: config.settings.prefixPath ? config.settings.prefixPath : '/',
+  });
 
   const store = configureStore(window.__data, history, api);
   persistAuthToken(store);

--- a/packages/volto/src/start-server.js
+++ b/packages/volto/src/start-server.js
@@ -18,14 +18,20 @@ export default function server() {
 
   server
     .listen(port, bind_address, () => {
-      console.log(`API server (API_PATH) is set to: ${app.apiPath}`);
+      console.log(
+        `The Volto server will make API requests to: ${app.internalApiPath || app.apiPath}/++api++`,
+      );
+      console.log(
+        `The Volto client will make API requests to: ${app.apiPath}/++api++`,
+      );
 
-      if (app.devProxyToApiPath)
+      if (app.devProxyToApiPath) {
         console.log(
           `Proxying API requests from ${app.publicURL}/++api++ to ${
             app.devProxyToApiPath
           }${app.proxyRewriteTarget || ''}`,
         );
+      }
       console.log(`🎭 Volto started at ${bind_address}:${port} 🚀`);
 
       if (!process.env.RAZZLE_PUBLIC_URL)


### PR DESCRIPTION
This is based on https://github.com/plone/volto/pull/6897 but also makes sure that API requests are made on the same subpath, so the top level of the domain can be used for some other software.

@nileshgulia1 @mamico You can change the base of the PR to prefix-path-revised if that is helpful for reviewing.

To do:
- Fix existing tests
- Merge the tests from https://github.com/plone/volto/pull/6976
- Docs