### PR TITLE
[Seven] fixed layout package styles

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -12,7 +12,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        name: ["@plone/registry", "@plone/components", "@plone/helpers"]
+        name:
+          # - '@plone/blocks'
+          - '@plone/cmsui'
+          - '@plone/components'
+          - '@plone/helpers'
+          - '@plone/layout'
+          - '@plone/react-router'
+          - '@plone/registry'
         node-version: [22.x]
     steps:
       - uses: actions/checkout@v4

--- a/apps/seven/news/+fixnotwstyles.bugfix
+++ b/apps/seven/news/+fixnotwstyles.bugfix
@@ -1,0 +1,1 @@
+Fixed styles when the main theme is tailwind-based. @pnicolli

--- a/packages/layout/blocks/BlockWrapper.tsx
+++ b/packages/layout/blocks/BlockWrapper.tsx
@@ -18,14 +18,10 @@ const BlockWrapper = (props: BlockWrapperProps) => {
   return (
     <div
       className={cx(
-        `
-          block
-          block-${data['@type']}
-        `,
+        'block',
+        'block-' + data['@type'],
         {
-          [`
-            category-${category}
-          `]: category,
+          ['category-' + category]: category,
         },
         classNames,
       )}

--- a/packages/layout/components/Sitemap/Sitemap.tsx
+++ b/packages/layout/components/Sitemap/Sitemap.tsx
@@ -1,4 +1,4 @@
-import { Link } from '@plone/components/quanta';
+import { Link } from '@plone/components';
 
 // TODO translations
 

--- a/packages/layout/news/+fixnotwstyles.bugfix
+++ b/packages/layout/news/+fixnotwstyles.bugfix
@@ -1,0 +1,1 @@
+Fixed styles when the main theme is tailwind-based. @pnicolli

--- a/packages/layout/styles/content-area.css
+++ b/packages/layout/styles/content-area.css
@@ -1,0 +1,93 @@
+main {
+  grid-area: 'content';
+}
+
+.content-area {
+  container-name: content;
+  container-type: inline-size;
+
+  /* Blocks spatial relationships */
+  /* TODO: Unify with below definition block */
+  & > .block {
+    max-width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    background: var(--background);
+    color: var(--foreground);
+  }
+
+  /* Category text */
+  .category-text {
+    --block-width: var(--narrow-container-width);
+  }
+
+  /* Category separator */
+  .category-separator {
+    --block-bottom-spacing: 0;
+  }
+  .block:has(+ .category-separator) {
+    --block-bottom-spacing: 0;
+  }
+
+  /* Category heading */
+  .category-heading {
+    --block-width: var(--default-container-width);
+    --block-bottom-spacing: calc(var(--spacing) * 14);
+  }
+
+  /* Category action */
+  .category-action {
+    --block-bottom-spacing: calc(var(--spacing) * 8);
+  }
+
+  .block {
+    & .block-inner-container {
+      display: grid;
+      width: 100%;
+      max-width: var(--block-width, var(--default-container-width));
+      align-items: var(--align-items, center);
+      padding-bottom: var(--block-bottom-spacing, calc(var(--spacing) * 3));
+      margin: 0 auto;
+      grid-auto-flow: var(--grid-auto-flow, row);
+      justify-items: var(--justify-items, start);
+    }
+
+    &.layout {
+      --block-width: var(--layout-container-width);
+    }
+
+    &.default {
+      --block-width: var(--default-container-width);
+    }
+
+    &.narrow {
+      --block-width: var(--narrow-container-width);
+    }
+  }
+}
+
+/* Blocks & Inner containers */
+
+[class*='section'] {
+  & .section-inner-container {
+    display: grid;
+    width: 100%;
+    max-width: var(--block-width, 100%);
+    align-items: var(--align-items, center);
+    margin: 0 auto;
+    grid-auto-flow: var(--grid-auto-flow, row);
+    justify-items: var(--justify-items, start);
+  }
+
+  &.layout {
+    --block-width: var(--layout-container-width);
+  }
+
+  &.default {
+    --block-width: var(--default-container-width);
+  }
+
+  &.narrow {
+    --block-width: var(--narrow-container-width);
+  }
+}

--- a/packages/layout/styles/footer.css
+++ b/packages/layout/styles/footer.css
@@ -1,0 +1,18 @@
+#footer {
+  container-name: footer;
+  container-type: inline-size;
+}
+
+.section-footer {
+  &.main-footer {
+    --justify-items: center;
+    .block-inner-container {
+      grid-auto-flow: row;
+      text-align: center;
+
+      .powered-by {
+        place-self: center;
+      }
+    }
+  }
+}

--- a/packages/layout/styles/header.css
+++ b/packages/layout/styles/header.css
@@ -1,0 +1,56 @@
+#header {
+  container-name: header;
+  container-type: inline-size;
+}
+
+.section-header {
+  .section-inner-container {
+    align-items: center;
+    grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+
+    /* Place the three direct children: logo, navigation, tools */
+    > :nth-child(1) {
+      /* logo slot */
+      grid-column: 1;
+      justify-self: start;
+    }
+    > :nth-child(2) {
+      /* navigation slot */
+      grid-column: 2;
+      justify-self: center; /* ensure centering within the middle column */
+    }
+    > :nth-child(3) {
+      /* tools wrapper */
+      display: inline-flex;
+      gap: 0.5rem;
+      grid-column: 3;
+      justify-self: end;
+    }
+  }
+
+  &.header-logo-nav-tools-wrapper {
+    --grid-auto-flow: column;
+
+    .navigation {
+      display: inline-flex;
+      align-items: center;
+      align-self: center;
+      justify-content: center;
+      justify-self: center;
+    }
+  }
+
+  &.breadcrumbs {
+    ol {
+      display: grid;
+      gap: 0.5rem;
+      grid-auto-flow: column;
+      list-style-type: none;
+
+      li {
+        display: flex;
+        align-items: end;
+      }
+    }
+  }
+}

