### PR TITLE
fix: Send factory as string in SchemaWidget and filter field types in types control panel

### DIFF
--- a/packages/volto/news/+schema-widget-factory.bugfix
+++ b/packages/volto/news/+schema-widget-factory.bugfix
@@ -1,0 +1,1 @@
+Fix SchemaWidget to send the field factory as a string instead of an object to the backend, and pass `filterFactory` in the types control panel to only allow valid content type field types. @Shyam-Raghuwanshi

--- a/packages/volto/src/components/manage/Controlpanels/ContentTypeSchema.jsx
+++ b/packages/volto/src/components/manage/Controlpanels/ContentTypeSchema.jsx
@@ -199,6 +199,33 @@ class ContentTypeSchema extends Component {
 
   form = React.createRef();
 
+  /**
+   * List of field factory tokens that are valid for content type schemas.
+   * These correspond to IFieldFactory utilities registered on the backend.
+   * Form-only field types (e.g., static_text, hidden, radio_group) are
+   * excluded since they don't have corresponding Plone field factories.
+   */
+  contentTypeFieldFactories = [
+    'label_textline_field',
+    'label_text_field',
+    'label_integer_field',
+    'label_float_field',
+    'label_boolean_field',
+    'label_password_field',
+    'label_datetime_field',
+    'label_date_field',
+    'label_choice_field',
+    'label_multi_choice_field',
+    'label_email',
+    'Rich Text',
+    'URL',
+    'File Upload',
+    'Image',
+    'Relation List',
+    'Relation Choice',
+    'JSONField',
+  ];
+
   makeSchemaList = (schema) => {
     const result = {
       title: 'Schema',
@@ -217,6 +244,13 @@ class ContentTypeSchema extends Component {
           type: 'schema',
           id: 'schema',
           widget: 'schema',
+          widgetOptions: {
+            frontendOptions: {
+              widgetProps: {
+                filterFactory: this.contentTypeFieldFactories,
+              },
+            },
+          },
         },
       },
       required: [],

--- a/packages/volto/src/components/manage/Widgets/SchemaWidget.jsx
+++ b/packages/volto/src/components/manage/Widgets/SchemaWidget.jsx
@@ -1007,6 +1007,10 @@ class SchemaWidget extends Component {
    * @returns {undefined}
    */
   onAddField(values) {
+    const factory =
+      typeof values.factory === 'object' && values.factory !== null
+        ? values.factory.value
+        : values.factory;
     const fieldId = slugify(
       values.id || values.title,
       keys(this.props.value.properties),
@@ -1023,19 +1027,18 @@ class SchemaWidget extends Component {
       : [...currentFieldsetFields, fieldId];
 
     const utility = config.getUtility({
-      name: values.factory,
+      name: factory,
       type: 'fieldFactoryInitialData',
     });
 
     const multiple =
-      values.factory === 'Multiple Choice' ||
-      values.factory === 'label_multi_choice_field';
+      factory === 'Multiple Choice' || factory === 'label_multi_choice_field';
 
     const initialData = utility.method
       ? omit(utility.method(this.props.intl), ['id'])
       : {
           type: 'string',
-          factory: values.factory,
+          factory: factory,
         };
 
     this.onChange({
@@ -1795,8 +1798,12 @@ class SchemaWidget extends Component {
             onCancel={this.onCancel}
             className={`field-${slugify(isString(this.state.addField) && this.state.addField !== '' ? this.state.addField : 'label_text_field')}`}
             onChangeFormData={(data) => {
+              const factoryValue =
+                typeof data.factory === 'object' && data.factory !== null
+                  ? data.factory.value
+                  : data.factory;
               this.setState({
-                addField: data.factory,
+                addField: factoryValue,
               });
             }}
             title={this.props.intl.formatMessage(messages.addField)}


### PR DESCRIPTION
When adding a new field in the dexterity types schema editor (/controlpanel/dexterity-types/<type>/schema), the field factory was sent to the backend as an object (e.g. {value: "label_text_field", label: "Text"}) instead of a plain string, causing a "missing parameter factory" error. Additionally, form-only field types (like static_text, hidden, radio_group) were shown in the field type dropdown even though they don't have corresponding Plone field factories on the backend.

Ref: https://github.com/plone/plone.restapi/pull/1969

- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't other open [pull requests](https://github.com/plone/volto/pulls) for the same change.
- [x] I followed the guidelines in [Contributing to Volto](https://6.docs.plone.org/volto/contributing/index.html).
- [x] I successfully ran [code linting checks](https://6.docs.plone.org/volto/contributing/linting.html) on my changes locally.
- [x] I successfully ran [unit tests](https://6.docs.plone.org/volto/contributing/testing.html) on my changes locally.
- [x] I successfully ran [acceptance tests](https://6.docs.plone.org/volto/contributing/acceptance-tests.html) on my changes locally.
- [x] If needed, I added new tests for my changes.
- [x] If needed, I added [documentation](https://6.docs.plone.org/volto/contributing/documentation.html#narrative-documentation) for my changes, either in the Storybook or narrative documentation.
- [x] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.


