### PR TITLE
[WIP] Add timezone selector to DateTimeWidget for event start and end

### DIFF
--- a/packages/volto/locales/af/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/af/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr ""
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5384,6 +5389,11 @@ msgstr ""
 #. Default: "Text"
 #: config/Blocks
 msgid "text"
+msgstr ""
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
 msgstr ""
 
 #. Default: "Title"

--- a/packages/volto/locales/ar/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ar/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr ""
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5384,6 +5389,11 @@ msgstr ""
 #. Default: "Text"
 #: config/Blocks
 msgid "text"
+msgstr ""
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
 msgstr ""
 
 #. Default: "Title"

--- a/packages/volto/locales/bg/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/bg/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr ""
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5384,6 +5389,11 @@ msgstr ""
 #. Default: "Text"
 #: config/Blocks
 msgid "text"
+msgstr ""
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
 msgstr ""
 
 #. Default: "Title"

--- a/packages/volto/locales/bn/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/bn/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr ""
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5384,6 +5389,11 @@ msgstr ""
 #. Default: "Text"
 #: config/Blocks
 msgid "text"
+msgstr ""
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
 msgstr ""
 
 #. Default: "Title"

--- a/packages/volto/locales/ca/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ca/LC_MESSAGES/volto.po
@@ -4846,6 +4846,11 @@ msgstr "Esborrany"
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5386,6 +5391,11 @@ msgstr "ruta de destí"
 #: config/Blocks
 msgid "text"
 msgstr "Text"
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
+msgstr ""
 
 #. Default: "Title"
 #: config/Blocks

--- a/packages/volto/locales/cs/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/cs/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr ""
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5384,6 +5389,11 @@ msgstr ""
 #. Default: "Text"
 #: config/Blocks
 msgid "text"
+msgstr ""
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
 msgstr ""
 
 #. Default: "Title"

--- a/packages/volto/locales/cy/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/cy/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr ""
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5384,6 +5389,11 @@ msgstr ""
 #. Default: "Text"
 #: config/Blocks
 msgid "text"
+msgstr ""
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
 msgstr ""
 
 #. Default: "Title"

--- a/packages/volto/locales/da/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/da/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr ""
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5384,6 +5389,11 @@ msgstr ""
 #. Default: "Text"
 #: config/Blocks
 msgid "text"
+msgstr ""
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
 msgstr ""
 
 #. Default: "Title"

--- a/packages/volto/locales/de/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/de/LC_MESSAGES/volto.po
@@ -4846,6 +4846,11 @@ msgstr "Entwurf"
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5386,6 +5391,11 @@ msgstr "Pfad möglicher Ziele"
 #: config/Blocks
 msgid "text"
 msgstr "Text"
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
+msgstr ""
 
 #. Default: "Title"
 #: config/Blocks

--- a/packages/volto/locales/el/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/el/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr ""
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5384,6 +5389,11 @@ msgstr ""
 #. Default: "Text"
 #: config/Blocks
 msgid "text"
+msgstr ""
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
 msgstr ""
 
 #. Default: "Title"

--- a/packages/volto/locales/en/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/en/LC_MESSAGES/volto.po
@@ -4844,6 +4844,11 @@ msgstr ""
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5383,6 +5388,11 @@ msgstr ""
 #. Default: "Text"
 #: config/Blocks
 msgid "text"
+msgstr ""
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
 msgstr ""
 
 #. Default: "Title"

--- a/packages/volto/locales/en_AU/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/en_AU/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr ""
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5384,6 +5389,11 @@ msgstr ""
 #. Default: "Text"
 #: config/Blocks
 msgid "text"
+msgstr ""
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
 msgstr ""
 
 #. Default: "Title"

--- a/packages/volto/locales/en_GB/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/en_GB/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr ""
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5384,6 +5389,11 @@ msgstr ""
 #. Default: "Text"
 #: config/Blocks
 msgid "text"
+msgstr ""
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
 msgstr ""
 
 #. Default: "Title"

--- a/packages/volto/locales/eo/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/eo/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr ""
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5384,6 +5389,11 @@ msgstr ""
 #. Default: "Text"
 #: config/Blocks
 msgid "text"
+msgstr ""
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
 msgstr ""
 
 #. Default: "Title"

