### PR TITLE
Align REST client path param names with REST API response semantics

### DIFF
--- a/apps/seven/app/middleware.server.test.ts
+++ b/apps/seven/app/middleware.server.test.ts
@@ -686,7 +686,7 @@ describe('middleware', () => {
         nextMock,
       );
 
-      expect(getUserMock).toHaveBeenCalledWith({ userId: 'testuser' });
+      expect(getUserMock).toHaveBeenCalledWith({ id: 'testuser' });
       expect(context.get(ploneUserContext)).toEqual(mockUser.data);
       expect(getContentMock).toHaveBeenCalledWith({
         path: '/',

--- a/apps/seven/app/middleware.server.ts
+++ b/apps/seven/app/middleware.server.ts
@@ -121,7 +121,7 @@ export const fetchPloneContent: Route.MiddlewareFunction = async (
     const [content, site, user] = await Promise.all([
       cli.getContent({ path, expand }),
       cli.getSite(),
-      userId ? cli.getUser({ userId }) : Promise.resolve(null),
+      userId ? cli.getUser({ id: userId }) : Promise.resolve(null),
     ]);
 
     migrateContent(content.data);

--- a/apps/seven/news/+unify-rest-path-params.internal
+++ b/apps/seven/news/+unify-rest-path-params.internal
@@ -1,0 +1,1 @@
+Adapt Seven middleware to the updated `@plone/client` user lookup argument names. @sneridagh

--- a/packages/client/news/+unify-rest-path-params.breaking
+++ b/packages/client/news/+unify-rest-path-params.breaking
@@ -1,0 +1,1 @@
+Align REST client path argument names with REST API semantics, using canonical keys like `id`, `type`, `name`, and `in_reply_to` across affected endpoints. @sneridagh

--- a/packages/client/src/restapi/addons/get.test.ts
+++ b/packages/client/src/restapi/addons/get.test.ts
@@ -19,8 +19,8 @@ afterEach(async () => {
 
 describe('Get Addon', () => {
   test('Successful', async () => {
-    const addonId = '/plone.app.iterate';
-    const result = await cli.getAddon({ addonId });
+    const id = '/plone.app.iterate';
+    const result = await cli.getAddon({ id });
 
     expect(result.data['@id']).toBe(
       'http://localhost:55001/plone/@addons/plone.app.iterate',
@@ -28,10 +28,10 @@ describe('Get Addon', () => {
   });
 
   test('Failure', async () => {
-    const addonId = 'blah';
+    const id = 'blah';
 
     try {
-      await cli.getAddon({ addonId });
+      await cli.getAddon({ id });
     } catch (err) {
       expect((err as RequestError).status).toBe(404);
     }

--- a/packages/client/src/restapi/addons/get.ts
+++ b/packages/client/src/restapi/addons/get.ts
@@ -5,24 +5,24 @@ import { z } from 'zod';
 import type { RequestResponse } from '../types';
 
 const getAddonSchema = z.object({
-  addonId: z.string(),
+  id: z.string(),
 });
 
 export type AddonArgs = z.infer<typeof getAddonSchema> & {};
 
 export async function getAddon(
   this: PloneClient,
-  { addonId }: AddonArgs,
+  { id }: AddonArgs,
 ): Promise<RequestResponse<GetAddonResponse>> {
   const validatedArgs = getAddonSchema.parse({
-    addonId,
+    id,
   });
 
   const options: ApiRequestParams = {
     config: this.config,
     params: {},
   };
-  const addonName = `@addons/${validatedArgs.addonId}`;
+  const addonName = `@addons/${validatedArgs.id}`;
 
   return apiRequest('get', addonName, options);
 }

--- a/packages/client/src/restapi/addons/install.test.ts
+++ b/packages/client/src/restapi/addons/install.test.ts
@@ -18,9 +18,9 @@ afterEach(async () => {
 
 describe('Install Addon', () => {
   test('Successful', async () => {
-    const addonId = '/plone.app.iterate';
+    const id = '/plone.app.iterate';
 
-    const result = await cli.installAddon({ addonId });
+    const result = await cli.installAddon({ id });
     expect(result.status).toBe(204);
   });
 });

--- a/packages/client/src/restapi/addons/install.ts
+++ b/packages/client/src/restapi/addons/install.ts
@@ -4,24 +4,24 @@ import type PloneClient from '../../client';
 import type { RequestResponse } from '../types';
 
 const installAddonSchema = z.object({
-  addonId: z.string(),
+  id: z.string(),
 });
 
 export type InstallAddonArgs = z.infer<typeof installAddonSchema>;
 
 export async function installAddon(
   this: PloneClient,
-  { addonId }: InstallAddonArgs,
+  { id }: InstallAddonArgs,
 ): Promise<RequestResponse<undefined>> {
   const validatedArgs = installAddonSchema.parse({
-    addonId,
+    id,
   });
 
   const options: ApiRequestParams = {
     config: this.config,
     params: {},
   };
-  const addonName = `@addons/${validatedArgs.addonId}/install`;
+  const addonName = `@addons/${validatedArgs.id}/install`;
 
   return apiRequest('post', addonName, options);
 }

--- a/packages/client/src/restapi/addons/install_profile.test.ts
+++ b/packages/client/src/restapi/addons/install_profile.test.ts
@@ -18,10 +18,10 @@ afterEach(async () => {
 
 describe('Install Addon Profile', () => {
   test('Successful', async () => {
-    const addonId = '/plone.restapi';
+    const id = '/plone.restapi';
     const profile = 'import/testing-workflows';
 
-    const result = await cli.installAddonProfile({ addonId, profile });
+    const result = await cli.installAddonProfile({ id, profile });
     expect(result.status).toBe(204);
   });
 });

--- a/packages/client/src/restapi/addons/install_profile.ts
+++ b/packages/client/src/restapi/addons/install_profile.ts
@@ -4,7 +4,7 @@ import type PloneClient from '../../client';
 import type { RequestResponse } from '../types';
 
 const installAddonProfileSchema = z.object({
-  addonId: z.string(),
+  id: z.string(),
   profile: z.string(),
 });
 
@@ -12,10 +12,10 @@ export type InstallAddonProfileArgs = z.infer<typeof installAddonProfileSchema>;
 
 export async function installAddonProfile(
   this: PloneClient,
-  { addonId, profile }: InstallAddonProfileArgs,
+  { id, profile }: InstallAddonProfileArgs,
 ): Promise<RequestResponse<undefined>> {
   const validatedArgs = installAddonProfileSchema.parse({
-    addonId,
+    id,
     profile,
   });
 
@@ -23,7 +23,7 @@ export async function installAddonProfile(
     config: this.config,
     params: {},
   };
-  const addonName = `@addons/${validatedArgs.addonId}/${profile}`;
+  const addonName = `@addons/${validatedArgs.id}/${profile}`;
 
   return apiRequest('post', addonName, options);
 }

--- a/packages/client/src/restapi/addons/uninstall.test.ts
+++ b/packages/client/src/restapi/addons/uninstall.test.ts
@@ -18,9 +18,9 @@ afterEach(async () => {
 
 describe('Uninstall Addon', () => {
   test('Successful', async () => {
-    const addonId = '/plone.app.session';
+    const id = '/plone.app.session';
 
-    const result = await cli.uninstallAddon({ addonId });
+    const result = await cli.uninstallAddon({ id });
     expect(result.status).toBe(204);
   });
 });

--- a/packages/client/src/restapi/addons/uninstall.ts
+++ b/packages/client/src/restapi/addons/uninstall.ts
@@ -4,24 +4,24 @@ import type PloneClient from '../../client';
 import type { RequestResponse } from '../types';
 
 const uninstallAddonSchema = z.object({
-  addonId: z.string(),
+  id: z.string(),
 });
 
 export type UninstallAddonArgs = z.infer<typeof uninstallAddonSchema>;
 
 export async function uninstallAddon(
   this: PloneClient,
-  { addonId }: UninstallAddonArgs,
+  { id }: UninstallAddonArgs,
 ): Promise<RequestResponse<undefined>> {
   const validatedArgs = uninstallAddonSchema.parse({
-    addonId,
+    id,
   });
 
   const options: ApiRequestParams = {
     config: this.config,
     params: {},
   };
-  const addonName = `@addons/${validatedArgs.addonId}/uninstall`;
+  const addonName = `@addons/${validatedArgs.id}/uninstall`;
 
   return apiRequest('post', addonName, options);
 }

--- a/packages/client/src/restapi/addons/upgrade.test.ts
+++ b/packages/client/src/restapi/addons/upgrade.test.ts
@@ -18,9 +18,9 @@ afterEach(async () => {
 
 describe('Upgrade Addon', () => {
   test('Successful', async () => {
-    const addonId = '/plone.app.volto';
+    const id = '/plone.app.volto';
 
-    const result = await cli.upgradeAddon({ addonId });
+    const result = await cli.upgradeAddon({ id });
     expect(result.status).toBe(204);
   });
 });

--- a/packages/client/src/restapi/addons/upgrade.ts
+++ b/packages/client/src/restapi/addons/upgrade.ts
@@ -4,24 +4,24 @@ import type PloneClient from '../../client';
 import type { RequestResponse } from '../types';
 
 const upgradeAddonSchema = z.object({
-  addonId: z.string(),
+  id: z.string(),
 });
 
 export type UpgradeAddonArgs = z.infer<typeof upgradeAddonSchema>;
 
 export async function upgradeAddon(
   this: PloneClient,
-  { addonId }: UpgradeAddonArgs,
+  { id }: UpgradeAddonArgs,
 ): Promise<RequestResponse<undefined>> {
   const validatedArgs = upgradeAddonSchema.parse({
-    addonId,
+    id,
   });
 
   const options: ApiRequestParams = {
     config: this.config,
     params: {},
   };
-  const addonName = `@addons/${validatedArgs.addonId}/upgrade`;
+  const addonName = `@addons/${validatedArgs.id}/upgrade`;
 
   return apiRequest('post', addonName, options);
 }

--- a/packages/client/src/restapi/comments/create.ts
+++ b/packages/client/src/restapi/comments/create.ts
@@ -6,7 +6,7 @@ import type { RequestResponse } from '../types';
 
 export const createCommentArgsSchema = z.object({
   path: z.string(),
-  reply_id: z.string().optional(),
+  in_reply_to: z.string().optional(),
   data: createCommentDataSchema,
 });
 
@@ -14,11 +14,11 @@ export type CreateCommentArgs = z.infer<typeof createCommentArgsSchema>;
 
 export async function createComment(
   this: PloneClient,
-  { path, reply_id, data }: CreateCommentArgs,
+  { path, in_reply_to, data }: CreateCommentArgs,
 ): Promise<RequestResponse<undefined>> {
   const validatedArgs = createCommentArgsSchema.parse({
     path,
-    reply_id,
+    in_reply_to,
     data,
   });
 
@@ -27,8 +27,8 @@ export async function createComment(
     config: this.config,
   };
 
-  const commentsPath = reply_id
-    ? `/${validatedArgs.path}/@comments/${validatedArgs.reply_id}`
+  const commentsPath = in_reply_to
+    ? `/${validatedArgs.path}/@comments/${validatedArgs.in_reply_to}`
     : `/${validatedArgs.path}/@comments`;
 
   return apiRequest('post', commentsPath, options);

--- a/packages/client/src/restapi/controlpanels/get.test.ts
+++ b/packages/client/src/restapi/controlpanels/get.test.ts
@@ -18,34 +18,34 @@ afterEach(async () => {
 
 describe('Get Controlpanel', () => {
   test('Successful - editing', async () => {
-    const path = 'editing';
+    const id = 'editing';
 
-    const result = await cli.getControlpanel({ path });
+    const result = await cli.getControlpanel({ id });
 
     expect(result.data['@id']).toBe(
-      `http://localhost:55001/plone/@controlpanels/${path}`,
+      `http://localhost:55001/plone/@controlpanels/${id}`,
     );
     expect(result.data.group).toBe('Content');
   });
 
   test('Successful - content-rules', async () => {
-    const path = 'content-rules';
+    const id = 'content-rules';
 
-    const result = await cli.getControlpanel({ path });
+    const result = await cli.getControlpanel({ id });
 
     expect(result.data['@id']).toBe(
-      `http://localhost:55001/plone/@controlpanels/${path}`,
+      `http://localhost:55001/plone/@controlpanels/${id}`,
     );
     expect(result.data.title).toBe('Content Rules');
   });
 
   test('Successful - dexterity-types', async () => {
-    const path = 'dexterity-types';
+    const id = 'dexterity-types';
 
-    const result = await cli.getControlpanel({ path });
+    const result = await cli.getControlpanel({ id });
 
     expect(result.data['@id']).toBe(
-      `http://localhost:55001/plone/@controlpanels/${path}`,
+      `http://localhost:55001/plone/@controlpanels/${id}`,
     );
     expect(result.data.title).toBe('Content Types');
   });

--- a/packages/client/src/restapi/controlpanels/get.ts
+++ b/packages/client/src/restapi/controlpanels/get.ts
@@ -5,17 +5,17 @@ import type PloneClient from '../../client';
 import type { RequestResponse } from '../types';
 
 const getControlpanelSchema = z.object({
-  path: z.string(),
+  id: z.string(),
 });
 
 export type ControlpanelArgs = z.infer<typeof getControlpanelSchema>;
 
 export async function getControlpanel(
   this: PloneClient,
-  { path }: ControlpanelArgs,
+  { id }: ControlpanelArgs,
 ): Promise<RequestResponse<GetControlpanelResponse>> {
   const validatedArgs = getControlpanelSchema.parse({
-    path,
+    id,
   });
 
   const options: ApiRequestParams = {
@@ -23,7 +23,7 @@ export async function getControlpanel(
     params: {},
   };
 
-  const getControlpanelPath = `@controlpanels/${validatedArgs.path}`;
+  const getControlpanelPath = `@controlpanels/${validatedArgs.id}`;
 
   return apiRequest('get', getControlpanelPath, options);
 }

--- a/packages/client/src/restapi/controlpanels/update.test.ts
+++ b/packages/client/src/restapi/controlpanels/update.test.ts
@@ -31,7 +31,7 @@ describe('Update Controlpanel', () => {
       data: updateControlpanelData,
     });
 
-    const controlpanel = await cli.getControlpanel({ path });
+    const controlpanel = await cli.getControlpanel({ id: path });
     expect(controlpanel.status).toBe(200);
   });
 
@@ -62,7 +62,7 @@ describe('Update Controlpanel', () => {
       data: updateControlpanelData,
     });
 
-    const result = await cli.getControlpanel({ path });
+    const result = await cli.getControlpanel({ id: path });
     expect(result.status).toBe(200);
   });
 
@@ -99,7 +99,7 @@ describe('Update Controlpanel', () => {
       data: updateControlpanelData,
     });
 
-    const controlpanel = await cli.getControlpanel({ path });
+    const controlpanel = await cli.getControlpanel({ id: path });
 
     expect(controlpanel.data.items[0][0].description).toBe(
       updateControlpanelData.description,

--- a/packages/client/src/restapi/groups/delete.test.ts
+++ b/packages/client/src/restapi/groups/delete.test.ts
@@ -27,7 +27,7 @@ describe('Delete Group', () => {
 
     await cli.createGroup({ data: groupData });
 
-    const result = await cli.deleteGroup({ groupId: groupData.groupname });
+    const result = await cli.deleteGroup({ id: groupData.groupname });
     expect(result.status).toBe(204);
   });
 
@@ -35,7 +35,7 @@ describe('Delete Group', () => {
     const groupId = 'blah';
 
     try {
-      await cli.deleteGroup({ groupId });
+      await cli.deleteGroup({ id: groupId });
     } catch (err) {
       expect((err as RequestError).status).toBe(404);
     }

--- a/packages/client/src/restapi/groups/delete.ts
+++ b/packages/client/src/restapi/groups/delete.ts
@@ -4,24 +4,24 @@ import type PloneClient from '../../client';
 import type { RequestResponse } from '../types';
 
 export const deleteGroupArgsSchema = z.object({
-  groupId: z.string(),
+  id: z.string(),
 });
 
 type DeleteGroupArgs = z.infer<typeof deleteGroupArgsSchema>;
 
 export async function deleteGroup(
   this: PloneClient,
-  { groupId }: DeleteGroupArgs,
+  { id }: DeleteGroupArgs,
 ): Promise<RequestResponse<undefined>> {
   const validatedArgs = deleteGroupArgsSchema.parse({
-    groupId,
+    id,
   });
 
   const options: ApiRequestParams = {
     config: this.config,
   };
 
-  const groupName = `/@groups/${validatedArgs.groupId}`;
+  const groupName = `/@groups/${validatedArgs.id}`;
 
   return apiRequest('delete', groupName, options);
 }

--- a/packages/client/src/restapi/groups/get.test.ts
+++ b/packages/client/src/restapi/groups/get.test.ts
@@ -22,7 +22,7 @@ describe('Get Group', () => {
   test('Successful', async () => {
     const groupId = '/Administrators';
 
-    const result = await cli.getGroup({ groupId });
+    const result = await cli.getGroup({ id: groupId });
     expect(result.data.id).toBe('Administrators');
   });
 
@@ -34,7 +34,7 @@ describe('Get Group', () => {
 
     await cli.createGroup({ data: groupData });
 
-    const result = await cli.getGroup({ groupId: groupData.groupname });
+    const result = await cli.getGroup({ id: groupData.groupname });
     expect(result.data.id).toBe(groupData.groupname);
   });
 
@@ -42,7 +42,7 @@ describe('Get Group', () => {
     const groupId = 'blah';
 
     try {
-      await cli.getGroup({ groupId });
+      await cli.getGroup({ id: groupId });
     } catch (err) {
       expect((err as RequestError).status).toBe(404);
     }

--- a/packages/client/src/restapi/groups/get.ts
+++ b/packages/client/src/restapi/groups/get.ts
@@ -5,24 +5,24 @@ import type PloneClient from '../../client';
 import type { RequestResponse } from '../types';
 
 const getGroupSchema = z.object({
-  groupId: z.string(),
+  id: z.string(),
 });
 
 export type GroupArgs = z.infer<typeof getGroupSchema>;
 
 export async function getGroup(
   this: PloneClient,
-  { groupId }: GroupArgs,
+  { id }: GroupArgs,
 ): Promise<RequestResponse<GetGroupResponse>> {
   const validatedArgs = getGroupSchema.parse({
-    groupId,
+    id,
   });
 
   const options: ApiRequestParams = {
     config: this.config,
     params: {},
   };
-  const groupName = `@groups/${validatedArgs.groupId}`;
+  const groupName = `@groups/${validatedArgs.id}`;
 
   return apiRequest('get', groupName, options);
 }

--- a/packages/client/src/restapi/groups/update.test.ts
+++ b/packages/client/src/restapi/groups/update.test.ts
@@ -32,12 +32,12 @@ describe('Update Group', () => {
       description: 'changed description',
     };
     await cli.updateGroup({
-      groupId: groupData.groupname,
+      id: groupData.groupname,
       data: updateGroupData,
     });
 
     const group = await cli.getGroup({
-      groupId: groupData.groupname,
+      id: groupData.groupname,
     });
 
     expect(group.data.description).toBe('changed description');
@@ -50,7 +50,7 @@ describe('Update Group', () => {
     };
 
     try {
-      await cli.updateGroup({ groupId, data: updateGroupData });
+      await cli.updateGroup({ id: groupId, data: updateGroupData });
     } catch (err) {
       expect((err as RequestError).status).toBe(400);
     }

--- a/packages/client/src/restapi/groups/update.ts
+++ b/packages/client/src/restapi/groups/update.ts
@@ -5,7 +5,7 @@ import type PloneClient from '../../client';
 import type { RequestResponse } from '../types';
 
 export const updateGroupArgsSchema = z.object({
-  groupId: z.string(),
+  id: z.string(),
   data: updateGroupDataSchema,
 });
 
@@ -13,10 +13,10 @@ export type UpdateGroupArgs = z.infer<typeof updateGroupArgsSchema>;
 
 export async function updateGroup(
   this: PloneClient,
-  { groupId, data }: UpdateGroupArgs,
+  { id, data }: UpdateGroupArgs,
 ): Promise<RequestResponse<undefined>> {
   const validatedArgs = updateGroupArgsSchema.parse({
-    groupId,
+    id,
     data,
   });
 
@@ -25,7 +25,7 @@ export async function updateGroup(
     config: this.config,
   };
 
-  const groupName = `/@groups/${validatedArgs.groupId}`;
+  const groupName = `/@groups/${validatedArgs.id}`;
 
   return apiRequest('patch', groupName, options);
 }

--- a/packages/client/src/restapi/registry/get.test.ts
+++ b/packages/client/src/restapi/registry/get.test.ts
@@ -19,17 +19,17 @@ afterEach(async () => {
 
 describe('Get Registry', () => {
   test('Successful', async () => {
-    const registryName = 'plone.app.querystring.field.path.title';
-    const result = await cli.getRegistryRecord({ registryName });
+    const name = 'plone.app.querystring.field.path.title';
+    const result = await cli.getRegistryRecord({ name });
 
     expect(result.data).toBe('Location');
   });
 
   test('Failure', async () => {
-    const registryName = '/blah';
+    const name = '/blah';
 
     try {
-      await cli.getRegistryRecord({ registryName });
+      await cli.getRegistryRecord({ name });
     } catch (err) {
       expect((err as RequestError).status).toBe(503);
     }

--- a/packages/client/src/restapi/registry/get.ts
+++ b/packages/client/src/restapi/registry/get.ts
@@ -4,17 +4,17 @@ import type PloneClient from '../../client';
 import type { RequestResponse } from '../types';
 
 const getRegistryRecordSchema = z.object({
-  registryName: z.string(),
+  name: z.string(),
 });
 
 export type GetRegistryArgs = z.infer<typeof getRegistryRecordSchema>;
 
 export async function getRegistryRecord(
   this: PloneClient,
-  { registryName }: GetRegistryArgs,
+  { name }: GetRegistryArgs,
 ): Promise<RequestResponse<string>> {
   const validatedArgs = getRegistryRecordSchema.parse({
-    registryName,
+    name,
   });
 
   const options: ApiRequestParams = {
@@ -22,7 +22,7 @@ export async function getRegistryRecord(
     params: {},
   };
 
-  const registryPath = `/@registry/${validatedArgs.registryName}`;
+  const registryPath = `/@registry/${validatedArgs.name}`;
 
   return apiRequest('get', registryPath, options);
 }

--- a/packages/client/src/restapi/registry/update.test.ts
+++ b/packages/client/src/restapi/registry/update.test.ts
@@ -28,7 +28,7 @@ describe('Update Registry', () => {
     });
 
     const registry = await cli.getRegistryRecord({
-      registryName: 'plone.app.querystring.field.path.title',
+      name: 'plone.app.querystring.field.path.title',
     });
 
     expect(registry.data).toBe('Value');

--- a/packages/client/src/restapi/translations/get.test.ts
+++ b/packages/client/src/restapi/translations/get.test.ts
@@ -27,7 +27,7 @@ describe('Get Translations', () => {
 
     // We need to install 'plone.app.multilingual' in order to use translations endpoint
     await cli.installAddon({
-      addonId: 'plone.app.multilingual',
+      id: 'plone.app.multilingual',
     });
 
     const contentDataES = {
@@ -69,7 +69,7 @@ describe('Get Translations', () => {
 
     // We need to install 'plone.app.multilingual' in order to use translations endpoint
     await cli.installAddon({
-      addonId: 'plone.app.multilingual',
+      id: 'plone.app.multilingual',
     });
 
     const path = '/en/blah';

--- a/packages/client/src/restapi/translations/link.test.ts
+++ b/packages/client/src/restapi/translations/link.test.ts
@@ -27,7 +27,7 @@ describe('Content', () => {
 
     // We need to install 'plone.app.multilingual' in order to use translations endpoint
     await cli.installAddon({
-      addonId: 'plone.app.multilingual',
+      id: 'plone.app.multilingual',
     });
 
     const contentDataES = {
@@ -64,7 +64,7 @@ describe('Content', () => {
 
     // We need to install 'plone.app.multilingual' in order to use translations endpoint
     await cli.installAddon({
-      addonId: 'plone.app.multilingual',
+      id: 'plone.app.multilingual',
     });
 
     const linkData = {

--- a/packages/client/src/restapi/translations/unlink.test.ts
+++ b/packages/client/src/restapi/translations/unlink.test.ts
@@ -24,7 +24,7 @@ describe('Content', () => {
 
     // We need to install 'plone.app.multilingual' in order to use translations endpoint
     await cli.installAddon({
-      addonId: 'plone.app.multilingual',
+      id: 'plone.app.multilingual',
     });
 
     const contentDataES = {
@@ -69,7 +69,7 @@ describe('Content', () => {
 
     // We need to install 'plone.app.multilingual' in order to use translations endpoint
     await cli.installAddon({
-      addonId: 'plone.app.multilingual',
+      id: 'plone.app.multilingual',
     });
 
     const unlinkData = {

--- a/packages/client/src/restapi/types/get.test.ts
+++ b/packages/client/src/restapi/types/get.test.ts
@@ -19,7 +19,7 @@ afterEach(async () => {
 
 describe('Get Type', () => {
   test('Successful', async () => {
-    const result = await cli.getType({ contentType: 'Document' });
+    const result = await cli.getType({ type: 'Document' });
 
     expect(result.data).toHaveProperty('title');
     expect(result.data).toHaveProperty('type');
@@ -27,7 +27,7 @@ describe('Get Type', () => {
 
   test('Failure', async () => {
     try {
-      await cli.getType({ contentType: 'blah' });
+      await cli.getType({ type: 'blah' });
     } catch (err) {
       expect((err as RequestError).status).toBe(404);
     }

--- a/packages/client/src/restapi/types/get.ts
+++ b/packages/client/src/restapi/types/get.ts
@@ -5,24 +5,24 @@ import type PloneClient from '../../client';
 import type { RequestResponse } from '../types';
 
 const getTypeSchema = z.object({
-  contentType: z.string(),
+  type: z.string(),
 });
 
 export type GetTypeArgs = z.infer<typeof getTypeSchema>;
 
 export async function getType(
   this: PloneClient,
-  { contentType }: GetTypeArgs,
+  { type }: GetTypeArgs,
 ): Promise<RequestResponse<GetTypeResponse>> {
   const validatedArgs = getTypeSchema.parse({
-    contentType,
+    type,
   });
 
   const options: ApiRequestParams = {
     config: this.config,
     params: {},
   };
-  const contentPathPath = `/@types/${validatedArgs.contentType}`;
+  const contentPathPath = `/@types/${validatedArgs.type}`;
 
   return apiRequest('get', contentPathPath, options);
 }

--- a/packages/client/src/restapi/types/update_type_field.test.ts
+++ b/packages/client/src/restapi/types/update_type_field.test.ts
@@ -70,7 +70,7 @@ describe('Update Type', () => {
       data: updateTypeFieldData,
     });
 
-    const type = await cli.getType({ contentType: 'Document' });
+    const type = await cli.getType({ type: 'Document' });
     const lastIndex = type.data.fieldsets.length - 1;
 
     expect(type.data.fieldsets?.[lastIndex].id).toBe(

--- a/packages/client/src/restapi/users/delete.test.ts
+++ b/packages/client/src/restapi/users/delete.test.ts
@@ -27,12 +27,12 @@ describe('Delete UserDelete', () => {
 
     await cli.createUser({ data: userData });
 
-    await cli.deleteUser({ userId: userData.username });
+    await cli.deleteUser({ id: userData.username });
   });
 
   test('Failure', async () => {
     try {
-      await cli.deleteUser({ userId: 'blah' });
+      await cli.deleteUser({ id: 'blah' });
     } catch (err) {
       expect((err as RequestError).status).toBe(404);
     }

--- a/packages/client/src/restapi/users/delete.ts
+++ b/packages/client/src/restapi/users/delete.ts
@@ -4,24 +4,24 @@ import type PloneClient from '../../client';
 import type { RequestResponse } from '../types';
 
 export const deleteUserArgsSchema = z.object({
-  userId: z.string(),
+  id: z.string(),
 });
 
 type DeleteUserArgs = z.infer<typeof deleteUserArgsSchema>;
 
 export async function deleteUser(
   this: PloneClient,
-  { userId }: DeleteUserArgs,
+  { id }: DeleteUserArgs,
 ): Promise<RequestResponse<undefined>> {
   const validatedArgs = deleteUserArgsSchema.parse({
-    userId,
+    id,
   });
 
   const options: ApiRequestParams = {
     config: this.config,
   };
 
-  const userName = `/@users/${validatedArgs.userId}`;
+  const userName = `/@users/${validatedArgs.id}`;
 
   return apiRequest('delete', userName, options);
 }

--- a/packages/client/src/restapi/users/get.test.ts
+++ b/packages/client/src/restapi/users/get.test.ts
@@ -30,7 +30,7 @@ describe('Get User', () => {
 
     await cli.createUser({ data: userData });
 
-    const result = await cli.getUser({ userId: userData.username });
+    const result = await cli.getUser({ id: userData.username });
 
     expect(result.data.id).toBe(userData.username);
   });
@@ -43,7 +43,7 @@ describe('Get User', () => {
     };
 
     try {
-      await cli.getUser({ userId: userData.username });
+      await cli.getUser({ id: userData.username });
     } catch (err) {
       expect((err as RequestError).status).toBe(404);
     }

--- a/packages/client/src/restapi/users/get.ts
+++ b/packages/client/src/restapi/users/get.ts
@@ -5,24 +5,24 @@ import type PloneClient from '../../client';
 import type { RequestResponse } from '../types';
 
 const getUserSchema = z.object({
-  userId: z.string(),
+  id: z.string(),
 });
 
 export type UserArgs = z.infer<typeof getUserSchema>;
 
 export async function getUser(
   this: PloneClient,
-  { userId }: UserArgs,
+  { id }: UserArgs,
 ): Promise<RequestResponse<GetUserResponse>> {
   const validatedArgs = getUserSchema.parse({
-    userId,
+    id,
   });
 
   const options: ApiRequestParams = {
     config: this.config,
     params: {},
   };
-  const userName = `@users/${validatedArgs.userId}`;
+  const userName = `@users/${validatedArgs.id}`;
 
   return apiRequest('get', userName, options);
 }

--- a/packages/client/src/restapi/users/reset_password.test.ts
+++ b/packages/client/src/restapi/users/reset_password.test.ts
@@ -34,7 +34,7 @@ describe('PasswordReset', () => {
 
     await loginWithCreate(cli, userData);
 
-    const result = await cli.resetPassword({ userId: username });
+    const result = await cli.resetPassword({ id: username });
     expect(result.status).toBe(200);
   });
 });

--- a/packages/client/src/restapi/users/reset_password.ts
+++ b/packages/client/src/restapi/users/reset_password.ts
@@ -4,24 +4,24 @@ import type PloneClient from '../../client';
 import type { RequestResponse } from '../types';
 
 export const resetPasswordArgsSchema = z.object({
-  userId: z.string(),
+  id: z.string(),
 });
 
 export type ResetUserArgs = z.infer<typeof resetPasswordArgsSchema>;
 
 export async function resetPassword(
   this: PloneClient,
-  { userId }: ResetUserArgs,
+  { id }: ResetUserArgs,
 ): Promise<RequestResponse<undefined>> {
   const validatedArgs = resetPasswordArgsSchema.parse({
-    userId,
+    id,
   });
 
   const options: ApiRequestParams = {
     config: this.config,
   };
 
-  const userName = `@users/${validatedArgs.userId}/reset-password`;
+  const userName = `@users/${validatedArgs.id}/reset-password`;
 
   return apiRequest('post', userName, options);
 }

--- a/packages/client/src/restapi/users/reset_password_with_token.ts
+++ b/packages/client/src/restapi/users/reset_password_with_token.ts
@@ -5,7 +5,7 @@ import type PloneClient from '../../client';
 import type { RequestResponse } from '../types';
 
 export const resetPasswordWithTokenArgsSchema = z.object({
-  userId: z.string(),
+  id: z.string(),
   data: resetPasswordWithTokenDataSchema,
 });
 
@@ -15,10 +15,10 @@ export type ResetPasswordWithTokenUserArgs = z.infer<
 
 export async function resetPasswordWithToken(
   this: PloneClient,
-  { userId, data }: ResetPasswordWithTokenUserArgs,
+  { id, data }: ResetPasswordWithTokenUserArgs,
 ): Promise<RequestResponse<undefined>> {
   const validatedArgs = resetPasswordWithTokenArgsSchema.parse({
-    userId,
+    id,
     data,
   });
 
@@ -27,7 +27,7 @@ export async function resetPasswordWithToken(
     config: this.config,
   };
 
-  const userName = `@users/${validatedArgs.userId}/reset-password`;
+  const userName = `@users/${validatedArgs.id}/reset-password`;
 
   return apiRequest('post', userName, options);
 }

--- a/packages/client/src/restapi/users/update.test.ts
+++ b/packages/client/src/restapi/users/update.test.ts
@@ -34,7 +34,7 @@ describe('Update User', () => {
     await cli.createUser({ data: userData });
 
     await cli.updateUser({
-      userId: userData.username,
+      id: userData.username,
       data: updateUserData,
     });
 
@@ -67,7 +67,7 @@ describe('Update User', () => {
     await cli.createUser({ data: userData });
 
     await cli.updateUser({
-      userId: userData.username,
+      id: userData.username,
       data: updatePortraitData,
     });
 
@@ -103,7 +103,7 @@ describe('Update User', () => {
     await cli.createUser({ data: userData });
 
     await cli.updateUser({
-      userId: userData.username,
+      id: userData.username,
       data: updatePortraitData,
     });
 
@@ -140,7 +140,7 @@ describe('Update User', () => {
     await cli.createUser({ data: userData });
 
     await cli.updateUser({
-      userId: userData.username,
+      id: userData.username,
       data: updateUserData,
     });
 

--- a/packages/client/src/restapi/users/update.test.ts
+++ b/packages/client/src/restapi/users/update.test.ts
@@ -39,7 +39,7 @@ describe('Update User', () => {
     });
 
     const user = await cli.getUser({
-      userId: userData.username,
+      id: userData.username,
     });
 
     expect(user.data.username).toBe('changedUsername');
@@ -72,7 +72,7 @@ describe('Update User', () => {
     });
 
     const user = await cli.getUser({
-      userId: userData.username,
+      id: userData.username,
     });
 
     expect(user.data.portrait).toBe(
@@ -108,7 +108,7 @@ describe('Update User', () => {
     });
 
     const user = await cli.getUser({
-      userId: userData.username,
+      id: userData.username,
     });
 
     expect(user.data.portrait).toBe(
@@ -145,7 +145,7 @@ describe('Update User', () => {
     });
 
     const user = await cli.getUser({
-      userId: userData.username,
+      id: userData.username,
     });
 
     expect(user.data.username).toBe(updateUserData.username);

--- a/packages/client/src/restapi/users/update.ts
+++ b/packages/client/src/restapi/users/update.ts
@@ -5,7 +5,7 @@ import type PloneClient from '../../client';
 import type { RequestResponse } from '../types';
 
 export const updateUserArgsSchema = z.object({
-  userId: z.string(),
+  id: z.string(),
   data: updateUserDataSchema,
 });
 
@@ -13,10 +13,10 @@ export type UpdateUserArgs = z.infer<typeof updateUserArgsSchema>;
 
 export async function updateUser(
   this: PloneClient,
-  { userId, data }: UpdateUserArgs,
+  { id, data }: UpdateUserArgs,
 ): Promise<RequestResponse<undefined>> {
   const validatedArgs = updateUserArgsSchema.parse({
-    userId,
+    id,
     data,
   });
 
@@ -25,7 +25,7 @@ export async function updateUser(
     config: this.config,
   };
 
-  const userName = `/@users/${validatedArgs.userId}`;
+  const userName = `/@users/${validatedArgs.id}`;
 
   return apiRequest('patch', userName, options);
 }

--- a/packages/client/src/restapi/users/update_password.test.ts
+++ b/packages/client/src/restapi/users/update_password.test.ts
@@ -39,7 +39,7 @@ describe('PasswordUpdate', () => {
     };
 
     await cli.updatePassword({
-      userId: username,
+      id: username,
       data: resetUserData,
     });
   });

--- a/packages/client/src/restapi/users/update_password.ts
+++ b/packages/client/src/restapi/users/update_password.ts
@@ -5,7 +5,7 @@ import type PloneClient from '../../client';
 import type { RequestResponse } from '../types';
 
 export const updatePasswordArgsSchema = z.object({
-  userId: z.string(),
+  id: z.string(),
   data: updatePasswordDataSchema,
 });
 
@@ -13,10 +13,10 @@ export type UpdatePasswordArgs = z.infer<typeof updatePasswordArgsSchema>;
 
 export async function updatePassword(
   this: PloneClient,
-  { userId, data }: UpdatePasswordArgs,
+  { id, data }: UpdatePasswordArgs,
 ): Promise<RequestResponse<undefined>> {
   const validatedArgs = updatePasswordArgsSchema.parse({
-    userId,
+    id,
     data,
   });
 
@@ -25,7 +25,7 @@ export async function updatePassword(
     config: this.config,
   };
 
-  const userName = `@users/${validatedArgs.userId}/reset-password`;
+  const userName = `@users/${validatedArgs.id}/reset-password`;
 
   return apiRequest('post', userName, options);
 }

--- a/packages/client/src/restapi/workingcopy/check-in.test.ts
+++ b/packages/client/src/restapi/workingcopy/check-in.test.ts
@@ -21,7 +21,7 @@ afterEach(async () => {
 describe('WorkingCopy', () => {
   test('Successful', async () => {
     // We need to install 'plone.app.iterate' in order to use workingcopy endpoint
-    await cli.installAddon({ addonId: '/plone.app.iterate' });
+    await cli.installAddon({ id: '/plone.app.iterate' });
 
     const randomId = uuid();
     const path = '/';
@@ -55,7 +55,7 @@ describe('WorkingCopy', () => {
 
   test('Failure', async () => {
     // We need to install 'plone.app.iterate' in order to use workingcopy endpoint
-    await cli.installAddon({ addonId: '/plone.app.iterate' });
+    await cli.installAddon({ id: '/plone.app.iterate' });
 
     const path = 'blah';
 

--- a/packages/client/src/restapi/workingcopy/create.test.ts
+++ b/packages/client/src/restapi/workingcopy/create.test.ts
@@ -21,7 +21,7 @@ afterEach(async () => {
 describe('Workingcopy', () => {
   test('Successful', async () => {
     // We need to install 'plone.app.iterate' in order to use workingcopy endpoint
-    await cli.installAddon({ addonId: '/plone.app.iterate' });
+    await cli.installAddon({ id: '/plone.app.iterate' });
 
     const randomId = uuid();
     const path = '/';
@@ -41,7 +41,7 @@ describe('Workingcopy', () => {
 
   test('Failure', async () => {
     // We need to install 'plone.app.iterate' in order to use workingcopy endpoint
-    await cli.installAddon({ addonId: '/plone.app.iterate' });
+    await cli.installAddon({ id: '/plone.app.iterate' });
 
     const path = 'blah';
 

--- a/packages/client/src/restapi/workingcopy/delete.test.ts
+++ b/packages/client/src/restapi/workingcopy/delete.test.ts
@@ -21,7 +21,7 @@ afterEach(async () => {
 describe('Delete Workingcopy', () => {
   test('Successful', async () => {
     // We need to install 'plone.app.iterate' in order to use workingcopy endpoint
-    await cli.installAddon({ addonId: '/plone.app.iterate' });
+    await cli.installAddon({ id: '/plone.app.iterate' });
 
     const randomId = uuid();
     const path = '/';
@@ -44,7 +44,7 @@ describe('Delete Workingcopy', () => {
 
   test('Failure', async () => {
     // We need to install 'plone.app.iterate' in order to use workingcopy endpoint
-    await cli.installAddon({ addonId: '/plone.app.iterate' });
+    await cli.installAddon({ id: '/plone.app.iterate' });
 
     const path = 'blah';
 

--- a/packages/client/src/restapi/workingcopy/get.test.ts
+++ b/packages/client/src/restapi/workingcopy/get.test.ts
@@ -21,7 +21,7 @@ afterEach(async () => {
 describe('Get WorkingCopy', () => {
   test('Successful', async () => {
     // We need to install 'plone.app.iterate' in order to use workingcopy endpoint
-    await cli.installAddon({ addonId: '/plone.app.iterate' });
+    await cli.installAddon({ id: '/plone.app.iterate' });
 
     const randomId = uuid();
     const path = '/';
@@ -40,7 +40,7 @@ describe('Get WorkingCopy', () => {
 
   test('Failure', async () => {
     // We need to install 'plone.app.iterate' in order to use workingcopy endpoint
-    await cli.installAddon({ addonId: '/plone.app.iterate' });
+    await cli.installAddon({ id: '/plone.app.iterate' });
     const path = 'blah';
 
     try {

--- a/packages/cmsui/news/+unify-rest-path-params.internal
+++ b/packages/cmsui/news/+unify-rest-path-params.internal
@@ -1,0 +1,1 @@
+Adapt CMSUI routes to the updated `@plone/client` path argument names for control panel and type loading. @sneridagh

--- a/packages/cmsui/routes/controlpanel.tsx
+++ b/packages/cmsui/routes/controlpanel.tsx
@@ -43,7 +43,7 @@ export async function loader({
 
   const cli = context.get(ploneClientContext);
 
-  const { data: controlpanel } = await cli.getControlpanel({ path: panel_id });
+  const { data: controlpanel } = await cli.getControlpanel({ id: panel_id });
   return { controlpanel };
 }
 

--- a/packages/cmsui/routes/edit.tsx
+++ b/packages/cmsui/routes/edit.tsx
@@ -48,7 +48,7 @@ export async function loader({
   const cli = context.get(ploneClientContext);
   const content = context.get(ploneContentContext);
 
-  const { data: schema } = await cli.getType({ contentType: content['@type'] });
+  const { data: schema } = await cli.getType({ type: content['@type'] });
 
   return data(flattenToAppURL({ content, schema }));
 }


### PR DESCRIPTION
## Summary
This PR aligns several `@plone/client` path parameter names with the identifiers and field names exposed by Plone REST API responses and endpoint semantics.

This aggregates the two branch commits:
- `459295b42` `Align REST client path param names with response IDs`
- `7fce196ae` `Align more REST client path params with API semantics`

## Breaking Changes
Existing callers using the old argument names must be updated.

Updated endpoint contracts:
- `@users`: `userId` -> `id`
- `@groups`: `groupId` -> `id`
- `@addons`: `addonId` -> `id`
- `@types/{type}`: `contentType` -> `type`
- `comments.createComment`: `reply_id` -> `in_reply_to`
- `registry.getRegistryRecord`: `registryName` -> `name`
- `controlpanels.getControlpanel`: `path` -> `id`

## Scope
This PR updates:
- endpoint schemas and URL builders in `packages/client/src/restapi`
- in-repo callers in `packages/cmsui`
- affected client tests and dependent tests that exercise these endpoint contracts

## Notes
- The type field endpoints were intentionally left unchanged in this PR.
- `packages/volto` was intentionally not modified.
- Local commit hooks (`eslint` and `prettier`) ran successfully on the committed files.