### PR TITLE
Add underline to formtabs items for proper link identification

### DIFF
--- a/packages/volto/theme/themes/pastanaga/extras/main.less
+++ b/packages/volto/theme/themes/pastanaga/extras/main.less
@@ -445,6 +445,17 @@ fieldset.invisible {
   margin: 0;
 }
 
+// Form tabs content types
+.menu.formtabs {
+  .item:not(.active) {
+    text-decoration: underline;
+
+    &:hover {
+      text-decoration: none;
+    }
+  }
+}
+
 .vertical-form {
   .ui.grid.stackable {
     .stretched.nine.wide.column {


### PR DESCRIPTION
Add underline to links in content type's - menu formtabs

Links in content types with multiple tabs now have proper visual identification with an underline.
The change was applied directly in Volto’s CSS, as the Semantic UI <Tab> component does not allow direct customization for that.

**Important: Cherry-pick required for V18 and V17**

<img width="1183" height="399" alt="Screenshot 2025-09-29 at 14 36 15" src="https://github.com/user-attachments/assets/d98272ad-c8c3-44dc-80ba-e0ce06c893b9" />
