### PR TITLE
fix: LinkEditor not opening from SlateEditor

### DIFF
--- a/packages/volto-slate/news/4130.bugfix
+++ b/packages/volto-slate/news/4130.bugfix
@@ -1,0 +1,1 @@
+fix LinkEditor not opening from SlateEditor @CannedShroud

--- a/packages/volto-slate/src/editor/plugins/Link/index.jsx
+++ b/packages/volto-slate/src/editor/plugins/Link/index.jsx
@@ -91,7 +91,6 @@ const LinkEditor = (props) => {
         }}
         onOverrideContent={(c) => {
           dispatch(setPluginOptions(pid, { show_sidebar_editor: false }));
-          savedPosition.current = null;
         }}
       />
     </PositionedToolbar>


### PR DESCRIPTION
Backport of #4146 to Volto 18.