### PR TITLE
Fix redirect after login on non-content routes

### DIFF
--- a/packages/volto/news/+login-redirect.bugfix
+++ b/packages/volto/news/+login-redirect.bugfix
@@ -1,1 +1,1 @@
-Fix redirect after logging in starting from the Unauthorized component on a non-content route. @davisagli
+Fixed redirect after logging in when starting from the `Unauthorized` component on a non-content route, such as control panels. @davisagli

--- a/packages/volto/news/+login-redirect.bugfix
+++ b/packages/volto/news/+login-redirect.bugfix
@@ -1,0 +1,1 @@
+Fix redirect after logging in starting from the Unauthorized component on a non-content route. @davisagli

--- a/packages/volto/src/components/theme/Unauthorized/Unauthorized.jsx
+++ b/packages/volto/src/components/theme/Unauthorized/Unauthorized.jsx
@@ -4,7 +4,6 @@ import { Container } from 'semantic-ui-react';
 import { useSelector } from 'react-redux';
 import { useLocation } from 'react-router-dom';
 import { withServerErrorCode } from '@plone/volto/helpers/Utils/Utils';
-import { getBaseUrl } from '@plone/volto/helpers/Url/Url';
 import BodyClass from '@plone/volto/helpers/BodyClass/BodyClass';
 
 const Unauthorized = () => {
@@ -33,7 +32,7 @@ const Unauthorized = () => {
               login: (
                 <Link
                   to={{
-                    pathname: `${getBaseUrl(location.pathname)}/login`,
+                    pathname: `${location.pathname.replace(/\/$/, '')}/login`,
                     state: {
                       // This is needed to cover the use case of being logged in in
                       // another backend (eg. in development), having a token for


### PR DESCRIPTION
This is a follow-up on discussion in https://github.com/plone/volto/issues/6736#issuecomment-4274450790 and below.

If the user tries to access a non-content route and sees the Unauthorized component, the link to the login form should keep the full route as the base, so that the user is taken back to the correct place after logging in.