### PR TITLE
fix: added the number of results when using the content folder search for screen readers

### DIFF
--- a/packages/volto/locales/ca/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ca/LC_MESSAGES/volto.po
@@ -4976,6 +4976,11 @@ msgstr ""
 msgid "refers to"
 msgstr ""
 
+#. Default: "Result count"
+#: components/manage/Contents/Contents
+msgid "resultCount"
+msgstr ""
+
 #. Default: "results"
 #: components/theme/Search/Search
 msgid "results found"

--- a/packages/volto/locales/de/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/de/LC_MESSAGES/volto.po
@@ -4975,6 +4975,11 @@ msgstr "Verweise"
 msgid "refers to"
 msgstr "verweist auf"
 
+#. Default: "Result count"
+#: components/manage/Contents/Contents
+msgid "resultCount"
+msgstr "Ergebnisanzahl"
+
 #. Default: "results"
 #: components/theme/Search/Search
 msgid "results found"

--- a/packages/volto/locales/en/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/en/LC_MESSAGES/volto.po
@@ -4970,6 +4970,11 @@ msgstr ""
 msgid "refers to"
 msgstr ""
 
+#. Default: "Result count"
+#: components/manage/Contents/Contents
+msgid "resultCount"
+msgstr ""
+
 #. Default: "results"
 #: components/theme/Search/Search
 msgid "results found"

--- a/packages/volto/locales/es/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/es/LC_MESSAGES/volto.po
@@ -4977,6 +4977,11 @@ msgstr "referencias"
 msgid "refers to"
 msgstr ""
 
+#. Default: "Result count"
+#: components/manage/Contents/Contents
+msgid "resultCount"
+msgstr "Cantidad de resultados"
+
 #. Default: "results"
 #: components/theme/Search/Search
 msgid "results found"

--- a/packages/volto/locales/eu/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/eu/LC_MESSAGES/volto.po
@@ -4977,6 +4977,11 @@ msgstr ""
 msgid "refers to"
 msgstr ""
 
+#. Default: "Result count"
+#: components/manage/Contents/Contents
+msgid "resultCount"
+msgstr ""
+
 #. Default: "results"
 #: components/theme/Search/Search
 msgid "results found"

--- a/packages/volto/locales/fi/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/fi/LC_MESSAGES/volto.po
@@ -4975,6 +4975,11 @@ msgstr ""
 msgid "refers to"
 msgstr ""
 
+#. Default: "Result count"
+#: components/manage/Contents/Contents
+msgid "resultCount"
+msgstr ""
+
 #. Default: "results"
 #: components/theme/Search/Search
 msgid "results found"

--- a/packages/volto/locales/fr/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/fr/LC_MESSAGES/volto.po
@@ -4977,6 +4977,11 @@ msgstr ""
 msgid "refers to"
 msgstr ""
 
+#. Default: "Result count"
+#: components/manage/Contents/Contents
+msgid "resultCount"
+msgstr ""
+
 #. Default: "results"
 #: components/theme/Search/Search
 msgid "results found"

--- a/packages/volto/locales/hi/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/hi/LC_MESSAGES/volto.po
@@ -4970,6 +4970,11 @@ msgstr "संदर्भ"
 msgid "refers to"
 msgstr ""
 
+#. Default: "Result count"
+#: components/manage/Contents/Contents
+msgid "resultCount"
+msgstr ""
+
 #. Default: "results"
 #: components/theme/Search/Search
 msgid "results found"

--- a/packages/volto/locales/it/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/it/LC_MESSAGES/volto.po
@@ -4970,6 +4970,11 @@ msgstr "riferimenti"
 msgid "refers to"
 msgstr "fa riferimento a"
 
+#. Default: "Result count"
+#: components/manage/Contents/Contents
+msgid "resultCount"
+msgstr "Totale risultati"
+
 #. Default: "results"
 #: components/theme/Search/Search
 msgid "results found"

--- a/packages/volto/locales/ja/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ja/LC_MESSAGES/volto.po
@@ -4975,6 +4975,11 @@ msgstr ""
 msgid "refers to"
 msgstr ""
 
+#. Default: "Result count"
+#: components/manage/Contents/Contents
+msgid "resultCount"
+msgstr ""
+
 #. Default: "results"
 #: components/theme/Search/Search
 msgid "results found"

--- a/packages/volto/locales/nl/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/nl/LC_MESSAGES/volto.po
@@ -4974,6 +4974,11 @@ msgstr "referenties"
 msgid "refers to"
 msgstr ""
 
+#. Default: "Result count"
+#: components/manage/Contents/Contents
+msgid "resultCount"
+msgstr ""
+
 #. Default: "results"
 #: components/theme/Search/Search
 msgid "results found"

--- a/packages/volto/locales/pt/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/pt/LC_MESSAGES/volto.po
@@ -4973,6 +4973,11 @@ msgstr ""
 #. Default: "refers to"
 #: components/manage/Contents/ContentsDeleteModal
 msgid "refers to"
+msgstr "Total de resultados"
+
+#. Default: "Result count"
+#: components/manage/Contents/Contents
+msgid "resultCount"
 msgstr ""
 
 #. Default: "results"

--- a/packages/volto/locales/pt_BR/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/pt_BR/LC_MESSAGES/volto.po
@@ -4976,6 +4976,11 @@ msgstr "referências"
 msgid "refers to"
 msgstr "refere-se a"
 
