### PR TITLE
Fixed alias bug in razzle configuration and webpack-less-plugin

### DIFF
--- a/packages/volto/news/+depsloader.bugfix
+++ b/packages/volto/news/+depsloader.bugfix
@@ -1,0 +1,1 @@
+Fixed bug in razzle configuration and webpack-less-plugin that could generate wrong aliases and configurations for building the site. @pnicolli

--- a/packages/volto/razzle.config.js
+++ b/packages/volto/razzle.config.js
@@ -310,6 +310,7 @@ const defaultModify = ({
     'load-volto-addons': addonsLoaderPath,
     ...registry.getResolveAliases(),
     '@plone/volto': `${registry.voltoPath}/src`,
+    '@plone/volto-slate': `${registry.voltoPath}/../volto-slate/src`,
     // to be able to reference path uncustomized by webpack
     '@plone/volto-original': `${registry.voltoPath}/src`,
     // be able to reference current package from customized package

--- a/packages/volto/webpack-plugins/webpack-less-plugin.js
+++ b/packages/volto/webpack-plugins/webpack-less-plugin.js
@@ -143,7 +143,7 @@ module.exports = (userOptions = {}) => ({
           /packages\/volto\/theme/,
           /plone\.volto\/theme/,
           /node_modules\/semantic-ui-less/,
-          ...Object.values(registry.getResolveAliases()),
+          ...Object.values(registry.packages).map((p) => p.modulePath),
         ],
         use: isServer
           ? [


### PR DESCRIPTION
Backport of #8034 to Volto 18.