### PR TITLE
[Seven] Added link view redirects and handled redirects from the backend

### DIFF
--- a/apps/seven/app/middleware.server.test.ts
+++ b/apps/seven/app/middleware.server.test.ts
@@ -1005,8 +1005,8 @@ describe('middleware', () => {
 
       await initializePloneClientContext(request, context);
 
-      try {
-        await fetchPloneContent(
+      await expect(() =>
+        fetchPloneContent(
           {
             request,
             params: {},
@@ -1015,10 +1015,8 @@ describe('middleware', () => {
             unstable_url: new URL(request.url),
           },
           nextMock,
-        );
-      } catch (err: any) {
-        expect(err.init.status).toEqual(301);
-      }
+        ),
+      ).rejects.toMatchObject({ init: { status: 301 } });
     });
   });
 

--- a/apps/seven/app/middleware.server.test.ts
+++ b/apps/seven/app/middleware.server.test.ts
@@ -7,6 +7,7 @@ import {
   fetchPloneContent,
   getAPIResourceWithAuth,
   installServerMiddleware,
+  linkMiddleware,
   ploneClearAuthCookieContext,
   PloneClientMiddleware,
   otherResources,
@@ -956,6 +957,135 @@ describe('middleware', () => {
       });
       expect(context.get(ploneUserContext)).toBeNull();
       expect(context.get(ploneClearAuthCookieContext)).toBe(true);
+    });
+
+    it('redirects when getContent throws a 3xx error with location', async () => {
+      const getContentMock = vi
+        .fn()
+        .mockRejectedValue({ status: 301, location: '/new-path' });
+      const getSiteMock = vi.fn().mockResolvedValue({ data: {} });
+      config.settings.apiPath = 'http://example.com';
+      registerPloneClientFactory({
+        getContent: getContentMock,
+        getSite: getSiteMock,
+      });
+      const request = new Request('http://example.com');
+      const context = new RouterContextProvider();
+      const nextMock = vi.fn();
+
+      await initializePloneClientContext(request, context);
+
+      const result = await fetchPloneContent(
+        {
+          request,
+          params: {},
+          context,
+          unstable_pattern: '/',
+          unstable_url: new URL(request.url),
+        },
+        nextMock,
+      );
+
+      expect(result).toBeInstanceOf(Response);
+      expect((result as Response).status).toBe(301);
+      expect((result as Response).headers.get('Location')).toBe('/new-path');
+    });
+
+    it('throws content error when error has 3xx status but no location', async () => {
+      const getContentMock = vi.fn().mockRejectedValue({ status: 301 });
+      const getSiteMock = vi.fn().mockResolvedValue({ data: {} });
+      config.settings.apiPath = 'http://example.com';
+      registerPloneClientFactory({
+        getContent: getContentMock,
+        getSite: getSiteMock,
+      });
+      const request = new Request('http://example.com');
+      const context = new RouterContextProvider();
+      const nextMock = vi.fn();
+
+      await initializePloneClientContext(request, context);
+
+      try {
+        await fetchPloneContent(
+          {
+            request,
+            params: {},
+            context,
+            unstable_pattern: '/',
+            unstable_url: new URL(request.url),
+          },
+          nextMock,
+        );
+      } catch (err: any) {
+        expect(err.init.status).toEqual(301);
+      }
+    });
+  });
+
+  describe('linkMiddleware', () => {
+    const makeArgs = (context: RouterContextProvider) => ({
+      request: new Request('http://example.com/link'),
+      context,
+      params: {},
+      unstable_pattern: '/link',
+      unstable_url: new URL('http://example.com/link'),
+    });
+
+    it('redirects to remoteUrl when content is a Link without edit permission', async () => {
+      const context = new RouterContextProvider();
+      context.set(ploneContentContext, {
+        '@type': 'Link',
+        remoteUrl: 'https://external.example.com',
+        '@components': {
+          actions: {
+            // @ts-expect-error
+            object: [{ id: 'view' }, { id: 'history' }],
+          },
+        },
+      });
+
+      const result = await linkMiddleware(makeArgs(context), vi.fn());
+
+      expect(result).toBeInstanceOf(Response);
+      expect((result as Response).status).toBe(302);
+      expect((result as Response).headers.get('Location')).toBe(
+        'https://external.example.com',
+      );
+    });
+
+    it('does not redirect when content is a Link with edit permission', async () => {
+      const context = new RouterContextProvider();
+      context.set(ploneContentContext, {
+        '@type': 'Link',
+        remoteUrl: 'https://external.example.com',
+        '@components': {
+          actions: {
+            // @ts-expect-error
+            object: [{ id: 'view' }, { id: 'edit' }],
+          },
+        },
+      });
+
+      const result = await linkMiddleware(makeArgs(context), vi.fn());
+
+      expect(result).toBeUndefined();
+    });
+
+    it('does not redirect when content is not a Link type', async () => {
+      const context = new RouterContextProvider();
+      context.set(ploneContentContext, {
+        '@type': 'Document',
+        '@components': {
+          actions: {
+            // @ts-expect-error
+            object: [{ id: 'view' }],
+          },
+        },
+      });
+
+      const result = await linkMiddleware(makeArgs(context), vi.fn());
+
+      expect(result).toBeUndefined();
     });
   });
 });