+#. Default: "Result count"
+#: components/manage/Contents/Contents
+msgid "resultCount"
+msgstr "Total de resultados"
+
 #. Default: "results"
 #: components/theme/Search/Search
 msgid "results found"

--- a/packages/volto/locales/ro/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ro/LC_MESSAGES/volto.po
@@ -4976,6 +4976,11 @@ msgstr "referințe"
 msgid "refers to"
 msgstr ""
 
+#. Default: "Result count"
+#: components/manage/Contents/Contents
+msgid "resultCount"
+msgstr ""
+
 #. Default: "results"
 #: components/theme/Search/Search
 msgid "results found"

--- a/packages/volto/locales/ru/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ru/LC_MESSAGES/volto.po
@@ -4975,6 +4975,11 @@ msgstr "ссылки"
 msgid "refers to"
 msgstr "ссылается на"
 
+#. Default: "Result count"
+#: components/manage/Contents/Contents
+msgid "resultCount"
+msgstr ""
+
 #. Default: "results"
 #: components/theme/Search/Search
 msgid "results found"

--- a/packages/volto/locales/volto.pot
+++ b/packages/volto/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2025-09-10T17:55:27.539Z\n"
+"POT-Creation-Date: 2025-09-15T08:48:33.741Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Content-Type: text/plain; charset=utf-8\n"
@@ -4970,6 +4970,11 @@ msgstr ""
 #. Default: "refers to"
 #: components/manage/Contents/ContentsDeleteModal
 msgid "refers to"
+msgstr ""
+
+#. Default: "Result count"
+#: components/manage/Contents/Contents
+msgid "resultCount"
 msgstr ""
 
 #. Default: "results"

--- a/packages/volto/locales/zh_CN/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/zh_CN/LC_MESSAGES/volto.po
@@ -4976,6 +4976,11 @@ msgstr ""
 msgid "refers to"
 msgstr ""
 
+#. Default: "Result count"
+#: components/manage/Contents/Contents
+msgid "resultCount"
+msgstr ""
+
 #. Default: "results"
 #: components/theme/Search/Search
 msgid "results found"

--- a/packages/volto/src/components/manage/Contents/Contents.jsx
+++ b/packages/volto/src/components/manage/Contents/Contents.jsx
@@ -264,6 +264,10 @@ const messages = defineMessages({
     id: 'All',
     defaultMessage: 'All',
   },
+  resultCount: {
+    id: 'resultCount',
+    defaultMessage: 'Result count',
+  },
 });
 
 /**
@@ -1218,8 +1222,9 @@ class Contents extends Component {
                                 as={Button}
                                 onClick={this.upload}
                                 className="upload"
+                                aria-controls="contents-table-wrapper"
                                 aria-label={this.props.intl.formatMessage(
-                                  messages.upload,
+                                  messages.filter,
                                 )}
                               >
                                 <Icon
@@ -1551,7 +1556,20 @@ class Contents extends Component {
                           </Dropdown.Menu>
                         </Dropdown>
                       </Segment>
-                      <div className="contents-table-wrapper">
+                      <div
+                        id="contents-table-wrapper"
+                        className="contents-table-wrapper"
+                        role="region"
+                      >
+                        <span
+                          aria-live="polite"
+                          className="search-feedback"
+                          role="status"
+                        >
+                          {`${this.props.intl.formatMessage(
+                            messages.resultCount,
+                          )}: ${this.props.total || 0}`}
+                        </span>
                         <Table selectable compact singleLine attached>
                           <Table.Header>
                             <Table.Row>

--- a/packages/volto/src/components/manage/Contents/__snapshots__/Contents.test.jsx.snap
+++ b/packages/volto/src/components/manage/Contents/__snapshots__/Contents.test.jsx.snap
@@ -45,7 +45,8 @@ exports[`Contents > renders a folder contents view component 1`] = `
                   class="menu top-menu-menu"
                 >
                   <button
-                    aria-label="Upload"
+                    aria-controls="contents-table-wrapper"
+                    aria-label="Filter…"
                     class="ui button icon item upload"
                   >
                     <svg
@@ -744,7 +745,16 @@ exports[`Contents > renders a folder contents view component 1`] = `
               </div>
               <div
                 class="contents-table-wrapper"
+                id="contents-table-wrapper"
+                role="region"
               >
+                <span
+                  aria-live="polite"
+                  class="search-feedback"
+                  role="status"
+                >
+                  Result count: 1
+                </span>
                 <table
                   class="ui selectable single line attached compact table"
                 >

--- a/packages/volto/theme/themes/pastanaga/extras/contents.less
+++ b/packages/volto/theme/themes/pastanaga/extras/contents.less
@@ -107,6 +107,18 @@
       top: auto;
       bottom: 100%;
     }
+
+    .search-feedback {
+      position: absolute;
+      overflow: hidden;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      border: 0;
+      margin: -1px;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+    }
   }
 
   .ui.table .icon-align,


### PR DESCRIPTION
PR for main based on 18.x.x changes: https://github.com/plone/volto/pull/7305

Update folder content search input to announce result count for screen readers on search or input change.

<img width="1458" height="737" alt="Screenshot 2025-09-02 at 08 56 37" src="https://github.com/user-attachments/assets/39a9f854-240d-4915-a08e-643eadd2d624" />

Video:
https://github.com/user-attachments/assets/e35e5a7d-84e7-4301-a877-0c60093a45ac

**FYI: This modification is needed in volto 17 and 18 too, a cherry-pick is needed**