### PR TITLE
change hotkey for strikethrough in Slate editor

### DIFF
--- a/packages/volto-slate/news/4196.breaking
+++ b/packages/volto-slate/news/4196.breaking
@@ -1,0 +1,1 @@
+Change hotkey for strikethrough text to Ctrl+Shift+X / Cmd+Shift+X. @MAX-786

--- a/packages/volto-slate/src/editor/config.jsx
+++ b/packages/volto-slate/src/editor/config.jsx
@@ -207,7 +207,7 @@ export const hotkeys = {
   'mod+b': { format: 'strong', type: 'inline' },
   'mod+i': { format: 'em', type: 'inline' },
   'mod+u': { format: 'u', type: 'inline' },
-  'mod+s': { format: 'del', type: 'inline' },
+  'mod+shift+x': { format: 'del', type: 'inline' },
   // 'mod+`': { format: 'code', type: 'inline' },
   // TODO: more hotkeys, including from plugins!
 };


### PR DESCRIPTION
Backport of #4197 to Volto 18.