--- a/packages/volto/locales/es/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/es/LC_MESSAGES/volto.po
@@ -4846,6 +4846,11 @@ msgstr "Borrador"
 msgid "drag_block"
 msgstr "arrastrar bloque {type}"
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5386,6 +5391,11 @@ msgstr "ruta de destino"
 #: config/Blocks
 msgid "text"
 msgstr "Texto"
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
+msgstr ""
 
 #. Default: "Title"
 #: config/Blocks

--- a/packages/volto/locales/et/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/et/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr ""
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5384,6 +5389,11 @@ msgstr ""
 #. Default: "Text"
 #: config/Blocks
 msgid "text"
+msgstr ""
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
 msgstr ""
 
 #. Default: "Title"

--- a/packages/volto/locales/eu/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/eu/LC_MESSAGES/volto.po
@@ -4846,6 +4846,11 @@ msgstr "Zirriborroa"
 msgid "drag_block"
 msgstr "arrastatu {type} blokea"
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5386,6 +5391,11 @@ msgstr "helburuaren patha"
 #: config/Blocks
 msgid "text"
 msgstr "Testua"
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
+msgstr ""
 
 #. Default: "Title"
 #: config/Blocks

--- a/packages/volto/locales/fa/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/fa/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr ""
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5384,6 +5389,11 @@ msgstr ""
 #. Default: "Text"
 #: config/Blocks
 msgid "text"
+msgstr ""
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
 msgstr ""
 
 #. Default: "Title"

--- a/packages/volto/locales/fi/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/fi/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr "luonnos"
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5384,6 +5389,11 @@ msgstr ""
 #. Default: "Text"
 #: config/Blocks
 msgid "text"
+msgstr ""
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
 msgstr ""
 
 #. Default: "Title"

--- a/packages/volto/locales/fr/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/fr/LC_MESSAGES/volto.po
@@ -4846,6 +4846,11 @@ msgstr "Brouillon"
 msgid "drag_block"
 msgstr "glisser {type} bloc"
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5386,6 +5391,11 @@ msgstr "chemin cible"
 #: config/Blocks
 msgid "text"
 msgstr "Texte"
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
+msgstr ""
 
 #. Default: "Title"
 #: config/Blocks

--- a/packages/volto/locales/fu/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/fu/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr ""
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5384,6 +5389,11 @@ msgstr ""
 #. Default: "Text"
 #: config/Blocks
 msgid "text"
+msgstr ""
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
 msgstr ""
 
 #. Default: "Title"

--- a/packages/volto/locales/gl/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/gl/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr "Borrador"
 msgid "drag_block"
 msgstr "arrastre bloque {type}"
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5385,6 +5390,11 @@ msgstr "obxectivo da ruta"
 #: config/Blocks
 msgid "text"
 msgstr "Texto"
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
+msgstr ""
 
 #. Default: "Title"
 #: config/Blocks

--- a/packages/volto/locales/he/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/he/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr ""
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5384,6 +5389,11 @@ msgstr ""
 #. Default: "Text"
 #: config/Blocks
 msgid "text"
+msgstr ""
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
 msgstr ""
 
 #. Default: "Title"

--- a/packages/volto/locales/hi/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/hi/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr "ड्राफ़्ट"
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5385,6 +5390,11 @@ msgstr "लक्ष्य पथ"
 #: config/Blocks
 msgid "text"
 msgstr "पाठ"
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
+msgstr ""
 
 #. Default: "Title"
 #: config/Blocks

--- a/packages/volto/locales/hr/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/hr/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr ""
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5384,6 +5389,11 @@ msgstr ""
 #. Default: "Text"
 #: config/Blocks
 msgid "text"
+msgstr ""
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
 msgstr ""
 
 #. Default: "Title"

--- a/packages/volto/locales/hu/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/hu/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr ""
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5384,6 +5389,11 @@ msgstr ""
 #. Default: "Text"
 #: config/Blocks
 msgid "text"
+msgstr ""
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
 msgstr ""
 
 #. Default: "Title"

--- a/packages/volto/locales/hy/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/hy/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr ""
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5384,6 +5389,11 @@ msgstr ""
 #. Default: "Text"
 #: config/Blocks
 msgid "text"
