### PR TITLE
Ensure the Refresh Content button correctly loads the preview image w…

### DIFF
--- a/packages/volto/news/+preview_image_link.bugfix
+++ b/packages/volto/news/+preview_image_link.bugfix
@@ -1,0 +1,1 @@
+Ensure the Refresh Content button correctly loads the preview image when using preview_image_link for Teaser block. @iFlameing

--- a/packages/volto/src/components/manage/Blocks/Teaser/Data.jsx
+++ b/packages/volto/src/components/manage/Blocks/Teaser/Data.jsx
@@ -74,12 +74,14 @@ const TeaserData = (props) => {
       image_scales: {
         preview_image: [resp?.preview_image],
         image: [resp?.image],
-        preview_image_link: [
-          {
-            ...resp?.preview_image_link?.['image_scales']?.image?.[0],
-            base_path: resp?.preview_image_link?.['@id'],
-          },
-        ],
+        preview_image_link: resp?.preview_image_link
+          ? [
+              {
+                ...resp?.preview_image_link?.['image_scales']?.image?.[0],
+                base_path: resp?.preview_image_link?.['@id'],
+              },
+            ]
+          : [],
       },
       title: resp.title,
     };

--- a/packages/volto/src/components/manage/Blocks/Teaser/Data.jsx
+++ b/packages/volto/src/components/manage/Blocks/Teaser/Data.jsx
@@ -29,6 +29,16 @@ const messages = defineMessages({
   },
 });
 
+function getImageField(resp) {
+  if (!resp) return null;
+
+  if (resp.preview_image_link) return 'preview_image_link';
+  if (resp.preview_image) return 'preview_image';
+  if (resp.image) return 'image';
+
+  return null;
+}
+
 const TeaserData = (props) => {
   const {
     block,
@@ -58,16 +68,18 @@ const TeaserData = (props) => {
       '@type': resp?.['@type'],
       Description: resp?.description,
       Title: resp.title,
-      hasPreviewImage: resp?.preview_image ? true : false,
+      hasPreviewImage: getImageField(resp) ? true : false,
       head_title: resp.head_title ?? null,
-      image_field: resp?.preview_image
-        ? 'preview_image'
-        : resp?.image
-          ? 'image'
-          : null,
+      image_field: getImageField(resp),
       image_scales: {
         preview_image: [resp?.preview_image],
         image: [resp?.image],
+        preview_image_link: [
+          {
+            ...resp?.preview_image_link?.['image_scales']?.image?.[0],
+            base_path: resp?.preview_image_link?.['@id'],
+          },
+        ],
       },
       title: resp.title,
     };


### PR DESCRIPTION
…hen using preview_image_link for Teaser block.

> [!CAUTION]
The Volto Team has suspended its review of new pull requests from first-time contributors until the [release of Plone 7](https://plone.org/download/release-schedule), which is preliminarily scheduled for the second quarter of 2026.
> [Read details](https://6.docs.plone.org/volto/contributing/index.html).

-----

- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't other open [pull requests](https://github.com/plone/volto/pulls) for the same change.
- [x] I followed the guidelines in [Contributing to Volto](https://6.docs.plone.org/volto/contributing/index.html).
- [x] I successfully ran [code linting checks](https://6.docs.plone.org/volto/contributing/linting.html) on my changes locally.
- [x] I successfully ran [unit tests](https://6.docs.plone.org/volto/contributing/testing.html) on my changes locally.
- [x] I successfully ran [acceptance tests](https://6.docs.plone.org/volto/contributing/acceptance-tests.html) on my changes locally.
- [ ] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/volto/contributing/documentation.html#narrative-documentation) for my changes, either in the Storybook or narrative documentation.
- [ ] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

If your pull request closes an open issue, include the exact text below, immediately followed by the issue number. When your pull request gets merged, then that issue will close automatically.

Closes #

-----

If your pull request includes changes to the documentation—either in narrative documentation, Storybook, or configuration—then a pull request preview will be generated and a link will populate in the description of your pull request below.
By clicking that link, you can use the visual diff menu in the upper right corner to navigate to pages that have changes, then display the diff by checking the `Show diff` checkbox.
