### PR TITLE
forward cache-status header in images middleware

### DIFF
--- a/packages/volto/src/express-middleware/files.js
+++ b/packages/volto/src/express-middleware/files.js
@@ -10,6 +10,7 @@ const HEADERS = [
   'x-sendfile',
   'x-accel-redirect',
   'x-robots-tag',
+  'cache-status',
 ];
 
 function filesMiddlewareFn(req, res, next) {


### PR DESCRIPTION
Closes # [7962](https://github.com/plone/volto/issues/7962)

Fix: Forward Cache-Status header in images middleware

The images middleware maintains an explicit allowlist of response headers forwarded from the backend.
The  Cache-Status header (RFC 9211) was missing from this list, causing it to be stripped from responses.



