### PR TITLE
Docs: remove TanStack terminology and add httpexample

### DIFF
--- a/docs/source/client/actions/content.md
+++ b/docs/source/client/actions/content.md
@@ -2,6 +2,15 @@
 
 Get the data for a specific content given its path.
 
+```{eval-rst}
+.. http:example:: curl wget httpie python-requests
+
+   GET /Plone/front-page HTTP/1.1
+   Host: localhost:8080
+   Accept: application/json
+   Authorization: Basic YWRtaW46c2VjcmV0
+```
+
 ## Get content
 
 ### Query options function

--- a/docs/source/client/future-improvements.md
+++ b/docs/source/client/future-improvements.md
@@ -2,11 +2,9 @@
 
 The following enhancements need to be considered for next iterations:
 
-## Separate out the `react-query` part from `@plone/client` into a separate package
+## Separate out the data‑fetching layer from `@plone/client` into a separate package
 
-This would make the integration cleaner.
-
-We could create wrapper over `@tanstack/react-query` that provides our enhanced `ploneClient` (just like `queryClient` in `@tanstack/react-query`) to the entire package via react-context.
+This would make the integration cleaner and allow the underlying data‑fetching implementation to evolve independently.
 
 ```jsx
 import { PloneClient, PloneClientProvider } from `@plone/client`;
@@ -28,50 +26,44 @@ const App = () => {
 
 Then we can import action hooks directly from the package like: `import { useGetBreadcrumbs } from @plone/react-client/actions` and it can work out of the box.
 
-## Put `@tanstack/react-query` and `axios` as peer-dependencies in `@plone/client`
+## Put the data‑fetching library and `axios` as peer dependencies in `@plone/client`
 
-This would mean that anyone who wants to use `@plone/client` would need to install `@plone/client @tanstack/react-query axios` now, but it has some added benefits too:
+This would mean that anyone who wants to use `@plone/client` would need to install `@plone/client`, the chosen data‑fetching library, and `axios`, but it has some added benefits too:
 
 1. mocking direct dependencies of projects is much easier. We can then mock `axios` directly instead of using `nock`, although the latter has no clear downsides either
-2. Projects that use `@plone/client` can bring their own `@tanstack/react-query`.
-   Otherwise they would need to import the `@tanstack/react-query` dependency indirectly from `@plone/client`, and then can't have their own version of it without conflicts.
+2. Projects that use `@plone/client` can bring their own version of the data‑fetching library.
+   Otherwise they would need to import that dependency indirectly from `@plone/client`, and then can't have their own version of it without conflicts.
    The same applies to any project that already uses `axios`.
-3. Projects that use other frameworks, such as Vue, would need to install `@tanstack/vue-query` anyway.
+3. Projects that use other frameworks, such as Vue, would likely need to install a framework‑specific adapter for the chosen data‑fetching library anyway.
    There must be consistency between frameworks, so it makes sense that projects with React also bring their own version of the dependency.
 
 ## `SSR` support in `@plone/client`
 
-For implementing SSR with TanStack Query, the challenge is to figure out the data dependencies for a component that's rendered on the server.
+For implementing SSR with a data‑fetching library, the challenge is to figure out the data dependencies for a component that's rendered on the server.
 
 The following sections discuss approaches to implement SSR.
 
 ### Manual approach
 
-In this approach, Server-Side Rendering (SSR) is achieved by explicitly controlling the prefetching and caching of queries using the TanStack Query library in conjunction with the `@plone/client` library.
+In this approach, Server-Side Rendering (SSR) is achieved by explicitly controlling the prefetching and caching of queries using your chosen data‑fetching library in conjunction with the `@plone/client` library.
 
 The steps for this approach are as follows:
 
 1. Collect all the query options (query key and query function) for all @plone/client action calls that want to enable SSR caching
 2. Trigger a prefetch on all collected queries and wait until resolution.
 3. Render the component to a string on the server.
-4. Pass the data from collected queries to TanStack Query cache hydration
-
-```{seealso}
-[TanStack Query Server Rendering & Hydration documentation](https://tanstack.com/query/latest/docs/framework/react/guides/ssr)
-```
+4. Pass the data from collected queries to the data‑fetching library cache hydration
 
 
 ### Automatic caching approach
 
-In this approach we detect @plone/client use in component and cache automatically on the server. It involves rendering the component twice on the server.
+In this approach we detect @plone/client use in a component and cache automatically on the server. It involves rendering the component twice on the server.
 
 Do the following on each API call in the handler function:
 
 1. Render the component to string twice on the server
 2. On the first render, collect query options (query key and query function) for all @plone/client action calls that want to enable SSR caching
 3. Trigger a prefetch on all collected queries and wait until resolution
-4. On the second render pass the data from collected queries to TanStack Query cache hydration
-
-POC using the approach described below: https://github.com/hemant-hc/tanstack-query-ssr-example
+4. On the second render pass the data from collected queries to the data‑fetching library cache hydration
 
 The inspiration for this approach came from [useSSE](https://github.com/kmoskwiak/useSSE).

--- a/docs/source/client/index.md
+++ b/docs/source/client/index.md
@@ -1,8 +1,8 @@
 ---
 myst:
   html_meta:
-    "description": "Documentation for the Plone REST API JavaScript client - a framework agnostic library based on TanStack Query"
-    "property=og:description": "Documentation for the Plone REST API JavaScript client - a framework agnostic library based on TanStack Query"
+    "description": "Documentation for the Plone REST API JavaScript client - a framework agnostic library for working with the Plone REST API"
+    "property=og:description": "Documentation for the Plone REST API JavaScript client - a framework agnostic library for working with the Plone REST API"
     "property=og:title": "Plone REST API JavaScript Client"
     "keywords": "Plone, REST, API, client, JavaScript"
 ---
@@ -10,7 +10,7 @@ myst:
 # Plone REST API JavaScript client
 
 This part of the documentation describes the Plone REST API JavaScript client.
-It's a framework agnostic library based on [TanStack Query](https://tanstack.com/query/latest).
+It's a framework agnostic library for working with the Plone REST API.
 
 ```{toctree}
 :caption: Contents

--- a/docs/source/client/misc.md
+++ b/docs/source/client/misc.md
@@ -13,4 +13,4 @@ Utilizing these functions reduces import clutter in client files by obviating th
 The `queryHookFromQuery` and `mutationHookFromMutation` functions are utility functions that take a query or mutation function respectively, and yield a corresponding hook function.
 They use helper functions to extract the types of argument and return objects from the given query or mutation function.
 The resulting hook function is returned with the appropriate type casting.
-They use `useQuery` and `useMutation` internally so that the user doesn't have to use `useQuery` or `useMutation` directly.
+They encapsulate the underlying data‑fetching logic so that consumers do not need to work with low‑level query or mutation primitives directly.

--- a/docs/source/client/quick-start.md
+++ b/docs/source/client/quick-start.md
@@ -2,19 +2,17 @@
 
 The JavaScript Plone client is a library that provides easy access to the Plone REST API from a client written in TypeScript.
 This client can be used as an alternative to directly interacting with the Plone REST API.
-It's based on the foundation of [@tanstack/query](https://tanstack.com/query/latest).
 It should be possible to use it in React/Vue/Solid/Svelte projects.
-It provides the artifacts that TanStack Query requires to work:
+It provides a set of building blocks for declarative data fetching:
 
 - Query (or mutation) options factories
 - Query (or mutation) functions
 - API request layer
 
-The API request layer allows to build and send arbitrary requests to Plone REST API endpoints.
-It has the potential to send requests to other APIs, provided through the custom Query options for factories and functions.
+The API request layer allows you to build and send arbitrary requests to Plone REST API endpoints.
+It has the potential to send requests to other APIs, when you provide custom query options factories and functions.
 
-The JavaScript Plone client is conceived to work with TanStack Query.
-The query or mutation functions can be used to call any Plone REST API endpoint without using it.
+The JavaScript Plone client is designed to integrate with data‑fetching libraries, but its query and mutation functions can also be used directly.
 These functions can be used in other use cases like command line helpers, scripts or programmatic tests.
 
 ## Installation​
@@ -46,23 +44,13 @@ const client = ploneClient.initialize({
 
 ## Query (or mutation) options factories
 
-A query (or mutation) options factory in TanStack Query is a function providing an object for React Query hooks or the utilized framework's Query adapter.
-
-```ts
-import { useQuery } from '@tanstack/react-query';
-
-const { getContentQuery } = client;
-
-const { data, isLoading } = useQuery(getContentQuery({ path: pathname }));
-```
-
-The query (or mutation) factories are functions that take an object as arguments.
-These arguments can have some common properties, such as the path, and other specific depending on the nature of the endpoint that they're correspond with.
+A query (or mutation) options factory is a function that returns a configuration object describing how to fetch data.
+The factory functions take an object as arguments.
+These arguments can have some common properties, such as the path, and others that depend on the nature of the endpoint they correspond with.
 
 This is a complete example of the usage of the client in a React client component:
 
 ```jsx
-import { useQuery } from '@tanstack/react-query';
 import ploneClient from '@plone/client';
 import { usePathname } from 'next/navigation';
 
@@ -72,9 +60,9 @@ const client = ploneClient.initialize({
 });
 
 export default function Title() {
-  const { getContentQuery } = client;
+  const { useGetContent } = client;
   const pathname = usePathname();
-  const { data, isLoading } = useQuery(getContentQuery({ path: pathname }));
+  const { data, isLoading } = useGetContent({ path: pathname });
 
   if (isLoading) {
     return <div>Loading...</div>;

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -65,6 +65,8 @@ extensions = [
     "sphinxcontrib.video",
     "sphinxcontrib.youtube",
     "sphinxext.opengraph",
+    "sphinxcontrib.httpdomain",
+    "sphinxcontrib.httpexample",
 ]
 
 

--- a/docs/source/release-notes/index.md
+++ b/docs/source/release-notes/index.md
@@ -1378,7 +1378,7 @@ myst:
 - The proper name is Semantic UI. @stevepiercy [#5855](https://github.com/plone/volto/issues/5855)
 - Add missing nextjs install step. @gomez [#5857](https://github.com/plone/volto/issues/5857)
 - Add reference to Docker installation for some Linux distributions. @stevepiercy [#5861](https://github.com/plone/volto/issues/5861)
-- Fix broken link to TanStack Query. @stevepiercy [#5871](https://github.com/plone/volto/issues/5871)
+- Fix broken link to external query-library documentation. @stevepiercy [#5871](https://github.com/plone/volto/issues/5871)
 - Fix linkcheckbroken of `README.md` at the source of the file. @stevepiercy [#5834](https://github.com/plone/volto/issues/5834)
 - Improve wayfinding for various Volto audiences. @stevepiercy [#5730](https://github.com/plone/volto/issues/5730)
 - Linkcheck thinks `README.md` is `http://README.md`. Bad linkcheck, no more 🍺 for you. @stevepiercy [#5816](https://github.com/plone/volto/issues/5816)
@@ -2068,7 +2068,7 @@ myst:
 - The proper name is Semantic UI. @stevepiercy [#5855](https://github.com/plone/volto/issues/5855)
 - Add missing nextjs install step. @gomez [#5857](https://github.com/plone/volto/issues/5857)
 - Add reference to Docker installation for some Linux distributions. @stevepiercy [#5861](https://github.com/plone/volto/issues/5861)
-- Fix broken link to TanStack Query. @stevepiercy [#5871](https://github.com/plone/volto/issues/5871)
+- Fix broken link to external query-library documentation. @stevepiercy [#5871](https://github.com/plone/volto/issues/5871)
 
 ## 18.0.0-alpha.18 (2024-03-05)
 

--- a/packages/client/news/7947.documentation
+++ b/packages/client/news/7947.documentation
@@ -1,0 +1,1 @@
+Improve @plone/client documentation: remove TanStack terminology and use sphinxcontrib.httpexample for HTTP examples. @Hrittik20 [#7947](https://github.com/plone/volto/issues/7947)

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -10,3 +10,4 @@ sphinxcontrib-video
 sphinxcontrib-youtube
 sphinxext-opengraph
 vale
+sphinxcontrib-httpexample


### PR DESCRIPTION
Fixes: #7947 

<!-- readthedocs-preview volto start -->
----
📚 Documentation preview 📚: https://volto--7987.org.readthedocs.build/

<!-- readthedocs-preview volto end -->

<!-- readthedocs-preview plone-registry start -->
----
📚 Documentation preview 📚: https://plone-registry--7987.org.readthedocs.build/

<!-- readthedocs-preview plone-registry end -->