### PR TITLE
[codex] Handle stale auth cookies on public requests

### DIFF
--- a/apps/seven/app/middleware.server.test.ts
+++ b/apps/seven/app/middleware.server.test.ts
@@ -853,11 +853,9 @@ describe('middleware', () => {
         .fn()
         .mockRejectedValueOnce({ data: undefined, status: 401 });
       const authSite = vi.fn().mockResolvedValue({ data: {} });
-      const anonymousContent = vi
-        .fn()
-        .mockResolvedValueOnce({
-          data: { '@id': 'http://example.com/', title: 'Home' },
-        });
+      const anonymousContent = vi.fn().mockResolvedValueOnce({
+        data: { '@id': 'http://example.com/', title: 'Home' },
+      });
       const anonymousSite = vi
         .fn()
         .mockResolvedValueOnce({ data: { '@id': 'http://example.com/' } });

--- a/apps/seven/app/middleware.server.test.ts
+++ b/apps/seven/app/middleware.server.test.ts
@@ -776,6 +776,48 @@ describe('middleware', () => {
       });
     });
 
+    it('keeps content and site loading successful when user fetch fails', async () => {
+      const getContentMock = vi.fn().mockResolvedValue({ data: {} });
+      const getSiteMock = vi.fn().mockResolvedValue({ data: {} });
+      const getUserMock = vi.fn().mockRejectedValue(new Error('User failed'));
+      config.settings.apiPath = 'http://example.com';
+      registerPloneClientFactory({
+        getContent: getContentMock,
+        getSite: getSiteMock,
+        getUser: getUserMock,
+      });
+      vi.mocked(getAuthFromRequest).mockResolvedValue('valid.jwt.token');
+      vi.mocked(jwtDecode).mockReturnValue({
+        sub: 'testuser',
+        exp: 9999999999,
+        fullname: 'Test User',
+      });
+      const request = new Request('http://example.com');
+      const context = new RouterContextProvider();
+      const nextMock = vi.fn();
+
+      await initializePloneClientContext(request, context);
+
+      await fetchPloneContent(
+        {
+          request,
+          params: {},
+          context,
+          unstable_pattern: '/',
+          unstable_url: new URL(request.url),
+        },
+        nextMock,
+      );
+
+      expect(getContentMock).toHaveBeenCalledWith({
+        path: '/',
+        expand: ['navroot', 'breadcrumbs', 'navigation', 'actions', 'types'],
+      });
+      expect(getSiteMock).toHaveBeenCalled();
+      expect(getUserMock).toHaveBeenCalledWith({ id: 'testuser' });
+      expect(context.get(ploneUserContext)).toBeNull();
+    });
+
     it('does not fetch user when token has no sub field', async () => {
       const getContentMock = vi.fn().mockResolvedValue({ data: {} });
       const getSiteMock = vi.fn().mockResolvedValue({ data: {} });

--- a/apps/seven/app/middleware.server.test.ts
+++ b/apps/seven/app/middleware.server.test.ts
@@ -507,7 +507,10 @@ describe('middleware', () => {
       const fetchMock = vi
         .fn()
         .mockResolvedValueOnce(
-          new Response('unauthorized', { status: 401, statusText: 'Unauthorized' }),
+          new Response('unauthorized', {
+            status: 401,
+            statusText: 'Unauthorized',
+          }),
         )
         .mockResolvedValueOnce(
           new Response('image', {
@@ -852,7 +855,9 @@ describe('middleware', () => {
       const authSite = vi.fn().mockResolvedValue({ data: {} });
       const anonymousContent = vi
         .fn()
-        .mockResolvedValueOnce({ data: { '@id': 'http://example.com/', title: 'Home' } });
+        .mockResolvedValueOnce({
+          data: { '@id': 'http://example.com/', title: 'Home' },
+        });
       const anonymousSite = vi
         .fn()
         .mockResolvedValueOnce({ data: { '@id': 'http://example.com/' } });

--- a/apps/seven/app/middleware.server.test.ts
+++ b/apps/seven/app/middleware.server.test.ts
@@ -7,6 +7,7 @@ import {
   fetchPloneContent,
   getAPIResourceWithAuth,
   installServerMiddleware,
+  ploneClearAuthCookieContext,
   PloneClientMiddleware,
   otherResources,
   ploneClientContext,
@@ -16,7 +17,13 @@ import {
 } from './middleware.server';
 
 vi.mock('jwt-decode');
-vi.mock('@plone/react-router', () => ({ getAuthFromRequest: vi.fn() }));
+vi.mock('@plone/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@plone/react-router')>();
+  return {
+    ...actual,
+    getAuthFromRequest: vi.fn(),
+  };
+});
 
 describe('middleware', () => {
   const initializePloneClientContext = async (
@@ -355,28 +362,29 @@ describe('middleware', () => {
       });
       global.fetch = fetchMock;
 
-      try {
-        await getAPIResourceWithAuth(
-          {
-            request,
-            params,
-            context,
-            unstable_pattern: '/image.png/@@images/image',
-            unstable_url: new URL(request.url),
-          },
-          nextMock,
-        );
-      } catch {
-        expect(fetchMock).toHaveBeenCalledWith(
-          'http://localhost:8080/Plone/image.png/@@images/image',
-          expect.objectContaining({
-            method: 'GET',
-            headers: expect.objectContaining({
-              Authorization: 'Bearer undefined',
-            }),
-          }),
-        );
-      }
+      await getAPIResourceWithAuth(
+        {
+          request,
+          params,
+          context,
+          unstable_pattern: '/image.png/@@images/image',
+          unstable_url: new URL(request.url),
+        },
+        nextMock,
+      );
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://localhost:8080/Plone/image.png/@@images/image',
+        expect.objectContaining({
+          method: 'GET',
+          headers: expect.any(Headers),
+        }),
+      );
+      expect(
+        (fetchMock.mock.calls[0]?.[1] as { headers: Headers }).headers.get(
+          'Authorization',
+        ),
+      ).toBeNull();
     });
 
     it('intercepts requests to special urls: @@download', async () => {
@@ -390,28 +398,29 @@ describe('middleware', () => {
       });
       global.fetch = fetchMock;
 
-      try {
-        await getAPIResourceWithAuth(
-          {
-            request,
-            params,
-            context,
-            unstable_pattern: '/file.txt/@@download/file',
-            unstable_url: new URL(request.url),
-          },
-          nextMock,
-        );
-      } catch {
-        expect(fetchMock).toHaveBeenCalledWith(
-          'http://localhost:8080/Plone/file.txt/@@download/file',
-          expect.objectContaining({
-            method: 'GET',
-            headers: expect.objectContaining({
-              Authorization: 'Bearer undefined',
-            }),
-          }),
-        );
-      }
+      await getAPIResourceWithAuth(
+        {
+          request,
+          params,
+          context,
+          unstable_pattern: '/file.txt/@@download/file',
+          unstable_url: new URL(request.url),
+        },
+        nextMock,
+      );
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://localhost:8080/Plone/file.txt/@@download/file',
+        expect.objectContaining({
+          method: 'GET',
+          headers: expect.any(Headers),
+        }),
+      );
+      expect(
+        (fetchMock.mock.calls[0]?.[1] as { headers: Headers }).headers.get(
+          'Authorization',
+        ),
+      ).toBeNull();
     });
 
     it('intercepts requests to special urls: @@site-logo', async () => {
@@ -425,28 +434,29 @@ describe('middleware', () => {
       });
       global.fetch = fetchMock;
 
-      try {
-        await getAPIResourceWithAuth(
-          {
-            request,
-            params,
-            context,
-            unstable_pattern: '/@@site-logo/image',
-            unstable_url: new URL(request.url),
-          },
-          nextMock,
-        );
-      } catch {
-        expect(fetchMock).toHaveBeenCalledWith(
-          'http://localhost:8080/Plone/@@site-logo/image',
-          expect.objectContaining({
-            method: 'GET',
-            headers: expect.objectContaining({
-              Authorization: 'Bearer undefined',
-            }),
-          }),
-        );
-      }
+      await getAPIResourceWithAuth(
+        {
+          request,
+          params,
+          context,
+          unstable_pattern: '/@@site-logo/image',
+          unstable_url: new URL(request.url),
+        },
+        nextMock,
+      );
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://localhost:8080/Plone/@@site-logo/image',
+        expect.objectContaining({
+          method: 'GET',
+          headers: expect.any(Headers),
+        }),
+      );
+      expect(
+        (fetchMock.mock.calls[0]?.[1] as { headers: Headers }).headers.get(
+          'Authorization',
+        ),
+      ).toBeNull();
     });
 
     it('intercepts requests to special urls: @portrait', async () => {
@@ -460,28 +470,91 @@ describe('middleware', () => {
       });
       global.fetch = fetchMock;
 
-      try {
-        await getAPIResourceWithAuth(
-          {
-            request,
-            params,
-            context,
-            unstable_pattern: '/@portrait/username',
-            unstable_url: new URL(request.url),
-          },
-          nextMock,
-        );
-      } catch {
-        expect(fetchMock).toHaveBeenCalledWith(
-          'http://localhost:8080/Plone/@portrait/username',
-          expect.objectContaining({
-            method: 'GET',
-            headers: expect.objectContaining({
-              Authorization: 'Bearer undefined',
-            }),
+      await getAPIResourceWithAuth(
+        {
+          request,
+          params,
+          context,
+          unstable_pattern: '/@portrait/username',
+          unstable_url: new URL(request.url),
+        },
+        nextMock,
+      );
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://localhost:8080/Plone/@portrait/username',
+        expect.objectContaining({
+          method: 'GET',
+          headers: expect.any(Headers),
+        }),
+      );
+      expect(
+        (fetchMock.mock.calls[0]?.[1] as { headers: Headers }).headers.get(
+          'Authorization',
+        ),
+      ).toBeNull();
+    });
+
+    it('retries resource requests anonymously after a 401 and clears the cookie', async () => {
+      const request = new Request('http://example.com', {
+        headers: {
+          Cookie: 'auth_seven=token',
+        },
+      });
+      const context = new RouterContextProvider();
+      const params = { '*': 'image.png/@@images/image' };
+      const nextMock = vi.fn();
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(
+          new Response('unauthorized', { status: 401, statusText: 'Unauthorized' }),
+        )
+        .mockResolvedValueOnce(
+          new Response('image', {
+            status: 200,
+            headers: { 'Content-Type': 'image/png' },
           }),
         );
-      }
+      global.fetch = fetchMock;
+      vi.mocked(getAuthFromRequest).mockResolvedValue('expired.jwt.token');
+
+      const response = (await getAPIResourceWithAuth(
+        {
+          request,
+          params,
+          context,
+          unstable_pattern: '/image.png/@@images/image',
+          unstable_url: new URL(request.url),
+        },
+        nextMock,
+      )) as Response;
+
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        1,
+        'http://localhost:8080/Plone/image.png/@@images/image',
+        expect.objectContaining({
+          headers: expect.any(Headers),
+        }),
+      );
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        2,
+        'http://localhost:8080/Plone/image.png/@@images/image',
+        expect.objectContaining({
+          headers: expect.any(Headers),
+        }),
+      );
+      expect(
+        (fetchMock.mock.calls[0]?.[1] as { headers: Headers }).headers.get(
+          'Authorization',
+        ),
+      ).toBe('Bearer expired.jwt.token');
+      expect(
+        (fetchMock.mock.calls[1]?.[1] as { headers: Headers }).headers.get(
+          'Authorization',
+        ),
+      ).toBeNull();
+      expect(response.status).toBe(200);
+      expect(response.headers.get('Set-Cookie')).toContain('auth_seven=');
     });
   });
 
@@ -770,6 +843,74 @@ describe('middleware', () => {
 
       expect(getUserMock).not.toHaveBeenCalled();
       expect(context.get(ploneUserContext)).toBeNull();
+    });
+
+    it('retries anonymously after a 401 and clears the auth cookie context', async () => {
+      const authContent = vi
+        .fn()
+        .mockRejectedValueOnce({ data: undefined, status: 401 });
+      const authSite = vi.fn().mockResolvedValue({ data: {} });
+      const anonymousContent = vi
+        .fn()
+        .mockResolvedValueOnce({ data: { '@id': 'http://example.com/', title: 'Home' } });
+      const anonymousSite = vi
+        .fn()
+        .mockResolvedValueOnce({ data: { '@id': 'http://example.com/' } });
+      config.settings.apiPath = 'http://example.com';
+      const initializeMock = vi
+        .fn()
+        .mockReturnValueOnce({
+          getContent: authContent,
+          getSite: authSite,
+          getUser: vi.fn(),
+        })
+        .mockReturnValueOnce({
+          getContent: anonymousContent,
+          getSite: anonymousSite,
+          getUser: vi.fn(),
+        });
+      config.registerUtility({
+        name: 'ploneClient',
+        type: 'client',
+        method: () =>
+          ({
+            prototype: {},
+            initialize: initializeMock,
+          }) as any,
+      });
+      vi.mocked(getAuthFromRequest).mockResolvedValue('expired.jwt.token');
+      vi.mocked(jwtDecode).mockReturnValue({
+        sub: 'testuser',
+        exp: 9999999999,
+        fullname: 'Test User',
+      });
+      const request = new Request('http://example.com');
+      const context = new RouterContextProvider();
+      const nextMock = vi.fn();
+
+      await initializePloneClientContext(request, context);
+
+      await fetchPloneContent(
+        {
+          request,
+          params: {},
+          context,
+          unstable_pattern: '/',
+          unstable_url: new URL(request.url),
+        },
+        nextMock,
+      );
+
+      expect(anonymousContent).toHaveBeenCalledWith({
+        path: '/',
+        expand: ['navroot', 'breadcrumbs', 'navigation', 'actions'],
+      });
+      expect(context.get(ploneContentContext)).toEqual({
+        '@id': '/',
+        title: 'Home',
+      });
+      expect(context.get(ploneUserContext)).toBeNull();
+      expect(context.get(ploneClearAuthCookieContext)).toBe(true);
     });
   });
 });

