### PR TITLE
Fix null port in virtual hosting path passed to backend by devproxy

### DIFF
--- a/packages/volto/news/+devproxy_port.bugfix
+++ b/packages/volto/news/+devproxy_port.bugfix
@@ -1,0 +1,1 @@
+Fix null port in virtual hosting path when the devproxy is used on an origin with an implicit port. @davisagli

--- a/packages/volto/src/express-middleware/devproxy.js
+++ b/packages/volto/src/express-middleware/devproxy.js
@@ -88,11 +88,13 @@ export default function devProxyMiddleware() {
             .map((part) => '/_vh_' + part)
             .join('')
         : '';
+      const port =
+        apiPathURL.port || (apiPathURL.protocol === 'https:' ? 443 : 80);
       const target =
         config.settings.proxyRewriteTarget ||
         `/VirtualHostBase/${apiPathURL.protocol.slice(0, -1)}/${
           apiPathURL.hostname
-        }:${apiPathURL.port}${instancePath}/++api++/VirtualHostRoot${vhSubpath}`;
+        }:${port}${instancePath}/++api++/VirtualHostRoot${vhSubpath}`;
 
       return `${target}${path.replace(`${config.settings.subpathPrefix}/++api++`, '')}`;
     },


### PR DESCRIPTION
I think this is why we're getting bad URLs from the backend on https://demo.plone.org/next/
