### PR TITLE
Add ReactAriaRouterProvider to enable client-side navigation support for React Aria Link components

### DIFF
--- a/packages/volto/news/+react-aria-provider.feature
+++ b/packages/volto/news/+react-aria-provider.feature
@@ -1,0 +1,1 @@
+Add ReactAriaRouterProvider to enable client-side navigation support for React Aria Link components. @iFlameing

--- a/packages/volto/package.json
+++ b/packages/volto/package.json
@@ -178,6 +178,7 @@
     "@plone/registry": "workspace:*",
     "@plone/scripts": "workspace:*",
     "@plone/volto-slate": "workspace:*",
+    "react-aria-components": "^1.17.0",
     "@redux-devtools/extension": "^3.3.0",
     "classnames": "2.5.1",
     "connected-react-router": "6.8.0",

--- a/packages/volto/src/start-client.jsx
+++ b/packages/volto/src/start-client.jsx
@@ -4,7 +4,9 @@ import React from 'react';
 import { hydrateRoot } from 'react-dom/client';
 import { Provider } from 'react-redux';
 import { IntlProvider } from 'react-intl-redux';
+import { RouterProvider } from 'react-aria-components';
 import { ConnectedRouter } from 'connected-react-router';
+import { useHistory } from 'react-router-dom';
 import { createBrowserHistory } from 'history';
 import { ReduxAsyncConnect } from '@plone/volto/helpers/AsyncConnect';
 import { loadableReady } from '@loadable/component';
@@ -22,6 +24,20 @@ export const history = createBrowserHistory();
 
 function reactIntlErrorHandler(error) {
   debug('i18n')(error);
+}
+
+function ReactAriaRouterProvider({ children }) {
+  const history = useHistory();
+
+  const navigate = (to, options = {}) => {
+    if (options.replace) {
+      history.replace(to);
+    } else {
+      history.push(to);
+    }
+  };
+
+  return <RouterProvider navigate={navigate}>{children}</RouterProvider>;
 }
 
 export default function client() {
@@ -70,9 +86,11 @@ export default function client() {
         <Provider store={store}>
           <IntlProvider onError={reactIntlErrorHandler}>
             <ConnectedRouter history={history}>
-              <ScrollToTop>
-                <ReduxAsyncConnect routes={routes} helpers={api} />
-              </ScrollToTop>
+              <ReactAriaRouterProvider>
+                <ScrollToTop>
+                  <ReduxAsyncConnect routes={routes} helpers={api} />
+                </ScrollToTop>
+              </ReactAriaRouterProvider>
             </ConnectedRouter>
           </IntlProvider>
         </Provider>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -608,6 +608,9 @@ importers:
       react-animate-height:
         specifier: 2.0.17
         version: 2.0.17(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react-aria-components:
+        specifier: ^1.17.0
+        version: 1.17.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react-beautiful-dnd:
         specifier: 13.0.0
         version: 13.0.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)


### PR DESCRIPTION
Backport of #8159 to Volto 18.