### PR TITLE
Fix error and rename test to "should save typed content in the Slate editor"

### DIFF
--- a/packages/volto/cypress/tests/core/volto-slate/02-block-slate.js
+++ b/packages/volto/cypress/tests/core/volto-slate/02-block-slate.js
@@ -3,8 +3,9 @@ import { slateBeforeEach } from '../../../support/helpers';
 describe('Block Tests', () => {
   beforeEach(slateBeforeEach);
 
-  it('should create 4 slate blocks, first 3 with mouse, the last with an Enter in the third block', () => {
-    cy.getSlate().focus().click().type('Hello Slate World').type('{enter}');
+  it('should save typed content in the Slate editor', () => {
+    cy.getSlateEditorAndType('Hello Slate World');
+    cy.getSlateEditorAndType('{enter}');
 
     // Save
     cy.toolbarSave();

--- a/packages/volto/news/7507.internal
+++ b/packages/volto/news/7507.internal
@@ -1,0 +1,1 @@
+Fix error and rename test to "should save typed content in the Slate editor". @wesleybl


### PR DESCRIPTION
Backport of #7507 to Volto 18
