### PR TITLE
Reset `fieldset.invisible` class definition in order to prevent clashes with other CSS frameworks that might have `invisible` as utility

### DIFF
--- a/packages/volto/news/+reset.fieldset.invisible.bugfix
+++ b/packages/volto/news/+reset.fieldset.invisible.bugfix
@@ -1,0 +1,1 @@
+Reset fieldset.invisible class definition in order to prevent clashes with other CSS frameworks that might have `invisible` as utility. @sneridagh

--- a/packages/volto/theme/themes/pastanaga/extras/main.less
+++ b/packages/volto/theme/themes/pastanaga/extras/main.less
@@ -440,6 +440,10 @@ fieldset.invisible {
   padding: 0;
   border: none;
   margin: 0;
+  // Reset visibility, this 'invisible' is not meant to hide the fieldset
+  // This prevents issues when used along other CSS framworks that might
+  // have this utility class defined (e.g. TailwindCSS)
+  visibility: initial;
 }
 
 .vertical-form {


### PR DESCRIPTION
Backport of #7523 to Volto 18