--- a/apps/seven/app/middleware.server.ts
+++ b/apps/seven/app/middleware.server.ts
@@ -1,9 +1,10 @@
 import { jwtDecode } from 'jwt-decode';
-import { data, createContext } from 'react-router';
+import { data, createContext, redirect } from 'react-router';
 import { flattenToAppURL } from '@plone/helpers';
 import { clearAuthOnResponse, getAuthFromRequest } from '@plone/react-router';
 import config from '@plone/registry';
 import type PloneClient from '@plone/client';
+import type { LinkCT } from '@plone/types';
 import type { Route } from './+types/root';
 import installServer from './config/server.server';
 import { migrateContent } from './config/server/content-migrations.server';
@@ -179,6 +180,11 @@ export const fetchPloneContent: Route.MiddlewareFunction = async (
 
     setPloneContext(content, site, user?.data ?? null);
   } catch (error: any) {
+    if (error.status >= 300 && error.status < 400 && error.location) {
+      return redirect(error.location, {
+        status: error.status,
+      });
+    }
     if (token && error?.status === 401) {
       const PloneClient = config
         .getUtility({
@@ -216,5 +222,21 @@ export const fetchPloneContent: Route.MiddlewareFunction = async (
     throw data('Content Not Found', {
       status: typeof error.status === 'number' ? error.status : 500,
     });
+  }
+};
+
+export const linkMiddleware: Route.MiddlewareFunction = async (
+  { context },
+  next,
+) => {
+  const content = context.get(ploneContentContext);
+
+  if (
+    content['@type'] === 'Link' &&
+    !content['@components'].actions.object.find(
+      (action) => action.id === 'edit',
+    )
+  ) {
+    return redirect((content as LinkCT).remoteUrl);
   }
 };

--- a/apps/seven/app/root.tsx
+++ b/apps/seven/app/root.tsx
@@ -15,6 +15,7 @@ import {
   ploneContentContext,
   ploneSiteContext,
   ploneUserContext,
+  linkMiddleware,
 } from './middleware.server';
 import { getClearAuthCookieHeader } from '@plone/react-router';
 
@@ -24,6 +25,7 @@ export const middleware = [
   otherResources,
   getAPIResourceWithAuth,
   fetchPloneContent,
+  linkMiddleware,
 ];
 
 export async function loader({ params, request, context }: Route.LoaderArgs) {
@@ -141,7 +143,7 @@ export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
           'The server encountered an internal error. Did you start the backend?';
         break;
       default:
-        message = 'Error';
+        message = 'Error ' + error.status;
         details = error.statusText || details;
         break;
     }

--- a/apps/seven/news/+handleredirects.feature
+++ b/apps/seven/news/+handleredirects.feature
@@ -1,0 +1,1 @@
+Handled redirect responses from the backend when fetching content objects. @pnicolli

--- a/apps/seven/news/+linkmiddleware.feature
+++ b/apps/seven/news/+linkmiddleware.feature
@@ -1,0 +1,1 @@
+Added a middleware to handle Link Content Type View redirecting users that don't have Edit permissions. @pnicolli

--- a/packages/client/news/+handleredirects.feature
+++ b/packages/client/news/+handleredirects.feature
@@ -1,0 +1,1 @@
+Handled redirect responses from the backend when fetching content objects. @pnicolli

--- a/packages/client/src/api.test.ts
+++ b/packages/client/src/api.test.ts
@@ -59,6 +59,77 @@ describe('apiRequest', () => {
     await apiRequest('GET', '/path', { config });
     expect(mockAxios.request).toHaveBeenCalledTimes(1);
   });
+
+  describe('error handler', () => {
+    it('should include location in error for 3xx redirect responses', async () => {
+      await apiRequest('GET', '/path', {
+        config: { apiPath: 'http://example.com' },
+      });
+
+      const errorHandler = mockAxios.interceptors.response.use.mock.calls[0][1];
+
+      await expect(
+        errorHandler({
+          status: 301,
+          response: {
+            headers: {
+              location: 'http://example.com/++api++/new-path?foo=bar',
+            },
+            data: undefined,
+          },
+        }),
+      ).rejects.toEqual({
+        status: 301,
+        data: undefined,
+        location: '/new-path',
+      });
+    });
+
+    it('should not include location in error for non-3xx responses', async () => {
+      await apiRequest('GET', '/path', {
+        config: { apiPath: 'http://example.com' },
+      });
+
+      const errorHandler = mockAxios.interceptors.response.use.mock.calls[0][1];
+
+      await expect(
+        errorHandler({
+          status: 404,
+          response: {
+            headers: {},
+            data: { message: 'Not found' },
+          },
+        }),
+      ).rejects.toMatchObject({
+        status: 404,
+        location: undefined,
+      });
+    });
+
+    it('should strip custom apiSuffix from location for 3xx responses', async () => {
+      await apiRequest('GET', '/path', {
+        config: { apiPath: 'http://example.com', apiSuffix: '/custom-api' },
+      });
+
+      const errorHandler = mockAxios.interceptors.response.use.mock.calls[0][1];
+
+      await expect(
+        errorHandler({
+          status: 302,
+          response: {
+            headers: {
+              location: 'http://example.com/custom-api/another-path',
+            },
+            data: undefined,
+          },
+        }),
+      ).rejects.toEqual({
+        status: 302,
+        data: undefined,
+        location: '/another-path',
+      });
+    });
+  });
 });
 
 describe('axiosConfigAdapter', () => {

--- a/packages/client/src/api.ts
+++ b/packages/client/src/api.ts
@@ -17,15 +17,16 @@ export type ApiRequestParams = {
   headers?: any;
   checkUrl?: boolean;
   raw?: boolean;
+  maxRedirects?: number;
 };
+
+const APISUFFIX = '/++api++';
 
 export function getBackendURL(
   apiPath: string,
   apiSuffix: string | undefined,
   path: string,
 ) {
-  const APISUFFIX = '/++api++';
-
   if (path.startsWith('http://') || path.startsWith('https://')) return path;
 
   const adjustedPath = path[0] !== '/' ? `/${path}` : path;
@@ -35,20 +36,37 @@ export function getBackendURL(
 
 const _handleResponse = (response: AxiosResponse) => response;
 
-const _handleError = (error: AxiosError) => {
-  debug(error);
-  return Promise.reject({
-    status: error.status ?? error.code,
-    data: error.response?.data,
-  });
-};
+const _handleError =
+  (config: ApiRequestParams['config']) => (error: AxiosError) => {
+    debug(error);
+    const status = error.status ?? 0;
+    return Promise.reject({
+      status: error.status ?? error.code,
+      data: error.response?.data,
+      location:
+        status >= 300 && status < 400
+          ? error.response?.headers.location
+              .replaceAll(
+                `${config.apiPath}${config.apiSuffix ?? APISUFFIX}`,
+                '',
+              )
+              .replace(/\?.*$/, '')
+          : undefined,
+    });
+  };
 
 export function axiosConfigAdapter(
   method: string,
   path: string,
   options: ApiRequestParams,
 ): AxiosRequestConfig {
-  const { config, params, data, headers = {} }: ApiRequestParams = options;
+  const {
+    config,
+    params,
+    data,
+    maxRedirects,
+    headers = {},
+  }: ApiRequestParams = options;
   const axiosConfig: AxiosRequestConfig = {
     method,
     url: getBackendURL(config.apiPath, config.apiSuffix, path),
@@ -64,6 +82,7 @@ export function axiosConfigAdapter(
     paramsSerializer: function (params) {
       return qs.stringify(params, { arrayFormat: 'colon-list-separator' });
     },
+    maxRedirects,
   };
 
   if (config.token && axiosConfig.headers) {
@@ -83,9 +102,12 @@ export async function apiRequest(
   const instance = axios.create();
 
   if (options.raw) {
-    instance.interceptors.response.use(undefined, _handleError);
+    instance.interceptors.response.use(undefined, _handleError(options.config));
   } else {
-    instance.interceptors.response.use(_handleResponse, _handleError);
+    instance.interceptors.response.use(
+      _handleResponse,
+      _handleError(options.config),
+    );
   }
 
   return instance.request(axiosConfigAdapter(method, path, options));

--- a/packages/client/src/restapi/content/get.ts
+++ b/packages/client/src/restapi/content/get.ts
@@ -28,6 +28,7 @@ export async function getContent(
 
   const options: ApiRequestParams = {
     config: this.config,
+    maxRedirects: 0,
     params: {
       ...(validatedArgs.page && { page: validatedArgs.page }),
       ...(validatedArgs.version && { version: validatedArgs.version }),


### PR DESCRIPTION
This adds two unrelated but similar features:

- when fetching content items of type Link, a new middleware checks user permissions and redirects to the remoteUrl if the user cannot edit the item
- when fetching content from the backend, `@plone/client` returns the location header from 3xx responses and the app middleware redirects if that happens