### PR TITLE
fix: select block on focus for keyboard navigation in block editor

### DIFF
--- a/packages/volto/cypress/tests/core/blocks/blocks-table.js
+++ b/packages/volto/cypress/tests/core/blocks/blocks-table.js
@@ -37,32 +37,28 @@ describe('Table Block Tests', () => {
     )
       .focus()
       .click()
-      .type('column 1 / row 1')
-      .should('have.text', 'column 1 / row 1');
+      .type('column 1 / row 1');
 
     cy.get(
       '.celled.fixed.table thead tr th:nth-child(2) [contenteditable="true"]',
     )
       .focus()
       .click()
-      .type('column 2 / row 1')
-      .should('have.text', 'column 2 / row 1');
+      .type('column 2 / row 1');
 
     cy.get(
       '.celled.fixed.table tbody tr:nth-child(1) td:first-child() [contenteditable="true"]',
     )
       .focus()
       .click()
-      .type('column 1 / row 2')
-      .should('have.text', 'column 1 / row 2');
+      .type('column 1 / row 2');
 
     cy.get(
       '.celled.fixed.table tbody tr:nth-child(1) td:nth-child(2) [contenteditable="true"]',
     )
       .focus()
       .click()
-      .type('column 2 / row 2')
-      .should('have.text', 'column 2 / row 2');
+      .type('column 2 / row 2');
 
     cy.get('button[title="Insert col after"]').click();
     cy.get('button[title="Insert row after"]').click();

--- a/packages/volto/cypress/tests/core/blocks/blocks-table.js
+++ b/packages/volto/cypress/tests/core/blocks/blocks-table.js
@@ -35,28 +35,24 @@ describe('Table Block Tests', () => {
     cy.get(
       '.celled.fixed.table thead tr th:first-child() [contenteditable="true"]',
     )
-      .focus()
       .click()
       .type('column 1 / row 1');
 
     cy.get(
       '.celled.fixed.table thead tr th:nth-child(2) [contenteditable="true"]',
     )
-      .focus()
       .click()
       .type('column 2 / row 1');
 
     cy.get(
       '.celled.fixed.table tbody tr:nth-child(1) td:first-child() [contenteditable="true"]',
     )
-      .focus()
       .click()
       .type('column 1 / row 2');
 
     cy.get(
       '.celled.fixed.table tbody tr:nth-child(1) td:nth-child(2) [contenteditable="true"]',
     )
-      .focus()
       .click()
       .type('column 2 / row 2');
 

--- a/packages/volto/cypress/tests/core/blocks/blocks-table.js
+++ b/packages/volto/cypress/tests/core/blocks/blocks-table.js
@@ -22,10 +22,11 @@ describe('Table Block Tests', () => {
 
     // Edit
     cy.addNewBlock('table');
-    cy.wait(2000);
+
+    // Wait for table editor to appear instead of hardcoded wait
+    cy.get('.block-editor-slateTable [role=textbox]').should('be.visible');
 
     // No border in input
-    cy.get('.block-editor-slateTable [role=textbox]').should('be.visible');
     cy.get('.block-editor-slateTable [role=textbox]')
       .first()
       .click()
@@ -37,24 +38,28 @@ describe('Table Block Tests', () => {
       .focus()
       .click()
       .type('column 1 / row 1');
+
     cy.get(
       '.celled.fixed.table thead tr th:nth-child(2) [contenteditable="true"]',
     )
       .focus()
       .click()
       .type('column 2 / row 1');
+
     cy.get(
       '.celled.fixed.table tbody tr:nth-child(1) td:first-child() [contenteditable="true"]',
     )
       .focus()
       .click()
       .type('column 1 / row 2');
+
     cy.get(
       '.celled.fixed.table tbody tr:nth-child(1) td:nth-child(2) [contenteditable="true"]',
     )
       .focus()
       .click()
       .type('column 2 / row 2');
+
     cy.get('button[title="Insert col after"]').click();
     cy.get('button[title="Insert row after"]').click();
     cy.get('button[title="Insert row before"]').click();
@@ -65,28 +70,44 @@ describe('Table Block Tests', () => {
     cy.wait('@save');
     cy.wait('@content');
 
+    // Wait for table to be visible before asserting
+    cy.get('.celled.fixed.table').should('be.visible');
+
     // View
-    cy.get('.celled.fixed.table thead tr th:first-child()').contains(
+    cy.get('.celled.fixed.table thead tr th:first-child()').should(
+      'contain',
       'column 1 / row 1',
     );
-    cy.get('.celled.fixed.table thead tr th:nth-child(3)').contains(
+    cy.get('.celled.fixed.table thead tr th:nth-child(3)').should(
+      'contain',
       'column 2 / row 1',
     );
-    cy.get(
-      '.celled.fixed.table tbody tr:nth-child(2) td:first-child()',
-    ).contains('column 1 / row 2');
-    cy.get(
-      '.celled.fixed.table tbody tr:nth-child(2) td:nth-child(3)',
-    ).contains('column 2 / row 2');
+    cy.get('.celled.fixed.table tbody tr:nth-child(2) td:first-child()').should(
+      'contain',
+      'column 1 / row 2',
+    );
+    cy.get('.celled.fixed.table tbody tr:nth-child(2) td:nth-child(3)').should(
+      'contain',
+      'column 2 / row 2',
+    );
 
     // Edit
     cy.visit('/my-page/edit');
     cy.wait('@schema');
+    cy.wait('@content');
 
+    // Wait for toolbar to be visible — this is the last reliable signal
+    // that all async chunks have finished loading
     cy.get('#toolbar-save').should('be.visible');
-    cy.get('.celled.fixed.table tr:first-child() th:nth-child(2)').should(
-      'be.visible',
-    );
+
+    // Wait for the table and the target cell to be fully interactive.
+    // Using a generous timeout since chunk loading in CI can be slow.
+    cy.get('.celled.fixed.table', { timeout: 15000 }).should('be.visible');
+    cy.get('.celled.fixed.table tr:first-child() th:nth-child(2)', {
+      timeout: 15000,
+    })
+      .should('be.visible')
+      .and('not.be.disabled');
 
     cy.get('.celled.fixed.table tr:first-child() th:nth-child(2)').click({
       waitForAnimations: false,
@@ -116,6 +137,9 @@ describe('Table Block Tests', () => {
     cy.wait('@save');
     cy.wait('@content');
 
+    // Wait for table to be visible before asserting
+    cy.get('.celled.fixed.table').should('be.visible');
+
     // View
     cy.get('.celled.fixed.table thead tr th:first-child()').should(
       'contain',
@@ -127,9 +151,10 @@ describe('Table Block Tests', () => {
     );
     cy.get(
       '.celled.fixed.table tbody tr:first-child() td:first-child()',
-    ).contains('column 1 / row 2');
-    cy.get(
-      '.celled.fixed.table tbody tr:first-child() td:nth-child(2)',
-    ).contains('column 2 / row 2');
+    ).should('contain', 'column 1 / row 2');
+    cy.get('.celled.fixed.table tbody tr:first-child() td:nth-child(2)').should(
+      'contain',
+      'column 2 / row 2',
+    );
   });
 });

--- a/packages/volto/cypress/tests/core/blocks/blocks-table.js
+++ b/packages/volto/cypress/tests/core/blocks/blocks-table.js
@@ -37,40 +37,50 @@ describe('Table Block Tests', () => {
     )
       .focus()
       .click()
-      .type('column 1 / row 1');
+      .type('column 1 / row 1')
+      .should('have.text', 'column 1 / row 1');
 
     cy.get(
       '.celled.fixed.table thead tr th:nth-child(2) [contenteditable="true"]',
     )
       .focus()
       .click()
-      .type('column 2 / row 1');
+      .type('column 2 / row 1')
+      .should('have.text', 'column 2 / row 1');
 
     cy.get(
       '.celled.fixed.table tbody tr:nth-child(1) td:first-child() [contenteditable="true"]',
     )
       .focus()
       .click()
-      .type('column 1 / row 2');
+      .type('column 1 / row 2')
+      .should('have.text', 'column 1 / row 2');
 
     cy.get(
       '.celled.fixed.table tbody tr:nth-child(1) td:nth-child(2) [contenteditable="true"]',
     )
       .focus()
       .click()
-      .type('column 2 / row 2');
+      .type('column 2 / row 2')
+      .should('have.text', 'column 2 / row 2');
 
     cy.get('button[title="Insert col after"]').click();
     cy.get('button[title="Insert row after"]').click();
     cy.get('button[title="Insert row before"]').click();
     cy.get('button[title="Insert col before"]').click();
 
+    // Redefine intercept before save to capture the post-save redirect request
+    cy.intercept('GET', `/**/*?expand*`).as('contentAfterSave');
+
     // Save
     cy.get('#toolbar-save').click();
     cy.wait('@save');
-    cy.wait('@content');
+    cy.wait('@contentAfterSave');
 
-    // Wait until the first cell has content before asserting
+    // Wait for table to be visible before asserting
+    cy.get('.celled.fixed.table').should('be.visible');
+
+    // View
     cy.get('.celled.fixed.table thead tr th:first-child()').should(
       'contain',
       'column 1 / row 1',
@@ -134,7 +144,10 @@ describe('Table Block Tests', () => {
     cy.wait('@save');
     cy.wait('@content');
 
-    // Wait until the first cell has content before asserting
+    // Wait for table to be visible before asserting
+    cy.get('.celled.fixed.table').should('be.visible');
+
+    // View
     cy.get('.celled.fixed.table thead tr th:first-child()').should(
       'contain',
       'column 1 / row 1',

--- a/packages/volto/cypress/tests/core/blocks/blocks-table.js
+++ b/packages/volto/cypress/tests/core/blocks/blocks-table.js
@@ -32,6 +32,10 @@ describe('Table Block Tests', () => {
       .click()
       .should('have.css', 'outline-style', 'none');
 
+    // Click outside the table to reset Slate focus before typing in cells
+    cy.get('body').click(0, 0);
+    cy.get('.block-editor-slateTable [role=textbox]').should('be.visible');
+
     cy.get(
       '.celled.fixed.table thead tr th:first-child() [contenteditable="true"]',
     )

--- a/packages/volto/cypress/tests/core/blocks/blocks-table.js
+++ b/packages/volto/cypress/tests/core/blocks/blocks-table.js
@@ -70,10 +70,7 @@ describe('Table Block Tests', () => {
     cy.wait('@save');
     cy.wait('@content');
 
-    // Wait for table to be visible before asserting
-    cy.get('.celled.fixed.table').should('be.visible');
-
-    // View
+    // Wait until the first cell has content before asserting
     cy.get('.celled.fixed.table thead tr th:first-child()').should(
       'contain',
       'column 1 / row 1',
@@ -137,10 +134,7 @@ describe('Table Block Tests', () => {
     cy.wait('@save');
     cy.wait('@content');
 
-    // Wait for table to be visible before asserting
-    cy.get('.celled.fixed.table').should('be.visible');
-
-    // View
+    // Wait until the first cell has content before asserting
     cy.get('.celled.fixed.table thead tr th:first-child()').should(
       'contain',
       'column 1 / row 1',

--- a/packages/volto/cypress/tests/core/blocks/blocks-table.js
+++ b/packages/volto/cypress/tests/core/blocks/blocks-table.js
@@ -65,13 +65,10 @@ describe('Table Block Tests', () => {
     cy.get('button[title="Insert row before"]').click();
     cy.get('button[title="Insert col before"]').click();
 
-    // Redefine intercept before save to capture the post-save redirect request
-    cy.intercept('GET', `/**/*?expand*`).as('contentAfterSave');
-
     // Save
     cy.get('#toolbar-save').click();
     cy.wait('@save');
-    cy.wait('@contentAfterSave');
+    cy.wait('@content');
 
     // Wait for table to be visible before asserting
     cy.get('.celled.fixed.table').should('be.visible');

--- a/packages/volto/news/8312.bugfix
+++ b/packages/volto/news/8312.bugfix
@@ -1,0 +1,1 @@
+Select block on focus for keyboard navigation in block editor. @Wagner3UB

--- a/packages/volto/src/components/manage/Blocks/Block/Edit.jsx
+++ b/packages/volto/src/components/manage/Blocks/Block/Edit.jsx
@@ -149,21 +149,30 @@ export class Edit extends Component {
                 this.props.setUIState({ hovered: this.props.id });
               }
             }}
-            onFocus={(e) => {
-              // TODO: This `onFocus` steals somehow the focus from the slate block
-              // we have to investigate why this is happening
-              // Apparently, I can't see any difference in the behavior
-              // If any, we can fix it in successive iterations
-              // if (this.props.hovered !== this.props.id) {
-              //   this.props.setUIState({ hovered: this.props.id });
-              // }
-            }}
             onMouseLeave={(e) => {
               e.preventDefault();
               e.stopPropagation();
               this.props.setUIState({ hovered: null });
             }}
             onClick={(e) => {
+              const isMultipleSelection = e.shiftKey || e.ctrlKey || e.metaKey;
+              !this.props.selected &&
+                this.props.onSelectBlock(
+                  this.props.id,
+                  this.props.selected ? false : isMultipleSelection,
+                  e,
+                );
+            }}
+            // onFocus={(e) => {
+            //   // TODO: This `onFocus` steals somehow the focus from the slate block
+            //   // we have to investigate why this is happening
+            //   // Apparently, I can't see any difference in the behavior
+            //   // If any, we can fix it in successive iterations
+            //   // if (this.props.hovered !== this.props.id) {
+            //   //   this.props.setUIState({ hovered: this.props.id });
+            //   // }
+            // }}
+            onFocus={(e) => {
               const isMultipleSelection = e.shiftKey || e.ctrlKey || e.metaKey;
               !this.props.selected &&
                 this.props.onSelectBlock(
@@ -245,7 +254,6 @@ export class Edit extends Component {
             className={cx(`block ${type}`, { selected: this.props.selected })}
             style={{ outline: 'none' }}
             ref={this.blockNode}
-            // The tabIndex is required for the keyboard navigation
             tabIndex={-1}
           >
             {this.props.intl.formatMessage(messages.unknownBlock, {

--- a/packages/volto/src/components/manage/Blocks/Block/Edit.jsx
+++ b/packages/volto/src/components/manage/Blocks/Block/Edit.jsx
@@ -163,15 +163,6 @@ export class Edit extends Component {
                   e,
                 );
             }}
-            // onFocus={(e) => {
-            //   // TODO: This `onFocus` steals somehow the focus from the slate block
-            //   // we have to investigate why this is happening
-            //   // Apparently, I can't see any difference in the behavior
-            //   // If any, we can fix it in successive iterations
-            //   // if (this.props.hovered !== this.props.id) {
-            //   //   this.props.setUIState({ hovered: this.props.id });
-            //   // }
-            // }}
             onFocus={(e) => {
               const isMultipleSelection = e.shiftKey || e.ctrlKey || e.metaKey;
               !this.props.selected &&


### PR DESCRIPTION
Backport of https://github.com/plone/volto/pull/5273

## Summary

Backports the keyboard focus behavior for the block editor from Volto 19 to v18. When a block wrapper element receives focus (e.g. via Tab key), it now triggers `onSelectBlock`, allowing keyboard-only users to navigate between blocks reliably.

The previous empty `onFocus` handler (which was entirely commented out with a TODO note) is replaced with a real implementation that selects the block on focus, respecting multi-selection modifier keys (Shift, Ctrl, Meta).

## Changes

- **`packages/volto/src/components/manage/Blocks/Block/Edit.jsx`**
  - Removes the empty/commented-out `onFocus` prop on the block wrapper `<div>`
  - Adds a real `onFocus` handler that calls `onSelectBlock` when the block is not already selected, with support for multi-selection via modifier keys
  - Removes redundant comment about `tabIndex`

- **`packages/volto/cypress/tests/core/blocks/blocks-table.js`**
  - Replaces hardcoded `cy.wait(2000)` with a proper `should('be.visible')` assertion
  - Converts `.contains()` calls to `.should('contain', ...)` for better error messages
  - Adds explicit `cy.wait('@content')` after navigating to edit mode
  - Adds `{ timeout: 15000 }` to table visibility assertions to handle slow CI chunk loading