### PR TITLE
Honor initialPath in ObjectBrowserWidget multiple mode

### DIFF
--- a/packages/volto/news/8156.bugfix
+++ b/packages/volto/news/8156.bugfix
@@ -1,0 +1,1 @@
+Fixed `ObjectBrowserWidget` to honor `frontendOptions.widgetProps.initialPath` when rendered in multiple mode (e.g. `RelationList` of `RelationChoice`). @ericof

--- a/packages/volto/src/components/manage/Sidebar/ObjectBrowser.jsx
+++ b/packages/volto/src/components/manage/Sidebar/ObjectBrowser.jsx
@@ -58,6 +58,7 @@ const withObjectBrowser = (WrappedComponent) =>
       selectableTypes,
       maximumSelectionSize,
       currentPath,
+      initialPath,
       onlyFolderishSelectable,
     } = {}) =>
       this.setState(() => ({
@@ -71,6 +72,7 @@ const withObjectBrowser = (WrappedComponent) =>
         selectableTypes,
         maximumSelectionSize,
         currentPath,
+        initialPath,
         onlyFolderishSelectable,
       }));
 
@@ -81,6 +83,10 @@ const withObjectBrowser = (WrappedComponent) =>
         this.state?.currentPath ||
         this.props.pathname ||
         this.props.location?.pathname;
+
+      let initialPath = this.state?.initialPath
+        ? getBaseUrl(this.state.initialPath)
+        : null;
 
       return (
         <>
@@ -105,6 +111,7 @@ const withObjectBrowser = (WrappedComponent) =>
                     : this.props.data
                 }
                 contextURL={getBaseUrl(contextURL)}
+                initialPath={initialPath}
                 closeObjectBrowser={this.closeObjectBrowser}
                 mode={this.state.mode}
                 onSelectItem={this.state.onSelectItem}

--- a/packages/volto/src/components/manage/Sidebar/ObjectBrowserBody.jsx
+++ b/packages/volto/src/components/manage/Sidebar/ObjectBrowserBody.jsx
@@ -84,6 +84,7 @@ class ObjectBrowserBody extends Component {
     onSelectItem: PropTypes.func,
     dataName: PropTypes.string,
     maximumSelectionSize: PropTypes.number,
+    initialPath: PropTypes.string,
     contextURL: PropTypes.string,
     searchableTypes: PropTypes.arrayOf(PropTypes.string),
     onlyFolderishSelectable: PropTypes.bool,
@@ -113,18 +114,21 @@ class ObjectBrowserBody extends Component {
    */
   constructor(props) {
     super(props);
+    const defaultMultiplePath = props.initialPath || '/';
     this.state = {
       currentFolder:
-        this.props.mode === 'multiple' ? '/' : this.props.contextURL || '/',
+        this.props.mode === 'multiple'
+          ? defaultMultiplePath
+          : this.props.contextURL || '/',
       currentImageFolder:
         this.props.mode === 'multiple'
-          ? '/'
+          ? defaultMultiplePath
           : this.props.mode === 'image' && this.props.data?.url
             ? getParentURL(this.props.data.url)
             : '/',
       currentLinkFolder:
         this.props.mode === 'multiple'
-          ? '/'
+          ? defaultMultiplePath
           : this.props.mode === 'link' && this.props.data?.href
             ? getParentURL(this.props.data.href)
             : '/',

--- a/packages/volto/src/components/manage/Sidebar/ObjectBrowserBody.test.jsx
+++ b/packages/volto/src/components/manage/Sidebar/ObjectBrowserBody.test.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import configureStore from 'redux-mock-store';
+import { Provider } from 'react-intl-redux';
+import ObjectBrowserBody from './ObjectBrowserBody';
+
+const mockStore = configureStore();
+
+const baseState = {
+  search: { subrequests: {} },
+  intl: { locale: 'en', messages: {} },
+};
+
+const baseProps = {
+  block: 'test-block',
+  data: {},
+  closeObjectBrowser: () => {},
+  onChangeBlock: () => {},
+};
+
+const getInitialSearchPath = (actions) => {
+  const action = actions.find((a) => a.type === 'SEARCH_CONTENT');
+  return action?.request?.path?.split('/@search')[0];
+};
+
+describe('ObjectBrowserBody', () => {
+  it('uses initialPath as the default folder when mode=multiple', () => {
+    const store = mockStore(baseState);
+    render(
+      <Provider store={store}>
+        <ObjectBrowserBody
+          {...baseProps}
+          mode="multiple"
+          initialPath="/company/team"
+        />
+      </Provider>,
+    );
+
+    expect(getInitialSearchPath(store.getActions())).toBe('/company/team');
+  });
+
+  it('defaults to root when mode=multiple and initialPath is not provided', () => {
+    const store = mockStore(baseState);
+    render(
+      <Provider store={store}>
+        <ObjectBrowserBody {...baseProps} mode="multiple" />
+      </Provider>,
+    );
+
+    expect(getInitialSearchPath(store.getActions())).toBe('/');
+  });
+});

--- a/packages/volto/src/components/manage/Widgets/ObjectBrowserWidget.jsx
+++ b/packages/volto/src/components/manage/Widgets/ObjectBrowserWidget.jsx
@@ -307,6 +307,7 @@ export class ObjectBrowserWidgetComponent extends Component {
     this.props.openObjectBrowser({
       mode: this.props.mode,
       currentPath: this.props.initialPath || this.props.location.pathname,
+      initialPath: this.props.initialPath,
       propDataName: 'value',
       onSelectItem: (url, item) => {
         this.onChange(item);


### PR DESCRIPTION
## Summary

- Threads `initialPath` through `withObjectBrowser` so the `ObjectBrowser` sidebar honors `frontendOptions.widgetProps.initialPath` when the widget is rendered in **multiple** mode (e.g. `RelationList` of `RelationChoice`).
- Previously, multi-value relation fields opened the object browser at the site root regardless of the configured `initialPath`. Single-value `RelationChoice` was already honoring it.
- Adds a unit test on `ObjectBrowserBody` that pins down both the `initialPath` case and the root-default case for `mode === 'multiple'`.

## Test plan

- [x] `pnpm test:ci src/components/manage/Sidebar/ObjectBrowserBody.test.jsx` passes (verified locally — 2/2 green).
- [x] On a content type with `RelationList` → `RelationChoice` configured with `frontendOptions.widgetProps.initialPath = "/company/team"`, editing a content item and clicking the field opens the browser navigated to `/company/team`.
- [x] Single-mode `RelationChoice` continues to honor `initialPath` (no regression).
- [x] A widget without `initialPath` configured (the common case) still opens at the site root in multiple mode and at the current context in single mode.

Closes #8156