### PR TITLE
Fix random failure in test cypress blocks-table.js

### DIFF
--- a/packages/volto/cypress/tests/core/blocks/blocks-table.js
+++ b/packages/volto/cypress/tests/core/blocks/blocks-table.js
@@ -81,22 +81,18 @@ describe('Table Block Tests', () => {
     cy.get('.celled.fixed.table').should('be.visible');
 
     // View
-    cy.get('.celled.fixed.table thead tr th:first-child()').should(
-      'contain',
-      'column 1 / row 1',
-    );
-    cy.get('.celled.fixed.table thead tr th:nth-child(3)').should(
-      'contain',
-      'column 2 / row 1',
-    );
-    cy.get('.celled.fixed.table tbody tr:nth-child(2) td:first-child()').should(
-      'contain',
-      'column 1 / row 2',
-    );
-    cy.get('.celled.fixed.table tbody tr:nth-child(2) td:nth-child(3)').should(
-      'contain',
-      'column 2 / row 2',
-    );
+    cy.get('.celled.fixed.table thead tr th:first-child()', {
+      timeout: 15000,
+    }).should('contain', 'column 1 / row 1');
+    cy.get('.celled.fixed.table thead tr th:nth-child(3)', {
+      timeout: 15000,
+    }).should('contain', 'column 2 / row 1');
+    cy.get('.celled.fixed.table tbody tr:nth-child(2) td:first-child()', {
+      timeout: 15000,
+    }).should('contain', 'column 1 / row 2');
+    cy.get('.celled.fixed.table tbody tr:nth-child(2) td:nth-child(3)', {
+      timeout: 15000,
+    }).should('contain', 'column 2 / row 2');
 
     // Redefine all intercepts before the second visit to avoid alias conflicts
     cy.intercept('GET', `/**/*?expand*`).as('content2');
@@ -152,20 +148,17 @@ describe('Table Block Tests', () => {
     cy.get('.celled.fixed.table').should('be.visible');
 
     // View
-    cy.get('.celled.fixed.table thead tr th:first-child()').should(
-      'contain',
-      'column 1 / row 1',
-    );
-    cy.get('.celled.fixed.table thead tr th:nth-child(2)> p ').should(
-      'have.text',
-      'column 2 / row 1',
-    );
-    cy.get(
-      '.celled.fixed.table tbody tr:first-child() td:first-child()',
-    ).should('contain', 'column 1 / row 2');
-    cy.get('.celled.fixed.table tbody tr:first-child() td:nth-child(2)').should(
-      'contain',
-      'column 2 / row 2',
-    );
+    cy.get('.celled.fixed.table thead tr th:first-child()', {
+      timeout: 15000,
+    }).should('contain', 'column 1 / row 1');
+    cy.get('.celled.fixed.table thead tr th:nth-child(2)> p ', {
+      timeout: 15000,
+    }).should('have.text', 'column 2 / row 1');
+    cy.get('.celled.fixed.table tbody tr:first-child() td:first-child()', {
+      timeout: 15000,
+    }).should('contain', 'column 1 / row 2');
+    cy.get('.celled.fixed.table tbody tr:first-child() td:nth-child(2)', {
+      timeout: 15000,
+    }).should('contain', 'column 2 / row 2');
   });
 });

--- a/packages/volto/news/8326.internal
+++ b/packages/volto/news/8326.internal
@@ -1,0 +1,1 @@
+Fix random failure in test cypress `blocks-table.js`. @wesleybl


### PR DESCRIPTION
Added `{ timeout: 15000 }` to all view-mode assertions after save.

Fix error:

```
  1) Table Block Tests
       Add table block:
     AssertionError: Timed out retrying after 4000ms: expected '<th.left.aligned.middle.aligned>' to contain 'column 1 / row 1'
      at Context.eval (webpack://@plone/volto/./cypress/tests/core/blocks/blocks-table.js:77:60)
```

See: https://github.com/plone/volto/actions/runs/27320633041/job/80710719698?pr=8325#step:4:714