### PR TITLE
Revert #7389 ESlint rule definition

### DIFF
--- a/packages/volto/.eslintrc
+++ b/packages/volto/.eslintrc
@@ -37,13 +37,6 @@
     "react-hooks/exhaustive-deps": "warn",
     "react/react-in-jsx-scope": "off",
     "jsx-a11y/label-has-associated-control": "off",
-    "no-restricted-syntax": [
-      "error",
-      {
-        "selector": "JSXElement[openingElement.name.name='img']",
-        "message": "Use the Image component from '@plone/volto/components/theme/Image/Image' instead of <img> tag."
-      }
-    ]
   },
   "settings": {
     "import/resolver": {
@@ -82,19 +75,6 @@
         "import/no-anonymous-default-export": "off",
       },
     },
-    {
-      "files": [
-        "**/Image/Image.jsx", 
-        "**/Image/Image.js",
-        "**/*.stories.js",
-        "**/*.stories.jsx", 
-        "**/*.test.js",
-        "**/*.test.jsx"
-      ],
-      "rules": {
-        "no-restricted-syntax": "off"
-      }
-    }
   ],
   "globals": {
     "root": true,
@@ -111,7 +91,7 @@
     "jest": true,
     "socket": true,
     "webpackIsomorphicTools": true,
-    "vitest":true,
-    "vi":true
+    "vitest": true,
+    "vi": true,
   },
 }

--- a/packages/volto/.eslintrc.core.js
+++ b/packages/volto/.eslintrc.core.js
@@ -35,6 +35,14 @@ if (process.env.VOLTOCONFIG) {
           "Importing directly from `lodash` is not allowed. Please use `import <helper> from 'lodash/<helper>'` instead.",
       },
     ],
+    'no-restricted-syntax': [
+      'warn',
+      {
+        selector: "JSXElement[openingElement.name.name='img']",
+        message:
+          "Use the Image component from '@plone/volto/components/theme/Image/Image' instead of <img> tag.",
+      },
+    ],
   };
 }
 

--- a/packages/volto/news/7401.bugfix
+++ b/packages/volto/news/7401.bugfix
@@ -1,0 +1,1 @@
+Revert #7389 ESlint rule definition. @sneridagh

--- a/packages/volto/src/components/theme/Image/Image.jsx
+++ b/packages/volto/src/components/theme/Image/Image.jsx
@@ -82,6 +82,7 @@ export default function Image({
     attrs.fetchpriority = 'high';
   }
 
+  // eslint-disable-next-line no-restricted-syntax
   return <img {...attrs} alt={alt} {...imageProps} />;
 }
 


### PR DESCRIPTION
Since it was a breaking change.

I added it to `.eslintrc.core.js` so it's still enforced in core.