### PR TITLE
Docs: replace ReactJS with React

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## Introduction
 
-[Volto](https://github.com/plone/volto) is a ReactJS-based frontend for the [Plone](https://plone.org) Content Management System.
+[Volto](https://github.com/plone/volto) is a React-based frontend for the [Plone](https://plone.org) Content Management System.
 It is the default frontend starting with the Plone 6 release.
 
 [Plone](https://plone.org) is a CMS built on Python with more than 20 years of history and experience.

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -5,7 +5,7 @@
 [![Build Status](https://github.com/plone/components/actions/workflows/unit.yml/badge.svg)](https://github.com/plone/components/actions)
 [![Build Status](https://app.readthedocs.org/projects/plone-components/badge/?version=latest)](https://plone-components.readthedocs.io/latest/)
 
-This package contains ReactJS components for using Plone as a headless CMS.
+This package contains React components for using Plone as a headless CMS.
 
 The purpose of this package is to provide an agnostic set of baseline components to build sites upon.
 

--- a/packages/volto/README.md
+++ b/packages/volto/README.md
@@ -11,7 +11,7 @@
 
 ## Introduction
 
-[Volto](https://github.com/plone/volto) is a ReactJS-based frontend for the [Plone](https://plone.org) Content Management System.
+[Volto](https://github.com/plone/volto) is a React-based frontend for the [Plone](https://plone.org) Content Management System.
 It is the default frontend starting with the Plone 6 release.
 
 [Plone](https://plone.org) is a CMS built on Python with more than 20 years of history and experience.


### PR DESCRIPTION
This is a small documentation-only change to modernize wording (ReactJS → React). No code or behavior changes.

I understand first-time PRs are not being reviewed until Plone 7, but I’m happy to keep this open for future review.
