### PR TITLE
docs: add no-animal-violence Vale package for inclusive language checking

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -4,9 +4,9 @@ MinAlertLevel = suggestion
 
 Vocab = Base,Plone
 
-Packages = Microsoft, Speciesism
+Packages = Microsoft, NoAnimalViolence
 
 [*.md]
-BasedOnStyles = Vale, Microsoft, Speciesism
+BasedOnStyles = Vale, Microsoft, NoAnimalViolence
 Microsoft.Contractions = suggestion
 Microsoft.Units = suggestion


### PR DESCRIPTION
## Summary

Adds the [no-animal-violence](https://github.com/Open-Paws/vale-no-animal-violence) Vale package to the existing Vale configuration.

Volto already uses the `Microsoft` Vale package for documentation style. The `NoAnimalViolence` package extends this by catching phrases that normalize violence toward animals and suggesting clearer, more professional alternatives:

- "kill two birds with one stone" → "accomplish two things at once"
- "guinea pig" → "test subject"
- "sacred cow" → "unquestioned belief"
- "scapegoat" → "blame target"
- "beat a dead horse" → "belabor the point"

These appear occasionally in technical documentation and the alternatives are shorter and more universally clear.

**Package source**: https://github.com/Open-Paws/vale-no-animal-violence

## Changes

- `.vale.ini`: add `NoAnimalViolence` to `Packages` and `BasedOnStyles`