### PR TITLE
fix(a11y): use visually-hidden on empty aria-live region in FormFieldWrapper

### DIFF
--- a/packages/volto/news/8319.bugfix
+++ b/packages/volto/news/8319.bugfix
@@ -1,0 +1,1 @@
+Fix layout regression in `FormFieldWrapper` where the empty `aria-live` container was acting as an extra flex item, breaking widget layouts like `SizeWidget`. @Wagner3UB

--- a/packages/volto/src/components/manage/Controlpanels/__snapshots__/Aliases.test.jsx.snap
+++ b/packages/volto/src/components/manage/Controlpanels/__snapshots__/Aliases.test.jsx.snap
@@ -92,6 +92,7 @@ exports[`Aliases > renders an aliases control component 1`] = `
                           <div
                             aria-atomic="true"
                             aria-live="polite"
+                            class="visually-hidden"
                           />
                         </div>
                       </div>
@@ -192,6 +193,7 @@ exports[`Aliases > renders an aliases control component 1`] = `
                           <div
                             aria-atomic="true"
                             aria-live="polite"
+                            class="visually-hidden"
                           />
                         </div>
                       </div>

--- a/packages/volto/src/components/manage/Widgets/FormFieldWrapper.jsx
+++ b/packages/volto/src/components/manage/Widgets/FormFieldWrapper.jsx
@@ -61,7 +61,11 @@ const FormFieldWrapper = ({
     <>
       {children}
 
-      <div aria-live="polite" aria-atomic="true">
+      <div
+        aria-live="polite"
+        aria-atomic="true"
+        className={cx({ 'visually-hidden': !error?.length })}
+      >
         {map(error, (message) => (
           <Label key={message} basic color="red" className="form-error-label">
             {message}

--- a/packages/volto/src/components/manage/Widgets/__snapshots__/AlignWidget.test.tsx.snap
+++ b/packages/volto/src/components/manage/Widgets/__snapshots__/AlignWidget.test.tsx.snap
@@ -87,6 +87,7 @@ exports[`AlignWidget > renders with custom actions 1`] = `
           <div
             aria-atomic="true"
             aria-live="polite"
+            class="visually-hidden"
           />
         </div>
       </div>
@@ -313,6 +314,7 @@ exports[`AlignWidget > renders with default actions 1`] = `
           <div
             aria-atomic="true"
             aria-live="polite"
+            class="visually-hidden"
           />
         </div>
       </div>

--- a/packages/volto/src/components/manage/Widgets/__snapshots__/ArrayWidget.test.jsx.snap
+++ b/packages/volto/src/components/manage/Widgets/__snapshots__/ArrayWidget.test.jsx.snap
@@ -191,6 +191,7 @@ exports[`No 'No value' option when default value is 0 1`] = `
           <div
             aria-atomic="true"
             aria-live="polite"
+            class="visually-hidden"
           />
         </div>
       </div>
@@ -380,6 +381,7 @@ exports[`renders an array widget component 1`] = `
         <div
           aria-atomic="true"
           aria-live="polite"
+          className="visually-hidden"
         />
       </div>
     </div>

--- a/packages/volto/src/components/manage/Widgets/__snapshots__/ButtonsWidget.test.tsx.snap
+++ b/packages/volto/src/components/manage/Widgets/__snapshots__/ButtonsWidget.test.tsx.snap
@@ -87,6 +87,7 @@ exports[`ButtonsWidget > renders actions info provided via props 1`] = `
           <div
             aria-atomic="true"
             aria-live="polite"
+            class="visually-hidden"
           />
         </div>
       </div>
@@ -289,6 +290,7 @@ exports[`ButtonsWidget > renders string-based actions 1`] = `
           <div
             aria-atomic="true"
             aria-live="polite"
+            class="visually-hidden"
           />
         </div>
       </div>

--- a/packages/volto/src/components/manage/Widgets/__snapshots__/CheckboxGroupWidget.test.jsx.snap
+++ b/packages/volto/src/components/manage/Widgets/__snapshots__/CheckboxGroupWidget.test.jsx.snap
@@ -31,6 +31,7 @@ exports[`renders a checkbox group widget component 1`] = `
           <div
             aria-atomic="true"
             aria-live="polite"
+            class="visually-hidden"
           />
         </div>
       </div>

--- a/packages/volto/src/components/manage/Widgets/__snapshots__/CheckboxWidget.test.jsx.snap
+++ b/packages/volto/src/components/manage/Widgets/__snapshots__/CheckboxWidget.test.jsx.snap
@@ -39,6 +39,7 @@ exports[`CheckboxWidget > renders a checkbox widget component 1`] = `
           <div
             aria-atomic="true"
             aria-live="polite"
+            class="visually-hidden"
           />
         </div>
       </div>
@@ -87,6 +88,7 @@ exports[`CheckboxWidget > renders a checkbox widget component checked 1`] = `
           <div
             aria-atomic="true"
             aria-live="polite"
+            class="visually-hidden"
           />
         </div>
       </div>

--- a/packages/volto/src/components/manage/Widgets/__snapshots__/DatetimeWidget.test.jsx.snap
+++ b/packages/volto/src/components/manage/Widgets/__snapshots__/DatetimeWidget.test.jsx.snap
@@ -105,6 +105,7 @@ exports[`datetime widget converts UTC date and adapts to local datetime 1`] = `
           <div
             aria-atomic="true"
             aria-live="polite"
+            class="visually-hidden"
           />
         </div>
       </div>
@@ -218,6 +219,7 @@ exports[`renders a datetime widget component 1`] = `
           <div
             aria-atomic="true"
             aria-live="polite"
+            class="visually-hidden"
           />
         </div>
       </div>

--- a/packages/volto/src/components/manage/Widgets/__snapshots__/EmailWidget.test.jsx.snap
+++ b/packages/volto/src/components/manage/Widgets/__snapshots__/EmailWidget.test.jsx.snap
@@ -45,6 +45,7 @@ exports[`renders an email widget component 1`] = `
         <div
           aria-atomic="true"
           aria-live="polite"
+          className="visually-hidden"
         />
       </div>
     </div>

--- a/packages/volto/src/components/manage/Widgets/__snapshots__/IdWidget.test.jsx.snap
+++ b/packages/volto/src/components/manage/Widgets/__snapshots__/IdWidget.test.jsx.snap
@@ -41,6 +41,7 @@ exports[`IdWidget > renders an empty id widget component 1`] = `
           <div
             aria-atomic="true"
             aria-live="polite"
+            class="visually-hidden"
           />
         </div>
       </div>
@@ -90,6 +91,7 @@ exports[`IdWidget > renders an id widget with a valid dot character 1`] = `
           <div
             aria-atomic="true"
             aria-live="polite"
+            class="visually-hidden"
           />
         </div>
       </div>
@@ -139,6 +141,7 @@ exports[`IdWidget > renders an id widget with a valid value 1`] = `
           <div
             aria-atomic="true"
             aria-live="polite"
+            class="visually-hidden"
           />
         </div>
       </div>
@@ -188,6 +191,7 @@ exports[`IdWidget > renders an id widget with an reserved name 1`] = `
           <div
             aria-atomic="true"
             aria-live="polite"
+            class=""
           >
             <div
               class="ui red basic label form-error-label"
@@ -243,6 +247,7 @@ exports[`IdWidget > renders an id widget with invalid characters 1`] = `
           <div
             aria-atomic="true"
             aria-live="polite"
+            class=""
           >
             <div
               class="ui red basic label form-error-label"

--- a/packages/volto/src/components/manage/Widgets/__snapshots__/ImageSizeWidget.test.jsx.snap
+++ b/packages/volto/src/components/manage/Widgets/__snapshots__/ImageSizeWidget.test.jsx.snap
@@ -87,6 +87,7 @@ exports[`renders an image sizes widget component 1`] = `
         <div
           aria-atomic="true"
           aria-live="polite"
+          className="visually-hidden"
         />
       </div>
     </div>

--- a/packages/volto/src/components/manage/Widgets/__snapshots__/NumberWidget.test.jsx.snap
+++ b/packages/volto/src/components/manage/Widgets/__snapshots__/NumberWidget.test.jsx.snap
@@ -45,6 +45,7 @@ exports[`renders a number widget component 1`] = `
         <div
           aria-atomic="true"
           aria-live="polite"
+          className="visually-hidden"
         />
       </div>
     </div>

--- a/packages/volto/src/components/manage/Widgets/__snapshots__/ObjectBrowserWidget.test.jsx.snap
+++ b/packages/volto/src/components/manage/Widgets/__snapshots__/ObjectBrowserWidget.test.jsx.snap
@@ -64,6 +64,7 @@ exports[`renders a objectBrowser widget component 1`] = `
           <div
             aria-atomic="true"
             aria-live="polite"
+            class="visually-hidden"
           />
         </div>
       </div>

--- a/packages/volto/src/components/manage/Widgets/__snapshots__/ObjectListWidget.test.jsx.snap
+++ b/packages/volto/src/components/manage/Widgets/__snapshots__/ObjectListWidget.test.jsx.snap
@@ -77,6 +77,7 @@ exports[`renders an object list widget component 1`] = `
             <div
               aria-atomic="true"
               aria-live="polite"
+              class="visually-hidden"
             />
           </div>
         </div>

--- a/packages/volto/src/components/manage/Widgets/__snapshots__/PasswordWidget.test.jsx.snap
+++ b/packages/volto/src/components/manage/Widgets/__snapshots__/PasswordWidget.test.jsx.snap
@@ -46,6 +46,7 @@ exports[`renders a password widget component 1`] = `
         <div
           aria-atomic="true"
           aria-live="polite"
+          className="visually-hidden"
         />
       </div>
     </div>

--- a/packages/volto/src/components/manage/Widgets/__snapshots__/RadioGroupWidget.test.jsx.snap
+++ b/packages/volto/src/components/manage/Widgets/__snapshots__/RadioGroupWidget.test.jsx.snap
@@ -31,6 +31,7 @@ exports[`renders a radio group widget component 1`] = `
           <div
             aria-atomic="true"
             aria-live="polite"
+            class="visually-hidden"
           />
         </div>
       </div>

--- a/packages/volto/src/components/manage/Widgets/__snapshots__/ReferenceWidget.test.jsx.snap
+++ b/packages/volto/src/components/manage/Widgets/__snapshots__/ReferenceWidget.test.jsx.snap
@@ -83,6 +83,7 @@ exports[`renders an array widget component 1`] = `
         <div
           aria-atomic="true"
           aria-live="polite"
+          className="visually-hidden"
         />
       </div>
     </div>

--- a/packages/volto/src/components/manage/Widgets/__snapshots__/RegistryImageWidget.test.jsx.snap
+++ b/packages/volto/src/components/manage/Widgets/__snapshots__/RegistryImageWidget.test.jsx.snap
@@ -83,6 +83,7 @@ exports[`RegistryImageWidget > renders a file widget component with value 1`] = 
           <div
             aria-atomic="true"
             aria-live="polite"
+            class="visually-hidden"
           />
         </div>
       </div>
@@ -153,6 +154,7 @@ exports[`RegistryImageWidget > renders an empty file widget component 1`] = `
           <div
             aria-atomic="true"
             aria-live="polite"
+            class="visually-hidden"
           />
         </div>
       </div>

--- a/packages/volto/src/components/manage/Widgets/__snapshots__/SelectAutoComplete.test.jsx.snap
+++ b/packages/volto/src/components/manage/Widgets/__snapshots__/SelectAutoComplete.test.jsx.snap
@@ -102,6 +102,7 @@ exports[`renders a select widget component 1`] = `
           <div
             aria-atomic="true"
             aria-live="polite"
+            class="visually-hidden"
           />
         </div>
       </div>

--- a/packages/volto/src/components/manage/Widgets/__snapshots__/SelectWidget.test.jsx.snap
+++ b/packages/volto/src/components/manage/Widgets/__snapshots__/SelectWidget.test.jsx.snap
@@ -195,6 +195,7 @@ exports[`No 'No value' option when default value is 0 1`] = `
           <div
             aria-atomic="true"
             aria-live="polite"
+            class="visually-hidden"
           />
         </div>
       </div>
@@ -311,6 +312,7 @@ exports[`renders a select widget component 1`] = `
           <div
             aria-atomic="true"
             aria-live="polite"
+            class="visually-hidden"
           />
         </div>
       </div>

--- a/packages/volto/src/components/manage/Widgets/__snapshots__/StaticTextWidget.test.jsx.snap
+++ b/packages/volto/src/components/manage/Widgets/__snapshots__/StaticTextWidget.test.jsx.snap
@@ -28,6 +28,7 @@ exports[`renders a text widget component 1`] = `
         <div
           aria-atomic="true"
           aria-live="polite"
+          className="visually-hidden"
         />
       </div>
     </div>

--- a/packages/volto/src/components/manage/Widgets/__snapshots__/TextWidget.test.jsx.snap
+++ b/packages/volto/src/components/manage/Widgets/__snapshots__/TextWidget.test.jsx.snap
@@ -45,6 +45,7 @@ exports[`renders a text widget component 1`] = `
         <div
           aria-atomic="true"
           aria-live="polite"
+          className="visually-hidden"
         />
       </div>
     </div>

--- a/packages/volto/src/components/manage/Widgets/__snapshots__/TextareaWidget.test.jsx.snap
+++ b/packages/volto/src/components/manage/Widgets/__snapshots__/TextareaWidget.test.jsx.snap
@@ -38,6 +38,7 @@ exports[`renders a textarea widget component 1`] = `
         <div
           aria-atomic="true"
           aria-live="polite"
+          className="visually-hidden"
         />
       </div>
     </div>

--- a/packages/volto/src/components/manage/Widgets/__snapshots__/TimeWidget.test.jsx.snap
+++ b/packages/volto/src/components/manage/Widgets/__snapshots__/TimeWidget.test.jsx.snap
@@ -69,6 +69,7 @@ exports[`renders a time widget component 1`] = `
           <div
             aria-atomic="true"
             aria-live="polite"
+            class="visually-hidden"
           />
         </div>
       </div>

--- a/packages/volto/src/components/manage/Widgets/__snapshots__/TokenWidget.test.jsx.snap
+++ b/packages/volto/src/components/manage/Widgets/__snapshots__/TokenWidget.test.jsx.snap
@@ -145,6 +145,7 @@ exports[`renders a token widget component 1`] = `
         <div
           aria-atomic="true"
           aria-live="polite"
+          className="visually-hidden"
         />
       </div>
     </div>

--- a/packages/volto/src/components/manage/Widgets/__snapshots__/UrlWidget.test.jsx.snap
+++ b/packages/volto/src/components/manage/Widgets/__snapshots__/UrlWidget.test.jsx.snap
@@ -68,6 +68,7 @@ exports[`renders an url widget component 1`] = `
           <div
             aria-atomic="true"
             aria-live="polite"
+            class="visually-hidden"
           />
         </div>
       </div>

--- a/packages/volto/src/components/manage/Widgets/__snapshots__/VocabularyTermsWidget.test.jsx.snap
+++ b/packages/volto/src/components/manage/Widgets/__snapshots__/VocabularyTermsWidget.test.jsx.snap
@@ -292,6 +292,7 @@ exports[`renders a dictionary widget component 1`] = `
           <div
             aria-atomic="true"
             aria-live="polite"
+            class="visually-hidden"
           />
         </div>
       </div>


### PR DESCRIPTION
Fix [#8317](https://github.com/plone/volto/issues/8317)

Regression introduced by #8033: the `div[aria-live]` added to `FormFieldWrapper` was acting as an extra flex/grid item inside the widget column, breaking the layout of widgets like `SizeWidget` (S/M/L buttons misaligned).

## Changes

- `FormFieldWrapper.jsx`: apply `visually-hidden` class to the `aria-live` container when there are no errors. This removes it from the flex/grid flow via `position: absolute` while keeping it in the accessibility tree so the live region continues to work correctly for screen readers.
- Snapshots updated to reflect the new class on the error container.