--- a/packages/layout/styles/publicui.css
+++ b/packages/layout/styles/publicui.css
@@ -1,3 +1,8 @@
+@import '@plone/components/src/styles/basic/icons.css';
+@import '@plone/components/src/styles/basic/Link.css';
+@import '@plone/components/src/styles/basic/Breadcrumbs.css';
+@import '@plone/components/src/styles/basic/Container.css';
+
 @layer custom {
   :root {
     @property --block-width {
@@ -13,185 +18,11 @@
     }
   }
 
-  main {
-    grid-area: 'content';
-  }
-
-  .content-area {
-    /* Blocks spatial relationships */
-    /* TODO: Unify with below definition block */
-    & > .block {
-      max-width: 100%;
-      margin-right: auto;
-      margin-left: auto;
-      background: var(--background);
-      color: var(--foreground);
-    }
-
-    /* Category text */
-    .category-text {
-      --block-width: var(--narrow-container-width);
-    }
-
-    /* Category separator */
-    .category-separator {
-      --block-bottom-spacing: 0;
-    }
-    .block:has(+ .category-separator) {
-      --block-bottom-spacing: 0;
-    }
-
-    /* Category heading */
-    .category-heading {
-      --block-width: var(--default-container-width);
-      --block-bottom-spacing: calc(var(--spacing) * 14);
-    }
-
-    /* Category action */
-    .category-action {
-      --block-bottom-spacing: calc(var(--spacing) * 8);
-    }
-  }
+  @import './header.css';
+  @import './content-area.css';
+  @import './footer.css';
 
   figure img {
     width: 100%;
-  }
-
-  /* Container Query Contexts */
-  #header,
-  #footer,
-  .content-area {
-    container-type: inline-size;
-  }
-
-  #header {
-    container-name: header;
-  }
-
-  #footer {
-    container-name: footer;
-  }
-
-  .content-area {
-    container-name: content;
-  }
-
-  /* Blocks & Inner containers */
-
-  [class*='section'] {
-    & .section-inner-container {
-      display: grid;
-      width: 100%;
-      max-width: var(--block-width, 100%);
-      align-items: var(--align-items, center);
-      margin: 0 auto;
-      grid-auto-flow: var(--grid-auto-flow, row);
-      justify-items: var(--justify-items, start);
-    }
-
-    &.layout {
-      --block-width: var(--layout-container-width);
-    }
-
-    &.default {
-      --block-width: var(--default-container-width);
-    }
-
-    &.narrow {
-      --block-width: var(--narrow-container-width);
-    }
-  }
-
-  .content-area {
-    .block {
-      & .block-inner-container {
-        display: grid;
-        width: 100%;
-        max-width: var(--block-width, var(--default-container-width));
-        align-items: var(--align-items, center);
-        padding-bottom: var(--block-bottom-spacing, calc(var(--spacing) * 3));
-        margin: 0 auto;
-        grid-auto-flow: var(--grid-auto-flow, row);
-        justify-items: var(--justify-items, start);
-      }
-
-      &.layout {
-        --block-width: var(--layout-container-width);
-      }
-
-      &.default {
-        --block-width: var(--default-container-width);
-      }
-
-      &.narrow {
-        --block-width: var(--narrow-container-width);
-      }
-    }
-  }
-
-  .section-header {
-    .section-inner-container {
-      align-items: center;
-      grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
-
-      /* Place the three direct children: logo, navigation, tools */
-      > :nth-child(1) {
-        /* logo slot */
-        grid-column: 1;
-        justify-self: start;
-      }
-      > :nth-child(2) {
-        /* navigation slot */
-        grid-column: 2;
-        justify-self: center; /* ensure centering within the middle column */
-      }
-      > :nth-child(3) {
-        /* tools wrapper */
-        display: inline-flex;
-        gap: 0.5rem;
-        grid-column: 3;
-        justify-self: end;
-      }
-    }
-
-    &.header-logo-nav-tools-wrapper {
-      --grid-auto-flow: column;
-
-      .navigation {
-        display: inline-flex;
-        align-items: center;
-        align-self: center;
-        justify-content: center;
-        justify-self: center;
-      }
-    }
-
-    &.breadcrumbs {
-      ol {
-        display: grid;
-        gap: 0.5rem;
-        grid-auto-flow: column;
-        list-style-type: none;
-
-        li {
-          display: flex;
-          align-items: end;
-        }
-      }
-    }
-  }
-
-  .section-footer {
-    &.main-footer {
-      --justify-items: center;
-      .block-inner-container {
-        grid-auto-flow: row;
-        text-align: center;
-
-        .powered-by {
-          place-self: center;
-        }
-      }
-    }
   }
 }

