### PR TITLE
fix(a11y): use button elements for formtabs menu items

### DIFF
--- a/packages/volto/cypress/tests/core/controlpanels/dexterity-controlpanel-schema.js
+++ b/packages/volto/cypress/tests/core/controlpanels/dexterity-controlpanel-schema.js
@@ -73,7 +73,7 @@ describe('ControlPanel: Dexterity Content-Types Schema', () => {
     cy.get('#toolbar-add').click();
     cy.get('#toolbar-add-bike').click();
     cy.get('input[name="title"]').type('Kona').should('have.value', 'Kona');
-    cy.get('.formtabs a').contains('Specifications').click();
+    cy.get('.formtabs button').contains('Specifications').click();
     cy.get('.react-select-container[id="field-color"]')
       .click()
       .type('Green{enter}');

--- a/packages/volto/news/8219.bugfix
+++ b/packages/volto/news/8219.bugfix
@@ -1,0 +1,1 @@
+Use `<button>` elements instead of `<a>` for formtabs menu items to fix accessibility and keyboard navigation. @Wagner3UB

--- a/packages/volto/src/components/manage/Form/Form.jsx
+++ b/packages/volto/src/components/manage/Form/Form.jsx
@@ -976,6 +976,7 @@ class Form extends Component {
                         key: item.id,
                         content: item.title,
                         as: 'button',
+                        type: 'button',
                       },
                       render: () => [
                         !settings.verticalFormTabs && this.props.title && (

--- a/packages/volto/src/components/manage/Form/Form.jsx
+++ b/packages/volto/src/components/manage/Form/Form.jsx
@@ -972,7 +972,11 @@ class Form extends Component {
                     onTabChange={this.onTabChange}
                     activeIndex={this.state.activeIndex}
                     panes={map(schema.fieldsets, (item) => ({
-                      menuItem: item.title,
+                      menuItem: {
+                        key: item.id,
+                        content: item.title,
+                        as: 'button',
+                      },
                       render: () => [
                         !settings.verticalFormTabs && this.props.title && (
                           <Segment secondary attached key={this.props.title}>

--- a/packages/volto/src/components/manage/Sidebar/Sidebar.jsx
+++ b/packages/volto/src/components/manage/Sidebar/Sidebar.jsx
@@ -155,6 +155,7 @@ const Sidebar = (props) => {
                 key: 'documentTab',
                 as: 'button',
                 className: 'ui button',
+                type: 'button',
                 content: type || intl.formatMessage(messages.document),
               },
               pane: (
@@ -170,6 +171,7 @@ const Sidebar = (props) => {
                 key: 'blockTab',
                 as: 'button',
                 className: 'ui button',
+                type: 'button',
                 content: intl.formatMessage(messages.block),
               },
               pane: (

--- a/packages/volto/src/components/manage/Sidebar/__snapshots__/Sidebar.test.jsx.snap
+++ b/packages/volto/src/components/manage/Sidebar/__snapshots__/Sidebar.test.jsx.snap
@@ -46,12 +46,14 @@ exports[`renders a sidebar component 1`] = `
         <button
           className="active item ui button"
           onClick={[Function]}
+          type="button"
         >
           Document
         </button>
         <button
           className="item ui button"
           onClick={[Function]}
+          type="button"
         >
           Block
         </button>


### PR DESCRIPTION
## Summary

Ports the accessibility fix from the `formtabs-tab-links` PR (#7308) to Volto 19.

Tab items in `Form` and `Sidebar` were rendered as `<a>` elements (Semantic UI default) without an `href`, which is semantically incorrect and causes issues with keyboard navigation and screen readers. This fix forces them to render as `<button>` elements.

## Changes

- **`Form.jsx`**: Changed `menuItem` from a plain string to an object with `as: 'button'`, so all fieldset tabs in forms render as buttons.
- **`Sidebar.jsx`**: Added `type: 'button'` to the `blockTab` menu item (already present in `documentTab`), preventing accidental form submission.
- **`dexterity-controlpanel-schema.js`**: Updated Cypress selector from `.formtabs a` to `.formtabs button`.