### PR TITLE
razzle.config.js: Fix defaultPlugins missing name property to enable addon SCSS plugin replacement

### DIFF
--- a/packages/volto/news/7908.internal
+++ b/packages/volto/news/7908.internal
@@ -1,0 +1,1 @@
+Fix razzle.config.js defaultPlugins missing name property to ensure addon SCSS plugin replacement works correctly. @Manik-Khajuria-5

--- a/packages/volto/razzle.config.js
+++ b/packages/volto/razzle.config.js
@@ -420,11 +420,26 @@ const defaultModify = ({
 const addonExtenders = registry.getAddonExtenders().map((m) => require(m));
 
 const defaultPlugins = [
-  { object: require('./webpack-plugins/webpack-less-plugin')({ registry }) },
-  { object: require('./webpack-plugins/webpack-svg-plugin') },
-  { object: require('./webpack-plugins/webpack-bundle-analyze-plugin') },
-  { object: require('./jest-extender-plugin') },
-  'scss',
+  {
+    name: 'less',
+    object: require('./webpack-plugins/webpack-less-plugin')({ registry }),
+  },
+  {
+    name: 'svg',
+    object: require('./webpack-plugins/webpack-svg-plugin'),
+  },
+  {
+    name: 'bundle-analyze',
+    object: require('./webpack-plugins/webpack-bundle-analyze-plugin'),
+  },
+  {
+    name: 'jest-extender',
+    object: require('./jest-extender-plugin'),
+  },
+  {
+    name: 'scss',
+    object: require('razzle-plugin-scss'),
+  },
 ];
 
 const plugins = addonExtenders.reduce(


### PR DESCRIPTION
Backport of #7908 to Volto 18.