### PR TITLE
fix(eslint): calling inside volto addons to fix lints

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,6 @@
 {
   "extends": ["react-app", "prettier", "plugin:jsx-a11y/recommended"],
-  "plugins": ["prettier", "react-hooks", "jsx-a11y"],
+  "plugins": ["prettier", "jsx-a11y"],
   "env": {
     "es6": true,
     "browser": true,

--- a/news/7591.bugfix
+++ b/news/7591.bugfix
@@ -1,0 +1,1 @@
+Removed `react-hooks` plugin from eslint config being duplicated by `eslint-config-react-app`. @ichim-david


### PR DESCRIPTION
Fixes #7591 by removing our reference to react-hooks since it's already loaded by esliint-config-react-app.

Not targeting 18 and main as I have a feeling that pnpm might be smarter.
If any of the core team members ran into this issue I can also make pr's for the main and 18 branch.