### PR TITLE
fix: remove duplicated text in 7894.internal changelog entry

### DIFF
--- a/packages/volto/news/7894.internal
+++ b/packages/volto/news/7894.internal
@@ -1,2 +1,1 @@
-Exclude `.storybook` from ESLint's default hidden directory ignore list via `.eslintignore` to allow linting of Storybook configuration files. @Shyam-RaghuwanshiExclude `.storybook` from ESLint's default hidden directory ignore list via `.eslintignore` to allow linting of Storybook configuration files. @Shyam-Raghuwanshi
-
+Exclude `.storybook` from ESLint's default hidden directory ignore list via `.eslintignore` to allow linting of Storybook configuration files. @Shyam-Raghuwanshi


### PR DESCRIPTION
Fixes the duplicated changelog entry in 7894.internal that was merged with #7931.

The text was accidentally pasted twice on the same line and included an extra trailing blank line.