+msgstr ""
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
 msgstr ""
 
 #. Default: "Title"

--- a/packages/volto/locales/id/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/id/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr ""
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5384,6 +5389,11 @@ msgstr ""
 #. Default: "Text"
 #: config/Blocks
 msgid "text"
+msgstr ""
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
 msgstr ""
 
 #. Default: "Title"

--- a/packages/volto/locales/it/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/it/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr "Bozza"
 msgid "drag_block"
 msgstr "Trascina il blocco {type}"
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5385,6 +5390,11 @@ msgstr "percorso di destinazione"
 #: config/Blocks
 msgid "text"
 msgstr "Testo"
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
+msgstr ""
 
 #. Default: "Title"
 #: config/Blocks

--- a/packages/volto/locales/ja/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ja/LC_MESSAGES/volto.po
@@ -4846,6 +4846,11 @@ msgstr "下書き(draft)"
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5385,6 +5390,11 @@ msgstr ""
 #. Default: "Text"
 #: config/Blocks
 msgid "text"
+msgstr ""
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
 msgstr ""
 
 #. Default: "Title"

--- a/packages/volto/locales/ka/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ka/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr ""
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5384,6 +5389,11 @@ msgstr ""
 #. Default: "Text"
 #: config/Blocks
 msgid "text"
+msgstr ""
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
 msgstr ""
 
 #. Default: "Title"

--- a/packages/volto/locales/kn/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/kn/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr ""
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5384,6 +5389,11 @@ msgstr ""
 #. Default: "Text"
 #: config/Blocks
 msgid "text"
+msgstr ""
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
 msgstr ""
 
 #. Default: "Title"

--- a/packages/volto/locales/ko/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ko/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr ""
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5384,6 +5389,11 @@ msgstr ""
 #. Default: "Text"
 #: config/Blocks
 msgid "text"
+msgstr ""
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
 msgstr ""
 
 #. Default: "Title"

--- a/packages/volto/locales/lt/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/lt/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr ""
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5384,6 +5389,11 @@ msgstr ""
 #. Default: "Text"
 #: config/Blocks
 msgid "text"
+msgstr ""
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
 msgstr ""
 
 #. Default: "Title"

--- a/packages/volto/locales/lv/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/lv/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr ""
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5384,6 +5389,11 @@ msgstr ""
 #. Default: "Text"
 #: config/Blocks
 msgid "text"
+msgstr ""
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
 msgstr ""
 
 #. Default: "Title"

--- a/packages/volto/locales/mi/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/mi/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr ""
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5384,6 +5389,11 @@ msgstr ""
 #. Default: "Text"
 #: config/Blocks
 msgid "text"
+msgstr ""
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
 msgstr ""
 
 #. Default: "Title"

--- a/packages/volto/locales/mk/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/mk/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr ""
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5384,6 +5389,11 @@ msgstr ""
 #. Default: "Text"
 #: config/Blocks
 msgid "text"
+msgstr ""
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
 msgstr ""
 
 #. Default: "Title"

--- a/packages/volto/locales/my/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/my/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr ""
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5384,6 +5389,11 @@ msgstr ""
 #. Default: "Text"
 #: config/Blocks
 msgid "text"
+msgstr ""
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
 msgstr ""
 
 #. Default: "Title"

--- a/packages/volto/locales/nb_NO/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/nb_NO/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr ""
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5384,6 +5389,11 @@ msgstr ""
 #. Default: "Text"
 #: config/Blocks
 msgid "text"
+msgstr ""
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
 msgstr ""
 
 #. Default: "Title"

--- a/packages/volto/locales/nl/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/nl/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr "voorlopige versie"
 msgid "drag_block"
 msgstr "versleep {type} blok"
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5385,6 +5390,11 @@ msgstr "pad naar doel"
 #: config/Blocks
 msgid "text"
 msgstr "Tekst"
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
+msgstr ""
 
 #. Default: "Title"
 #: config/Blocks

--- a/packages/volto/locales/nn/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/nn/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr ""
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5384,6 +5389,11 @@ msgstr ""
 #. Default: "Text"
 #: config/Blocks
 msgid "text"
+msgstr ""
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
 msgstr ""
 
 #. Default: "Title"

