### PR TITLE
Fix Babel compare toolbar click

### DIFF
--- a/packages/volto/cypress/tests/multilingual/babelview.js
+++ b/packages/volto/cypress/tests/multilingual/babelview.js
@@ -75,7 +75,21 @@ describe('Babel View Tests', () => {
     );
 
     // Click on the menu
-    cy.findByLabelText('Confronta con').click();
+    cy.findByLabelText('Confronta con')
+      .should('have.attr', 'type', 'button')
+      .should(($button) => {
+        const button = $button[0];
+        const rect = button.getBoundingClientRect();
+        const target = button.ownerDocument.elementFromPoint(
+          rect.left + rect.width / 2,
+          rect.top + rect.height / 2,
+        );
+
+        expect(rect.width).to.be.at.least(42);
+        expect(rect.height).to.be.at.least(42);
+        expect(button === target || button.contains(target)).to.eq(true);
+      })
+      .click();
     cy.findByLabelText('Confronta con english').click();
 
     // The babel view is there

--- a/packages/volto/news/8323.bugfix
+++ b/packages/volto/news/8323.bugfix
@@ -1,0 +1,1 @@
+Fixed the Babel compare language toolbar button closing immediately after user clicks by treating the trigger and popup as one outside-click boundary. @sneridagh

--- a/packages/volto/src/components/manage/Multilingual/CompareLanguages.jsx
+++ b/packages/volto/src/components/manage/Multilingual/CompareLanguages.jsx
@@ -28,19 +28,9 @@ const CompareLanguagesMenu = ({
 }) => {
   const intl = useIntl();
 
-  const ClickOutsideListener = () => {
-    closeMenu();
-  };
-
-  const ref = useDetectClickOutside({
-    onTriggered: ClickOutsideListener,
-    triggerKeys: ['Escape'],
-  });
-
   return (
     <div
       className="toolbar-content show compare-languages"
-      ref={ref}
       style={{
         flex: theToolbar.current
           ? `0 0 ${theToolbar.current.getBoundingClientRect().width}px`
@@ -106,6 +96,10 @@ const CompareLanguages = React.forwardRef((props, ref) => {
   const intl = useIntl();
   const [viewMenu, setViewMenu] = useState(false);
   const translations = content?.['@components']?.translations?.items || [];
+  const compareLanguagesRef = useDetectClickOutside({
+    onTriggered: () => setViewMenu(false),
+    triggerKeys: ['Escape'],
+  });
 
   const translationsObject = {};
   translations.forEach((t) => {
@@ -114,19 +108,27 @@ const CompareLanguages = React.forwardRef((props, ref) => {
 
   if (translations.length > 0) {
     return (
-      <div className="toolbar-compare-translations-wrapper">
+      <div
+        className="toolbar-compare-translations-wrapper"
+        ref={compareLanguagesRef}
+      >
         <div className="toolbar-button-spacer" />
 
         <Button
+          type="button"
           aria-label={intl.formatMessage(messages.compare_to)}
           title={intl.formatMessage(messages.compare_to)}
           onClick={() => {
-            setViewMenu(!viewMenu);
+            setViewMenu((viewMenu) => !viewMenu);
           }}
           id="toolbar-compare-translations"
           className="toolbar-button-compare-translations"
         >
-          <Icon className="mobile hidden" name={translateSVG} size="30px" />
+          <Icon
+            className="mobile hidden"
+            name={viewMenu ? clearSVG : translateSVG}
+            size="30px"
+          />
           {viewMenu ? (
             <Icon className="mobile only" name={clearSVG} size="30px" />
           ) : (

--- a/packages/volto/theme/themes/pastanaga/extras/toolbar.less
+++ b/packages/volto/theme/themes/pastanaga/extras/toolbar.less
@@ -714,8 +714,16 @@ body:not(.has-sidebar):not(.has-sidebar-collapsed) {
   .toolbar-compare-translations-wrapper {
     position: relative;
 
-    .toolbar-button-compare-translations .icon {
-      padding: 4px;
+    .toolbar-button-compare-translations {
+      display: flex;
+      width: 42px;
+      height: 42px;
+      align-items: center;
+      justify-content: center;
+
+      .icon {
+        padding: 4px;
+      }
     }
 
     .compare-languages {


### PR DESCRIPTION
## Summary

Fixes the Babel compare language toolbar control so users can reliably open the "Compare to language" menu from the edit toolbar.

Closes #8323.

## Root cause

The compare language menu used the shared `useDetectClickOutside` hook, but the outside-click boundary was attached only to the floating popup menu. The toolbar trigger button itself was outside that boundary.

With a real pointer click, the trigger could successfully receive the click and toggle `viewMenu` to `true`, which briefly changed the icon to the close icon and mounted the menu. The same interaction could then be treated as outside the popup boundary and close the menu immediately. This made the UI appear unclickable for users even though programmatic test clicks could pass.

## What changed

- Move the outside-click ref to `.toolbar-compare-translations-wrapper`, so the boundary includes both the trigger button and the popup menu.
- Keep the Semantic UI `Button` to avoid changing the public component shape.
- Set the trigger to `type="button"` to avoid accidental form-submit behavior.
- Preserve the previous icon behavior by switching the desktop icon to the close icon while the menu is open.
- Normalize the compare toolbar trigger hit target to `42px` by `42px`, matching the adjacent toolbar controls.
- Strengthen the Cypress test to assert that the trigger is a button, has a usable hit target, and is the element under its center point before clicking it.

## Validation

- Verified manually in the in-app browser with the multilingual edit fixture:
  - the trigger remains a Semantic UI button
  - the hit target is `42px` by `42px`
  - clicking the trigger opens the compare language menu
  - the icon changes to the close icon while the menu is open
  - clicking the language option enters the compare view
- Ran `pnpm exec prettier --single-quote --check src/components/manage/Multilingual/CompareLanguages.jsx cypress/tests/multilingual/babelview.js`
- Ran `pnpm exec eslint src/components/manage/Multilingual/CompareLanguages.jsx cypress/tests/multilingual/babelview.js`
- Ran `pnpm exec stylelint theme/themes/pastanaga/extras/toolbar.less`
- Ran `pnpm exec cypress run --config-file cypress.config.js --spec cypress/tests/multilingual/babelview.js --browser chrome`