--- a/apps/seven/app/middleware.server.test.ts
+++ b/apps/seven/app/middleware.server.test.ts
@@ -907,12 +907,12 @@ describe('middleware', () => {
         .mockReturnValueOnce({
           getContent: authContent,
           getSite: authSite,
-          getUser: vi.fn(),
+          getUser: vi.fn().mockResolvedValue(null),
         })
         .mockReturnValueOnce({
           getContent: anonymousContent,
           getSite: anonymousSite,
-          getUser: vi.fn(),
+          getUser: vi.fn().mockResolvedValue(null),
         });
       config.registerUtility({
         name: 'ploneClient',

--- a/apps/seven/app/middleware.server.ts
+++ b/apps/seven/app/middleware.server.ts
@@ -171,13 +171,13 @@ export const fetchPloneContent: Route.MiddlewareFunction = async (
   };
 
   try {
-    const [content, site] = await Promise.all([
+    const [content, site, user] = await Promise.all([
       cli.getContent({ path, expand }),
       cli.getSite(),
+      userId
+        ? Promise.resolve(cli.getUser({ id: userId })).catch(() => null)
+        : null,
     ]);
-    const user = userId
-      ? await cli.getUser({ id: userId }).catch(() => null)
-      : null;
 
     setPloneContext(content, site, user?.data ?? null);
   } catch (error: any) {

--- a/apps/seven/app/middleware.server.ts
+++ b/apps/seven/app/middleware.server.ts
@@ -174,9 +174,7 @@ export const fetchPloneContent: Route.MiddlewareFunction = async (
     const [content, site, user] = await Promise.all([
       cli.getContent({ path, expand }),
       cli.getSite(),
-      userId
-        ? Promise.resolve(cli.getUser({ id: userId })).catch(() => null)
-        : null,
+      userId ? cli.getUser({ id: userId }).catch(() => null) : null,
     ]);
 
     setPloneContext(content, site, user?.data ?? null);

--- a/apps/seven/app/middleware.server.ts
+++ b/apps/seven/app/middleware.server.ts
@@ -1,7 +1,7 @@
 import { jwtDecode } from 'jwt-decode';
 import { data, createContext } from 'react-router';
 import { flattenToAppURL } from '@plone/helpers';
-import { getAuthFromRequest } from '@plone/react-router';
+import { clearAuthOnResponse, getAuthFromRequest } from '@plone/react-router';
 import config from '@plone/registry';
 import type PloneClient from '@plone/client';
 import type { Route } from './+types/root';
@@ -16,6 +16,22 @@ export const ploneSiteContext =
 export const ploneUserContext = createContext<
   Awaited<ReturnType<PloneClient['getUser']>>['data'] | null
 >(null);
+export const ploneClearAuthCookieContext = createContext<boolean>(false);
+
+function getAuthorizedResourceHeaders(
+  request: Request,
+  token?: string,
+): HeadersInit {
+  const headers = new Headers(request.headers);
+
+  if (token) {
+    headers.set('Authorization', `Bearer ${token}`);
+  } else {
+    headers.delete('Authorization');
+  }
+
+  return headers;
+}
 
 export const installServerMiddleware: Route.MiddlewareFunction = async (
   { request, context },
@@ -82,13 +98,38 @@ export const getAPIResourceWithAuth: Route.MiddlewareFunction = async (
     /\/@portrait\//.test(path)
   ) {
     const token = await getAuthFromRequest(request);
-    return await fetch(`${config.settings.apiPath}${path}`, {
+    const url = `${config.settings.apiPath}${path}`;
+    const response = await fetch(url, {
       method: 'GET',
-      headers: {
-        ...request.headers,
-        Authorization: `Bearer ${token}`,
-      },
+      headers: getAuthorizedResourceHeaders(request, token),
     });
+
+    if (token && response.status === 401) {
+      const anonymousResponse = await fetch(url, {
+        method: 'GET',
+        headers: getAuthorizedResourceHeaders(request),
+      });
+
+      if (anonymousResponse.ok) {
+        return clearAuthOnResponse(
+          new Response(anonymousResponse.body, {
+            status: anonymousResponse.status,
+            statusText: anonymousResponse.statusText,
+            headers: anonymousResponse.headers,
+          }),
+        );
+      }
+
+      return clearAuthOnResponse(
+        new Response(response.body, {
+          status: response.status,
+          statusText: response.statusText,
+          headers: response.headers,
+        }),
+      );
+    }
+
+    return response;
   }
 };
 
@@ -99,7 +140,7 @@ export const fetchPloneContent: Route.MiddlewareFunction = async (
   const expand = ['navroot', 'breadcrumbs', 'navigation', 'actions'];
   const token = await getAuthFromRequest(request);
 
-  const cli = context.get(ploneClientContext);
+  let cli = context.get(ploneClientContext);
 
   const path = `/${params['*'] || ''}`;
 
@@ -117,19 +158,63 @@ export const fetchPloneContent: Route.MiddlewareFunction = async (
 
   if (userId) expand.push('types');
 
-  try {
-    const [content, site, user] = await Promise.all([
-      cli.getContent({ path, expand }),
-      cli.getSite(),
-      userId ? cli.getUser({ id: userId }) : Promise.resolve(null),
-    ]);
-
+  const setPloneContext = (
+    content: Awaited<ReturnType<PloneClient['getContent']>>,
+    site: Awaited<ReturnType<PloneClient['getSite']>>,
+    user: Awaited<ReturnType<PloneClient['getUser']>>['data'] | null,
+  ) => {
     migrateContent(content.data);
 
     context.set(ploneContentContext, flattenToAppURL(content.data));
     context.set(ploneSiteContext, flattenToAppURL(site.data));
-    context.set(ploneUserContext, user?.data ?? null);
+    context.set(ploneUserContext, user);
+  };
+
+  try {
+    const [content, site] = await Promise.all([
+      cli.getContent({ path, expand }),
+      cli.getSite(),
+    ]);
+    const user = userId
+      ? await cli.getUser({ id: userId }).catch(() => null)
+      : null;
+
+    setPloneContext(content, site, user?.data ?? null);
   } catch (error: any) {
+    if (token && error?.status === 401) {
+      const PloneClient = config
+        .getUtility({
+          name: 'ploneClient',
+          type: 'client',
+        })
+        .method();
+      cli = PloneClient.initialize({
+        apiPath: config.settings.apiPath,
+      });
+      context.set(ploneClientContext, cli);
+
+      try {
+        const [content, site] = await Promise.all([
+          cli.getContent({
+            path,
+            expand: expand.filter((item) => item !== 'types'),
+          }),
+          cli.getSite(),
+        ]);
+
+        setPloneContext(content, site, null);
+        context.set(ploneClearAuthCookieContext, true);
+        return;
+      } catch (anonymousError: any) {
+        throw data('Content Not Found', {
+          status:
+            typeof anonymousError.status === 'number'
+              ? anonymousError.status
+              : 500,
+        });
+      }
+    }
+
     throw data('Content Not Found', {
       status: typeof error.status === 'number' ? error.status : 500,
     });

--- a/apps/seven/app/root.test.tsx
+++ b/apps/seven/app/root.test.tsx
@@ -5,6 +5,7 @@ import config from '@plone/registry';
 import { Layout, ErrorBoundary, loader } from './root';
 import {
   ploneClientContext,
+  ploneClearAuthCookieContext,
   ploneContentContext,
   ploneSiteContext,
 } from './middleware.server';
@@ -87,7 +88,7 @@ describe('loader', () => {
     context.set(ploneContentContext, mockContent as any);
     context.set(ploneSiteContext, mockSite as any);
 
-    const data = await loader({
+    const result = await loader({
       request,
       params: {},
       context,
@@ -95,9 +96,9 @@ describe('loader', () => {
       unstable_url: new URL(request.url),
     });
 
-    expect(data.locale).toBe('en');
-    expect(data.content).toBeDefined();
-    expect(data.site).toBeDefined();
+    expect(result.data.locale).toBe('en');
+    expect(result.data.content).toBeDefined();
+    expect(result.data.site).toBeDefined();
   });
 
   it('should return content for a non-root path', async () => {
@@ -114,7 +115,7 @@ describe('loader', () => {
     context.set(ploneContentContext, mockContent as any);
     context.set(ploneSiteContext, mockSite as any);
 
-    const data = await loader({
+    const result = await loader({
       request,
       params: { '*': 'test-content' },
       context,
@@ -122,9 +123,33 @@ describe('loader', () => {
       unstable_url: new URL(request.url),
     });
 
-    expect(data.locale).toBe('en');
-    expect(data.content).toBeDefined();
-    expect(data.site).toBeDefined();
+    expect(result.data.locale).toBe('en');
+    expect(result.data.content).toBeDefined();
+    expect(result.data.site).toBeDefined();
+  });
+
+  it('should clear the auth cookie when middleware requests it', async () => {
+    config.settings.defaultLanguage = 'en';
+    config.settings.supportedLanguages = ['en'];
+    const mockContent = { '@id': 'http://example.com/', title: 'Home' };
+    const mockSite = { '@id': 'http://example.com/' };
+    const request = new Request('http://example.com');
+    const context = new RouterContextProvider();
+    context.set(ploneClientContext, {} as any);
+    context.set(ploneContentContext, mockContent as any);
+    context.set(ploneSiteContext, mockSite as any);
+    context.set(ploneClearAuthCookieContext, true);
+
+    const result = (await loader({
+      request,
+      params: {},
+      context,
+      unstable_pattern: '/',
+      unstable_url: new URL(request.url),
+    })) as any;
+
+    expect(result.data.content).toEqual(mockContent);
+    expect(result.init.headers['Set-Cookie']).toContain('auth_seven=');
   });
 });
 
@@ -181,7 +206,7 @@ it('should place the migrated title block in the legacy block order', async () =
   context.set(ploneContentContext, mockContent as any);
   context.set(ploneSiteContext, mockSite as any);
 
-  const data = await loader({
+  const result = await loader({
     request,
     params: {},
     context,
@@ -190,7 +215,7 @@ it('should place the migrated title block in the legacy block order', async () =
   });
 
   expect(somersaultMigration).toHaveBeenCalledTimes(1);
-  expect(data.content.blocks.__somersault__).toEqual({
+  expect(result.data.content.blocks.__somersault__).toEqual({
     '@type': '__somersault__',
     value: [
       {
@@ -249,7 +274,7 @@ it('should skip somersault migration when the somersault block already exists', 
   context.set(ploneClientContext, {} as any);
   context.set(ploneContentContext, mockContent as any);
   context.set(ploneSiteContext, mockSite as any);
-  const data = await loader({
+  const result = await loader({
     request,
     params: {},
     context,
@@ -258,7 +283,7 @@ it('should skip somersault migration when the somersault block already exists', 
   });
 
   expect(somersaultMigration).not.toHaveBeenCalled();
-  expect(data.content.blocks.__somersault__).toEqual({
+  expect(result.data.content.blocks.__somersault__).toEqual({
     '@type': '__somersault__',
     value: existingSomersaultValue,
   });

--- a/apps/seven/app/root.tsx
+++ b/apps/seven/app/root.tsx
@@ -5,6 +5,7 @@ import i18next from './i18next.server';
 import type { Route } from './+types/root';
 import config from '@plone/registry';
 import {
+  ploneClearAuthCookieContext,
   fetchPloneContent,
   getAPIResourceWithAuth,
   installServerMiddleware,
@@ -14,6 +15,7 @@ import {
   ploneContentContext,
   ploneSiteContext,
 } from './middleware.server';
+import { getClearAuthCookieHeader } from '@plone/react-router';
 
 export const middleware = [
   installServerMiddleware,
@@ -65,7 +67,7 @@ export async function loader({ params, request, context }: Route.LoaderArgs) {
       ),
     ]);
 
-    return {
+    const loaderData = {
       content,
       site,
       locale,
@@ -73,6 +75,14 @@ export async function loader({ params, request, context }: Route.LoaderArgs) {
         .filter((item) => item)
         .reduce((acc, item) => ({ ...acc, ...item }), {}),
     };
+
+    return data(loaderData, {
+      headers: context.get(ploneClearAuthCookieContext)
+        ? {
+            'Set-Cookie': await getClearAuthCookieHeader(),
+          }
+        : undefined,
+    });
   } catch (error: any) {
     throw data('Content Not Found', {
       status: typeof error.status === 'number' ? error.status : 500,
@@ -111,11 +121,16 @@ export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
   let message = 'Oops!';
   let details = 'An unexpected error occurred.';
   let stack: string | undefined;
+
   if (isRouteErrorResponse(error)) {
     switch (error.status) {
       case 404:
         message = '404';
         details = 'The requested page could not be found.';
+        break;
+      case 401:
+        message = '401';
+        details = 'You are not authorized to view this page.';
         break;
       case 500:
         message = '500';

--- a/apps/seven/news/+stale-auth-cookie-public-pages.bugfix
+++ b/apps/seven/news/+stale-auth-cookie-public-pages.bugfix
@@ -1,0 +1,1 @@
+Gracefully clear stale `auth_seven` cookies and retry public page and asset requests anonymously instead of surfacing a `401` error boundary. @sneridagh

--- a/packages/react-router/news/+auth-cookie-clear-helpers.internal
+++ b/packages/react-router/news/+auth-cookie-clear-helpers.internal
@@ -1,0 +1,1 @@
+Add shared auth cookie clearing helpers so Seven routes can centralize stale-cookie cleanup behavior. @sneridagh

--- a/packages/react-router/src/index.ts
+++ b/packages/react-router/src/index.ts
@@ -109,14 +109,33 @@ export async function setAuthOnResponse(
   return response;
 }
 
+export async function clearAuthOnResponse(
+  response: Response,
+  options?: Parameters<typeof cookie.serialize>[1],
+) {
+  const header = await cookie.serialize('', {
+    maxAge: 0,
+    ...options,
+  });
+  response.headers.append('Set-Cookie', header);
+  return response;
+}
+
+export async function getClearAuthCookieHeader(
+  options?: Parameters<typeof cookie.serialize>[1],
+) {
+  return await cookie.serialize('', {
+    maxAge: 0,
+    ...options,
+  });
+}
+
 export async function requireAuthCookie(request: Request) {
   const token = await getAuthFromRequest(request);
   if (!token) {
     throw redirect('/login', {
       headers: {
-        'Set-Cookie': await cookie.serialize('', {
-          maxAge: 0,
-        }),
+        'Set-Cookie': await getClearAuthCookieHeader(),
       },
     });
   }
@@ -134,11 +153,5 @@ export async function redirectIfLoggedInLoader({
 }
 
 export async function redirectWithClearedCookie() {
-  return redirect('/', {
-    headers: {
-      'Set-Cookie': await cookie.serialize('', {
-        maxAge: 0,
-      }),
-    },
-  });
+  return clearAuthOnResponse(redirect('/'));
 }

--- a/packages/react-router/src/index.ts
+++ b/packages/react-router/src/index.ts
@@ -113,10 +113,7 @@ export async function clearAuthOnResponse(
   response: Response,
   options?: Parameters<typeof cookie.serialize>[1],
 ) {
-  const header = await cookie.serialize('', {
-    maxAge: 0,
-    ...options,
-  });
+  const header = await getClearAuthCookieHeader(options);
   response.headers.append('Set-Cookie', header);
   return response;
 }
@@ -133,11 +130,7 @@ export async function getClearAuthCookieHeader(
 export async function requireAuthCookie(request: Request) {
   const token = await getAuthFromRequest(request);
   if (!token) {
-    throw redirect('/login', {
-      headers: {
-        'Set-Cookie': await getClearAuthCookieHeader(),
-      },
-    });
+    throw await redirectWithClearedCookie('/login');
   }
   return token;
 }
@@ -152,6 +145,6 @@ export async function redirectIfLoggedInLoader({
   return null;
 }
 
-export async function redirectWithClearedCookie() {
-  return clearAuthOnResponse(redirect('/'));
+export async function redirectWithClearedCookie(url = '/') {
+  return clearAuthOnResponse(redirect(url));
 }


### PR DESCRIPTION
## Summary

This PR fixes Seven's behavior when the `auth_seven` cookie contains a stale or invalid token and the user requests public content.

Previously, Seven initialized the Plone client with whatever token was present in the cookie and sent it as `Authorization: Bearer <token>` on content and asset requests. When that token was no longer valid, the backend returned `401`, and Seven surfaced that failure through the root `ErrorBoundary` even for public pages.

This change makes Seven recover gracefully instead of failing hard.

## What changed

- Added anonymous fallback behavior in `apps/seven/app/middleware.server.ts`.
- When a token-authenticated content or site request returns `401`, Seven now reinitializes the client without the token, retries the request anonymously, and continues rendering if anonymous access succeeds.
- When a stale cookie is detected and anonymous fallback succeeds, Seven now clears the `auth_seven` cookie on the final page response.
- Added the same stale-cookie recovery for proxied asset requests (`@@images`, `@@download`, `@@site-logo`, `@portrait`) so public assets still resolve when the cookie is invalid.
- Avoided sending `Authorization: Bearer undefined` on anonymous proxied asset requests.
- Decoupled `getUser()` lookup from the main content/site fetch so user lookup failures do not break otherwise public rendering.
- Centralized cookie-clearing helpers in `@plone/react-router` with shared helpers for clearing the auth cookie on a response or generating the clearing `Set-Cookie` header.
- Added regression tests for the anonymous retry flow, cookie clearing behavior, and the updated loader response shape.
- Added towncrier news entries for `apps/seven` and `packages/react-router`.

## Impact

- Public pages keep rendering even when the user's auth cookie has expired or become invalid.
- The stale auth cookie is removed automatically once Seven confirms anonymous access works.
- Shared auth-cookie cleanup behavior is available centrally from `@plone/react-router`.

## Validation

- `pnpm exec vitest run app/root.test.tsx app/middleware.server.test.ts`
- `pnpm --filter seven typecheck`
- `pnpm --filter @plone/react-router build`