--- a/packages/volto/locales/pl/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/pl/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr ""
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5384,6 +5389,11 @@ msgstr ""
 #. Default: "Text"
 #: config/Blocks
 msgid "text"
+msgstr ""
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
 msgstr ""
 
 #. Default: "Title"

--- a/packages/volto/locales/pt/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/pt/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr "Rascunho"
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5385,6 +5390,11 @@ msgstr "caminho do destino"
 #: config/Blocks
 msgid "text"
 msgstr "texto"
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
+msgstr ""
 
 #. Default: "Title"
 #: config/Blocks

--- a/packages/volto/locales/pt_BR/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/pt_BR/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr "Rascunho"
 msgid "drag_block"
 msgstr "arrastar bloco {type}"
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5385,6 +5390,11 @@ msgstr "caminho do destino"
 #: config/Blocks
 msgid "text"
 msgstr "texto"
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
+msgstr ""
 
 #. Default: "Title"
 #: config/Blocks

--- a/packages/volto/locales/rm/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/rm/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr ""
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5384,6 +5389,11 @@ msgstr ""
 #. Default: "Text"
 #: config/Blocks
 msgid "text"
+msgstr ""
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
 msgstr ""
 
 #. Default: "Title"

--- a/packages/volto/locales/ro/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ro/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr "proiect"
 msgid "drag_block"
 msgstr "glisați blocul {type}"
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5385,6 +5390,11 @@ msgstr "cale destinație"
 #: config/Blocks
 msgid "text"
 msgstr "Text"
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
+msgstr ""
 
 #. Default: "Title"
 #: config/Blocks

--- a/packages/volto/locales/ru/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ru/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr "Черновик"
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5385,6 +5390,11 @@ msgstr "целевой путь"
 #: config/Blocks
 msgid "text"
 msgstr "Текст"
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
+msgstr ""
 
 #. Default: "Title"
 #: config/Blocks

--- a/packages/volto/locales/sk/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/sk/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr ""
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5384,6 +5389,11 @@ msgstr ""
 #. Default: "Text"
 #: config/Blocks
 msgid "text"
+msgstr ""
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
 msgstr ""
 
 #. Default: "Title"

--- a/packages/volto/locales/sl/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/sl/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr ""
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5384,6 +5389,11 @@ msgstr ""
 #. Default: "Text"
 #: config/Blocks
 msgid "text"
+msgstr ""
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
 msgstr ""
 
 #. Default: "Title"

--- a/packages/volto/locales/sm/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/sm/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr ""
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5384,6 +5389,11 @@ msgstr ""
 #. Default: "Text"
 #: config/Blocks
 msgid "text"
+msgstr ""
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
 msgstr ""
 
 #. Default: "Title"

--- a/packages/volto/locales/sq/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/sq/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr ""
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5384,6 +5389,11 @@ msgstr ""
 #. Default: "Text"
 #: config/Blocks
 msgid "text"
+msgstr ""
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
 msgstr ""
 
 #. Default: "Title"

--- a/packages/volto/locales/sr/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/sr/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr ""
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5384,6 +5389,11 @@ msgstr ""
 #. Default: "Text"
 #: config/Blocks
 msgid "text"
+msgstr ""
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
 msgstr ""
 
 #. Default: "Title"

--- a/packages/volto/locales/sr@cyrl/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/sr@cyrl/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr ""
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5384,6 +5389,11 @@ msgstr ""
 #. Default: "Text"
 #: config/Blocks
 msgid "text"
+msgstr ""
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
 msgstr ""
 
 #. Default: "Title"

--- a/packages/volto/locales/sr@latn/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/sr@latn/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr ""
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5384,6 +5389,11 @@ msgstr ""
 #. Default: "Text"
 #: config/Blocks
 msgid "text"
+msgstr ""
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
 msgstr ""
 
 #. Default: "Title"

--- a/packages/volto/locales/sv/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/sv/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr ""
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5384,6 +5389,11 @@ msgstr ""
 #. Default: "Text"
 #: config/Blocks
 msgid "text"
+msgstr ""
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
 msgstr ""
 
 #. Default: "Title"

--- a/packages/volto/locales/ta/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ta/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr "வரைவு"
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5385,6 +5390,11 @@ msgstr "இலக்கு பாதை"
 #: config/Blocks
 msgid "text"
 msgstr "உரை"
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
+msgstr ""
 
 #. Default: "Title"
 #: config/Blocks

