### PR TITLE
Use Slate Table block when pasting tables snippets (fix for 18.x.x)

### DIFF
--- a/packages/volto-slate/news/7865.bugfix
+++ b/packages/volto-slate/news/7865.bugfix
@@ -1,0 +1,1 @@
+Use Slate Table block when pasting tables snippets (instead of deprecated DraftJS) @cekk

--- a/packages/volto-slate/src/blocks/Table/deconstruct.js
+++ b/packages/volto-slate/src/blocks/Table/deconstruct.js
@@ -19,7 +19,7 @@ import {
 export function syncCreateTableBlock(rows) {
   const id = uuid();
   const block = {
-    '@type': 'table',
+    '@type': 'slateTable',
     table: {
       rows,
     },

--- a/packages/volto-slate/src/blocks/Table/deconstruct.test.js
+++ b/packages/volto-slate/src/blocks/Table/deconstruct.test.js
@@ -1,0 +1,24 @@
+import { syncCreateTableBlock } from './deconstruct';
+
+describe('syncCreateTableBlock', () => {
+  it('creates a slateTable block with the given rows', () => {
+    const rows = [
+      {
+        key: 'row1',
+        cells: [
+          {
+            key: 'cell1',
+            type: 'data',
+            value: [{ children: [{ text: '1' }] }],
+          },
+        ],
+      },
+    ];
+
+    const [id, block] = syncCreateTableBlock(rows);
+
+    expect(id).toBeDefined();
+    expect(block['@type']).toBe('slateTableaa');
+    expect(block.table.rows).toEqual(rows);
+  });
+});


### PR DESCRIPTION
Backport of #7865 to Volto 18.