### PR TITLE
[Seven] Added Brain to image component item types

### DIFF
--- a/packages/layout/components/Image/Image.tsx
+++ b/packages/layout/components/Image/Image.tsx
@@ -5,6 +5,7 @@ import type {
   ContainedItem,
   Content,
   RelatedItem,
+  Brain,
 } from '@plone/types';
 
 function removeObjectIdFromURL(basePath: string, scale: string) {
@@ -31,7 +32,7 @@ export function flattenScales(path: string, image: any) {
 }
 
 export interface ImageProps extends ImgHTMLAttributes<HTMLImageElement> {
-  item?: Content | ContainedItem | RelatedItem;
+  item?: Content | Brain | ContainedItem | RelatedItem;
   imageField?: string;
   src?: string;
   alt: string;

--- a/packages/layout/news/+moreimagetypes.bugfix
+++ b/packages/layout/news/+moreimagetypes.bugfix
@@ -1,0 +1,1 @@
+Added Brain to image component item types. @pnicolli


### PR DESCRIPTION
I forgot to add the Brain type in the last PR :(

<!-- readthedocs-preview volto start -->
----
📚 Documentation preview 📚: https://volto--7474.org.readthedocs.build/

<!-- readthedocs-preview volto end -->

<!-- readthedocs-preview plone-registry start -->
----
📚 Documentation preview 📚: https://plone-registry--7474.org.readthedocs.build/

<!-- readthedocs-preview plone-registry end -->