### PR TITLE
fix(css-modules): replace literal [local] placeholder in production .…

### DIFF
--- a/packages/volto/news/7587.bugfix
+++ b/packages/volto/news/7587.bugfix
@@ -1,0 +1,1 @@
+Fixes a bug where `[local]` remained literal in class names generated for `.module.less` files in production builds due to a custom `getLocalIdent`; the token is now replaced before calling `interpolateName`.

--- a/packages/volto/webpack-plugins/webpack-less-plugin.js
+++ b/packages/volto/webpack-plugins/webpack-less-plugin.js
@@ -19,7 +19,13 @@ function getLocalIdent(loaderContext, localIdentName, localName, options) {
   // eslint-disable-next-line no-param-reassign
   options.content = `${options.hashPrefix}${relativeResourcePath}\x00${localName}`;
 
-  return interpolateName(loaderContext, localIdentName, options);
+  // css-loader does not post-process localIdentName when a custom getLocalIdent is defined.
+  // Therefore we must manually replace the [local] token before calling interpolateName.
+  const finalLocalIdentName = localIdentName.includes('[local]')
+    ? localIdentName.replace(/\[local\]/g, localName)
+    : localIdentName;
+
+  return interpolateName(loaderContext, finalLocalIdentName, options);
 }
 
 const hasPostCssConfig = () => {


### PR DESCRIPTION
### Summary
Fix CSS class name generation for `.module.less` files in production builds: the literal `[local]` placeholder was not expanded, producing names like `Component-module__[local]___Abc12`. It is now correctly replaced, yielding `Component-module__container___Abc12`.

### Context / Problem
In production (`dev=false`), the `webpack-less-plugin` provides a custom `getLocalIdent`. When `getLocalIdent` is defined, `css-loader` skips its usual post-processing of `localIdentName`. Our implementation called `interpolateName` directly, which doesn’t know the `[local]` token, leaving it untouched.

Observed:
```
Carousel-module__[local]___KTvpt
```
Expected:
```
Carousel-module__slide___KTvpt
```

It went unnoticed because in development mode (`dev=true`) the custom `getLocalIdent` isn't applied.

### Reproduction Steps
1. Create `Example.module.less`:
   ```less
   .container {
     color: red;
   }
   ```
2. Import in a React component:
   ```jsx
   import styles from './Example.module.less';
   <div className={styles.container}>Test</div>
   ```
3. Run a production build:
   ```
   pnpm --filter @plone/volto build
   ```
4. Inspect generated CSS and find a class with literal `[local]`.
5. In dev mode (`pnpm --filter @plone/volto start`) the name is correct.

### Implemented Solution
In webpack-less-plugin.js, inside `getLocalIdent`:
- Manually replace all `[local]` occurrences with `localName` before calling `interpolateName`.

### Risks / Impact
- Production class names for `.module.less` change (now correct). Any global overrides relying on the buggy literal `[local]` will stop working (expected).
- Hash stability preserved (hash content basis unchanged).


Closes #7587 