### PR TITLE
Excludes badge links from readme-link-check

### DIFF
--- a/.github/workflows/readme-link-check.yml
+++ b/.github/workflows/readme-link-check.yml
@@ -30,5 +30,6 @@ jobs:
           --exclude https://medium.com/
           --exclude https://www.linkedin.com/
           --exclude https://tanstack.com/
+          --exclude 'https://github.com/.*/actions/workflows/.*badge.svg'
           'packages/**/README.md'
           '*.md'

--- a/packages/volto/news/8189.internal
+++ b/packages/volto/news/8189.internal
@@ -1,0 +1,1 @@
+Excludes badge links from readme-link-check. @wesleybl


### PR DESCRIPTION
It usually returns temporary errors.
