### PR TITLE
fix: show only error message in toast instead of stringified JSON (backport #7692)

### DIFF
--- a/packages/volto/news/7692.bugfix
+++ b/packages/volto/news/7692.bugfix
@@ -1,0 +1,1 @@
+Fix ContentTypeSchema error toast to display only error message instead of stringified JSON object. @Shyam-Raghuwanshi

--- a/packages/volto/src/components/manage/Controlpanels/ContentTypeSchema.jsx
+++ b/packages/volto/src/components/manage/Controlpanels/ContentTypeSchema.jsx
@@ -169,7 +169,7 @@ class ContentTypeSchema extends Component {
           error
           title={this.props.intl.formatMessage(messages.error)}
           content={JSON.stringify(
-            nextProps.schemaRequest.put.error.response.body ||
+            nextProps.schemaRequest.put.error.response.body?.message ||
               nextProps.schemaRequest.put.error.response.text,
           )}
         />,


### PR DESCRIPTION
Backpor #7692 
