### PR TITLE
Hide date/time fields when whole_day or open_end is checked in Event form

### DIFF
--- a/packages/volto/cypress/tests/core/content/content.js
+++ b/packages/volto/cypress/tests/core/content/content.js
@@ -163,6 +163,46 @@ describe('Add Content Tests', () => {
     );
   });
 
+  it('As editor I toggle whole_day and open_end checkboxes and date/time fields disappear', function () {
+    // when I add an Event
+    cy.get('#toolbar-add').click();
+    cy.get('#toolbar-add-event').click();
+    cy.get('#field-title').clear().type('Event checkbox test');
+
+    // then the time fields should be visible initially
+    cy.get('#start-time').should('be.visible');
+    cy.get('#end-time').should('be.visible');
+    cy.get('#end-date').should('be.visible');
+
+    // when I check the whole_day checkbox
+    cy.get('label[for="field-whole_day"]').click({ scrollBehavior: false });
+
+    // then the time fields should disappear
+    cy.get('#start-time').should('not.exist');
+    cy.get('#end-time').should('not.exist');
+
+    // when I uncheck the whole_day checkbox
+    cy.get('label[for="field-whole_day"]').click({ scrollBehavior: false });
+
+    // then the time fields should be visible again
+    cy.get('#start-time').should('be.visible');
+    cy.get('#end-time').should('be.visible');
+
+    // when I check the open_end checkbox
+    cy.get('label[for="field-open_end"]').click({ scrollBehavior: false });
+
+    // then the end-date and end-time fields should disappear
+    cy.get('#end-date').should('not.exist');
+    cy.get('#end-time').should('not.exist');
+
+    // when I uncheck the open_end checkbox
+    cy.get('label[for="field-open_end"]').click({ scrollBehavior: false });
+
+    // then the end-date and end-time fields should be visible again
+    cy.get('#end-date').should('be.visible');
+    cy.get('#end-time').should('be.visible');
+  });
+
   it('As editor I can add a Link (with an external link)', function () {
     cy.intercept('POST', '*').as('saveLink');
     // When I add a link

--- a/packages/volto/news/3243.bugfix
+++ b/packages/volto/news/3243.bugfix
@@ -1,0 +1,1 @@
+Hide date and time fields when either "Whole Day" or "Open End" is checked in the Event form. @wesleybl

--- a/packages/volto/src/components/manage/Widgets/DatetimeWidget.jsx
+++ b/packages/volto/src/components/manage/Widgets/DatetimeWidget.jsx
@@ -84,6 +84,7 @@ const DatetimeWidgetComponent = (props) => {
     widget,
     noPastDates: propNoPastDates,
     isDisabled,
+    formData,
   } = props;
 
   const intl = useIntl();
@@ -106,12 +107,21 @@ const DatetimeWidgetComponent = (props) => {
     );
   }, [value, lang, moment]);
 
+  // If open_end is checked and this is the end field, don't render
+  if (id === 'end' && formData?.open_end) {
+    return null;
+  }
+
   const getInternalValue = () => {
     return parseDateTime(toBackendLang(lang), value, undefined, moment.default);
   };
 
   const getDateOnly = () => {
-    return dateOnly || widget === 'date';
+    return (
+      dateOnly ||
+      widget === 'date' ||
+      ((id === 'start' || id === 'end') && formData?.whole_day)
+    );
   };
 
   const onDateChange = (date) => {


### PR DESCRIPTION
Backport of #7662 to Volto 18.