### PR TITLE
fix: removed auto-open

### DIFF
--- a/packages/volto/src/components/manage/Widgets/ObjectBrowserWidget.jsx
+++ b/packages/volto/src/components/manage/Widgets/ObjectBrowserWidget.jsx
@@ -147,6 +147,7 @@ export class ObjectBrowserWidgetComponent extends Component {
                   className="right"
                   onClick={(event) => {
                     event.preventDefault();
+                    event.stopPropagation();
                     this.removeItem(item);
                   }}
                 />
@@ -323,10 +324,26 @@ export class ObjectBrowserWidgetComponent extends Component {
       return;
     }
 
+    const selected = this.selectedItemsRef.current;
+    const placeholder = this.placeholderRef.current;
+
+    if (!selected) return;
+
     if (
-      e.target.contains(this.selectedItemsRef.current) ||
-      e.target.contains(this.placeholderRef.current)
+      selected === e.target ||
+      selected.contains(e.target) ||
+      (placeholder &&
+        (placeholder === e.target || placeholder.contains(e.target)))
     ) {
+      this.showObjectBrowser(e);
+    }
+  };
+
+  handleSelectedItemsKeyDown = (e) => {
+    if (this.props.isDisabled) return;
+
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
       this.showObjectBrowser(e);
     }
   };
@@ -368,7 +385,7 @@ export class ObjectBrowserWidgetComponent extends Component {
           <div
             className="selected-values"
             onClick={this.handleSelectedItemsRefClick}
-            onKeyDown={this.handleSelectedItemsRefClick}
+            onKeyDown={this.handleSelectedItemsKeyDown}
             role="searchbox"
             tabIndex={0}
             ref={this.selectedItemsRef}


### PR DESCRIPTION
> [!CAUTION]
The Volto Team has suspended its review of new pull requests from first-time contributors until the [release of Plone 7](https://plone.org/download/release-schedule), which is preliminarily scheduled for the second quarter of 2026.
> [Read details](https://6.docs.plone.org/volto/contributing/index.html).

-----

- [ ] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [ ] I verified there aren't other open [pull requests](https://github.com/plone/volto/pulls) for the same change.
- [ ] I followed the guidelines in [Contributing to Volto](https://6.docs.plone.org/volto/contributing/index.html).
- [ ] I successfully ran [code linting checks](https://6.docs.plone.org/volto/contributing/linting.html) on my changes locally.
- [ ] I successfully ran [unit tests](https://6.docs.plone.org/volto/contributing/testing.html) on my changes locally.
- [ ] I successfully ran [acceptance tests](https://6.docs.plone.org/volto/contributing/acceptance-tests.html) on my changes locally.
- [ ] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/volto/contributing/documentation.html#narrative-documentation) for my changes, either in the Storybook or narrative documentation.
- [ ] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

If your pull request closes an open issue, include the exact text below, immediately followed by the issue number. When your pull request gets merged, then that issue will close automatically.

Closes #

-----

If your pull request includes changes to the documentation—either in narrative documentation, Storybook, or configuration—then a pull request preview will be generated and a link will populate in the description of your pull request below.
By clicking that link, you can use the visual diff menu in the upper right corner to navigate to pages that have changes, then display the diff by checking the `Show diff` checkbox.
