### PR TITLE
Widget registry fixes

### DIFF
--- a/packages/cmsui/config/widgets.ts
+++ b/packages/cmsui/config/widgets.ts
@@ -10,7 +10,7 @@ import {
 import { DateField } from '@plone/components';
 
 export default function install(config: ConfigType) {
-  config.registerWidget({ key: 'default', definition: TextField });
+  config.registerDefaultWidget(TextField);
   config.registerWidget({ key: 'widget', definition: { date: DateField } });
   config.registerWidget({
     key: 'widget',

--- a/packages/cmsui/news/7334.feature
+++ b/packages/cmsui/news/7334.feature
@@ -1,0 +1,1 @@
+Updated widget config registration to reflect new API. @deodorhunter

--- a/packages/registry/news/7334.bugfix
+++ b/packages/registry/news/7334.bugfix
@@ -1,0 +1,1 @@
+Fixed `registerWidget` ssr error with dedicated APIs for default and generic Widgets. @deodorhunter

--- a/packages/registry/src/index.ts
+++ b/packages/registry/src/index.ts
@@ -560,30 +560,37 @@ class Config {
     type Definition = WidgetsConfig[K];
     type DefinitionKey = keyof Definition;
     const emptyDefinition: WidgetsConfig[K] = {} as Definition;
-
+    if (!options || !options.key || !options.definition) {
+      throw new Error('No widget definition provided');
+    }
     const { key, definition } = options;
+
+    if (key === 'default') {
+      throw new Error('Use registerDefaultWidget to set the default widget');
+    }
+
     const definitionIsObject = Object.keys(definition).length;
     if (!definitionIsObject) {
       this._data.widgets[key] = definition;
     } else {
-      const target = this._data.widgets[key] as Definition;
       for (const widgetKey of Object.keys(definition) as DefinitionKey[]) {
         // Now widgetKey is known by TS to be a valid key of definition, no casting needed.
-        if (this._data.widgets[key] === undefined) {
+        if (this._data.widgets[key] === undefined)
           this._data.widgets[key] = emptyDefinition;
-        }
-        if (target?.[widgetKey]) {
-          // If the widget already exists, we merge the definitions
-          this._data.widgets[key][widgetKey] = {
-            ...target[widgetKey],
-            ...definition[widgetKey],
-          };
-        } else {
-          // Otherwise, we just set it
-          this._data.widgets[key][widgetKey] = definition[widgetKey];
-        }
+
+        // Otherwise, we just set it
+        this._data.widgets[key][widgetKey] = definition[widgetKey];
       }
     }
+  }
+  /**
+   * Registers a default widget configuration into the registry.
+   *
+   * @param component - The default widget component to register.
+   *
+   */
+  registerDefaultWidget(component: React.ComponentType<any>) {
+    this._data.widgets.default = component;
   }
 
   /**

--- a/packages/registry/src/registry.test.tsx
+++ b/packages/registry/src/registry.test.tsx
@@ -17,7 +17,7 @@ beforeEach(() => {
   config.set('slots', {});
   config.set('utilities', {});
   config.set('widgets', {
-    default: { default: MockDefaultWidget },
+    default: MockDefaultWidget,
     id: {
       title: MockTextWidget,
     },

--- a/packages/registry/src/registry.test.tsx
+++ b/packages/registry/src/registry.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import config from './index';
-import { describe, expect, it, afterEach, beforeEach } from 'vitest';
+import { describe, expect, it, afterEach, beforeEach, beforeAll } from 'vitest';
+import type { WidgetsConfig } from '@plone/types';
 
 const MockDefaultWidget = () => <div data-testid="default-widget">Default</div>;
 const MockTextWidget = () => <input type="text" data-testid="text-widget" />;
@@ -16,7 +17,7 @@ beforeEach(() => {
   config.set('slots', {});
   config.set('utilities', {});
   config.set('widgets', {
-    default: MockDefaultWidget,
+    default: { default: MockDefaultWidget },
     id: {
       title: MockTextWidget,
     },
@@ -1282,21 +1283,26 @@ describe('Routes registry', () => {
     ]);
   });
 });
-describe('registerWidget', () => {
+describe('Widgets registry: registerWidget/registerDefaultWidget', () => {
   const DummyWidget = () => <div>Dummy Widget</div>;
+  DummyWidget.displayName = 'DummyWidget';
   const AnotherWidget = () => <div>Another Widget</div>;
+  AnotherWidget.displayName = 'AnotherWidget';
+  const ThirdWidget = () => <div>Third Widget</div>;
+  ThirdWidget.displayName = 'ThirdWidget';
 
   beforeEach(() => {
-    config._data.widgets = {}; // reset registry for a clean test state
+    config._data.widgets = {} as WidgetsConfig; // reset registry for a clean test state
   });
 
   it('registers a default widget', () => {
-    config.registerWidget({
-      key: 'default',
-      definition: DummyWidget,
-    });
-
-    expect(config.widgets?.default).toBe(DummyWidget);
+    config.registerDefaultWidget(AnotherWidget);
+    expect(config.widgets?.default.displayName).toBe('AnotherWidget');
+  });
+  it('errors when trying to register a default widget with the wrong API', () => {
+    expect(() => {
+      config.registerWidget({ key: 'default', definition: AnotherWidget });
+    }).toThrow('Use registerDefaultWidget to set the default widget');
   });
 
   it('registers a widget in the "widget" group', () => {
@@ -1307,80 +1313,8 @@ describe('registerWidget', () => {
       },
     });
 
-    expect(config.widgets?.widget?.special).toBe(DummyWidget);
+    expect(config.widgets?.widget?.special?.displayName).toBe('DummyWidget');
   });
-
-  it('registers a widget in the "factory" group', () => {
-    config.registerWidget({
-      key: 'factory',
-      definition: {
-        'my.custom.Factory': DummyWidget,
-      },
-    });
-
-    expect(config.widgets?.factory?.['my.custom.Factory']).toBe(DummyWidget);
-  });
-
-  it('overwrites existing widgets of the same key', () => {
-    config.registerWidget({
-      key: 'default',
-      definition: DummyWidget,
-    });
-
-    config.registerWidget({
-      key: 'default',
-      definition: AnotherWidget,
-    });
-
-    expect(config.widgets?.default).toBe(AnotherWidget);
-  });
-
-  it('preserves unrelated widget keys', () => {
-    config.registerWidget({
-      key: 'default',
-      definition: DummyWidget,
-    });
-
-    config.registerWidget({
-      key: 'widget',
-      definition: {
-        special: AnotherWidget,
-      },
-    });
-
-    expect(config.widgets?.default).toBe(DummyWidget);
-    expect(config.widgets?.widget?.special).toBe(AnotherWidget);
-  });
-});
-
-describe('Widgets registry: registerWidget', () => {
-  const DummyWidget = () => <div>Dummy Widget</div>;
-  const AnotherWidget = () => <div>Another Widget</div>;
-
-  beforeEach(() => {
-    config._data.widgets = {}; // reset registry for a clean test state
-  });
-
-  it('registers a default widget', () => {
-    config.registerWidget({
-      key: 'default',
-      definition: DummyWidget,
-    });
-
-    expect(config.widgets?.default).toBe(DummyWidget);
-  });
-
-  it('registers a widget in the "widget" group', () => {
-    config.registerWidget({
-      key: 'widget',
-      definition: {
-        special: DummyWidget,
-      },
-    });
-
-    expect(config.widgets?.widget?.special).toBe(DummyWidget);
-  });
-
   it('registers two widgets in the "widget" group', () => {
     config.registerWidget({
       key: 'widget',
@@ -1394,20 +1328,8 @@ describe('Widgets registry: registerWidget', () => {
         another: DummyWidget,
       },
     });
-    expect(config.widgets?.widget?.special).toBe(DummyWidget);
-    expect(config.widgets?.widget?.another).toBe(DummyWidget);
-  });
-
-  it('registers several widgets in the "widget" group at once', () => {
-    config.registerWidget({
-      key: 'widget',
-      definition: {
-        special: DummyWidget,
-        another: DummyWidget,
-      },
-    });
-    expect(config.widgets?.widget?.special).toBe(DummyWidget);
-    expect(config.widgets?.widget?.another).toBe(DummyWidget);
+    expect(config.widgets?.widget?.special?.displayName).toBe('DummyWidget');
+    expect(config.widgets?.widget?.another?.displayName).toBe('DummyWidget');
   });
 
   it('registers a widget in the "factory" group', () => {
@@ -1418,28 +1340,49 @@ describe('Widgets registry: registerWidget', () => {
       },
     });
 
-    expect(config.widgets?.factory?.['my.custom.Factory']).toBe(DummyWidget);
+    expect(config.widgets?.factory?.['my.custom.Factory']?.displayName).toBe(
+      'DummyWidget',
+    );
+  });
+  it('registers several widgets in the "widget" group at once', () => {
+    config.registerWidget({
+      key: 'widget',
+      definition: {
+        special: DummyWidget,
+        another: ThirdWidget,
+      },
+    });
+    expect(config.widgets?.widget?.special?.displayName).toBe('DummyWidget');
+    expect(config.widgets?.widget?.another?.displayName).toBe('ThirdWidget');
   });
 
+  it('overwrites existing default widget', () => {
+    // TODO: disallow overwriting default widget with non specific API
+    config.registerDefaultWidget(AnotherWidget);
+    expect(config.widgets?.default.displayName).toBe('AnotherWidget');
+
+    config.registerDefaultWidget(ThirdWidget);
+
+    expect(config.widgets?.default.displayName).toBe('ThirdWidget');
+  });
   it('overwrites existing widgets of the same key', () => {
+    // TODO: , disallow overwriting default widget with non specific API
     config.registerWidget({
-      key: 'default',
-      definition: DummyWidget,
+      key: 'widget',
+      definition: { size: AnotherWidget },
     });
+    expect(config.widgets?.widget.size?.displayName).toBe('AnotherWidget');
 
     config.registerWidget({
-      key: 'default',
-      definition: AnotherWidget,
+      key: 'widget',
+      definition: { size: ThirdWidget },
     });
 
-    expect(config.widgets?.default).toBe(AnotherWidget);
+    expect(config.widgets?.widget.size?.displayName).toBe('ThirdWidget');
   });
 
   it('preserves unrelated widget keys', () => {
-    config.registerWidget({
-      key: 'default',
-      definition: DummyWidget,
-    });
+    config.registerDefaultWidget(DummyWidget);
 
     config.registerWidget({
       key: 'widget',
@@ -1448,8 +1391,8 @@ describe('Widgets registry: registerWidget', () => {
       },
     });
 
-    expect(config.widgets?.default).toBe(DummyWidget);
-    expect(config.widgets?.widget?.special).toBe(AnotherWidget);
+    expect(config.widgets?.default.displayName).toBe('DummyWidget');
+    expect(config.widgets?.widget?.special?.displayName).toBe('AnotherWidget');
   });
 });
 

--- a/packages/types/news/7334.internal
+++ b/packages/types/news/7334.internal
@@ -1,0 +1,1 @@
+Update Widgets types. @deodorhunter

--- a/packages/types/src/config/Widgets.d.ts
+++ b/packages/types/src/config/Widgets.d.ts
@@ -153,7 +153,7 @@ export type WidgetsConfigViewByType<
 }>;
 
 export interface WidgetsConfigViews<P = any> {
-  getWidget: React.ComponentType<P>;
+  // getWidget: React.ComponentType<P>;
   default: React.ComponentType<P>;
   id: WidgetsConfigViewById;
   widget: WidgetsConfigViewByWidget;


### PR DESCRIPTION
> [!CAUTION]
The Volto Team has suspended its review of new pull requests from first-time contributors until the [release of Plone 7](https://plone.org/download/release-schedule), which is preliminarily scheduled for the second quarter of 2026.
> [Read details](https://6.docs.plone.org/volto/contributing/index.html).

-----

- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't other open [pull requests](https://github.com/plone/volto/pulls) for the same change.
- [x] I followed the guidelines in [Contributing to Volto](https://6.docs.plone.org/volto/contributing/index.html).
- [x] I successfully ran [code linting checks](https://6.docs.plone.org/volto/contributing/linting.html) on my changes locally.
- [x] I successfully ran [unit tests](https://6.docs.plone.org/volto/contributing/testing.html) on my changes locally.
- [x] I successfully ran [acceptance tests](https://6.docs.plone.org/volto/contributing/acceptance-tests.html) on my changes locally.
- [x] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/volto/contributing/documentation.html#narrative-documentation) for my changes, either in the Storybook or narrative documentation.
- [x] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

@sneridagh here is the pr for what we debugged this morning, and some very tentative docs

- Added validation in `registerWidget()` to prevent `key: 'default'`
- Throws error: `"Use registerDefaultWidget to set the default widget"` when trying to add a default widget with registerWidget method instead of registerDefaultWidget
- Added test for error throwing behavior and improved test reliability
- Fixed test using wrong API (`registerWidget({ key: 'default' })` → `registerDefaultWidget()`)
- Updated type definitions for widget registry methods
- Updated config to use correct API pattern

### Breaking Change

Code using `registerWidget({ key: 'default' })` must migrate:

```diff
- config.registerWidget({ key: 'default', definition: MyWidget });
+ config.registerDefaultWidget(MyWidget);
```

### Usage

**Correct API usage:**
```typescript
// Register default widget
config.registerDefaultWidget(TextField);

// Register categorized widgets  
config.registerWidget({ 
  key: 'widget', 
  definition: { date: DateField } 
});

config.registerWidget({ 
  key: 'factory', 
  definition: { 'my.Factory': CustomWidget } 
});
```

**Error handling:**
```typescript
// This will throw an error
config.registerWidget({ key: 'default', definition: MyWidget });
// Error: "Use registerDefaultWidget to set the default widget"
```