### PR TITLE
fix: improve input placeholder contrast ratio for a11y

### DIFF
--- a/packages/volto/news/8182.bugfix
+++ b/packages/volto/news/8182.bugfix
@@ -1,0 +1,1 @@
+Replace hard-coded color values with Semantic UI theme variables for input field to improve accessibility. @Wagner3UB

--- a/packages/volto/theme/themes/default/globals/site.variables
+++ b/packages/volto/theme/themes/default/globals/site.variables
@@ -82,8 +82,8 @@
 
 /* Input Text Color */
 @inputColor: @textColor;
-@inputPlaceholderColor: lighten(@inputColor, 75);
-@inputPlaceholderFocusColor: lighten(@inputColor, 45);
+@inputPlaceholderColor: lighten(@inputColor, 35);
+@inputPlaceholderFocusColor: lighten(@inputColor, 65);
 
 /* Line Height Default For Inputs in Browser (Descenders are 17px at 14px base em) */
 @inputLineHeight: unit((17 / 14), em);

--- a/packages/volto/theme/themes/pastanaga/globals/site.variables
+++ b/packages/volto/theme/themes/pastanaga/globals/site.variables
@@ -48,8 +48,6 @@
 /* This adjusts the default form input across all elements */
 @inputHorizontalPadding : 0;
 
-/* Input Text Color */
-@inputPlaceholderColor: #B8C6C8;
 
 
 /*-------------------


### PR DESCRIPTION
Port of #8044 to 18.x.x

Fixes accessibility issue with input placeholder text contrast ratio (WCAG 2.1).

**Changes:**
- `default/globals/site.variables`: `@inputPlaceholderColor` from `lighten(75)` to `lighten(35)` (darker, better contrast); `@inputPlaceholderFocusColor` from `lighten(45)` to `lighten(65)` (lighter on focus — correct behavior)
- `pastanaga/globals/site.variables`: removed hardcoded `#B8C6C8` that failed contrast requirements, now inherits from default theme