--- a/packages/volto/locales/te/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/te/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr ""
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5384,6 +5389,11 @@ msgstr ""
 #. Default: "Text"
 #: config/Blocks
 msgid "text"
+msgstr ""
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
 msgstr ""
 
 #. Default: "Title"

--- a/packages/volto/locales/th/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/th/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr ""
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5384,6 +5389,11 @@ msgstr ""
 #. Default: "Text"
 #: config/Blocks
 msgid "text"
+msgstr ""
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
 msgstr ""
 
 #. Default: "Title"

--- a/packages/volto/locales/to/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/to/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr ""
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5384,6 +5389,11 @@ msgstr ""
 #. Default: "Text"
 #: config/Blocks
 msgid "text"
+msgstr ""
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
 msgstr ""
 
 #. Default: "Title"

--- a/packages/volto/locales/tr/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/tr/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr ""
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5384,6 +5389,11 @@ msgstr ""
 #. Default: "Text"
 #: config/Blocks
 msgid "text"
+msgstr ""
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
 msgstr ""
 
 #. Default: "Title"

--- a/packages/volto/locales/uk/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/uk/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr ""
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5384,6 +5389,11 @@ msgstr ""
 #. Default: "Text"
 #: config/Blocks
 msgid "text"
+msgstr ""
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
 msgstr ""
 
 #. Default: "Title"

--- a/packages/volto/locales/vi/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/vi/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr ""
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5384,6 +5389,11 @@ msgstr ""
 #. Default: "Text"
 #: config/Blocks
 msgid "text"
+msgstr ""
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
 msgstr ""
 
 #. Default: "Title"

--- a/packages/volto/locales/volto.pot
+++ b/packages/volto/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2026-05-07T07:25:19.397Z\n"
+"POT-Creation-Date: 2026-05-30T12:08:30.264Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Content-Type: text/plain; charset=utf-8\n"
@@ -4841,6 +4841,11 @@ msgstr ""
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5380,6 +5385,11 @@ msgstr ""
 #. Default: "Text"
 #: config/Blocks
 msgid "text"
+msgstr ""
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
 msgstr ""
 
 #. Default: "Title"

--- a/packages/volto/locales/zh_CN/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/zh_CN/LC_MESSAGES/volto.po
@@ -4846,6 +4846,11 @@ msgstr "草案"
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5385,6 +5390,11 @@ msgstr ""
 #. Default: "Text"
 #: config/Blocks
 msgid "text"
+msgstr ""
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
 msgstr ""
 
 #. Default: "Title"

--- a/packages/volto/locales/zh_Hant/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/zh_Hant/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr ""
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5384,6 +5389,11 @@ msgstr ""
 #. Default: "Text"
 #: config/Blocks
 msgid "text"
+msgstr ""
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
 msgstr ""
 
 #. Default: "Title"

--- a/packages/volto/locales/zh_Hant_HK/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/zh_Hant_HK/LC_MESSAGES/volto.po
@@ -4845,6 +4845,11 @@ msgstr ""
 msgid "drag_block"
 msgstr ""
 
+#. Default: "Edit time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "editTimezone"
+msgstr ""
+
 #. Default: "Input must be valid email (something@domain.com)"
 #: helpers/MessageLabels/MessageLabels
 msgid "email"
@@ -5384,6 +5389,11 @@ msgstr ""
 #. Default: "Text"
 #: config/Blocks
 msgid "text"
+msgstr ""
+
+#. Default: "Time zone"
+#: components/manage/Widgets/DatetimeWidget
+msgid "timezone"
 msgstr ""
 
 #. Default: "Title"

--- a/packages/volto/src/components/manage/Widgets/DatetimeWidget.jsx
+++ b/packages/volto/src/components/manage/Widgets/DatetimeWidget.jsx
@@ -5,12 +5,23 @@ import loadable from '@loadable/component';
 import cx from 'classnames';
 import Icon from '@plone/volto/components/theme/Icon/Icon';
 import FormFieldWrapper from '@plone/volto/components/manage/Widgets/FormFieldWrapper';
