### PR TITLE
increase icon size to comply with WCAG 2.2

### DIFF
--- a/packages/volto/news/8297.bugfix
+++ b/packages/volto/news/8297.bugfix
@@ -1,1 +1,1 @@
-increase home icon size to comply with WCAG 2.2 accessibility @polyester
+Increase home icon size to comply with WCAG 2.2 accessibility. @polyester

--- a/packages/volto/news/8297.bugfix
+++ b/packages/volto/news/8297.bugfix
@@ -1,0 +1,1 @@
+increase home icon size to comply with WCAG 2.2 accessibility @polyester

--- a/packages/volto/src/components/theme/Breadcrumbs/Breadcrumbs.jsx
+++ b/packages/volto/src/components/theme/Breadcrumbs/Breadcrumbs.jsx
@@ -67,7 +67,7 @@ const BreadcrumbsComponent = ({ pathname }) => {
             className="section"
             title={intl.formatMessage(messages.home)}
           >
-            <Icon name={homeSVG} size="18px" />
+            <Icon name={homeSVG} size="24px" />
           </Link>
           {items.map((item, index, items) => [
             <Breadcrumb.Divider key={`divider-${item.url}`} />,

--- a/packages/volto/src/components/theme/Breadcrumbs/__snapshots__/Breadcrumbs.test.jsx.snap
+++ b/packages/volto/src/components/theme/Breadcrumbs/__snapshots__/Breadcrumbs.test.jsx.snap
@@ -29,7 +29,7 @@ exports[`Breadcrumbs > renders a breadcrumbs component 1`] = `
           style={
             {
               "fill": "currentColor",
-              "height": "18px",
+              "height": "24px",
               "width": "auto",
             }
           }

--- a/packages/volto/theme/themes/pastanaga/collections/breadcrumb.overrides
+++ b/packages/volto/theme/themes/pastanaga/collections/breadcrumb.overrides
@@ -8,6 +8,8 @@
   padding-right: 1rem;
   padding-left: 1rem;
 
+  svg.icon {height: 24px !important}
+
   a.section {
     color: #0074a3;
   }

--- a/packages/volto/theme/themes/pastanaga/collections/breadcrumb.overrides
+++ b/packages/volto/theme/themes/pastanaga/collections/breadcrumb.overrides
@@ -8,8 +8,6 @@
   padding-right: 1rem;
   padding-left: 1rem;
 
-  svg.icon {height: 24px !important}
-
   a.section {
     color: #0074a3;
   }


### PR DESCRIPTION
According to WCAG 2.2 criterion 2.5.8, a target for navigation should be 24 css pixels minimum. 

<img width="215" height="106" alt="Screenshot 2026-05-29 at 9 58 52 AM" src="https://github.com/user-attachments/assets/a37b10fe-86f0-4cd6-9695-3190481021c7" />
