### PR TITLE
Fixes an intermittent error in the Cypress tests blocks-slate-backspace.js and blocks-slate-delete.js

### DIFF
--- a/packages/volto/cypress/tests/core/blocks/blocks-slate-backspace.js
+++ b/packages/volto/cypress/tests/core/blocks/blocks-slate-backspace.js
@@ -19,7 +19,7 @@ describe('Slate Backspace Behavior', () => {
   it('Backspace at start of second block deletes it and merges content into first block', () => {
     cy.getSlateEditorAndType('First block text');
 
-    cy.addNewBlock('slate');
+    cy.getSlateEditorAndType('{enter}');
     cy.getSlateEditorAndType('Second block text');
 
     cy.getSlate().setCursorBefore('Second').type('{backspace}');
@@ -33,7 +33,7 @@ describe('Slate Backspace Behavior', () => {
   it('Enter after Backspace merge splits back into a new block', () => {
     cy.getSlateEditorAndType('Hello');
 
-    cy.addNewBlock('slate');
+    cy.getSlateEditorAndType('{enter}');
     cy.getSlateEditorAndType('World');
 
     cy.getSlate().setCursorBefore('World').type('{backspace}');

--- a/packages/volto/cypress/tests/core/blocks/blocks-slate-delete.js
+++ b/packages/volto/cypress/tests/core/blocks/blocks-slate-delete.js
@@ -18,7 +18,7 @@ describe('Slate Delete key behavior', () => {
   it('Delete at end of A merges B text block into A and removes B', () => {
     cy.getSlateEditorAndType('First block text');
 
-    cy.addNewBlock('slate');
+    cy.getSlateEditorAndType('{enter}');
     cy.getSlateEditorAndType('Second block text');
 
     cy.get(
@@ -30,7 +30,13 @@ describe('Slate Delete key behavior', () => {
       '.content-area .block-editor-slate .slate-editor [contenteditable=true]',
     )
       .first()
-      .type('{moveToEnd}{del}');
+      .type('{moveToEnd}')
+      .trigger('keydown', {
+        key: 'Delete',
+        keyCode: 46,
+        which: 46,
+        bubbles: true,
+      });
 
     cy.get(
       '.content-area .block-editor-slate .slate-editor [contenteditable=true]',
@@ -45,7 +51,7 @@ describe('Slate Delete key behavior', () => {
   it('Delete at end of A removes empty next slate block', () => {
     cy.getSlateEditorAndType('Keep me');
 
-    cy.addNewBlock('slate');
+    cy.getSlateEditorAndType('{enter}');
 
     cy.get(
       '.content-area .block-editor-slate .slate-editor [contenteditable=true]',
@@ -56,7 +62,13 @@ describe('Slate Delete key behavior', () => {
       '.content-area .block-editor-slate .slate-editor [contenteditable=true]',
     )
       .first()
-      .type('{moveToEnd}{del}');
+      .type('{moveToEnd}')
+      .trigger('keydown', {
+        key: 'Delete',
+        keyCode: 46,
+        which: 46,
+        bubbles: true,
+      });
 
     cy.get(
       '.content-area .block-editor-slate .slate-editor [contenteditable=true]',
@@ -94,7 +106,13 @@ describe('Slate Delete key behavior', () => {
       '.content-area .block-editor-slate .slate-editor [contenteditable=true]',
     )
       .first()
-      .type('{moveToEnd}{del}');
+      .type('{moveToEnd}')
+      .trigger('keydown', {
+        key: 'Delete',
+        keyCode: 46,
+        which: 46,
+        bubbles: true,
+      });
 
     cy.get(
       '.content-area .block-editor-slate .slate-editor [contenteditable=true]',

--- a/packages/volto/news/8190.internal
+++ b/packages/volto/news/8190.internal
@@ -1,0 +1,1 @@
+Fixes an intermittent error in the Cypress tests blocks-slate-backspace.js and blocks-slate-delete.js. @wesleybl


### PR DESCRIPTION
Backport of #8190 to Volto 18.