-import { parseDateTime, toBackendLang } from '@plone/volto/helpers/Utils/Utils';
+import {
+  parseDateTime,
+  toBackendLang,
+  getTimeZoneOffset,
+} from '@plone/volto/helpers/Utils/Utils';
 import { injectLazyLibs } from '@plone/volto/helpers/Loadable/Loadable';
+import {
+  customSelectStyles,
+  DropdownIndicator,
+  Option,
+  selectTheme,
+} from '@plone/volto/components/manage/Widgets/SelectStyling';
 
 import leftKey from '@plone/volto/icons/left-key.svg';
 import rightKey from '@plone/volto/icons/right-key.svg';
 import clearSVG from '@plone/volto/icons/clear.svg';
+import clockSVG from '@plone/volto/icons/clock.svg';
 
 import 'rc-time-picker/assets/index.css';
 import 'react-dates/initialize';
@@ -26,6 +37,14 @@ const messages = defineMessages({
   time: {
     id: 'Time',
     defaultMessage: 'Time',
+  },
+  timezone: {
+    id: 'timezone',
+    defaultMessage: 'Time zone',
+  },
+  editTimezone: {
+    id: 'editTimezone',
+    defaultMessage: 'Edit time zone',
   },
   clearDateTime: {
     id: 'Clear date/time',
@@ -71,6 +90,52 @@ const defaultTimeDateOnly = {
   second: 0,
 };
 
+const TimezoneSelector = injectLazyLibs(['reactSelect'])(({
+  value,
+  onChange,
+  reactSelect,
+}) => {
+  const intl = useIntl();
+  const [open, setOpen] = useState(false);
+  const Select = reactSelect.default;
+
+  return (
+    <div className="date-time-widget-timezone">
+      <button
+        type="button"
+        aria-label={intl.formatMessage(messages.editTimezone)}
+        onClick={() => setOpen(!open)}
+      >
+        <Icon name={clockSVG} size="16px" /> {open ? null : value}
+      </button>
+      {open ? (
+        <div className="date-time-widget-timezone-selector">
+          <Select
+            placeholder={intl.formatMessage(messages.editTimezone)}
+            // eslint-disable-next-line jsx-a11y/no-autofocus
+            autoFocus
+            value={{ value, label: value }}
+            onChange={(option) => {
+              onChange(option.value);
+              setOpen(false);
+            }}
+            onBlur={() => setOpen(false)}
+            options={Intl.supportedValuesOf('timeZone').map((tz) => ({
+              value: tz,
+              label: tz,
+            }))}
+            styles={customSelectStyles}
+            theme={selectTheme}
+            components={{
+              DropdownIndicator,
+              Option,
+            }}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+});
 const DatetimeWidgetComponent = (props) => {
   const {
     id,
@@ -101,20 +166,30 @@ const DatetimeWidgetComponent = (props) => {
 
   const renderWidget = !(id === 'end' && formData?.open_end);
 
+  const localTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const selectedTimezone = formData?.[id + '_timezone'] || localTimezone;
+
   useEffect(() => {
     const parsedDateTime = parseDateTime(
       toBackendLang(lang),
       value,
       undefined,
       moment.default,
+      selectedTimezone,
     );
     setIsDefault(
       parsedDateTime?.toISOString() === moment.default().utc().toISOString(),
     );
-  }, [value, lang, moment]);
+  }, [value, lang, moment, selectedTimezone]);
 
   const getInternalValue = () => {
-    return parseDateTime(toBackendLang(lang), value, undefined, moment.default);
+    return parseDateTime(
+      toBackendLang(lang),
+      value,
+      undefined,
+      moment.default,
+      selectedTimezone,
+    );
   };
 
   const getDateOnly = () => {
@@ -151,6 +226,18 @@ const DatetimeWidgetComponent = (props) => {
       });
       const dateValue = base.toISOString();
       onChange(id, dateValue);
+    }
+  };
+
+  const onTimezoneChange = (timezone) => {
+    if (timezone) {
+      let value = getInternalValue();
+      value = value.utcOffset(
+        getTimeZoneOffset(value.toDate(), timezone),
+        true,
+      );
+      onChange(id, value.toISOString());
+      onChange(id + '_timezone', timezone);
     }
   };
 
@@ -198,68 +285,76 @@ const DatetimeWidgetComponent = (props) => {
   return (
     <FormFieldWrapper {...props}>
       {renderWidget && (
-        <div className="date-time-widget-wrapper">
-          <div
-            className={cx('ui input date-input', {
-              'default-date': isDefault,
-            })}
-          >
-            <SingleDatePicker
-              date={datetime}
-              disabled={isDisabled}
-              onDateChange={onDateChange}
-              focused={focused}
-              numberOfMonths={1}
-              {...(noPastDates ? {} : { isOutsideRange: () => false })}
-              onFocusChange={onFocusChange}
-              noBorder
-              required={required}
-              displayFormat={moment.default
-                .localeData(toBackendLang(lang))
-                .longDateFormat('L')}
-              navPrev={<PrevIcon />}
-              navNext={<NextIcon />}
-              id={`${id}-date`}
-              placeholder={intl.formatMessage(messages.date)}
-            />
-          </div>
-          {!isDateOnly && (
+        <>
+          <div className="date-time-widget-wrapper">
             <div
-              ref={timeInputRef}
-              className={cx('ui input time-input', {
+              className={cx('ui input date-input', {
                 'default-date': isDefault,
               })}
             >
-              <TimePicker
+              <SingleDatePicker
+                date={datetime}
                 disabled={isDisabled}
-                defaultValue={datetime}
-                value={datetime}
-                onChange={onTimeChange}
-                allowEmpty={false}
-                showSecond={false}
-                use12Hours={lang === 'en'}
-                id={`${id}-time`}
-                format={moment.default
+                onDateChange={onDateChange}
+                focused={focused}
+                numberOfMonths={1}
+                {...(noPastDates ? {} : { isOutsideRange: () => false })}
+                onFocusChange={onFocusChange}
+                noBorder
+                required={required}
+                displayFormat={moment.default
                   .localeData(toBackendLang(lang))
-                  .longDateFormat('LT')}
-                placeholder={intl.formatMessage(messages.time)}
-                focusOnOpen
-                placement="bottomRight"
+                  .longDateFormat('L')}
+                navPrev={<PrevIcon />}
+                navNext={<NextIcon />}
+                id={`${id}-date`}
+                placeholder={intl.formatMessage(messages.date)}
               />
             </div>
-          )}
-          {resettable && (
-            <button
-              type="button"
-              disabled={isDisabled || !datetime}
-              onClick={onResetDates}
-              className="item ui noborder button"
-              aria-label={intl.formatMessage(messages.clearDateTime)}
-            >
-              <Icon name={clearSVG} size="24px" className="close" />
-            </button>
-          )}
-        </div>
+            {!isDateOnly && (
+              <div
+                ref={timeInputRef}
+                className={cx('ui input time-input', {
+                  'default-date': isDefault,
+                })}
+              >
+                <TimePicker
+                  disabled={isDisabled}
+                  defaultValue={datetime}
+                  value={datetime}
+                  onChange={onTimeChange}
+                  allowEmpty={false}
+                  showSecond={false}
+                  use12Hours={lang === 'en'}
+                  id={`${id}-time`}
+                  format={moment.default
+                    .localeData(toBackendLang(lang))
+                    .longDateFormat('LT')}
+                  placeholder={intl.formatMessage(messages.time)}
+                  focusOnOpen
+                  placement="bottomRight"
+                />
+              </div>
+            )}
+            {resettable && (
+              <button
+                type="button"
+                disabled={isDisabled || !datetime}
+                onClick={onResetDates}
+                className="item ui noborder button"
+                aria-label={intl.formatMessage(messages.clearDateTime)}
+              >
+                <Icon name={clearSVG} size="24px" className="close" />
+              </button>
+            )}
+          </div>
+          {id === 'start' || id === 'end' ? (
+            <TimezoneSelector
+              value={selectedTimezone}
+              onChange={onTimezoneChange}
+            />
+          ) : null}
+        </>
       )}
     </FormFieldWrapper>
   );
@@ -289,6 +384,6 @@ DatetimeWidgetComponent.defaultProps = {
   resettable: true,
 };
 
-export default injectLazyLibs(['reactDates', 'moment'])(
+export default injectLazyLibs(['reactDates', 'reactSelect', 'moment'])(
   DatetimeWidgetComponent,
 );

--- a/packages/volto/src/helpers/Utils/Utils.jsx
+++ b/packages/volto/src/helpers/Utils/Utils.jsx
@@ -165,6 +165,12 @@ export const getColor = (name) => {
   return namedColor;
 };
 
+export const getTimeZoneOffset = (date, timeZone) => {
+  const toTimeZone = (z) =>
+    new Date(date.toLocaleString('sv', { timeZone: z }).replace(' ', 'T'));
+  return (toTimeZone(timeZone) - toTimeZone('UTC')) / 60_000;
+};
+
 /**
  * Fixes TimeZones issues on moment date objects
  * Parses a DateTime and sets correct moment locale
@@ -173,7 +179,7 @@ export const getColor = (name) => {
  * @param {string} format Date format of choice
  * @returns {Object|string} Moment object or string if format is set
  */
-export const parseDateTime = (locale, value, format, moment) => {
+export const parseDateTime = (locale, value, format, moment, timezone) => {
   //  Used to set a server timezone or UTC as default
   moment.updateLocale(locale, moment.localeData(locale)._config); // copy locale to moment-timezone
   let datetime = null;
@@ -186,6 +192,9 @@ export const parseDateTime = (locale, value, format, moment) => {
           moment(value)
         : // This might happen in old Plone versions dates
           moment(`${value}Z`);
+    if (timezone) {
+      datetime.utcOffset(getTimeZoneOffset(datetime.toDate(), timezone));
+    }
   }
 
   if (format && datetime) {

--- a/packages/volto/theme/themes/pastanaga/extras/react-dates-overrides.less
+++ b/packages/volto/theme/themes/pastanaga/extras/react-dates-overrides.less
@@ -108,6 +108,28 @@ ul.DayPicker_weekHeader_ul {
   align-items: center;
 }
 
+.date-time-widget-timezone {
+  display: flex;
+  justify-content: flex-end;
+  margin: 5px 16px 0 0;
+  font-size: 0.9rem;
+
+  button {
+    cursor: pointer;
+    opacity: 0.5;
+
+    & > svg {
+      display: inline-block;
+      vertical-align: bottom;
+    }
+  }
+}
+
+.date-time-widget-timezone-selector {
+  position: relative;
+  flex-grow: 1;
+}
+
 .sidebar-container:not(.full-size) #sidebar-metadata {
   .DateInput {
     width: 110px !important;


### PR DESCRIPTION
Refs https://github.com/plone/Products.CMFPlone/issues/4115

This updates the existing DateTimeWidget to display the selected timezone for event start and end dates, and provide a selector for changing it.

<img width="401" height="311" alt="Screenshot 2026-05-30 at 2 07 03 PM" src="https://github.com/user-attachments/assets/e6291c7c-e2dc-47d1-8d83-ed8cf14c363a" />
<img width="402" height="420" alt="Screenshot 2026-05-30 at 2 07 22 PM" src="https://github.com/user-attachments/assets/b789de34-7ba5-4c6f-b9b3-681e75186051" />

Depends on the REST API support in https://github.com/plone/plone.restapi/pull/2018

Notes:
- If there's an existing value, its timezone is displayed.
- If there's no existing value (on the add form, for example) we use the browser's local timezone as the initial timezone.
- When the timezone is changed, the absolute datetime value is also adjusted (so for example if I see 1pm in Europe/Vienna and change the timezone to America/Los_Angeles, the raw value is set 9 hours earlier so the user still sees 1pm in the new timezone)

To do:
- [ ] Test how timezones work with whole-day events
- [ ] Add support for AoE ("anywhere on earth")
- [ ] Update the display widget, and other components that show event datetimes
- [ ] Update tests
- [ ] Review usability
- [ ] Review a11y
- [ ] Update storybook

Intentionally out of scope for this PR:
- Other changes to the widgets (like improving the help text and the whole day and open end fields)
- Switch to new widgets. We still should switch to the date and time pickers from `@plone/components` in the long term (for better a11y and avoiding momentjs), but that was a bigger project than I could tackle today, and I wanted to implement this in a way that can potentially be merged for Volto 19 without breaking changes.
- Show the timezone selector for other datetime fields. We can do this if we want, it will require a few more changes in the plone.restapi branch.
- Per-user timezone preference