### PR TITLE
Use `getSlateEditorAndType` in `03-block-slate.js` to make the test more robust

### DIFF
--- a/packages/volto/cypress/tests/core/volto-slate/03-block-slate.js
+++ b/packages/volto/cypress/tests/core/volto-slate/03-block-slate.js
@@ -3,10 +3,7 @@ import { slateBeforeEach, getSlateBlockValue } from '../../../support/helpers';
 describe('Block Tests', () => {
   beforeEach(slateBeforeEach);
   it('should create a block with some text, move the cursor in the middle of the text, insert a line break, and then have 2 blocks with the two parts of the initial text', () => {
-    cy.getSlate()
-      .focus()
-      .click()
-      .type('hello, world')
+    cy.getSlateEditorAndType('hello, world')
       .type('{leftarrow}')
       .type('{leftarrow}')
       .type('{leftarrow}')

--- a/packages/volto/news/7924.internal
+++ b/packages/volto/news/7924.internal
@@ -1,0 +1,1 @@
+Use `getSlateEditorAndType` in `03-block-slate.js` to make the test more robust. @wesleybl


### PR DESCRIPTION
Backport of #7924 to Volto 18.