### PR TITLE
Refactor ObjectBrowserWidget: convert class-based component to functional component

### DIFF
--- a/packages/volto/news/7678.internal
+++ b/packages/volto/news/7678.internal
@@ -1,0 +1,1 @@
+Refactored ObjectBrowserWidget from a class-based component to a functional component using React hooks. @Manik-Khajuria-5

--- a/packages/volto/src/components/manage/Widgets/ObjectBrowserWidget.jsx
+++ b/packages/volto/src/components/manage/Widgets/ObjectBrowserWidget.jsx
@@ -3,15 +3,14 @@
  * @module components/manage/Widgets/ObjectBrowserWidget
  */
 
-import React, { Component } from 'react';
+import React, { useState, useRef, useCallback } from 'react';
 import PropTypes from 'prop-types';
-import { compose } from 'redux';
+import { useDispatch } from 'react-redux';
 import compact from 'lodash/compact';
 import includes from 'lodash/includes';
 import isArray from 'lodash/isArray';
 import isEmpty from 'lodash/isEmpty';
 import remove from 'lodash/remove';
-import { connect } from 'react-redux';
 import { Label, Popup, Button } from 'semantic-ui-react';
 import {
   flattenToAppURL,
@@ -22,7 +21,7 @@ import {
 import { urlValidator } from '@plone/volto/helpers/FormValidation/validators';
 import { searchContent } from '@plone/volto/actions/search/search';
 import withObjectBrowser from '@plone/volto/components/manage/Sidebar/ObjectBrowser';
-import { defineMessages, injectIntl } from 'react-intl';
+import { defineMessages, useIntl } from 'react-intl';
 import Icon from '@plone/volto/components/theme/Icon/Icon';
 import FormFieldWrapper from '@plone/volto/components/manage/Widgets/FormFieldWrapper';
 import config from '@plone/volto/registry';
@@ -32,7 +31,7 @@ import clearSVG from '@plone/volto/icons/clear.svg';
 import homeSVG from '@plone/volto/icons/home.svg';
 import aheadSVG from '@plone/volto/icons/ahead.svg';
 import blankSVG from '@plone/volto/icons/blank.svg';
-import { withRouter } from 'react-router';
+import { useLocation } from 'react-router';
 import Image from '@plone/volto/components/theme/Image/Image';
 
 const messages = defineMessages({
@@ -55,65 +54,242 @@ const messages = defineMessages({
 });
 
 /**
- * ObjectBrowserWidget component class.
- * @class ObjectBrowserWidget
- * @extends Component
+ * ObjectBrowserWidget component.
  */
-export class ObjectBrowserWidgetComponent extends Component {
-  /**
-   * Property types.
-   * @property {Object} propTypes Property types.
-   * @static
-   */
-  static propTypes = {
-    id: PropTypes.string.isRequired,
-    title: PropTypes.string.isRequired,
-    description: PropTypes.string,
-    mode: PropTypes.string, // link, image, multiple
-    return: PropTypes.string, // single, multiple
-    initialPath: PropTypes.string,
-    required: PropTypes.bool,
-    error: PropTypes.arrayOf(PropTypes.string),
-    value: PropTypes.oneOfType([
-      PropTypes.arrayOf(PropTypes.object),
-      PropTypes.object,
-    ]),
-    onChange: PropTypes.func.isRequired,
-    openObjectBrowser: PropTypes.func.isRequired,
-    allowExternals: PropTypes.bool,
-    placeholder: PropTypes.string,
-    onlyFolderishSelectable: PropTypes.bool,
-  };
+export const ObjectBrowserWidgetComponent = (props) => {
+  const {
+    id,
+    description,
+    fieldSet,
+    value,
+    mode = 'multiple',
+    return: returnMode = 'multiple',
+    onChange,
+    isDisabled,
+    openObjectBrowser,
+    allowExternals = false,
+    placeholder,
+    widgetOptions,
+    selectedItemAttrs,
+    selectableTypes,
+    maximumSelectionSize,
+    onlyFolderishSelectable = false,
+    initialPath = '',
+    block,
+  } = props;
 
-  /**
-   * Default properties
-   * @property {Object} defaultProps Default properties.
-   * @static
-   */
-  static defaultProps = {
-    description: null,
-    required: false,
-    error: [],
-    value: [],
-    mode: 'multiple',
-    return: 'multiple',
-    initialPath: '',
-    allowExternals: false,
-    onlyFolderishSelectable: false,
-  };
+  const intl = useIntl();
+  const dispatch = useDispatch();
+  const location = useLocation();
 
-  state = {
-    manualLinkInput: '',
-    validURL: false,
-    errors: [],
-  };
+  const [manualLinkInput, setManualLinkInput] = useState('');
+  const [validURL, setValidURL] = useState(false);
+  const [errors, setErrors] = useState([]);
 
-  constructor(props) {
-    super(props);
-    this.selectedItemsRef = React.createRef();
-    this.placeholderRef = React.createRef();
-  }
-  renderLabel(item) {
+  const selectedItemsRef = useRef(null);
+  const placeholderRef = useRef(null);
+
+  const validateManualLink = useCallback(
+    (url) => {
+      if (allowExternals && !url.startsWith('/')) {
+        const error = urlValidator({
+          value: url,
+          formatMessage: intl.formatMessage,
+        });
+        if (error && url !== '') {
+          setErrors([error]);
+        } else {
+          setErrors([]);
+        }
+        return !Boolean(error);
+      } else {
+        return isInternalURL(url);
+      }
+    },
+    [allowExternals, intl.formatMessage],
+  );
+
+  const removeItem = useCallback(
+    (item) => {
+      let newValue = [...value];
+      remove(newValue, function (_item) {
+        return _item['@id'] === item['@id'];
+      });
+      onChange(id, newValue);
+    },
+    [value, onChange, id],
+  );
+
+  const handleChange = useCallback(
+    (item) => {
+      let newValue = mode === 'multiple' && value ? [...value] : [];
+      newValue = newValue.filter((item) => item != null);
+      const maxSize =
+        widgetOptions?.pattern_options?.maximumSelectionSize || -1;
+      if (maxSize === 1 && newValue.length === 1) {
+        newValue = [];
+      }
+      let exists = false;
+      let index = -1;
+      newValue.forEach((_item, _index) => {
+        if (flattenToAppURL(_item['@id']) === flattenToAppURL(item['@id'])) {
+          exists = true;
+          index = _index;
+        }
+      });
+      if (!exists) {
+        let resultantItem = item;
+        if (selectedItemAttrs) {
+          const allowedItemKeys = [...selectedItemAttrs, '@id', 'title'];
+          resultantItem = Object.keys(item)
+            .filter((key) => allowedItemKeys.includes(key))
+            .reduce((obj, key) => {
+              obj[key] = item[key];
+              return obj;
+            }, {});
+        }
+        resultantItem = { ...resultantItem, '@id': item['@id'] };
+        newValue.push(resultantItem);
+        if (returnMode === 'single') {
+          onChange(id, newValue[0]);
+        } else {
+          onChange(id, newValue);
+        }
+      } else {
+        newValue.splice(index, 1);
+        onChange(id, newValue);
+      }
+    },
+    [mode, value, widgetOptions, selectedItemAttrs, returnMode, onChange, id],
+  );
+
+  const onManualLinkInput = useCallback(
+    (e) => {
+      setManualLinkInput(e.target.value);
+      if (validateManualLink(e.target.value)) {
+        setValidURL(true);
+      } else {
+        setValidURL(false);
+      }
+    },
+    [validateManualLink],
+  );
+
+  const onSubmitManualLink = useCallback(() => {
+    if (validateManualLink(manualLinkInput)) {
+      if (isInternalURL(manualLinkInput)) {
+        const link = manualLinkInput;
+        dispatch(
+          searchContent(
+            '/',
+            {
+              'path.query': flattenToAppURL(manualLinkInput),
+              'path.depth': '0',
+              sort_on: 'getObjPositionInParent',
+              metadata_fields: '_all',
+              b_size: 1000,
+            },
+            `${block}-${mode}`,
+          ),
+        ).then((resp) => {
+          if (resp.items?.length > 0) {
+            handleChange(resp.items[0]);
+          } else {
+            onChange(id, [
+              {
+                '@id': flattenToAppURL(link),
+                title: removeProtocol(link),
+              },
+            ]);
+          }
+        });
+      } else {
+        onChange(id, [
+          {
+            '@id': normalizeUrl(manualLinkInput),
+            title: removeProtocol(manualLinkInput),
+          },
+        ]);
+      }
+      setValidURL(true);
+      setManualLinkInput('');
+    }
+  }, [
+    validateManualLink,
+    manualLinkInput,
+    dispatch,
+    block,
+    mode,
+    handleChange,
+    onChange,
+    id,
+  ]);
+
+  const onKeyDownManualLink = useCallback(
+    (e) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        e.stopPropagation();
+        onSubmitManualLink();
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        e.stopPropagation();
+      }
+    },
+    [onSubmitManualLink],
+  );
+
+  const showObjectBrowser = useCallback(
+    (ev) => {
+      ev.preventDefault();
+      openObjectBrowser({
+        mode: mode,
+        currentPath: initialPath || location.pathname,
+        initialPath: initialPath,
+        propDataName: 'value',
+        onSelectItem: (url, item) => {
+          handleChange(item);
+        },
+        selectableTypes:
+          widgetOptions?.pattern_options?.selectableTypes || selectableTypes,
+        maximumSelectionSize:
+          widgetOptions?.pattern_options?.maximumSelectionSize ||
+          maximumSelectionSize,
+        onlyFolderishSelectable:
+          widgetOptions?.pattern_options?.onlyFolderishSelectable ||
+          onlyFolderishSelectable,
+      });
+    },
+    [
+      openObjectBrowser,
+      mode,
+      initialPath,
+      location.pathname,
+      handleChange,
+      widgetOptions,
+      selectableTypes,
+      maximumSelectionSize,
+      onlyFolderishSelectable,
+    ],
+  );
+
+  const handleSelectedItemsRefClick = useCallback(
+    (e) => {
+      if (isDisabled) {
+        return;
+      }
+
+      if (
+        e.target.contains(selectedItemsRef.current) ||
+        e.target.contains(placeholderRef.current)
+      ) {
+        showObjectBrowser(e);
+      }
+    },
+    [isDisabled, showObjectBrowser],
+  );
+
+  const renderLabel = (item) => {
     const href = item['@id'];
     return (
       <Popup
@@ -142,14 +318,14 @@ export class ObjectBrowserWidgetComponent extends Component {
               )}
             </div>
             <div>
-              {this.props.mode === 'multiple' && (
+              {mode === 'multiple' && (
                 <Icon
                   name={clearSVG}
                   size="12px"
                   className="right"
                   onClick={(event) => {
                     event.preventDefault();
-                    this.removeItem(item);
+                    removeItem(item);
                   }}
                 />
               )}
@@ -158,307 +334,137 @@ export class ObjectBrowserWidgetComponent extends Component {
         }
       />
     );
-  }
-
-  removeItem = (item) => {
-    let value = [...this.props.value];
-    remove(value, function (_item) {
-      return _item['@id'] === item['@id'];
-    });
-    this.props.onChange(this.props.id, value);
   };
 
-  onChange = (item) => {
-    let value =
-      this.props.mode === 'multiple' && this.props.value
-        ? [...this.props.value]
-        : [];
-    value = value.filter((item) => item != null);
-    const maxSize =
-      this.props.widgetOptions?.pattern_options?.maximumSelectionSize || -1;
-    if (maxSize === 1 && value.length === 1) {
-      value = []; //enable replace of selected item with another value, if maxsize is 1
-    }
-    let exists = false;
-    let index = -1;
-    value.forEach((_item, _index) => {
-      if (flattenToAppURL(_item['@id']) === flattenToAppURL(item['@id'])) {
-        exists = true;
-        index = _index;
-      }
-    });
-    //find(value, {
-    //   '@id': flattenToAppURL(item['@id']),
-    // });
-    if (!exists) {
-      // add item
-      // Check if we want to filter the attributes of the selected item
-      let resultantItem = item;
-      if (this.props.selectedItemAttrs) {
-        const allowedItemKeys = [
-          ...this.props.selectedItemAttrs,
-          // Add the required attributes for the widget to work
-          '@id',
-          'title',
-        ];
-        resultantItem = Object.keys(item)
-          .filter((key) => allowedItemKeys.includes(key))
-          .reduce((obj, key) => {
-            obj[key] = item[key];
-            return obj;
-          }, {});
-      }
-      // Add required @id field, just in case
-      resultantItem = { ...resultantItem, '@id': item['@id'] };
-      value.push(resultantItem);
-      if (this.props.return === 'single') {
-        this.props.onChange(this.props.id, value[0]);
-      } else {
-        this.props.onChange(this.props.id, value);
-      }
-    } else {
-      //remove item
-      value.splice(index, 1);
-      this.props.onChange(this.props.id, value);
-    }
-  };
+  let items = compact(!isArray(value) && value ? [value] : value || []);
 
-  onManualLinkInput = (e) => {
-    this.setState({ manualLinkInput: e.target.value });
-    if (this.validateManualLink(e.target.value)) {
-      this.setState({ validURL: true });
-    } else {
-      this.setState({ validURL: false });
-    }
-  };
+  let icon = mode === 'multiple' || items.length === 0 ? navTreeSVG : clearSVG;
+  let iconAction =
+    mode === 'multiple' || items.length === 0
+      ? showObjectBrowser
+      : (e) => {
+          e.preventDefault();
+          onChange(id, returnMode === 'single' ? null : []);
+        };
 
-  validateManualLink = (url) => {
-    if (this.props.allowExternals && !url.startsWith('/')) {
-      const error = urlValidator({
-        value: url,
-        formatMessage: this.props.intl.formatMessage,
-      });
-      if (error && url !== '') {
-        this.setState({ errors: [error] });
-      } else {
-        this.setState({ errors: [] });
-      }
-      return !Boolean(error);
-    } else {
-      return isInternalURL(url);
-    }
-  };
-
-  onSubmitManualLink = () => {
-    if (this.validateManualLink(this.state.manualLinkInput)) {
-      if (isInternalURL(this.state.manualLinkInput)) {
-        const link = this.state.manualLinkInput;
-        // convert it into an internal on if possible
-        this.props
-          .searchContent(
-            '/',
-            {
-              'path.query': flattenToAppURL(this.state.manualLinkInput),
-              'path.depth': '0',
-              sort_on: 'getObjPositionInParent',
-              metadata_fields: '_all',
-              b_size: 1000,
-            },
-            `${this.props.block}-${this.props.mode}`,
-          )
-          .then((resp) => {
-            if (resp.items?.length > 0) {
-              this.onChange(resp.items[0]);
-            } else {
-              this.props.onChange(this.props.id, [
-                {
-                  '@id': flattenToAppURL(link),
-                  title: removeProtocol(link),
-                },
-              ]);
-            }
-          });
-      } else {
-        this.props.onChange(this.props.id, [
-          {
-            '@id': normalizeUrl(this.state.manualLinkInput),
-            title: removeProtocol(this.state.manualLinkInput),
-          },
-        ]);
-      }
-      this.setState({ validURL: true, manualLinkInput: '' });
-    }
-  };
-
-  onKeyDownManualLink = (e) => {
-    if (e.key === 'Enter') {
-      e.preventDefault();
-      e.stopPropagation();
-      this.onSubmitManualLink();
-    } else if (e.key === 'Escape') {
-      e.preventDefault();
-      e.stopPropagation();
-      // TODO: Do something on ESC key
-    }
-  };
-
-  showObjectBrowser = (ev) => {
-    ev.preventDefault();
-    this.props.openObjectBrowser({
-      mode: this.props.mode,
-      currentPath: this.props.initialPath || this.props.location.pathname,
-      initialPath: this.props.initialPath,
-      propDataName: 'value',
-      onSelectItem: (url, item) => {
-        this.onChange(item);
-      },
-      selectableTypes:
-        this.props.widgetOptions?.pattern_options?.selectableTypes ||
-        this.props.selectableTypes,
-      maximumSelectionSize:
-        this.props.widgetOptions?.pattern_options?.maximumSelectionSize ||
-        this.props.maximumSelectionSize,
-      onlyFolderishSelectable:
-        this.props.widgetOptions?.pattern_options?.onlyFolderishSelectable ||
-        this.props.onlyFolderishSelectable,
-    });
-  };
-
-  handleSelectedItemsRefClick = (e) => {
-    if (this.props.isDisabled) {
-      return;
-    }
-
-    if (
-      e.target.contains(this.selectedItemsRef.current) ||
-      e.target.contains(this.placeholderRef.current)
-    ) {
-      this.showObjectBrowser(e);
-    }
-  };
-
-  /**
-   * Render method.
-   * @method render
-   * @returns {string} Markup for the component.
-   */
-  render() {
-    const { id, description, fieldSet, value, mode, onChange, isDisabled } =
-      this.props;
-
-    let items = compact(!isArray(value) && value ? [value] : value || []);
-
-    let icon =
-      mode === 'multiple' || items.length === 0 ? navTreeSVG : clearSVG;
-    let iconAction =
-      mode === 'multiple' || items.length === 0
-        ? this.showObjectBrowser
-        : (e) => {
-            e.preventDefault();
-            onChange(id, this.props.return === 'single' ? null : []);
-          };
-
-    return (
-      <FormFieldWrapper
-        {...this.props}
-        // At the moment, OBW handles its own errors and validation
-        error={this.state.errors}
-        className={description ? 'help text' : 'text'}
+  return (
+    <FormFieldWrapper
+      {...props}
+      error={errors}
+      className={description ? 'help text' : 'text'}
+    >
+      <div
+        className="objectbrowser-field"
+        aria-labelledby={`fieldset-${fieldSet || 'default'}-field-label-${id}`}
       >
         <div
-          className="objectbrowser-field"
-          aria-labelledby={`fieldset-${
-            fieldSet || 'default'
-          }-field-label-${id}`}
+          className="selected-values"
+          onClick={handleSelectedItemsRefClick}
+          onKeyDown={handleSelectedItemsRefClick}
+          role="searchbox"
+          tabIndex={0}
+          ref={selectedItemsRef}
         >
-          <div
-            className="selected-values"
-            onClick={this.handleSelectedItemsRefClick}
-            onKeyDown={this.handleSelectedItemsRefClick}
-            role="searchbox"
-            tabIndex={0}
-            ref={this.selectedItemsRef}
-          >
-            {items.map((item) => this.renderLabel(item))}
+          {items.map((item) => renderLabel(item))}
 
-            {items.length === 0 && this.props.mode === 'multiple' && (
-              <div className="placeholder" ref={this.placeholderRef}>
-                {this.props.placeholder ??
-                  this.props.intl.formatMessage(messages.placeholder)}
-              </div>
-            )}
-            {this.props.allowExternals &&
-              items.length === 0 &&
-              this.props.mode !== 'multiple' && (
-                <input
-                  onBlur={this.onSubmitManualLink}
-                  onKeyDown={this.onKeyDownManualLink}
-                  onChange={this.onManualLinkInput}
-                  value={this.state.manualLinkInput}
-                  placeholder={
-                    this.props.placeholder ??
-                    this.props.intl.formatMessage(messages.placeholder)
-                  }
-                />
-              )}
-          </div>
-          {this.state.manualLinkInput && isEmpty(items) && (
-            <Button.Group>
-              <Button
-                type="button"
-                basic
-                className="cancel"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  this.setState({ manualLinkInput: '' });
-                }}
-              >
-                <Icon name={clearSVG} size="18px" color="#e40166" />
-              </Button>
-              <Button
-                type="button"
-                basic
-                primary
-                disabled={!this.state.validURL}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  this.onSubmitManualLink();
-                }}
-              >
-                <Icon name={aheadSVG} size="18px" />
-              </Button>
-            </Button.Group>
+          {items.length === 0 && mode === 'multiple' && (
+            <div className="placeholder" ref={placeholderRef}>
+              {placeholder ?? intl.formatMessage(messages.placeholder)}
+            </div>
           )}
-          {!this.state.manualLinkInput && (
-            <Button
-              type="button"
-              aria-label={this.props.intl.formatMessage(
-                messages.openObjectBrowser,
-              )}
-              onClick={iconAction}
-              className="action"
-              disabled={isDisabled}
-            >
-              <Icon name={icon} size="18px" />
-            </Button>
+          {allowExternals && items.length === 0 && mode !== 'multiple' && (
+            <input
+              onBlur={onSubmitManualLink}
+              onKeyDown={onKeyDownManualLink}
+              onChange={onManualLinkInput}
+              value={manualLinkInput}
+              placeholder={
+                placeholder ?? intl.formatMessage(messages.placeholder)
+              }
+            />
           )}
         </div>
-      </FormFieldWrapper>
-    );
-  }
-}
+        {manualLinkInput && isEmpty(items) && (
+          <Button.Group>
+            <Button
+              type="button"
+              basic
+              className="cancel"
+              onClick={(e) => {
+                e.stopPropagation();
+                setManualLinkInput('');
+              }}
+            >
+              <Icon name={clearSVG} size="18px" color="#e40166" />
+            </Button>
+            <Button
+              type="button"
+              basic
+              primary
+              disabled={!validURL}
+              onClick={(e) => {
+                e.stopPropagation();
+                onSubmitManualLink();
+              }}
+            >
+              <Icon name={aheadSVG} size="18px" />
+            </Button>
+          </Button.Group>
+        )}
+        {!manualLinkInput && (
+          <Button
+            type="button"
+            aria-label={intl.formatMessage(messages.openObjectBrowser)}
+            onClick={iconAction}
+            className="action"
+            disabled={isDisabled}
+          >
+            <Icon name={icon} size="18px" />
+          </Button>
+        )}
+      </div>
+    </FormFieldWrapper>
+  );
+};
 
-const ObjectBrowserWidgetMode = (mode) =>
-  compose(
-    injectIntl,
-    withObjectBrowser,
-    withRouter,
-    connect(null, { searchContent }),
-  )((props) => <ObjectBrowserWidgetComponent {...props} mode={mode} />);
+ObjectBrowserWidgetComponent.propTypes = {
+  id: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+  description: PropTypes.string,
+  mode: PropTypes.string,
+  return: PropTypes.string,
+  initialPath: PropTypes.string,
+  required: PropTypes.bool,
+  error: PropTypes.arrayOf(PropTypes.string),
+  value: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.object),
+    PropTypes.object,
+  ]),
+  onChange: PropTypes.func.isRequired,
+  openObjectBrowser: PropTypes.func.isRequired,
+  allowExternals: PropTypes.bool,
+  placeholder: PropTypes.string,
+  onlyFolderishSelectable: PropTypes.bool,
+};
+
+ObjectBrowserWidgetComponent.defaultProps = {
+  description: null,
+  required: false,
+  error: [],
+  value: [],
+  mode: 'multiple',
+  return: 'multiple',
+  initialPath: '',
+  allowExternals: false,
+  onlyFolderishSelectable: false,
+};
+
+const ObjectBrowserWidgetMode = (mode) => {
+  const WrappedComponent = withObjectBrowser((props) => (
+    <ObjectBrowserWidgetComponent {...props} mode={mode} />
+  ));
+  return WrappedComponent;
+};
+
 export { ObjectBrowserWidgetMode };
-export default compose(
-  injectIntl,
-  withObjectBrowser,
-  withRouter,
-  connect(null, { searchContent }),
-)(ObjectBrowserWidgetComponent);
+export default withObjectBrowser(ObjectBrowserWidgetComponent);


### PR DESCRIPTION
**Issue number**
---
Contributes to — #4460 
---

## **Description**

This PR refactors the `ObjectBrowserWidget` from a class-based component into a modern functional component using React hooks.

-----

- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't other open [pull requests](https://github.com/plone/volto/pulls) for the same change.
- [x] I followed the guidelines in [Contributing to Volto](https://6.docs.plone.org/volto/contributing/index.html).
- [x] I successfully ran [code linting checks](https://6.docs.plone.org/volto/contributing/linting.html) on my changes locally.
- [x] I successfully ran [unit tests](https://6.docs.plone.org/volto/contributing/testing.html) on my changes locally.
- [x] I successfully ran [acceptance tests](https://6.docs.plone.org/volto/contributing/acceptance-tests.html) on my changes locally.
- [ ] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/volto/contributing/documentation.html#narrative-documentation) for my changes, either in the Storybook or narrative documentation.
- [x] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----