### PR TITLE
Fix images path in Volto README

### DIFF
--- a/packages/volto/README.md
+++ b/packages/volto/README.md
@@ -1,7 +1,7 @@
 # Volto - the default Plone 6 frontend
 
-<img align="right" width="300" alt="Volto logo png" src="./logos/VoltoLogoEra2.png#gh-light-mode-only" />
-<img align="right" width="300" alt="Volto logo png" src="./logos/VoltoLogoEra2-dark-mode.png#gh-dark-mode-only" />
+<img align="right" width="300" alt="Volto logo png" src="../../logos/VoltoLogoEra2.png#gh-light-mode-only" />
+<img align="right" width="300" alt="Volto logo png" src="../../logos/VoltoLogoEra2-dark-mode.png#gh-dark-mode-only" />
 
 [![NPM](https://img.shields.io/npm/v/@plone/volto.svg)](https://www.npmjs.com/package/@plone/volto)
 [![Unit Tests](https://github.com/plone/volto/actions/workflows/unit.yml/badge.svg)](https://github.com/plone/volto/actions/workflows/unit.yml)


### PR DESCRIPTION
This fix error in readme-link-checker:

https://github.com/plone/volto/actions/runs/18218436492/job/51872790526#step:3:98