### PR TITLE
Fix RegistryImageWidget appending stray '}' to base64 data

### DIFF
--- a/packages/volto/src/components/manage/Widgets/RegistryImageWidget.jsx
+++ b/packages/volto/src/components/manage/Widgets/RegistryImageWidget.jsx
@@ -99,7 +99,7 @@ const RegistryImageWidget = (props) => {
 
     readAsDataURL(file).then((data) => {
       const fields = data.match(/^data:(.*);(.*),(.*)$/);
-      onChange(id, `filenameb64:${btoa(file.name)};datab64:${fields[3]}}`);
+      onChange(id, `filenameb64:${btoa(file.name)};datab64:${fields[3]}`);
     });
 
     let reader = new FileReader();


### PR DESCRIPTION
## Summary

One-character fix. `RegistryImageWidget` appends a stray `}` to the base64 data of every uploaded file, producing invalid data URIs.

## Bug

Line 102 of `RegistryImageWidget.jsx`:

```javascript
onChange(id, `filenameb64:${btoa(file.name)};datab64:${fields[3]}}`);
//                                                              ^^ double }}
```

The template literal `${fields[3]}}` has a double `}}` — the first `}` closes the template expression, the second is a literal character appended to the string.

## Fix

```diff
- onChange(id, `filenameb64:${btoa(file.name)};datab64:${fields[3]}}`);
+ onChange(id, `filenameb64:${btoa(file.name)};datab64:${fields[3]}`);
```

## Impact

Every file uploaded through `RegistryImageWidget` (e.g. site logo via Site Setup → Site) gets a `}` appended to its base64 data. Backends constructing data URIs from the stored value produce invalid URIs that browsers cannot decode, causing images to appear blank.

## Test plan

- [ ] Upload an SVG logo via Site Setup → Site → Save
- [ ] Inspect stored value — should NOT end with `}`
- [ ] Logo should display correctly on the frontend
- [ ] Re-open Site Setup → Site — logo preview should render

Fixes #7899

Related: https://github.com/robgietema/nick/pull/19 (Nick CMS PR that includes a server-side workaround)