### PR TITLE
Add focus styles for image gallery view

### DIFF
--- a/packages/volto/news/6304.enhancement
+++ b/packages/volto/news/6304.enhancement
@@ -1,0 +1,1 @@
+Add focus styles for image gallery view

--- a/packages/volto/theme/themes/pastanaga/extras/gallery.less
+++ b/packages/volto/theme/themes/pastanaga/extras/gallery.less
@@ -1,0 +1,9 @@
+.image-gallery-icon:focus {
+  outline: 2px solid @linkColor;
+  outline-offset: 2px;
+}
+
+.image-gallery-thumbnail:focus {
+  outline: 2px solid @linkColor;
+  outline-offset: 2px;
+}

--- a/packages/volto/theme/themes/pastanaga/extras/main.less
+++ b/packages/volto/theme/themes/pastanaga/extras/main.less
@@ -156,6 +156,7 @@ button {
     outline: none;
   }
 }
+
 //checkbox overrides
 /* Unchecked */
 .ui.checkbox {
@@ -398,8 +399,10 @@ button {
 
   &::-webkit-scrollbar {
     width: 3px;
-    height: 3px; /* scrollbar height */
-    background: transparent; /* optional: just make scrollbar invisible */
+    height: 3px;
+    /* scrollbar height */
+    background: transparent;
+    /* optional: just make scrollbar invisible */
   }
 }
 
@@ -426,6 +429,7 @@ button {
     flex-wrap: wrap;
   }
 }
+
 //Add translation, Compare translation
 #page-add-translation,
 #page-compare-translation {
@@ -686,7 +690,8 @@ img.responsive {
   padding: 0;
   border: 0;
   margin: -1px;
-  clip: rect(1px, 1px, 1px, 1px); /* IE-style CSS for compatibility */
+  clip: rect(1px, 1px, 1px, 1px);
+  /* IE-style CSS for compatibility */
   white-space: nowrap;
   word-wrap: normal;
 }
@@ -713,4 +718,5 @@ img.responsive {
 @import 'views';
 @import 'toc';
 @import 'grid.less';
+@import 'gallery.less';
 .loadUIOverrides();


### PR DESCRIPTION
To fix this issue: #6304

Added visible focus indicators to image gallery icons and thumbnails for better keyboard navigation and screen reader support. 
Uses theme link color with 2px outline and 2px offset.