### PR TITLE
fix: show only error message in toast instead of stringified JSON

### DIFF
--- a/packages/volto/src/components/theme/Login/Login.jsx
+++ b/packages/volto/src/components/theme/Login/Login.jsx
@@ -112,13 +112,11 @@ const Login = (props) => {
         toast.dismiss('loggedOut');
       }
       if (!toast.isActive('loginFailed')) {
-        const errMessage =
-          JSON.parse(error)?.error?.message || JSON.parse(error)?.message || '';
         toast.error(
           <Toast
             error
             title={intl.formatMessage(messages.loginFailed)}
-            content={errMessage}
+            content={intl.formatMessage(messages.loginFailedContent)}
           />,
           { autoClose: false, toastId: 'loginFailed' },
         );

--- a/packages/volto/src/reducers/userSession/userSession.js
+++ b/packages/volto/src/reducers/userSession/userSession.js
@@ -57,7 +57,7 @@ export default function userSession(state = initialState, action = {}) {
         login: {
           loading: false,
           loaded: false,
-          error: action.error.response.text,
+          error: action.error.response.error,
         },
       };
     case `${LOGOUT}_FAIL`:


### PR DESCRIPTION
Now shows only error message in toast instead of stringified JSON

How to reproduce 
- go to - https://demo.plone.org/controlpanel/dexterity-types/Document/schema
- Try adding any new field using - Add field
- And fill only the required field - title
- Try to save



Before
<img width="1876" height="1126" alt="image" src="https://github.com/user-attachments/assets/2fad34e9-0a5c-40a4-9b39-95f4794a9e18" />

After

<img width="1876" height="1126" alt="image" src="https://github.com/user-attachments/assets/7046a00d-6a51-4a37-8659-3867f36a9162" />


- [X] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [X] I verified there aren't other open [pull requests](https://github.com/plone/volto/pulls) for the same change.
- [X] I followed the guidelines in [Contributing to Volto](https://6.docs.plone.org/volto/contributing/index.html).
- [X] I successfully ran [code linting checks](https://6.docs.plone.org/volto/contributing/linting.html) on my changes locally.
- [X] I successfully ran [unit tests](https://6.docs.plone.org/volto/contributing/testing.html) on my changes locally.
- [X] I successfully ran [acceptance tests](https://6.docs.plone.org/volto/contributing/acceptance-tests.html) on my changes locally.
- [X] If needed, I added new tests for my changes.
- [X] If needed, I added [documentation](https://6.docs.plone.org/volto/contributing/documentation.html#narrative-documentation) for my changes, either in the Storybook or narrative documentation.
- [X] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

