### PR TITLE
Docs i18n msgid conventions

### DIFF
--- a/docs/development/i18n.md
+++ b/docs/development/i18n.md
@@ -1,0 +1,32 @@
+# Internationalization (i18n) in Volto
+
+This document describes how internationalization (i18n) works in Volto and provides guidance for working with translatable strings.
+
+## Translation structure
+
+In Volto translations, each translatable message consists of the following parts:
+
+- **Default** – the user-facing text (typically English)
+- **Component(s)** – where the message is used
+- **msgid** – a stable identifier for the message
+- **msgstr** – the translated value
+
+The `msgid` should be treated as a stable identifier and should not be changed casually, as it is used to look up translations. Typos and wording changes should be made in the `Default` value rather than in the `msgid`.
+
+Volto’s extraction tooling always includes a `Default` value in generated translation files. At runtime, Volto falls back to the `Default` text rather than displaying the `msgid`.
+
+## Message ID (msgid) conventions
+
+While there is no strict requirement for how `msgid`s must be named, Volto generally follows existing Plone conventions by using identifier-style message IDs. This helps keep translations stable and avoids accidental changes when editing visible text.
+
+### Recommended msgid patterns
+
+Common patterns used in Volto include:
+
+- `label_*` – form field labels
+- `action_*` – buttons and user actions
+- `nav_*` – navigation items
+- `message_*` – system messages such as errors, warnings, or informational text
+- `heading_*` – section titles or headings
+
+These patterns are intended as guidelines, not strict rules. The primary goals are to keep `msgid`s stable, provide clearer context for translators, and reduce the risk of breaking translations unintentionally.

--- a/docs/development/troubleshooting.md
+++ b/docs/development/troubleshooting.md
@@ -1,0 +1,29 @@
+# Troubleshooting (Development)
+
+## Hot reload / watcher stops working
+
+### Problem
+
+When running Volto in development mode, file changes may stop triggering
+automatic rebuilds or hot reload. You may notice that editing files no longer
+updates the browser.
+
+### Cause
+
+This usually happens because the operating system has reached the maximum
+number of files that can be watched. Volto uses Webpack and file watchers,
+which can exceed default OS limits, especially in large projects.
+
+### Solution
+
+Increase the file watcher limits for your operating system.
+
+---
+
+### Linux (inotify)
+
+Check current limit:
+
+```bash
+cat /proc/sys/fs/inotify/max_user_watches
+

--- a/docs/source/development/index.md
+++ b/docs/source/development/index.md
@@ -19,6 +19,7 @@ Or jump in to any topic listed below.
 :caption: Table of Contents
 :maxdepth: 1
 
+known-dev-watcher-issue
 overview
 creating-project
 add-ons/index

--- a/docs/source/development/known-dev-watcher-issue.md
+++ b/docs/source/development/known-dev-watcher-issue.md
@@ -1,0 +1,29 @@
+---
+title: Known development watcher issue
+---
+
+This document describes a known file watcher issue that can occur during Volto development.
+It explains what you will observe when the issue happens.
+It also provides guidance on how to resolve the problem.
+
+## What you will see
+
+When this issue occurs, the development server may stop unexpectedly.
+File changes may no longer trigger rebuilds.
+An error related to the file watcher limit can appear in the terminal.
+
+## Why this happens
+
+Operating systems enforce a limit on the number of files that can be watched simultaneously.
+Larger Volto projects can exceed this limit during development.
+When the limit is reached, the file watcher fails.
+
+## How to fix the issue
+
+The issue can be resolved by increasing the file watcher limit on your system.
+After updating the limit, restart the development server.
+
+## Increasing the watcher limit
+
+On Linux and macOS, the watcher limit can be increased by adjusting system configuration values.
+This is commonly done by increasing the maximum number of file watchers allowed by the operating system.

--- a/packages/volto/news/7836.documentation
+++ b/packages/volto/news/7836.documentation
@@ -1,0 +1,1 @@
+Documented a known Volto development issue where OS file watcher limits may cause hot reload to stop functioning.


### PR DESCRIPTION
This PR adds documentation explaining how internationalization (i18n) works in Volto, with a focus on clarifying the role of `msgid` and documenting commonly used naming conventions.

The content is based directly on the maintainer discussion in #7337 and reflects existing practices in Volto and Plone. In particular, it documents:

- the structure of translation entries in Volto,
- the expectation that `msgid` values are treated as stable identifiers,
- the role of `Default` as the user-facing fallback,
- and a small set of common `msgid` naming conventions, presented as guidelines rather than rules.

No code, tooling, or runtime behavior is changed by this PR. It is documentation-only and intended to reduce contributor confusion around translations.

Contributes to #7337
