### PR TITLE
[Seven] Added RSC support to plone components

### DIFF
--- a/packages/components/news/+rsc.feature
+++ b/packages/components/news/+rsc.feature
@@ -1,0 +1,1 @@
+Added RSC compatibility. @pnicolli

--- a/packages/components/tsup.config.ts
+++ b/packages/components/tsup.config.ts
@@ -10,4 +10,9 @@ export default defineConfig({
   dts: true,
   outDir: 'dist',
   clean: true,
+  esbuildOptions(options) {
+    options.banner = {
+      js: '"use client"',
+    };
+  },
 });


### PR DESCRIPTION
This will add a "use client" line at the beginning of all cjs and js files that are generated for `@plone/components`.