### PR TITLE
[Seven] Make style fields first-class and preserve block width fallback

### DIFF
--- a/packages/blocks/Image/index.ts
+++ b/packages/blocks/Image/index.ts
@@ -15,10 +15,6 @@ const ImageBlockInfo = {
   category: 'media',
   blockSchema: ImageSchema,
   icon: ImageIcon,
-  blockWidth: {
-    defaultWidth: 'default',
-    widths: ['layout', 'default', 'narrow', 'full'],
-  },
 } satisfies Partial<BlockConfigBase>;
 
 export default ImageBlockInfo;

--- a/packages/blocks/Image/schema.tsx
+++ b/packages/blocks/Image/schema.tsx
@@ -54,6 +54,7 @@ export function ImageSchema({
         title: 'Block width',
         widget: 'width',
         default: 'default',
+        styleField: true,
       },
       align: {
         title: 'Alignment',

--- a/packages/blocks/news/+style-fields-width-fallback.internal
+++ b/packages/blocks/news/+style-fields-width-fallback.internal
@@ -1,0 +1,1 @@
+Added first-class generic style field support while preserving `blockWidth` fallback for Plone blocks and explicit width handling for Plate-native blocks. @sneridagh

--- a/packages/layout/helpers/index.ts
+++ b/packages/layout/helpers/index.ts
@@ -48,7 +48,7 @@ export function shouldShowToolbar(content?: Content | null) {
 export const getBlockStyleFieldConfigs = (
   data: BlocksFormData,
   blocksConfig?: BlocksConfigData,
-): Record<string, StyleFieldConfig> => {
+) => {
   const blockType = data['@type'];
 
   if (!blockType) return {};
@@ -56,8 +56,8 @@ export const getBlockStyleFieldConfigs = (
   const blockConfig = blocksConfig?.[blockType];
   const styleFields = getStyleFieldsFromBlockSchema(blockConfig, data);
 
-  // `blockWidth` is still configured in blocksConfig, not in the block schema,
-  // so public rendering needs to bridge that special case into the generic resolver.
+  // Keep `blockWidth` as a fallback for Plone blocks that wants to configure it
+  // in blocksConfig instead using a explicit width schema field marked with `styleField: true`.
   if (blockConfig?.blockWidth) {
     styleFields.blockWidth = {
       defaultValue: blockConfig.blockWidth.defaultWidth,
@@ -65,5 +65,5 @@ export const getBlockStyleFieldConfigs = (
     };
   }
 
-  return styleFields;
+  return styleFields as Record<string, StyleFieldConfig>;
 };

--- a/packages/layout/news/+style-fields-width-fallback.feature
+++ b/packages/layout/news/+style-fields-width-fallback.feature
@@ -1,0 +1,1 @@
+Added first-class generic style field support while preserving `blockWidth` fallback for Plone blocks and explicit width handling for Plate-native blocks. @sneridagh

--- a/packages/plate/components/editor/block-editor-base-kit.tsx
+++ b/packages/plate/components/editor/block-editor-base-kit.tsx
@@ -12,6 +12,7 @@ import { BaseListKit } from './plugins/list-base-kit';
 import { BaseMediaKit } from './plugins/media-base-kit';
 import { BaseMentionKit } from './plugins/mention-base-kit';
 import { BaseBlockWidthKit } from './plugins/block-width-base-kit';
+import { BaseStyleFieldsKit } from './plugins/style-fields-base-kit';
 import { BaseSuggestionKit } from './plugins/suggestion-base-kit';
 import { BaseTableKit } from './plugins/table-base-kit';
 import { BaseTocKit } from './plugins/toc-base-kit';
@@ -31,9 +32,10 @@ export const BlockBaseEditorKit = [
   ...BaseBasicMarksKit,
   ...BaseFontKit,
   ...BaseListKit,
+  ...BaseStyleFieldsKit,
+  ...BaseBlockWidthKit,
   ...BaseAlignKit,
   ...BaseLineHeightKit,
-  ...BaseBlockWidthKit,
   ...BaseCommentKit,
   ...BaseSuggestionKit,
 ];

--- a/packages/plate/components/editor/block-editor-kit.tsx
+++ b/packages/plate/components/editor/block-editor-kit.tsx
@@ -26,6 +26,7 @@ import { MarkdownKit } from './plugins/markdown-kit';
 import { MediaKit } from './plugins/media-kit';
 import { MentionKit } from './plugins/mention-kit';
 import { BlockWidthKit } from './plugins/block-width-kit';
+import { StyleFieldsKit } from './plugins/style-fields-kit';
 import { SlashKit } from './plugins/slash-kit';
 import { SuggestionKit } from './plugins/suggestion-kit';
 import { TableKit } from './plugins/table-kit';
@@ -54,10 +55,11 @@ export const BlockEditorKit = [
   ...FontKit,
 
   // Block Style
+  ...StyleFieldsKit,
+  ...BlockWidthKit,
   ...ListKit,
   ...AlignKit,
   ...LineHeightKit,
-  ...BlockWidthKit,
 
   // Collaboration
   ...DiscussionKit,

--- a/packages/plate/components/editor/editor-base-kit.tsx
+++ b/packages/plate/components/editor/editor-base-kit.tsx
@@ -13,6 +13,7 @@ import { MarkdownKit } from './plugins/markdown-kit';
 import { BaseMediaKit } from './plugins/media-base-kit';
 import { BaseMentionKit } from './plugins/mention-base-kit';
 import { BaseBlockWidthKit } from './plugins/block-width-base-kit';
+import { BaseStyleFieldsKit } from './plugins/style-fields-base-kit';
 // import { BaseSuggestionKit } from './plugins/suggestion-base-kit';
 import { BaseTableKit } from './plugins/table-base-kit';
 import { BaseTocKit } from './plugins/toc-base-kit';
@@ -32,9 +33,10 @@ export const BaseEditorKit = [
   ...BaseBasicMarksKit,
   ...BaseFontKit,
   ...BaseListKit,
+  ...BaseStyleFieldsKit,
+  ...BaseBlockWidthKit,
   ...BaseAlignKit,
   ...BaseLineHeightKit,
-  ...BaseBlockWidthKit,
   // ...BaseCommentKit,
   // ...BaseSuggestionKit,
   ...MarkdownKit,

--- a/packages/plate/components/editor/editor-kit.tsx
+++ b/packages/plate/components/editor/editor-kit.tsx
@@ -27,6 +27,7 @@ import { MarkdownKit } from './plugins/markdown-kit';
 import { MediaKit } from './plugins/media-kit';
 import { MentionKit } from './plugins/mention-kit';
 import { BlockWidthKit } from './plugins/block-width-kit';
+import { StyleFieldsKit } from './plugins/style-fields-kit';
 import { SlashKit } from './plugins/slash-kit';
 // import { SuggestionKit } from './plugins/suggestion-kit';
 import { TableKit } from './plugins/table-kit';
@@ -54,10 +55,11 @@ export const EditorKit = [
   ...FontKit,
 
   // Block Style
+  ...StyleFieldsKit,
+  ...BlockWidthKit,
   ...ListKit,
   ...AlignKit,
   ...LineHeightKit,
-  ...BlockWidthKit,
 
   // Collaboration
   // ...DiscussionKit,

--- a/packages/plate/components/editor/plugins/block-width-plugin.test.ts
+++ b/packages/plate/components/editor/plugins/block-width-plugin.test.ts
@@ -141,12 +141,24 @@ describe('block width plugin', () => {
     });
   });
 
-  it('resolves plone block width config from config.blocks.blocksConfig', () => {
+  it('does not use blocksConfig.blockWidth for unknown blocks in BlockWidthPlugin', () => {
+    registryBlocks.widths = [
+      {
+        name: 'default',
+        label: 'Default',
+        style: { '--block-width': 'var(--default-container-width)' },
+      },
+      {
+        name: 'layout',
+        label: 'Layout',
+        style: { '--block-width': 'var(--layout-container-width)' },
+      },
+    ];
     registryBlocks.blocksConfig = {
       image: {
         blockWidth: {
-          defaultWidth: 'default',
-          widths: ['layout', 'default'],
+          defaultWidth: 'layout',
+          widths: ['layout'],
         },
       },
     };
@@ -161,7 +173,53 @@ describe('block width plugin', () => {
       } as any),
     ).toEqual({
       defaultWidth: 'default',
-      widths: ['layout', 'default'],
+      widths: ['default', 'layout'],
+    });
+  });
+
+  it('still uses blocksConfig.blockWidth as a fallback for unknown blocks in style fields', () => {
+    registryBlocks.widths = [
+      {
+        name: 'default',
+        label: 'Default',
+        style: { '--block-width': 'var(--default-container-width)' },
+      },
+      {
+        name: 'layout',
+        label: 'Layout',
+        style: { '--block-width': 'var(--layout-container-width)' },
+      },
+    ];
+    registryBlocks.blocksConfig = {
+      image: {
+        blockWidth: {
+          defaultWidth: 'layout',
+          widths: ['layout'],
+        },
+      },
+    };
+
+    const transformProps = (BaseStyleFieldsPlugin as any).inject.nodeProps
+      .transformProps as TransformPropsFn;
+
+    expect(
+      transformProps({
+        element: {
+          type: 'unknown',
+          '@type': 'image',
+          children: [{ text: '' }],
+        },
+        props: {
+          style: {
+            color: 'red',
+          },
+        },
+      }),
+    ).toEqual({
+      style: {
+        color: 'red',
+        '--block-width': 'var(--layout-container-width)',
+      },
     });
   });
 

--- a/packages/plate/components/editor/plugins/block-width-plugin.ts
+++ b/packages/plate/components/editor/plugins/block-width-plugin.ts
@@ -1,11 +1,13 @@
-import type { SlateEditor, TElement } from 'platejs';
+import {
+  createSlatePlugin,
+  ElementApi,
+  type SetNodesOptions,
+  type SlateEditor,
+  type TElement,
+} from 'platejs';
 import config from '@plone/registry';
 import type { StyleDefinition } from '@plone/types';
-
-import {
-  BaseStyleFieldsPlugin,
-  StyleFieldsPlugin,
-} from './style-fields-plugin';
+import { toPlatePlugin } from 'platejs/react';
 
 export const BLOCK_WIDTH_KEY = 'blockWidth';
 export const FALLBACK_BLOCK_WIDTH = 'default';
@@ -78,6 +80,9 @@ export const getBlockWidthOptions = () =>
     value: width.name as BlockWidthValue,
   }));
 
+const getBlockWidthStyle = (value?: string) =>
+  getBlockWidthDefinitions().find((width) => width.name === value)?.style;
+
 const getPlateBlockRegistryWidthConfig = (
   element?: TElement | null,
 ): BlockWidthConfig => {
@@ -109,6 +114,10 @@ export const resolveBlockWidthConfig = (
   editor: SlateEditor,
   element?: TElement | null,
 ): BlockWidthConfig => {
+  if (element?.type === 'unknown') {
+    return {};
+  }
+
   const registryConfig =
     element?.type === 'unknown'
       ? getPloneBlockRegistryWidthConfig(element)
@@ -163,10 +172,16 @@ export const applyBlockWidthDefaultsInValue = (value: unknown[]) => {
     const element = node as ValueElement;
     if (typeof element.type !== 'string') return;
 
-    const registryConfig =
-      element.type === 'unknown'
-        ? getPloneBlockRegistryWidthConfig(element as TElement)
-        : getPlateBlockRegistryWidthConfig(element as TElement);
+    if (element.type === 'unknown') {
+      if (Array.isArray(element.children)) {
+        element.children.forEach(visit);
+      }
+      return;
+    }
+
+    const registryConfig = getPlateBlockRegistryWidthConfig(
+      element as TElement,
+    );
     const defaultWidth = registryConfig.defaultWidth ?? fallbackDefaultWidth;
     const widths = registryConfig.widths?.length
       ? registryConfig.widths
@@ -204,6 +219,10 @@ export const withBlockWidthDefaults = <T extends TElement>(
   editor: SlateEditor,
   element: T,
 ): T => {
+  if (element.type === 'unknown') {
+    return element;
+  }
+
   const width = getEffectiveBlockWidth(editor, element);
 
   if (element[BLOCK_WIDTH_KEY] === width) {
@@ -216,5 +235,125 @@ export const withBlockWidthDefaults = <T extends TElement>(
   };
 };
 
-export const BaseBlockWidthPlugin = BaseStyleFieldsPlugin;
-export const BlockWidthPlugin = StyleFieldsPlugin;
+const withInsertedBlockWidthDefaults = (
+  editor: SlateEditor,
+  nodes: unknown,
+): unknown => {
+  if (Array.isArray(nodes)) {
+    return nodes.map((node) => withInsertedBlockWidthDefaults(editor, node));
+  }
+
+  if (!ElementApi.isElement(nodes)) {
+    return nodes;
+  }
+
+  const children: unknown[] | undefined = Array.isArray(nodes.children)
+    ? nodes.children.map((child: unknown) =>
+        withInsertedBlockWidthDefaults(editor, child),
+      )
+    : nodes.children;
+  const nextNode: TElement =
+    children === nodes.children ? nodes : ({ ...nodes, children } as TElement);
+
+  if (!editor.api.isBlock(nextNode) || nextNode.type === 'unknown') {
+    return nextNode;
+  }
+
+  return withBlockWidthDefaults(editor, nextNode);
+};
+
+const setBlockWidth = (
+  editor: SlateEditor,
+  value: string,
+  setNodesOptions?: SetNodesOptions,
+) => {
+  const matchesValue = (node: TElement) => {
+    if (node.type === 'unknown') return false;
+
+    const config = getBlockWidthConfig(editor, node);
+
+    return isAllowedWidth(config.widths, value);
+  };
+
+  editor.tf.setNodes(
+    { [BLOCK_WIDTH_KEY]: value },
+    {
+      match: (node) =>
+        ElementApi.isElement(node) &&
+        editor.api.isBlock(node) &&
+        matchesValue(node),
+      ...setNodesOptions,
+    },
+  );
+};
+
+export const BaseBlockWidthPlugin = createSlatePlugin({
+  key: BLOCK_WIDTH_KEY,
+  normalizeInitialValue: ({ value }) => {
+    applyBlockWidthDefaultsInValue(value);
+  },
+  inject: {
+    isBlock: true,
+    nodeProps: {
+      nodeKey: BLOCK_WIDTH_KEY,
+      transformProps: ({ editor, element, nodeValue, props }) => {
+        if (
+          !element ||
+          !ElementApi.isElement(element) ||
+          element.type === 'unknown'
+        ) {
+          return props;
+        }
+
+        const widthValue = getEffectiveBlockWidth(editor, element) ?? nodeValue;
+        const widthStyle = getBlockWidthStyle(widthValue);
+
+        if (!widthStyle) return props;
+
+        return {
+          ...props,
+          style: {
+            ...(props.style ?? {}),
+            ...widthStyle,
+          },
+        };
+      },
+    },
+  },
+  options: {
+    defaultWidths: [],
+  },
+  extendEditor: ({ editor }) => {
+    const createBlock = editor.api.create.block.bind(editor.api.create);
+    const insertNodes = editor.tf.insertNodes.bind(editor.tf);
+
+    editor.api.create.block = ((...args: any[]) =>
+      withInsertedBlockWidthDefaults(editor, createBlock(...args))) as any;
+
+    editor.tf.insertNodes = ((nodes: any, options?: any) =>
+      insertNodes(
+        withInsertedBlockWidthDefaults(editor, nodes) as any,
+        options,
+      )) as any;
+
+    return editor;
+  },
+}).extendTransforms(({ editor }) => ({
+  resetWidth: (options?: SetNodesOptions) => {
+    const blockEntry = editor.api.block();
+    const block =
+      blockEntry &&
+      ElementApi.isElement(blockEntry[0]) &&
+      blockEntry[0].type !== 'unknown'
+        ? blockEntry[0]
+        : undefined;
+    const { defaultWidth } = getBlockWidthConfig(editor, block);
+
+    setBlockWidth(editor, defaultWidth, options);
+  },
+  setWidth: (value: string, options?: SetNodesOptions) => {
+    setBlockWidth(editor, value, options);
+  },
+}));
+
+export const BlockWidthPlugin = toPlatePlugin(BaseBlockWidthPlugin);

--- a/packages/plate/components/editor/plugins/style-fields-base-kit.tsx
+++ b/packages/plate/components/editor/plugins/style-fields-base-kit.tsx
@@ -1,0 +1,3 @@
+import { BaseStyleFieldsPlugin } from './style-fields-plugin';
+
+export const BaseStyleFieldsKit = [BaseStyleFieldsPlugin];

--- a/packages/plate/components/editor/plugins/style-fields-kit.tsx
+++ b/packages/plate/components/editor/plugins/style-fields-kit.tsx
@@ -1,0 +1,3 @@
+import { StyleFieldsPlugin } from './style-fields-plugin';
+
+export const StyleFieldsKit = [StyleFieldsPlugin];

--- a/packages/plate/components/editor/plugins/style-fields-plugin.ts
+++ b/packages/plate/components/editor/plugins/style-fields-plugin.ts
@@ -17,7 +17,6 @@ import {
 import { toPlatePlugin } from 'platejs/react';
 
 export const STYLE_FIELDS_KEY = 'styleFields';
-const BLOCK_WIDTH_KEY = 'blockWidth';
 type StyleFieldConfig = {
   defaultValue?: string;
   values?: readonly string[];
@@ -50,20 +49,20 @@ const getGlobalDefaultWidth = () => {
   return values[0];
 };
 
-const getLegacyStyleFieldConfigs = (
+const withBlockWidthFallback = (
   styleFields: Record<string, StyleFieldConfig>,
-  legacyWidthConfig?: {
+  blockWidthConfig?: {
     defaultWidth?: string;
     widths?: readonly string[];
   },
 ) => {
-  if (!legacyWidthConfig) {
+  if (!blockWidthConfig) {
     return styleFields;
   }
 
-  styleFields[BLOCK_WIDTH_KEY] = {
-    defaultValue: legacyWidthConfig.defaultWidth ?? getGlobalDefaultWidth(),
-    values: legacyWidthConfig.widths ?? getGlobalWidthValues(),
+  styleFields.blockWidth = {
+    defaultValue: blockWidthConfig.defaultWidth ?? getGlobalDefaultWidth(),
+    values: blockWidthConfig.widths ?? getGlobalWidthValues(),
   };
 
   return styleFields;
@@ -84,7 +83,7 @@ const getElementStyleFieldConfigs = (
 
     const currentBlockConfig = blockConfig?.[blockType];
 
-    return getLegacyStyleFieldConfigs(
+    return withBlockWidthFallback(
       getStyleFieldsFromBlockSchema(
         currentBlockConfig,
         element as unknown as BlocksFormData,
@@ -93,22 +92,7 @@ const getElementStyleFieldConfigs = (
     );
   }
 
-  const plateBlocksConfig = (config.blocks as Record<string, unknown>)
-    .plateBlocksConfig as
-    | Record<
-        string,
-        {
-          blockWidth?: { defaultWidth?: string; widths?: readonly string[] };
-        }
-      >
-    | undefined;
-
-  return getLegacyStyleFieldConfigs(
-    {},
-    typeof element.type === 'string'
-      ? plateBlocksConfig?.[element.type]?.blockWidth
-      : undefined,
-  );
+  return {};
 };
 
 const applyStyleFieldDefaultsToElement = <T extends TElement>(

--- a/packages/plate/components/ui/block-width-toolbar-button.tsx
+++ b/packages/plate/components/ui/block-width-toolbar-button.tsx
@@ -14,7 +14,6 @@ import {
 
 import {
   BlockWidthPlugin,
-  BLOCK_WIDTH_KEY,
   getDefaultBlockWidth,
   getBlockWidthConfig,
   getBlockWidthOptions,
@@ -36,9 +35,9 @@ import {
 
 export function BlockWidthToolbarButton(props: DropdownMenuProps) {
   const { editor, tf } = useEditorPlugin(BlockWidthPlugin);
-  const styleFieldTransforms = tf.styleFields as {
-    resetStyleField: (fieldName: string) => void;
-    setStyleField: (fieldName: string, value: string) => void;
+  const blockWidthTransforms = tf.blockWidth as {
+    resetWidth: () => void;
+    setWidth: (value: string) => void;
   };
   const [open, setOpen] = React.useState(false);
   const activeBlock = editor.api.block()?.[0];
@@ -65,7 +64,7 @@ export function BlockWidthToolbarButton(props: DropdownMenuProps) {
       <ToolbarSplitButtonPrimary
         className="data-[state=on]:bg-accent data-[state=on]:text-accent-foreground"
         onClick={() => {
-          styleFieldTransforms.resetStyleField(BLOCK_WIDTH_KEY);
+          blockWidthTransforms.resetWidth();
           editor.tf.focus();
         }}
         data-state={value !== baseValue ? 'on' : 'off'}
@@ -82,7 +81,7 @@ export function BlockWidthToolbarButton(props: DropdownMenuProps) {
           <DropdownMenuRadioGroup
             value={value ?? baseValue}
             onValueChange={(newValue) => {
-              styleFieldTransforms.setStyleField(BLOCK_WIDTH_KEY, newValue);
+              blockWidthTransforms.setWidth(newValue);
               editor.tf.focus();
             }}
           >

--- a/packages/plate/news/+style-fields-width-fallback.feature
+++ b/packages/plate/news/+style-fields-width-fallback.feature
@@ -1,0 +1,1 @@
+Added first-class generic style field support while preserving `blockWidth` fallback for Plone blocks and explicit width handling for Plate-native blocks. @sneridagh


### PR DESCRIPTION
Added first-class generic style field support while preserving `blockWidth` fallback for Plone blocks and explicit width handling for Plate-native blocks.

## Summary

- load the generic style fields plugin as a first-class Plate plugin instead of hiding it behind block width
- keep `BlockWidthPlugin` explicit for Plate-native blocks while restoring `blocksConfig.blockWidth` fallback for `unknown` Plone blocks
- move the Image block width configuration to the schema-driven `styleField` path and cover the split behavior with plugin tests

## Validation

- `pnpm --filter @plone/plate test --run components/editor/plugins/block-width-plugin.test.ts`
- `pnpm --filter @plone/helpers test --run src/styleFields.test.ts`
- `pnpm --filter @plone/layout test --run blocks/BlockWrapper.test.tsx`
- `pnpm exec tsc --project packages/plate/tsconfig.json`
- `pnpm exec tsc --project packages/layout/tsconfig.json`
