### PR TITLE
Update CreateTranslation Component

### DIFF
--- a/packages/volto/news/7543.bugfix
+++ b/packages/volto/news/7543.bugfix
@@ -1,0 +1,1 @@
+Get translationObject from the store instead of directly from the response in CreateTranslation component. @rboixaderg

--- a/packages/volto/news/7543.feature
+++ b/packages/volto/news/7543.feature
@@ -1,1 +1,0 @@
-Get translationObject from the store instead of directly from the response in CreateTranslation component. @rboixaderg


### PR DESCRIPTION
This pull request refactors how the translation object is managed in the `CreateTranslation` component to improve state handling and consistency. The main change is switching from local component state to using Redux state via `useSelector`.

@davisagli We need to get the translationObject from the store instead of directly from the response, because in the content reducer we adapt this object, for example by flattening some attributes. In Guillotina, we have some attributes inside an object instead of at the top level of the object.

