### PR TITLE
Translate block titles in Order tab

### DIFF
--- a/packages/volto/news/7348.bugfix
+++ b/packages/volto/news/7348.bugfix
@@ -1,0 +1,1 @@
+Translate block titles displayed in the Order tab of the sidebar. @ericof

--- a/packages/volto/src/components/manage/BlockChooser/BlockChooser.jsx
+++ b/packages/volto/src/components/manage/BlockChooser/BlockChooser.jsx
@@ -10,6 +10,7 @@ import { useIntl, defineMessages } from 'react-intl';
 import Icon from '@plone/volto/components/theme/Icon/Icon';
 import AnimateHeight from 'react-animate-height';
 import config from '@plone/volto/registry';
+import { formatMessageWithFallback } from '@plone/volto/helpers/I18n/I18n';
 import upSVG from '@plone/volto/icons/up-key.svg';
 import downSVG from '@plone/volto/icons/down-key.svg';
 import BlockChooserSearch from './BlockChooserSearch';
@@ -98,16 +99,10 @@ const BlockChooser = ({
   }
   const [filterValue, setFilterValue] = React.useState('');
 
-  const getFormatMessage = (message) =>
-    intl.formatMessage({
-      id: message,
-      defaultMessage: message,
-    });
-
   function blocksAvailableFilter(blocks) {
     return blocks.filter(
       (block) =>
-        getFormatMessage(block.title)
+        formatMessageWithFallback(intl, block.title)
           .toLowerCase()
           .includes(filterValue.toLowerCase()) ||
         block.title.toLowerCase().includes(filterValue.toLowerCase()) ||
@@ -117,7 +112,7 @@ const BlockChooser = ({
   function filterVariations(block) {
     return block.variations?.filter(
       (variation) =>
-        getFormatMessage(variation.title)
+        formatMessageWithFallback(intl, variation.title)
           .toLowerCase()
           .includes(filterValue.toLowerCase()) &&
         !variation.title.toLowerCase().includes('default'),
@@ -145,9 +140,11 @@ const BlockChooser = ({
           }}
         >
           <Icon name={block.icon} size="36px" />
-          {getFormatMessage(block.title)}
+          {formatMessageWithFallback(intl, block.title)}
           {filterValue && variations?.[0]?.title && (
-            <small>{getFormatMessage(variations[0].title)}</small>
+            <small>
+              {formatMessageWithFallback(intl, variations[0].title)}
+            </small>
           )}
         </Button>
       </Button.Group>

--- a/packages/volto/src/components/manage/Blocks/Block/Order/Item.jsx
+++ b/packages/volto/src/components/manage/Blocks/Block/Order/Item.jsx
@@ -5,7 +5,9 @@ import includes from 'lodash/includes';
 import cx from 'classnames';
 import Icon from '@plone/volto/components/theme/Icon/Icon';
 import { setUIState } from '@plone/volto/actions/form/form';
+import { formatMessageWithFallback } from '@plone/volto/helpers/I18n/I18n';
 import config from '@plone/volto/registry';
+import { useIntl } from 'react-intl';
 
 import deleteSVG from '@plone/volto/icons/delete.svg';
 import dragSVG from '@plone/volto/icons/drag.svg';
@@ -34,6 +36,7 @@ export const Item = forwardRef(
     },
     ref,
   ) => {
+    const intl = useIntl();
     const selected = useSelector((state) => state.form.ui.selected);
     const hovered = useSelector((state) => state.form.ui.hovered);
     const multiSelected = useSelector((state) => state.form.ui.multiSelected);
@@ -49,7 +52,11 @@ export const Item = forwardRef(
         ? data.required
         : includes(config.blocks.requiredBlocks, data?.['@type']);
     const fixed = !!data?.fixed;
-
+    const configTitle = config.blocks.blocksConfig[data?.['@type']]?.title;
+    const blockTitle =
+      data?.plaintext ||
+      formatMessageWithFallback(intl, configTitle) ||
+      data?.title;
     return (
       <li
         className={classNames(
@@ -122,9 +129,7 @@ export const Item = forwardRef(
                 style={{ verticalAlign: 'middle' }}
               />
             )}{' '}
-            {data?.plaintext ||
-              config.blocks.blocksConfig[data?.['@type']]?.title ||
-              data?.title}
+            {blockTitle}
           </span>
           {!clone && onRemove && !required && (
             <button

--- a/packages/volto/src/components/manage/Controlpanels/BlockType.tsx
+++ b/packages/volto/src/components/manage/Controlpanels/BlockType.tsx
@@ -2,6 +2,7 @@ import { getBlockTypes } from '@plone/volto/actions/blockTypes/blockTypes';
 import Toolbar from '@plone/volto/components/manage/Toolbar/Toolbar';
 import Icon from '@plone/volto/components/theme/Icon/Icon';
 import { getParentUrl, flattenToAppURL } from '@plone/volto/helpers/Url/Url';
+import { formatMessageWithFallback } from '@plone/volto/helpers/I18n/I18n';
 import { useClient } from '@plone/volto/hooks';
 import config from '@plone/volto/registry';
 import { useEffect } from 'react';
@@ -86,9 +87,7 @@ const BlockTypeControlpanel = (props: RouteProps) => {
     return <Error error={blockTypes.error} />;
   }
 
-  const translatedTitle = block?.title
-    ? intl.formatMessage({ id: block.title, defaultMessage: block.title })
-    : id;
+  const translatedTitle = formatMessageWithFallback(intl, block?.title) || id;
 
   return (
     blockTypes.loaded && (

--- a/packages/volto/src/helpers/I18n/I18n.test.ts
+++ b/packages/volto/src/helpers/I18n/I18n.test.ts
@@ -1,0 +1,44 @@
+import { createIntl, createIntlCache } from 'react-intl';
+import type { IntlShape } from 'react-intl';
+import { formatMessageWithFallback } from './I18n';
+
+const buildIntl = (
+  locale: string,
+  messages: Record<string, string>,
+): IntlShape => createIntl({ locale, messages }, createIntlCache());
+
+describe('formatMessageWithFallback', () => {
+  it('returns the translated string when the locale catalog has an entry', () => {
+    const intl = buildIntl('pt-BR', { Image: 'Imagem' });
+    expect(formatMessageWithFallback(intl, 'Image')).toBe('Imagem');
+  });
+
+  it('falls back to the input message when no translation is registered', () => {
+    const intl = buildIntl('pt-BR', {});
+    expect(formatMessageWithFallback(intl, 'Image')).toBe('Image');
+  });
+
+  it('returns undefined unchanged', () => {
+    const intl = buildIntl('en', {});
+    expect(formatMessageWithFallback(intl, undefined)).toBeUndefined();
+  });
+
+  it('returns null unchanged', () => {
+    const intl = buildIntl('en', {});
+    expect(formatMessageWithFallback(intl, null)).toBeNull();
+  });
+
+  it('returns an empty string unchanged', () => {
+    const intl = buildIntl('en', {});
+    expect(formatMessageWithFallback(intl, '')).toBe('');
+  });
+
+  it('does not call intl.formatMessage when the message is falsy', () => {
+    const intl = buildIntl('en', {});
+    const spy = vi.spyOn(intl, 'formatMessage');
+    formatMessageWithFallback(intl, undefined);
+    formatMessageWithFallback(intl, null);
+    formatMessageWithFallback(intl, '');
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/volto/src/helpers/I18n/I18n.ts
+++ b/packages/volto/src/helpers/I18n/I18n.ts
@@ -1,0 +1,31 @@
+/**
+ * I18n helpers.
+ * @module helpers/I18n/I18n
+ */
+
+import type { IntlShape } from 'react-intl';
+
+/**
+ * Format a `react-intl` message using a plain string as both the id and the
+ * default fallback. Useful when a UI value (e.g. a block title configured as
+ * a plain string) should be looked up in the locale catalog when available,
+ * and rendered as-is otherwise.
+ *
+ * Returns the input untouched when it is falsy, so the result can be used
+ * directly in `||` fallback chains.
+ *
+ * @param intl react-intl `intl` instance, typically from `useIntl()`.
+ * @param message The string to translate; used as both `id` and
+ *   `defaultMessage`.
+ * @returns Translated text, or `message` unchanged if falsy / no translation.
+ */
+export function formatMessageWithFallback<T extends string | undefined | null>(
+  intl: IntlShape,
+  message: T,
+): T extends string ? string : T {
+  if (!message) return message as T extends string ? string : T;
+  return intl.formatMessage({
+    id: message,
+    defaultMessage: message,
+  }) as T extends string ? string : T;
+}

--- a/packages/volto/src/helpers/index.js
+++ b/packages/volto/src/helpers/index.js
@@ -112,6 +112,7 @@ export {
   normalizeString,
 } from '@plone/volto/helpers/Utils/Utils';
 export { messages } from './MessageLabels/MessageLabels';
+export { formatMessageWithFallback } from './I18n/I18n';
 export {
   withBlockSchemaEnhancer,
   withVariationSchemaEnhancer,


### PR DESCRIPTION
## Summary

- The Order tab in the block sidebar was rendering `config.blocks.blocksConfig[…].title` (a plain string like `"Image"`, `"Listing"`) as-is, ignoring the locale catalog. Visible to anyone using Volto in a non-English locale: the rest of the sidebar localized correctly, the Order tab did not.
- Extract the existing `intl.formatMessage({ id: x, defaultMessage: x })` pattern — already used in `BlockChooser` and `BlockType` — into a shared `formatMessageWithFallback` helper at [packages/volto/src/helpers/I18n/I18n.ts](packages/volto/src/helpers/I18n/I18n.ts).
- Route the three call sites (`Order/Item.jsx`, `BlockChooser.jsx`, `BlockType.tsx`) through the helper, removing the local `getFormatMessage` from `BlockChooser`.
- Add unit tests for the helper (translated case, fallback case, falsy passthrough for `undefined`/`null`/`''`, no-op assertion for falsy inputs).

The capitalized block title strings (`"Title"`, `"Image"`, `"Listing"`, …) already exist in the locale catalogs (verified in `pt_BR.json`), so this fix activates them without any catalog churn.

## Test plan

- [x] `pnpm test:ci src/helpers/I18n` passes (6/6 green).
- [x] `pnpm test:ci` for the three affected component directories passes (23 files / 45 tests green; no snapshot churn).
- [X] In a non-English locale (e.g. `pt-BR`), opening the Order tab on a page with several block types shows translated titles (`"Imagem"`, `"Listagem"`, …) instead of the English defaults.
- [X] Block Chooser still filters and renders block titles in the user's locale.
- [x] The `/controlpanel/block-type/<id>` page still shows the translated block title in its heading.

Closes #7348