### PR TITLE
Avoid unhydrated login form error

### DIFF
--- a/packages/volto/news/+login.bugfix
+++ b/packages/volto/news/+login.bugfix
@@ -1,0 +1,2 @@
+Fix "Cannot POST" error on login form if it was submitted before hydration
+finished, by disabling the submit button until then. @davisagli

--- a/packages/volto/src/components/theme/Login/Login.jsx
+++ b/packages/volto/src/components/theme/Login/Login.jsx
@@ -14,6 +14,7 @@ import qs from 'query-string';
 
 import Helmet from '@plone/volto/helpers/Helmet/Helmet';
 import { usePrevious } from '@plone/volto/helpers/Utils/usePrevious';
+import { useClient } from '@plone/volto/hooks/client/useClient';
 import config from '@plone/volto/registry';
 import Icon from '@plone/volto/components/theme/Icon/Icon';
 import {
@@ -84,6 +85,7 @@ const Login = (props) => {
     location.pathname.replace(/\/[^/]*\/?$/, '') ||
     '/';
   const previousToken = usePrevious(token);
+  const isClient = useClient();
 
   useEffect(() => {
     if (location?.state?.isLogout) {
@@ -252,6 +254,7 @@ const Login = (props) => {
                 aria-label={intl.formatMessage(messages.login)}
                 title={intl.formatMessage(messages.login)}
                 loading={loading}
+                disabled={!isClient}
               >
                 <Icon className="circled" name={aheadSVG} size="30px" />
               </Button>

--- a/packages/volto/src/components/theme/Login/__snapshots__/Login.test.jsx.snap
+++ b/packages/volto/src/components/theme/Login/__snapshots__/Login.test.jsx.snap
@@ -143,9 +143,11 @@ exports[`Login > renders a login component 1`] = `
         >
           <button
             aria-label="Log in"
-            className="ui basic icon primary right floated button"
+            className="ui basic icon primary disabled right floated button"
+            disabled={true}
             id="login-form-submit"
             onClick={[Function]}
+            tabIndex={-1}
             title="Log in"
             type="submit"
           >


### PR DESCRIPTION
- [ ] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [ ] I verified there aren't other open [pull requests](https://github.com/plone/volto/pulls) for the same change.
- [ ] I followed the guidelines in [Contributing to Volto](https://6.docs.plone.org/volto/contributing/index.html).
- [ ] I successfully ran [code linting checks](https://6.docs.plone.org/volto/contributing/linting.html) on my changes locally.
- [ ] I successfully ran [unit tests](https://6.docs.plone.org/volto/contributing/testing.html) on my changes locally.
- [ ] I successfully ran [acceptance tests](https://6.docs.plone.org/volto/contributing/acceptance-tests.html) on my changes locally.
- [ ] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/volto/contributing/documentation.html#narrative-documentation) for my changes, either in the Storybook or narrative documentation.
- [ ] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

If your pull request closes an open issue, include the exact text below, immediately followed by the issue number. When your pull request gets merged, then that issue will close automatically.

Closes #

-----

If your pull request includes changes to the documentation—either in narrative documentation, Storybook, or configuration—then a pull request preview will be generated and a link will populate in the description of your pull request below.
By clicking that link, you can use the visual diff menu in the upper right corner to navigate to pages that have changes, then display the diff by checking the `Show diff` checkbox.
