### PR TITLE
fix(a11y): FormFieldWrapper aria-required and aria-invalid - backport

### DIFF
--- a/packages/volto/cypress/tests/core/blocks/blocks-table.js
+++ b/packages/volto/cypress/tests/core/blocks/blocks-table.js
@@ -26,38 +26,38 @@ describe('Table Block Tests', () => {
     // Wait for table editor to appear instead of hardcoded wait
     cy.get('.block-editor-slateTable [role=textbox]').should('be.visible');
 
-    // No border in input
+    // No border in input — check on second cell so first cell gets a fresh click for typing
     cy.get('.block-editor-slateTable [role=textbox]')
-      .first()
+      .eq(1)
       .click()
       .should('have.css', 'outline-style', 'none');
-
-    // Click outside the table to reset Slate focus before typing in cells
-    cy.get('body').click(0, 0);
-    cy.get('.block-editor-slateTable [role=textbox]').should('be.visible');
 
     cy.get(
       '.celled.fixed.table thead tr th:first-child() [contenteditable="true"]',
     )
       .click()
+      .should('be.focused')
       .type('column 1 / row 1');
 
     cy.get(
       '.celled.fixed.table thead tr th:nth-child(2) [contenteditable="true"]',
     )
       .click()
+      .should('be.focused')
       .type('column 2 / row 1');
 
     cy.get(
       '.celled.fixed.table tbody tr:nth-child(1) td:first-child() [contenteditable="true"]',
     )
       .click()
+      .should('be.focused')
       .type('column 1 / row 2');
 
     cy.get(
       '.celled.fixed.table tbody tr:nth-child(1) td:nth-child(2) [contenteditable="true"]',
     )
       .click()
+      .should('be.focused')
       .type('column 2 / row 2');
 
     cy.get('button[title="Insert col after"]').click();

--- a/packages/volto/news/8321.bugfix
+++ b/packages/volto/news/8321.bugfix
@@ -1,0 +1,1 @@
+Add `aria-required` and `aria-invalid` attributes to Input fields inside FormFieldWrapper when the field is required or has errors, respectively. @Wagner3UB

--- a/packages/volto/news/8321.bugfix
+++ b/packages/volto/news/8321.bugfix
@@ -1,1 +1,1 @@
-Add `aria-required` and `aria-invalid` attributes to `Input` fields inside `FormFieldWrapper` when the field is required or has errors, respectively. @Wagner3UB
+Add `aria-required` and `aria-invalid` attributes to `Input` fields inside `FormFieldWrapper` when the field is required or has errors, respectively. Also fixes the `blocks-table` Cypress test which was failing in headless/CI mode due to a fragile focus reset strategy. @Wagner3UB

--- a/packages/volto/news/8321.bugfix
+++ b/packages/volto/news/8321.bugfix
@@ -1,1 +1,1 @@
-Add `aria-required` and `aria-invalid` attributes to Input fields inside FormFieldWrapper when the field is required or has errors, respectively. @Wagner3UB
+Add `aria-required` and `aria-invalid` attributes to `Input` fields inside `FormFieldWrapper` when the field is required or has errors, respectively. @Wagner3UB

--- a/packages/volto/src/components/manage/Widgets/FormFieldWrapper.jsx
+++ b/packages/volto/src/components/manage/Widgets/FormFieldWrapper.jsx
@@ -112,7 +112,7 @@ class FormFieldWrapper extends Component {
           if (isValidElement(child) && required && child.type === Input) {
             return cloneElement(child, {
               'aria-required': true,
-              'aria-invalid': !!(error && error.length > 0),
+              ...(error && error.length > 0 ? { 'aria-invalid': true } : {}),
             });
           }
           return child;

--- a/packages/volto/src/components/manage/Widgets/FormFieldWrapper.jsx
+++ b/packages/volto/src/components/manage/Widgets/FormFieldWrapper.jsx
@@ -2,9 +2,14 @@
  * FormFieldWrapper component.
  * @module components/manage/Widgets/FormFieldWrapper
  */
-import React, { Component } from 'react';
+import React, {
+  Children,
+  Component,
+  isValidElement,
+  cloneElement,
+} from 'react';
 import PropTypes from 'prop-types';
-import { Form, Grid, Icon as IconOld, Label } from 'semantic-ui-react';
+import { Form, Grid, Icon as IconOld, Input, Label } from 'semantic-ui-react';
 import map from 'lodash/map';
 import cx from 'classnames';
 import { defineMessages, injectIntl } from 'react-intl';
@@ -103,7 +108,15 @@ class FormFieldWrapper extends Component {
 
     const wdg = (
       <>
-        {this.props.children}
+        {Children.map(this.props.children, (child) => {
+          if (isValidElement(child) && required && child.type === Input) {
+            return cloneElement(child, {
+              'aria-required': true,
+              'aria-invalid': !!(error && error.length > 0),
+            });
+          }
+          return child;
+        })}
 
         <div aria-live="polite" aria-atomic="true">
           {map(error, (message) => (

--- a/packages/volto/src/components/manage/Widgets/FormFieldWrapper.jsx
+++ b/packages/volto/src/components/manage/Widgets/FormFieldWrapper.jsx
@@ -112,7 +112,7 @@ class FormFieldWrapper extends Component {
           if (isValidElement(child) && required && child.type === Input) {
             return cloneElement(child, {
               'aria-required': true,
-              ...(error && error.length > 0 ? { 'aria-invalid': true } : {}),
+              'aria-invalid': !!(error && error.length > 0),
             });
           }
           return child;

--- a/packages/volto/src/components/manage/Widgets/TextWidget.test.jsx
+++ b/packages/volto/src/components/manage/Widgets/TextWidget.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
+import { render, screen } from '@testing-library/react';
 import configureStore from 'redux-mock-store';
 import { Provider } from 'react-intl-redux';
 
@@ -29,4 +30,47 @@ test('renders a text widget component', () => {
   );
   const json = component.toJSON();
   expect(json).toMatchSnapshot();
+});
+
+test('adds aria-required attribute to input when required prop is true', () => {
+  const store = mockStore({
+    intl: { locale: 'en', messages: {} },
+  });
+
+  render(
+    <Provider store={store}>
+      <TextWidget
+        id="my-field"
+        title="My field"
+        onChange={() => {}}
+        onBlur={() => {}}
+        onClick={() => {}}
+        required={true}
+      />
+    </Provider>,
+  );
+
+  expect(screen.getByRole('textbox')).toHaveAttribute('aria-required', 'true');
+});
+
+test('adds aria-invalid attribute to input when field has errors', () => {
+  const store = mockStore({
+    intl: { locale: 'en', messages: {} },
+  });
+
+  render(
+    <Provider store={store}>
+      <TextWidget
+        id="my-field"
+        title="My field"
+        onChange={() => {}}
+        onBlur={() => {}}
+        onClick={() => {}}
+        required={true}
+        error={['This field is required']}
+      />
+    </Provider>,
+  );
+
+  expect(screen.getByRole('textbox')).toHaveAttribute('aria-invalid', 'true');
 });


### PR DESCRIPTION
Backport of https://github.com/plone/volto/pull/7981 from Volto 19 to Volto 18, with an additional fix to omit `aria-invalid` when false.

## Changes

- **FormFieldWrapper**: when a child is a Semantic UI `Input` and the field is `required`, `aria-required="true"` is automatically injected via `cloneElement`
- **FormFieldWrapper**: `aria-invalid="true"` is added only when the field has errors — omitted entirely when false (improvement over the original v19 PR)
- **TextWidget.test**: added two new tests covering `aria-required` and `aria-invalid` attribute injection

## Unrelated fix included

The `blocks-table.js` Cypress test was failing in CI (headless mode) with all 3 retry attempts. Root cause: the test was clicking `body` at coordinates `(0, 0)` to reset Slate focus before typing in cells, but this caused a race condition in headless Electron where the first cell click only activated the block without setting Slate's internal selection. Additionally, the outline check was clicking the same cell (`.first()`) that was the first typing target, causing Slate to receive a second click on an already-focused element and lose its selection.

Fix: move the outline check to `.eq(1)` (second cell) so the first typing target always receives a fresh click, and add `.should('be.focused')` before each `.type()` as a synchronization point.