### PR TITLE
docs: add versionchanged directive for visually-hidden -volto suffix in Volto 19

### DIFF
--- a/docs/source/contributing/accessibility-guidelines.md
+++ b/docs/source/contributing/accessibility-guidelines.md
@@ -45,6 +45,6 @@ This is true for one-element forms as well, such as the "Search" form on the fol
 Sometimes extra information needs to be provided to users who are not able to see the screen.
 The `.visually-hidden` class can be used to wrap elements which need to be exposed to assistive technologies, such as screen readers, without them being visible.
 
-```{versionremoved} Volto 19
-The suffix `-volto` was removed in Volto 19.
+```{versionchanged} Volto 19
+This CSS class was previously named `visually-hidden-volto`.
 ```

--- a/docs/source/contributing/accessibility-guidelines.md
+++ b/docs/source/contributing/accessibility-guidelines.md
@@ -44,3 +44,7 @@ This is true for one-element forms as well, such as the "Search" form on the fol
 
 Sometimes extra information needs to be provided to users who are not able to see the screen.
 The `.visually-hidden` class can be used to wrap elements which need to be exposed to assistive technologies, such as screen readers, without them being visible.
+
+```{versionremoved} Volto 19
+The suffix `-volto` was removed in Volto 19.
+```

--- a/docs/source/contributing/accessibility-guidelines.md
+++ b/docs/source/contributing/accessibility-guidelines.md
@@ -47,4 +47,5 @@ The `.visually-hidden` class can be used to wrap elements which need to be expos
 
 ```{versionchanged} Volto 19
 This CSS class was previously named `visually-hidden-volto`.
+The suffix `-volto` was removed in Volto 19.
 ```

--- a/docs/source/upgrade-guide/index.md
+++ b/docs/source/upgrade-guide/index.md
@@ -194,7 +194,8 @@ index c469fe9..c39a324 100644
 
 A new global CSS utility class called `visually-hidden` [`@packages/components/src/styles/basic/utility.css`] has been introduced to Volto's SCSS base.
 
-```{versionremoved} Volto 19
+```{versionchanged} Volto 19
+This CSS class was previously named `visually-hidden-volto`.
 The suffix `-volto` was removed in Volto 19.
 ```
 

--- a/docs/source/upgrade-guide/index.md
+++ b/docs/source/upgrade-guide/index.md
@@ -194,6 +194,10 @@ index c469fe9..c39a324 100644
 
 A new global CSS utility class called `visually-hidden` [`@packages/components/src/styles/basic/utility.css`] has been introduced to Volto's SCSS base.
 
+```{versionremoved} Volto 19
+The suffix `-volto` was removed in Volto 19.
+```
+
 This class allows developers to visually hide elements while keeping them accessible to screen readers, improving accessibility for assistive technologies.
 
 If your project, add-on, or custom theme already defines a `visually-hidden` class, or uses similar accessibility helpers, the new global definition may override or conflict with existing custom styles.

--- a/packages/volto/news/8155.documentation
+++ b/packages/volto/news/8155.documentation
@@ -1,0 +1,1 @@
+Added `{versionremoved}` directive documenting the removal of the `-volto` suffix from the `.visually-hidden-volto` CSS class in Volto 19. @Wagner3UB

--- a/packages/volto/news/8155.documentation
+++ b/packages/volto/news/8155.documentation
@@ -1,1 +1,1 @@
-Added `{versionremoved}` directive documenting the removal of the `-volto` suffix from the `.visually-hidden-volto` CSS class in Volto 19. @Wagner3UB
+Added `{versionchanged}` directive documenting the removal of the `-volto` suffix from the `visually-hidden-volto` CSS class in Volto 19. @Wagner3UB


### PR DESCRIPTION
 Add {versionremoved} directive for .visually-hidden-volto suffix                                           
                                                                                                             
The -volto suffix (.visually-hidden-volto) was deprecated in Volto 18 and removed in Volto 19. This PR adds the appropriate {versionremoved} Volto 19 directive in the two relevant documentation locations:          
                                                                                                             
  - docs/source/contributing/accessibility-guidelines.md — in the section about the .visually-hidden utility class                                                                                                    
  - docs/source/upgrade-guide/index.md — in the "New utility class visually-hidden" section                  
                                                                                                             
No code changes.           

<!-- readthedocs-preview volto start -->
----
📚 Documentation preview 📚: https://volto--8155.org.readthedocs.build/

<!-- readthedocs-preview volto end -->