--- a/packages/layout/views/FileView.tsx
+++ b/packages/layout/views/FileView.tsx
@@ -14,7 +14,7 @@ export default function FileView() {
   const { content } = rootData;
 
   return (
-    <Container className="view-wrapper">
+    <Container width="default">
       <h1 className="documentFirstHeading">{content.title}</h1>
       {content.description && (
         <p className="documentDescription">{content.description}</p>

--- a/packages/layout/views/ImageView.test.tsx
+++ b/packages/layout/views/ImageView.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { axe, toHaveNoViolations } from 'jest-axe';
 import ImageView from './ImageView';
-import { vi } from 'vitest';
+import { vi, expect, it } from 'vitest';
 
 expect.extend(toHaveNoViolations);
 
@@ -13,11 +13,15 @@ vi.mock('react-router', () => ({
   })),
   useRouteLoaderData: vi.fn(() => ({
     content: {
+      '@id': '/image.jpg',
       title: 'My image',
       description: 'That is a nice image.',
       image: {
-        download: 'http://somewhere/image.jpg',
+        download: '/image.jpg/@@images/image.jpg',
         size: 1200000,
+        width: 1920,
+        height: 1080,
+        scales: [],
       },
     },
   })),
@@ -31,7 +35,7 @@ it('ImageView basic test', async () => {
 
   expect(results).toHaveNoViolations();
   const link = screen.getByRole('link');
-  expect(link.getAttribute('href')).toBe('http://somewhere/image.jpg');
+  expect(link.getAttribute('href')).toBe('/image.jpg/@@images/image.jpg');
   const img = link.getElementsByTagName('img')[0];
-  expect(img.getAttribute('src')).toBe('http://somewhere/image.jpg');
+  expect(img.getAttribute('src')).toBe('/image.jpg/@@images/image.jpg');
 });

--- a/packages/theming/news/+fixnotwstyles.bugfix
+++ b/packages/theming/news/+fixnotwstyles.bugfix
@@ -1,0 +1,1 @@
+Fixed styles when the main theme is tailwind-based. @pnicolli

--- a/packages/theming/styles/simple/components.css
+++ b/packages/theming/styles/simple/components.css
@@ -1,0 +1,59 @@
+/* Copied from @plone/components/src/styles/basic/main.css */
+/* commented the ones already imported by @plone/layout */
+/* @import '@plone/components/src/styles/basic/theme.css'; */
+
+/* @import '@plone/components/src/styles/basic/icons.css'; */
+
+/* @import '@plone/components/src/styles/basic/Link.css'; */
+@import '@plone/components/src/styles/basic/Button.css';
+@import '@plone/components/src/styles/basic/ToggleButton.css';
+@import '@plone/components/src/styles/basic/Label.css';
+@import '@plone/components/src/styles/basic/Checkbox.css';
+
+@import '@plone/components/src/styles/basic/TextField.css';
+@import '@plone/components/src/styles/basic/Form.css';
+@import '@plone/components/src/styles/basic/CheckboxGroup.css';
+
+@import '@plone/components/src/styles/basic/ColorSlider.css';
+@import '@plone/components/src/styles/basic/ColorArea.css';
+@import '@plone/components/src/styles/basic/ColorField.css';
+@import '@plone/components/src/styles/basic/ColorSwatch.css';
+@import '@plone/components/src/styles/basic/ColorSwatchPicker.css';
+@import '@plone/components/src/styles/basic/Disclosure.css';
+@import '@plone/components/src/styles/basic/NumberField.css';
+@import '@plone/components/src/styles/basic/RadioGroup.css';
+@import '@plone/components/src/styles/basic/Switch.css';
+@import '@plone/components/src/styles/basic/Slider.css';
+@import '@plone/components/src/styles/basic/Calendar.css';
+@import '@plone/components/src/styles/basic/DateField.css';
+@import '@plone/components/src/styles/basic/RangeCalendar.css';
+@import '@plone/components/src/styles/basic/Meter.css';
+@import '@plone/components/src/styles/basic/ProgressBar.css';
+@import '@plone/components/src/styles/basic/SearchField.css';
+@import '@plone/components/src/styles/basic/TimeField.css';
+
+@import '@plone/components/src/styles/basic/ListBox.css';
+@import '@plone/components/src/styles/basic/GridList.css';
+
+@import '@plone/components/src/styles/basic/Modal.css';
+@import '@plone/components/src/styles/basic/Dialog.css';
+@import '@plone/components/src/styles/basic/Popover.css';
+@import '@plone/components/src/styles/basic/Tabs.css';
+@import '@plone/components/src/styles/basic/TagGroup.css';
+@import '@plone/components/src/styles/basic/Tooltip.css';
+
+@import '@plone/components/src/styles/basic/Menu.css';
+@import '@plone/components/src/styles/basic/Toolbar.css';
+@import '@plone/components/src/styles/basic/Table.css';
+@import '@plone/components/src/styles/basic/DatePicker.css';
+@import '@plone/components/src/styles/basic/DateRangePicker.css';
+@import '@plone/components/src/styles/basic/Select.css';
+@import '@plone/components/src/styles/basic/ComboBox.css';
+@import '@plone/components/src/styles/basic/ColorPicker.css';
+
+/* @import '@plone/components/src/styles/basic/Breadcrumbs.css'; */
+@import '@plone/components/src/styles/basic/BlockToolbar.css';
+@import '@plone/components/src/styles/basic/Tree.css';
+@import '@plone/components/src/styles/basic/Toast.css';
+
+/* @import '@plone/components/src/styles/basic/Container.css'; */

--- a/packages/theming/styles/simple/layout.css
+++ b/packages/theming/styles/simple/layout.css
@@ -1,3 +1,0 @@
-/* body {
-  background-color: red;
-} */

--- a/packages/theming/styles/simple/main.css
+++ b/packages/theming/styles/simple/main.css
@@ -1,6 +1,0 @@
-/* This is the base setup of a theming setup with pure CSS (Tailwind-less) */
-@layer reset, plone-components, layout, addons, theme;
-@import 'reset.css';
-@import 'base.css';
-@import '@plone/components/dist/basic.css';
-@import 'layout.css';

--- a/packages/theming/styles/theme.css
+++ b/packages/theming/styles/theme.css
@@ -1,6 +1,6 @@
 @import './simple/reset.css';
 @import './simple/base.css';
-@import '@plone/components/src/styles/basic/main.css';
+@import './simple/components.css';
 
 :root {
   --background: hsl(0 0% 100%);


### PR DESCRIPTION
Import `@plone/components` styles where the components are used (that is `@plone/layout`). If integrators remove `@plone/layout` then they should provide these same styles or any other that are needed, but this is a super advanced use case that I'm not sure will really happen.

This means these styles will be always loaded but they are also super thin at this time and afaict scoped in a good way.