### PR TITLE
Add underline to formtabs items for proper link identification (#7419)

### DIFF
--- a/packages/volto/news/7419.bugfix
+++ b/packages/volto/news/7419.bugfix
@@ -1,0 +1,1 @@
+Add underline to formtabs items for proper link identification. @Wagner3UB

--- a/packages/volto/theme/themes/pastanaga/extras/main.less
+++ b/packages/volto/theme/themes/pastanaga/extras/main.less
@@ -442,6 +442,17 @@ fieldset.invisible {
   margin: 0;
 }
 
+// Form tabs content types
+.menu.formtabs {
+  .item:not(.active) {
+    text-decoration: underline;
+
+    &:hover {
+      text-decoration: none;
+    }
+  }
+}
+
 .vertical-form {
   .ui.grid.stackable {
     .stretched.nine.wide.column {


### PR DESCRIPTION
Backport: https://github.com/plone/volto/pull/7419