### PR TITLE
Add triage label to feature request issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/2_feature_request.md
+++ b/.github/ISSUE_TEMPLATE/2_feature_request.md
@@ -2,7 +2,7 @@
 name: '🦄 Feature request'
 about: 'Suggest an idea for Volto'
 title: ''
-labels: '04 type: enhancement'
+labels: ['04 type: enhancement', '30 needs: triage']
 assignees: ''
 ---
 


### PR DESCRIPTION
Because we get too many overly eager first-timers.

I also recently updated documentation to help address the thundering horde.

https://6.docs.plone.org/contributing/first-time.html#work-with-github-issues

No change log needed for this trivial internal change.