### PR TITLE
Fix: adjust README image paths in packages/volto after copy during re…

### DIFF
--- a/packages/volto/.release-it.json
+++ b/packages/volto/.release-it.json
@@ -7,7 +7,7 @@
     "after:bump": [
       "pipx run towncrier build --draft --yes --version ${version} > .changelog.draft",
       "pipx run towncrier build --yes --version ${version}",
-      "cp ../../README.md ./",
+      "cp ../../README.md . && sed -i 's#docs/logos/#../../docs/logos/#g' README.md",
       "make release-notes-copy-to-docs"
     ],
     "after:release": "rm .changelog.draft"

--- a/packages/volto/news/7437.bugfix
+++ b/packages/volto/news/7437.bugfix
@@ -1,0 +1,1 @@
+Adjust README logo paths in packages/volto after copying from top-level README to prevent CI link-check failures. @aryan7081

--- a/packages/volto/src/components/manage/Widgets/RegistryImageWidget.jsx
+++ b/packages/volto/src/components/manage/Widgets/RegistryImageWidget.jsx
@@ -17,25 +17,6 @@ import { toPublicURL } from '@plone/volto/helpers/Url/Url';
 import { validateFileUploadSize } from '@plone/volto/helpers/FormValidation/FormValidation';
 import Image from '@plone/volto/components/theme/Image/Image';
 
-// Safe base64 decoder that works in both browser and Node test environments
-function decodeBase64(base64String) {
-  if (typeof atob === 'function') {
-    return atob(base64String);
-  }
-  try {
-    // Node.js fallback using Buffer when available
-    const NodeBuffer =
-      (typeof global !== 'undefined' && global.Buffer) ||
-      (typeof window !== 'undefined' && window.Buffer);
-    return NodeBuffer
-      ? NodeBuffer.from(base64String, 'base64').toString('utf-8')
-      : '';
-  } catch (e) {
-    // ignore and fall through
-  }
-  return '';
-}
-
 const imageMimetypes = [
   'image/png',
   'image/jpeg',
@@ -100,7 +81,7 @@ const RegistryImageWidget = (props) => {
   const [previewSrc, setPreviewSrc] = useState(() => {
     const fileName = value?.split(';')[0];
     return fileName
-      ? `${toPublicURL('/')}@@site-logo/${decodeBase64(
+      ? `${toPublicURL('/')}@@site-logo/${atob(
           fileName.replace('filenameb64:', ''),
         )}`
       : '';

--- a/packages/volto/src/components/manage/Widgets/RegistryImageWidget.jsx
+++ b/packages/volto/src/components/manage/Widgets/RegistryImageWidget.jsx
@@ -17,6 +17,22 @@ import { toPublicURL } from '@plone/volto/helpers/Url/Url';
 import { validateFileUploadSize } from '@plone/volto/helpers/FormValidation/FormValidation';
 import Image from '@plone/volto/components/theme/Image/Image';
 
+// Safe base64 decoder that works in both browser and Node test environments
+function decodeBase64(base64String) {
+  if (typeof atob === 'function') {
+    return atob(base64String);
+  }
+  try {
+    // Node.js fallback
+    if (typeof Buffer !== 'undefined') {
+      return Buffer.from(base64String, 'base64').toString('utf-8');
+    }
+  } catch (e) {
+    // ignore and fall through
+  }
+  return '';
+}
+
 const imageMimetypes = [
   'image/png',
   'image/jpeg',
@@ -81,7 +97,7 @@ const RegistryImageWidget = (props) => {
   const [previewSrc, setPreviewSrc] = useState(() => {
     const fileName = value?.split(';')[0];
     return fileName
-      ? `${toPublicURL('/')}@@site-logo/${atob(
+      ? `${toPublicURL('/')}@@site-logo/${decodeBase64(
           fileName.replace('filenameb64:', ''),
         )}`
       : '';

--- a/packages/volto/src/components/manage/Widgets/RegistryImageWidget.jsx
+++ b/packages/volto/src/components/manage/Widgets/RegistryImageWidget.jsx
@@ -23,10 +23,13 @@ function decodeBase64(base64String) {
     return atob(base64String);
   }
   try {
-    // Node.js fallback
-    if (typeof Buffer !== 'undefined') {
-      return Buffer.from(base64String, 'base64').toString('utf-8');
-    }
+    // Node.js fallback using Buffer when available
+    const NodeBuffer =
+      (typeof global !== 'undefined' && global.Buffer) ||
+      (typeof window !== 'undefined' && window.Buffer);
+    return NodeBuffer
+      ? NodeBuffer.from(base64String, 'base64').toString('utf-8')
+      : '';
   } catch (e) {
     // ignore and fall through
   }


### PR DESCRIPTION
Fixes [#7437 ](https://github.com/plone/volto/issues/7437)

The release process copies the root README.md into [https://github.com/plone/volto/blob/main/packages/volto/](https://github.com/plone/volto/blob/main/packages/volto/), leaving broken logo image paths `docs/logos/...`

This fix updates the `after: bump `hook in [https://github.com/plone/volto/blob/main/packages/volto/.release-it.json](https://github.com/plone/volto/blob/main/packages/volto/.release-it.json) to run a sed replacement, ensuring the paths become `../../docs/logos/...`, which allows logos to display correctly and the CI link checker to pass.