### PR TITLE
Backport: Fix flattenScales TypeError for 18.x.x (#7568)

### DIFF
--- a/packages/volto/news/7568.bugfix
+++ b/packages/volto/news/7568.bugfix
@@ -1,0 +1,1 @@
+Fixed a TypeError in `flattenScales` that occurred when `image.scales` was missing. @pratyush07-hub

--- a/packages/volto/src/helpers/Url/Url.js
+++ b/packages/volto/src/helpers/Url/Url.js
@@ -381,6 +381,7 @@ export function flattenScales(path, image) {
   const basePath = image.base_path || path;
   const imageInfo = {
     ...image,
+    scales: image.scales || {},
     download: flattenToAppURL(removeObjectIdFromURL(basePath, image.download)),
   };
 


### PR DESCRIPTION
# Backport PR

This is a backport of [PR #7568](https://github.com/plone/volto/pull/7568) to the `18.x.x` branch.

## Description

Fixed a TypeError in `flattenScales` that occurred when `image.scales` was missing.  
This issue was already fixed in the main branch and is now applied to the 18.x.x branch.

Changes included in this backport:
- `packages/volto/src/helpers/Url/Url.js`  
  - Added `scales: image.scales || {}` to prevent TypeError when `image.scales` is undefined.
- `packages/volto/news/7568.bugfix`  
  - Added news entry:  
    ```
    Fixed a TypeError in `flattenScales` that occurred when `image.scales` was missing. @pratyush07-hub
    ```

---
- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't other open [pull requests](https://github.com/plone/volto/pulls) for the same change.
- [x] I followed the guidelines in [Contributing to Volto](https://6.docs.plone.org/volto/contributing/index.html).
- [x] I successfully ran [code linting checks](https://6.docs.plone.org/volto/contributing/linting.html) on my changes locally.
- [x] I successfully ran [unit tests](https://6.docs.plone.org/volto/contributing/testing.html) on my changes locally.
- [x] I successfully ran [acceptance tests](https://6.docs.plone.org/volto/contributing/acceptance-tests.html) on my changes locally.
- [ ] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/volto/contributing/documentation.html#narrative-documentation) for my changes, either in the Storybook or narrative documentation.
- [x] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

Closes #

-----
