### PR TITLE
Add cypress test for refresh source content Teaser Block

### DIFF
--- a/packages/volto/cypress/tests/core/blocks/blocks-teaser.js
+++ b/packages/volto/cypress/tests/core/blocks/blocks-teaser.js
@@ -154,4 +154,33 @@ context('Blocks Acceptance Tests', () => {
       );
     cy.get('.block.teaser .content h2').contains('Blue Orchids');
   });
+
+  it('As editor I can refresh Teaser block source content', () => {
+    cy.navigate('/document/edit');
+    // WHEN I create a Teaser block and change the data of the referenced object
+    cy.get('.block .slate-editor [contenteditable=true]').click();
+    cy.get('.button .block-add-button').click({ force: true });
+    cy.get('.blocks-chooser .mostUsed .button.teaser')
+      .contains('Teaser')
+      .click({ force: true });
+    cy.get(
+      '.objectbrowser-field[aria-labelledby="fieldset-default-field-label-href"] button[aria-label="Open object browser"]',
+    ).click();
+    cy.get('[aria-label="Select Blue Orchids"]').dblclick();
+    cy.wait(500);
+    cy.get('input[name="field-overwrite"]').check({ force: true });
+    cy.get(
+      '.objectbrowser-field[aria-labelledby="fieldset-default-field-label-preview_image"]',
+    )
+      .click()
+      .type(
+        `https://github.com/plone/volto/raw/main/logos/volto-colorful.png{enter}`,
+      );
+    cy.get('.buttons.refresh.teaser').click();
+    cy.get('#toolbar-save').click();
+    cy.get('.image-wrapper > img')
+      .should('have.attr', 'src')
+      .and('include', '/preview-image/@@images/image-');
+    cy.get('.block.teaser .content h2').contains('Blue Orchids');
+  });
 });

--- a/packages/volto/news/+teaserRefreshCypress.internal
+++ b/packages/volto/news/+teaserRefreshCypress.internal
@@ -1,0 +1,1 @@
+Acceptance test for Teaser Block Refresh Source Content @Tishasoumya-02


### PR DESCRIPTION
> [!CAUTION]
The Volto Team has suspended its review of new pull requests from first-time contributors until the [release of Plone 7](https://plone.org/download/release-schedule), which is preliminarily scheduled for the second quarter of 2026.
> [Read details](https://6.docs.plone.org/volto/contributing/index.html).

-----

- [ ] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [ ] I verified there aren't other open [pull requests](https://github.com/plone/volto/pulls) for the same change.
- [ ] I followed the guidelines in [Contributing to Volto](https://6.docs.plone.org/volto/contributing/index.html).
- [ ] I successfully ran [code linting checks](https://6.docs.plone.org/volto/contributing/linting.html) on my changes locally.
- [ ] I successfully ran [unit tests](https://6.docs.plone.org/volto/contributing/testing.html) on my changes locally.
- [ ] I successfully ran [acceptance tests](https://6.docs.plone.org/volto/contributing/acceptance-tests.html) on my changes locally.
- [ ] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/volto/contributing/documentation.html#narrative-documentation) for my changes, either in the Storybook or narrative documentation.
- [ ] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

If your pull request closes an open issue, include the exact text below, immediately followed by the issue number. When your pull request gets merged, then that issue will close automatically.

Closes #

-----

If your pull request includes changes to the documentation—either in narrative documentation, Storybook, or configuration—then a pull request preview will be generated and a link will populate in the description of your pull request below.
By clicking that link, you can use the visual diff menu in the upper right corner to navigate to pages that have changes, then display the diff by checking the `Show diff` checkbox.
