### PR TITLE
Update 3_PLIP.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/3_PLIP.md
+++ b/.github/ISSUE_TEMPLATE/3_PLIP.md
@@ -1,6 +1,6 @@
 ---
 name: '🚀 PLIP'
-about: 'A Plone Improvement Proposal (PLIP) is a change to a Plone package that would affect everyone who uses that package.'
+about: 'A Plone Improvement Proposal (PLIP) is a larger change to Plone, usually affecting multiple packages, and which goes through a formal process.'
 title: ''
 labels: '03 type: feature (plip)'
 type: 'PLIP'


### PR DESCRIPTION
Remove redundant instruction which is now done automatically under `labels`

See also https://github.com/plone/Products.CMFPlone/pull/4221

I don't think a change log is necessary for this one and would add noise, but if I must, I will do so.