### PR TITLE
Update how-to.md fix-typo in confriguration

### DIFF
--- a/docs/source/configuration/how-to.md
+++ b/docs/source/configuration/how-to.md
@@ -69,7 +69,7 @@ a Volto project.
 
 ## settings
 
-The `settings` object of the configruration registry is a big registry of miscellaneous settings.
+The `settings` object of the configuration registry is a big registry of miscellaneous settings.
 See {doc}`settings-reference` for details.
 
 ## widgets


### PR DESCRIPTION
Fix typo in word `confriguration` for https://6.docs.plone.org/volto/configuration/how-to.html#settings

Typo on page /volto/configuration/how-to.html#settings, typo in word `configruration`
Closes https://github.com/plone/documentation/issues/1979 (alredy closed to reduce noise)



<!-- readthedocs-preview volto start -->
----
📚 Documentation preview 📚: https://volto--7524.org.readthedocs.build/

<!-- readthedocs-preview volto end -->