### PR TITLE
Add sphinx-reredirects to docs requirements-docs.txt to support moved…

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -5,6 +5,7 @@ plone-sphinx-theme<2
 sphinx-autobuild
 sphinx-copybutton
 sphinx-examples
+sphinx-reredirects
 sphinxcontrib-video
 sphinxcontrib-youtube
 sphinxext-opengraph


### PR DESCRIPTION
… files.

This also syncs up with `seven` branch, so when building docs locally, this requirement is no longer missing.