### PR TITLE
Add a view for the news item content type.

### DIFF
--- a/packages/layout/index.ts
+++ b/packages/layout/index.ts
@@ -5,6 +5,7 @@ import installToast from './config/toast';
 import DefaultView from './views/DefaultView';
 import FileView from './views/FileView';
 import ImageView from './views/ImageView';
+import NewsItemView from './views/NewsItemView';
 
 export default function install(config: ConfigType) {
   // Translation factory
@@ -18,6 +19,7 @@ export default function install(config: ConfigType) {
   config.views.contentTypesViews = {
     File: FileView,
     Image: ImageView,
+    'News Item': NewsItemView,
     ...config.views.contentTypesViews,
   };
   config.views.layoutViews = { ...config.views.layoutViews };

--- a/packages/layout/news/6709.feature
+++ b/packages/layout/news/6709.feature
@@ -1,0 +1,1 @@
+Added News Item content type view @thet

--- a/packages/layout/views/NewsItemView.test.tsx
+++ b/packages/layout/views/NewsItemView.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { vi } from 'vitest';
+import NewsItemView from './NewsItemView';
+
+expect.extend(toHaveNoViolations);
+
+vi.mock('react-router', () => ({
+  useFetcher: vi.fn(() => ({
+    data: { results: { items: [] }, breadcrumbs: { items: [] } },
+    state: 'idle',
+    load: vi.fn(),
+  })),
+  useRouteLoaderData: vi.fn(() => ({
+    content: {
+      title: 'My news item',
+      description: 'This is a news item.',
+    },
+  })),
+}));
+
+it('NewsItemView basic test', async () => {
+  await import('react-router');
+  const { container } = render(<NewsItemView />);
+
+  const results = await axe(container);
+
+  expect(results).toHaveNoViolations();
+  const title = screen.getByRole('heading', { level: 1 });
+  expect(title).toHaveTextContent('My news item');
+  const description = screen.getByText(/This is a news item\./i);
+  expect(description).toBeInTheDocument();
+});

--- a/packages/layout/views/NewsItemView.tsx
+++ b/packages/layout/views/NewsItemView.tsx
@@ -1,6 +1,7 @@
 import config from '@plone/registry';
 import RenderBlocks from '../blocks/RenderBlocks';
 import type { RootLoader } from 'seven/app/root';
+import { Container } from '@plone/components';
 import { hasBlocksData } from '@plone/helpers';
 import { useRouteLoaderData } from 'react-router';
 
@@ -16,7 +17,7 @@ export default function DefaultView() {
   const Image = config.getComponent({ name: 'Image' }).component;
 
   return (
-    <>
+    <Container width="default">
       {content.title && (
         <h1 className="documentFirstHeading">{content.title}</h1>
       )}
@@ -43,6 +44,6 @@ export default function DefaultView() {
           pathname="/"
         />
       )}
-    </>
+    </Container>
   );
 }

--- a/packages/layout/views/NewsItemView.tsx
+++ b/packages/layout/views/NewsItemView.tsx
@@ -1,0 +1,48 @@
+import config from '@plone/registry';
+import RenderBlocks from '../blocks/RenderBlocks';
+import type { RootLoader } from 'seven/app/root';
+import { hasBlocksData } from '@plone/helpers';
+import { useRouteLoaderData } from 'react-router';
+
+export default function DefaultView() {
+  const rootData = useRouteLoaderData<RootLoader>('root');
+
+  if (!rootData) {
+    return null;
+  }
+
+  const { content } = rootData;
+
+  const Image = config.getComponent({ name: 'Image' }).component;
+
+  return (
+    <>
+      {content.title && (
+        <h1 className="documentFirstHeading">{content.title}</h1>
+      )}
+
+      {content.description && (
+        <p className="documentDescription">{content.description}</p>
+      )}
+
+      {content.image && (
+        <Image
+          className="documentImage ui right floated image"
+          alt={content.title}
+          title={content.title}
+          item={content}
+          imageField="image"
+          responsive={true}
+        />
+      )}
+
+      {hasBlocksData(content) && (
+        <RenderBlocks
+          content={content}
+          blocksConfig={config.blocks.blocksConfig}
+          pathname="/"
+        />
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
@pnicolli @sneridagh 
hi, here is the news item view. Sorry to submit this PR not already on saturday.

But I had some troubles with it:

- It seems that the news item view isn't used. I added a news item, added a `<h1>testing</h1>` in `packages/layout/views/NewsItemView.tsx` and that didn't show up. I tried then the same with the image content type view, and this also doesn't show up. Is there something wrong on my local installation or is packages/layout not used yet?

- I tried to run the tests like so:
```bash
thet@thes:/home/_thet/data/dev/plone/volto7$ pnpm test packages/layout/views/NewsItemView.test.tsx 

> plone-frontend@ test /home/_thet/data/dev/plone/volto7
> pnpm --filter seven run test packages/layout/views/NewsItemView.test.tsx


> seven@1.0.0-alpha.0 test /home/_thet/data/dev/plone/volto7/apps/seven
> pnpm exec init-loaders && vitest --coverage packages/layout/views/NewsItemView.test.tsx


 DEV  v3.2.4 /home/_thet/data/dev/plone/volto7/apps/seven
      Coverage enabled with v8

No test files found. You can change the file name pattern by pressing "p"

filter: packages/layout/views/NewsItemView.test.tsx
include: **/*.{test,spec}.?(c|m)[jt]s?(x)
exclude:  **/node_modules/**, **/lib/**

 % Coverage report from v8
----------------------------|---------|----------|---------|---------|-------------------
File                        | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
----------------------------|---------|----------|---------|---------|-------------------
All files                   |       0 |    42.85 |   42.85 |       0 |                   
 seven                      |       0 |        0 |       0 |       0 |                   
  registry.loader.server.js |       0 |        0 |       0 |       0 | 1-24              
 seven/app                  |       0 |       50 |      50 |       0 |                   
  config.server.ts          |       0 |      100 |     100 |       0 | 4-35              
  config.ts                 |       0 |      100 |     100 |       0 | 4-15              
  middleware.server.ts      |       0 |        0 |       0 |       0 | 1-64              
  okroute.tsx               |       0 |        0 |       0 |       0 | 1-5               
  reset-fetcher.tsx         |       0 |        0 |       0 |       0 | 1-7               
  root.tsx                  |       0 |      100 |     100 |       0 | 2-155             
----------------------------|---------|----------|---------|---------|-------------------
```

Also looks like as if my test file wasn't tested.

- I get some unrelated test failure on this PR.





> [!CAUTION]
The Volto Team has suspended its review of new pull requests from first-time contributors until the [release of Plone 7](https://plone.org/download/release-schedule), which is preliminarily scheduled for the second quarter of 2026.
> [Read details](https://6.docs.plone.org/volto/contributing/index.html).

-----

- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't other open [pull requests](https://github.com/plone/volto/pulls) for the same change.
- [x] I followed the guidelines in [Contributing to Volto](https://6.docs.plone.org/volto/contributing/index.html).
- [x] I successfully ran [code linting checks](https://6.docs.plone.org/volto/contributing/linting.html) on my changes locally.
- [ ] I successfully ran [unit tests](https://6.docs.plone.org/volto/contributing/testing.html) on my changes locally.
- [ ] I successfully ran [acceptance tests](https://6.docs.plone.org/volto/contributing/acceptance-tests.html) on my changes locally.
- [x] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/volto/contributing/documentation.html#narrative-documentation) for my changes, either in the Storybook or narrative documentation.
- [x] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

If your pull request closes an open issue, include the exact text below, immediately followed by the issue number. When your pull request gets merged, then that issue will close automatically.

Closes #

-----

If your pull request includes changes to the documentation—either in narrative documentation, Storybook, or configuration—then a pull request preview will be generated and a link will populate in the description of your pull request below.
By clicking that link, you can use the visual diff menu in the upper right corner to navigate to pages that have changes, then display the diff by checking the `Show diff` checkbox.
