### PR TITLE
fix(types): correct typing for contentIcons and controlPanelsIcons

### DIFF
--- a/packages/types/news/7339.bugfix
+++ b/packages/types/news/7339.bugfix
@@ -1,0 +1,1 @@
+Fix typing for `contentIcons` and `controlPanelsIcons` in Settings config. Changed from `Record<string, React.ComponentType>` to `Record<string, string>` as they contain SVG paths. @YourGitHubUsername

--- a/packages/types/src/config/Settings.d.ts
+++ b/packages/types/src/config/Settings.d.ts
@@ -63,7 +63,7 @@ export interface SettingsConfig {
   persistentReducers: string[];
   initialReducersBlacklist: string[];
   asyncPropsExtenders: unknown[];
-  contentIcons: Record<string, React.ComponentType>;
+  contentIcons: Record<string, string>;
   loadables: unknown;
   lazyBundles: {
     [key: string]: string[];
@@ -82,7 +82,7 @@ export interface SettingsConfig {
   showTags: boolean;
   showRelatedItems: boolean;
   controlpanels: unknown[];
-  controlPanelsIcons: Record<string, React.ComponentType>;
+  controlPanelsIcons: Record<string, string>;
   filterControlPanels: unknown;
   filterControlPanelsSchema: unknown;
   externalRoutes: {


### PR DESCRIPTION
Backport of #7747 to Volto 18.