### PR TITLE
Backport: fixing Volto delivers HTTP 200 when no backend server is available

### DIFF
--- a/packages/volto/news/7754.bugfix
+++ b/packages/volto/news/7754.bugfix
@@ -1,0 +1,1 @@
+Set HTTP 503 status code for ConnectionRefused error page. @Shyam-Raghuwanshi

--- a/packages/volto/src/components/theme/App/App.jsx
+++ b/packages/volto/src/components/theme/App/App.jsx
@@ -174,7 +174,9 @@ export class App extends Component {
             <main ref={this.mainRef}>
               <OutdatedBrowser />
               {this.props.connectionRefused ? (
-                <ConnectionRefusedView />
+                <ConnectionRefusedView
+                  staticContext={this.props.staticContext}
+                />
               ) : this.state.hasError ? (
                 <Error
                   message={this.state.error.message}

--- a/packages/volto/src/components/theme/ConnectionRefused/ConnectionRefused.jsx
+++ b/packages/volto/src/components/theme/ConnectionRefused/ConnectionRefused.jsx
@@ -1,5 +1,5 @@
 /**
- * Home container.
+ * Connection refused error page.
  * @module components/theme/ConnectionRefused/ConnectionRefused
  */
 
@@ -7,6 +7,7 @@ import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import { Container } from 'semantic-ui-react';
 import config from '@plone/volto/registry';
+import { withServerErrorCode } from '@plone/volto/helpers/Utils/Utils';
 
 const ConnectionRefused = () => (
   <Container
@@ -71,4 +72,4 @@ const ConnectionRefused = () => (
   </Container>
 );
 
-export default ConnectionRefused;
+export default withServerErrorCode(503)(ConnectionRefused);


### PR DESCRIPTION

> [!CAUTION]
The Volto Team has suspended its review of new pull requests from first-time contributors until the [release of Plone 7](https://plone.org/download/release-schedule), which is preliminarily scheduled for the second quarter of 2026.
> [Read details](https://6.docs.plone.org/volto/contributing/index.html).

-----

- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't other open [pull requests](https://github.com/plone/volto/pulls) for the same change.
- [x] I followed the guidelines in [Contributing to Volto](https://6.docs.plone.org/volto/contributing/index.html).
- [x] I successfully ran [code linting checks](https://6.docs.plone.org/volto/contributing/linting.html) on my changes locally.
- [x] I successfully ran [unit tests](https://6.docs.plone.org/volto/contributing/testing.html) on my changes locally.
- [x] I successfully ran [acceptance tests](https://6.docs.plone.org/volto/contributing/acceptance-tests.html) on my changes locally.
- [x] If needed, I added new tests for my changes.
- [x] If needed, I added [documentation](https://6.docs.plone.org/volto/contributing/documentation.html#narrative-documentation) for my changes, either in the Storybook or narrative documentation.
- [x] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

Backport of #7754 to Volto 18.x.x

This backports the fix that returns a 503 status code if the backend is not running, instead of returning HTTP 200.

Closes #6447 (backport)
