### PR TITLE
Fix InlineForm to always pass error as array to prevent prop type errors

### DIFF
--- a/packages/volto/news/7267.bugfix
+++ b/packages/volto/news/7267.bugfix
@@ -1,0 +1,1 @@
+Fix `InlineForm` to always pass the error prop as an array, preventing prop type errors in widgets that use `InlineForm`. @alexandreIFB

--- a/packages/volto/src/components/manage/Form/InlineForm.jsx
+++ b/packages/volto/src/components/manage/Form/InlineForm.jsx
@@ -158,7 +158,7 @@ const InlineForm = (props) => {
                 onChangeField(id, value, itemInfo);
               }}
               key={field}
-              error={errors?.[block]?.[field] || {}}
+              error={errors?.[block]?.[field] || []}
               block={block}
             />
           ))}
@@ -199,7 +199,7 @@ const InlineForm = (props) => {
                         onChangeField(id, value);
                       }}
                       key={field}
-                      error={errors?.[block]?.[field] || {}}
+                      error={errors?.[block]?.[field] || []}
                       block={block}
                     />
                   ))}


### PR DESCRIPTION
Backport of #7268 to Volto 18