### PR TITLE
fix(a11y): hide clear button on required Select and ArrayWidget (backport #8315)

### DIFF
--- a/packages/volto/locales/af/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/af/LC_MESSAGES/volto.po
@@ -694,6 +694,11 @@ msgstr ""
 msgid "Clear search"
 msgstr ""
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "Maak keuse skoon"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/ar/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ar/LC_MESSAGES/volto.po
@@ -694,6 +694,11 @@ msgstr ""
 msgid "Clear search"
 msgstr ""
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "مسح التحديد"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/bg/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/bg/LC_MESSAGES/volto.po
@@ -694,6 +694,11 @@ msgstr ""
 msgid "Clear search"
 msgstr ""
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "Изчисти избора"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/bn/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/bn/LC_MESSAGES/volto.po
@@ -694,6 +694,11 @@ msgstr ""
 msgid "Clear search"
 msgstr ""
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "নির্বাচন সাফ করুন"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/ca/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ca/LC_MESSAGES/volto.po
@@ -695,6 +695,11 @@ msgstr "Esborra filtres"
 msgid "Clear search"
 msgstr "Neteja la cerca"
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "Esborra la selecció"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/cs/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/cs/LC_MESSAGES/volto.po
@@ -694,6 +694,11 @@ msgstr ""
 msgid "Clear search"
 msgstr ""
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "Zrušit výběr"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/cy/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/cy/LC_MESSAGES/volto.po
@@ -694,6 +694,11 @@ msgstr ""
 msgid "Clear search"
 msgstr ""
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "Clirio'r dewisiad"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/da/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/da/LC_MESSAGES/volto.po
@@ -694,6 +694,11 @@ msgstr ""
 msgid "Clear search"
 msgstr ""
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "Ryd valg"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/de/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/de/LC_MESSAGES/volto.po
@@ -695,6 +695,11 @@ msgstr "Filter entfernen"
 msgid "Clear search"
 msgstr ""
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "Auswahl löschen"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/el/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/el/LC_MESSAGES/volto.po
@@ -694,6 +694,11 @@ msgstr ""
 msgid "Clear search"
 msgstr ""
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "Εκκαθάριση επιλογής"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/en/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/en/LC_MESSAGES/volto.po
@@ -689,6 +689,11 @@ msgstr ""
 msgid "Clear search"
 msgstr ""
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "Clear selection"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/en_AU/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/en_AU/LC_MESSAGES/volto.po
@@ -694,6 +694,11 @@ msgstr ""
 msgid "Clear search"
 msgstr ""
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "Clear selection"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/en_GB/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/en_GB/LC_MESSAGES/volto.po
@@ -694,6 +694,11 @@ msgstr ""
 msgid "Clear search"
 msgstr ""
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "Clear selection"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/eo/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/eo/LC_MESSAGES/volto.po
@@ -694,6 +694,11 @@ msgstr ""
 msgid "Clear search"
 msgstr ""
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "Forigi elekton"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/es/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/es/LC_MESSAGES/volto.po
@@ -690,6 +690,11 @@ msgstr "Limpiar filtros"
 msgid "Clear search"
 msgstr "Borrar búsqueda"
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "Borrar selección"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/et/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/et/LC_MESSAGES/volto.po
@@ -694,6 +694,11 @@ msgstr ""
 msgid "Clear search"
 msgstr ""
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "Tühista valik"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/eu/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/eu/LC_MESSAGES/volto.po
@@ -690,6 +690,11 @@ msgstr "Garbitu filtroak"
 msgid "Clear search"
 msgstr "Garbitu bilaketa"
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "Garbitu hautaketa"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/fa/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/fa/LC_MESSAGES/volto.po
@@ -694,6 +694,11 @@ msgstr ""
 msgid "Clear search"
 msgstr ""
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "پاک کردن انتخاب"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/fi/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/fi/LC_MESSAGES/volto.po
@@ -694,6 +694,11 @@ msgstr "Tyhjennä suodattimet"
 msgid "Clear search"
 msgstr ""
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "Tyhjennä valinta"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/fr/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/fr/LC_MESSAGES/volto.po
@@ -696,6 +696,11 @@ msgstr "Effacer les filtres"
 msgid "Clear search"
 msgstr ""
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "Effacer la sélection"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/fu/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/fu/LC_MESSAGES/volto.po
@@ -694,6 +694,11 @@ msgstr ""
 msgid "Clear search"
 msgstr ""
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "Nete la selezion"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/gl/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/gl/LC_MESSAGES/volto.po
@@ -695,6 +695,11 @@ msgstr "Limpar filtros"
 msgid "Clear search"
 msgstr "Limpar busca"
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "Borrar selección"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/he/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/he/LC_MESSAGES/volto.po
@@ -694,6 +694,11 @@ msgstr ""
 msgid "Clear search"
 msgstr ""
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "נקה בחירה"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/hi/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/hi/LC_MESSAGES/volto.po
@@ -689,6 +689,11 @@ msgstr "फ़िल्टर साफ़ करें"
 msgid "Clear search"
 msgstr "खोज साफ़ करें"
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "चयन साफ़ करें"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/hr/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/hr/LC_MESSAGES/volto.po
@@ -694,6 +694,11 @@ msgstr ""
 msgid "Clear search"
 msgstr ""
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "Očisti odabir"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/hu/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/hu/LC_MESSAGES/volto.po
@@ -694,6 +694,11 @@ msgstr ""
 msgid "Clear search"
 msgstr ""
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "Kijelölés törlése"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/hy/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/hy/LC_MESSAGES/volto.po
@@ -694,6 +694,11 @@ msgstr ""
 msgid "Clear search"
 msgstr ""
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "Մաքրել ընտրությունը"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/id/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/id/LC_MESSAGES/volto.po
@@ -694,6 +694,11 @@ msgstr ""
 msgid "Clear search"
 msgstr ""
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "Hapus pilihan"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/it/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/it/LC_MESSAGES/volto.po
@@ -690,6 +690,11 @@ msgstr "Azzera filtri"
 msgid "Clear search"
 msgstr "Cancella ricerca"
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "Cancella selezione"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/ja/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ja/LC_MESSAGES/volto.po
@@ -694,6 +694,11 @@ msgstr ""
 msgid "Clear search"
 msgstr ""
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "選択をクリア"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/ka/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ka/LC_MESSAGES/volto.po
@@ -694,6 +694,11 @@ msgstr ""
 msgid "Clear search"
 msgstr ""
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "არჩევანის გასუფთავება"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/kn/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/kn/LC_MESSAGES/volto.po
@@ -694,6 +694,11 @@ msgstr ""
 msgid "Clear search"
 msgstr ""
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "ಆಯ್ಕೆ ತೆರವುಗೊಳಿಸಿ"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/ko/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ko/LC_MESSAGES/volto.po
@@ -694,6 +694,11 @@ msgstr ""
 msgid "Clear search"
 msgstr ""
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "선택 초기화"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/lt/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/lt/LC_MESSAGES/volto.po
@@ -694,6 +694,11 @@ msgstr ""
 msgid "Clear search"
 msgstr ""
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "Išvalyti pasirinkimą"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/lv/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/lv/LC_MESSAGES/volto.po
@@ -694,6 +694,11 @@ msgstr ""
 msgid "Clear search"
 msgstr ""
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "Notīrīt izvēli"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/mi/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/mi/LC_MESSAGES/volto.po
@@ -694,6 +694,11 @@ msgstr ""
 msgid "Clear search"
 msgstr ""
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "Ūkui tīpako"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/mk/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/mk/LC_MESSAGES/volto.po
@@ -694,6 +694,11 @@ msgstr ""
 msgid "Clear search"
 msgstr ""
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "Исчисти избор"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/my/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/my/LC_MESSAGES/volto.po
@@ -694,6 +694,11 @@ msgstr ""
 msgid "Clear search"
 msgstr ""
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "ရွေးချယ်မှု ရှင်းမည်"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/nb_NO/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/nb_NO/LC_MESSAGES/volto.po
@@ -694,6 +694,11 @@ msgstr ""
 msgid "Clear search"
 msgstr ""
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "Fjern valg"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/nl/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/nl/LC_MESSAGES/volto.po
@@ -690,6 +690,11 @@ msgstr "Filters leegmaken"
 msgid "Clear search"
 msgstr "Zoek leegmaken"
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "Selectie wissen"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/nn/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/nn/LC_MESSAGES/volto.po
@@ -694,6 +694,11 @@ msgstr ""
 msgid "Clear search"
 msgstr ""
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "Fjern val"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/pl/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/pl/LC_MESSAGES/volto.po
@@ -694,6 +694,11 @@ msgstr ""
 msgid "Clear search"
 msgstr ""
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "Wyczyść zaznaczenie"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/pt/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/pt/LC_MESSAGES/volto.po
@@ -689,6 +689,11 @@ msgstr "Limpar filtros"
 msgid "Clear search"
 msgstr "Limpar pesquisa"
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "Limpar seleção"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/pt_BR/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/pt_BR/LC_MESSAGES/volto.po
@@ -695,6 +695,11 @@ msgstr "Limpar filtros"
 msgid "Clear search"
 msgstr "Limpar pesquisa"
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "Limpar seleção"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/rm/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/rm/LC_MESSAGES/volto.po
@@ -694,6 +694,11 @@ msgstr ""
 msgid "Clear search"
 msgstr ""
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "Stizzar la selecziun"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/ro/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ro/LC_MESSAGES/volto.po
@@ -695,6 +695,11 @@ msgstr "Curațați filtrele"
 msgid "Clear search"
 msgstr "Ștergeți căutarea"
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "Șterge selecția"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/ru/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ru/LC_MESSAGES/volto.po
@@ -694,6 +694,11 @@ msgstr "Очистить фильтры"
 msgid "Clear search"
 msgstr "Очистить поиск"
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "Очистить выбор"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/sk/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/sk/LC_MESSAGES/volto.po
@@ -694,6 +694,11 @@ msgstr ""
 msgid "Clear search"
 msgstr ""
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "Zrušiť výber"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/sl/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/sl/LC_MESSAGES/volto.po
@@ -694,6 +694,11 @@ msgstr ""
 msgid "Clear search"
 msgstr ""
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "Počisti izbor"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/sm/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/sm/LC_MESSAGES/volto.po
@@ -694,6 +694,11 @@ msgstr ""
 msgid "Clear search"
 msgstr ""
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "Tape le filifiliga"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/sq/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/sq/LC_MESSAGES/volto.po
@@ -694,6 +694,11 @@ msgstr ""
 msgid "Clear search"
 msgstr ""
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "Pastro zgjedhjen"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/sr/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/sr/LC_MESSAGES/volto.po
@@ -694,6 +694,11 @@ msgstr ""
 msgid "Clear search"
 msgstr ""
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "Обриши избор"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/sr@cyrl/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/sr@cyrl/LC_MESSAGES/volto.po
@@ -694,6 +694,11 @@ msgstr ""
 msgid "Clear search"
 msgstr ""
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "Обриши избор"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/sr@latn/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/sr@latn/LC_MESSAGES/volto.po
@@ -694,6 +694,11 @@ msgstr ""
 msgid "Clear search"
 msgstr ""
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "Obriši izbor"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/sv/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/sv/LC_MESSAGES/volto.po
@@ -689,6 +689,11 @@ msgstr "Rensa filter"
 msgid "Clear search"
 msgstr "Rensa sökning"
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "Rensa val"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/ta/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ta/LC_MESSAGES/volto.po
@@ -690,6 +690,11 @@ msgstr "தெளிவான வடிப்பான்கள்"
 msgid "Clear search"
 msgstr "தேடலை அழி"
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "தேர்வை அழி"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/te/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/te/LC_MESSAGES/volto.po
@@ -694,6 +694,11 @@ msgstr ""
 msgid "Clear search"
 msgstr ""
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "ఎంపికను తీసివేయి"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/th/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/th/LC_MESSAGES/volto.po
@@ -694,6 +694,11 @@ msgstr ""
 msgid "Clear search"
 msgstr ""
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "ล้างการเลือก"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/to/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/to/LC_MESSAGES/volto.po
@@ -694,6 +694,11 @@ msgstr ""
 msgid "Clear search"
 msgstr ""
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "Fakaʻosi ha filí"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/tr/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/tr/LC_MESSAGES/volto.po
@@ -695,6 +695,11 @@ msgstr ""
 msgid "Clear search"
 msgstr ""
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "Seçimi temizle"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/uk/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/uk/LC_MESSAGES/volto.po
@@ -694,6 +694,11 @@ msgstr ""
 msgid "Clear search"
 msgstr ""
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "Очистити вибір"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/vi/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/vi/LC_MESSAGES/volto.po
@@ -694,6 +694,11 @@ msgstr ""
 msgid "Clear search"
 msgstr ""
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "Xóa lựa chọn"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/volto.pot
+++ b/packages/volto/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2026-05-13T09:11:26.038Z\n"
+"POT-Creation-Date: 2026-06-15T12:41:40.824Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Content-Type: text/plain; charset=utf-8\n"
@@ -689,6 +689,11 @@ msgstr ""
 #. Default: "Clear search"
 #: components/manage/BlockChooser/BlockChooserSearch
 msgid "Clear search"
+msgstr ""
+
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
 msgstr ""
 
 #. Default: "Click to download full sized image"

--- a/packages/volto/locales/zh_CN/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/zh_CN/LC_MESSAGES/volto.po
@@ -695,6 +695,11 @@ msgstr "清除过滤器"
 msgid "Clear search"
 msgstr ""
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "清除选择"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/zh_Hant/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/zh_Hant/LC_MESSAGES/volto.po
@@ -694,6 +694,11 @@ msgstr ""
 msgid "Clear search"
 msgstr ""
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "清除選取"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/locales/zh_Hant_HK/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/zh_Hant_HK/LC_MESSAGES/volto.po
@@ -694,6 +694,11 @@ msgstr ""
 msgid "Clear search"
 msgstr ""
 
+#. Default: "Clear selection"
+#: components/manage/Widgets/SelectStyling
+msgid "Clear selection"
+msgstr "清除選擇"
+
 #. Default: "Click to download full sized image"
 #: components/theme/View/ImageView
 msgid "Click to download full sized image"

--- a/packages/volto/news/8336.bugfix
+++ b/packages/volto/news/8336.bugfix
@@ -1,1 +1,1 @@
-Hide the clear button on required Select and ArrayWidget fields to prevent invalid state and improve accessibility. @Wagner3UB
+Hide the clear button on required `Select` and `ArrayWidget` fields to prevent invalid state and improve accessibility. @Wagner3UB

--- a/packages/volto/news/8336.bugfix
+++ b/packages/volto/news/8336.bugfix
@@ -1,0 +1,1 @@
+Hide the clear button on required Select and ArrayWidget fields to prevent invalid state and improve accessibility. @Wagner3UB

--- a/packages/volto/src/components/manage/Widgets/ArrayWidget.jsx
+++ b/packages/volto/src/components/manage/Widgets/ArrayWidget.jsx
@@ -384,7 +384,7 @@ class ArrayWidget extends Component {
               )
             )
           }
-          isClearable
+          isClearable={!this.props.required}
           isMulti
         />
       </FormFieldWrapper>

--- a/packages/volto/src/components/manage/Widgets/SelectStyling.jsx
+++ b/packages/volto/src/components/manage/Widgets/SelectStyling.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { defineMessages, useIntl } from 'react-intl';
 import { Popup } from 'semantic-ui-react';
 import { injectLazyLibs } from '@plone/volto/helpers/Loadable/Loadable';
 import Icon from '@plone/volto/components/theme/Icon/Icon';
@@ -9,6 +10,13 @@ import upSVG from '@plone/volto/icons/up-key.svg';
 import checkSVG from '@plone/volto/icons/check.svg';
 import checkBlankSVG from '@plone/volto/icons/check-blank.svg';
 import clearSVG from '@plone/volto/icons/clear.svg';
+
+const messages = defineMessages({
+  clearSelection: {
+    id: 'Clear selection',
+    defaultMessage: 'Clear selection',
+  },
+});
 
 export const MenuList = ({ children }) => {
   return <DynamicHeightList>{children}</DynamicHeightList>;
@@ -86,8 +94,32 @@ export const DropdownIndicator = injectLazyLibs('reactSelect')((props) => {
 
 export const ClearIndicator = injectLazyLibs('reactSelect')((props) => {
   const { ClearIndicator } = props.reactSelect.components;
+  const intl = useIntl();
+  const fieldLabelId = props.selectProps?.['aria-labelledby'];
+  const clearLabelId = `${props.selectProps?.inputId}-clear-label`;
   return (
-    <ClearIndicator {...props}>
+    <ClearIndicator
+      {...props}
+      innerProps={{
+        ...props.innerProps,
+        'aria-hidden': false,
+        ...(fieldLabelId
+          ? { 'aria-labelledby': `${fieldLabelId} ${clearLabelId}` }
+          : { 'aria-label': intl.formatMessage(messages.clearSelection) }),
+        role: 'button',
+        tabIndex: 0,
+        onKeyDown: (e) => {
+          if (e.key === 'Enter' || e.key === ' ' || e.key === 'Spacebar') {
+            e.preventDefault();
+            e.stopPropagation();
+            props.clearValue();
+          }
+        },
+      }}
+    >
+      <span id={clearLabelId} hidden>
+        {intl.formatMessage(messages.clearSelection)}
+      </span>
       <Icon name={clearSVG} size="18px" color="#e40166" />
     </ClearIndicator>
   );

--- a/packages/volto/src/components/manage/Widgets/SelectWidget.jsx
+++ b/packages/volto/src/components/manage/Widgets/SelectWidget.jsx
@@ -304,7 +304,7 @@ class SelectWidget extends Component {
                 : undefined,
             );
           }}
-          isClearable={this.props.isClearable}
+          isClearable={!this.props.required && this.props.isClearable}
         />
       </FormFieldWrapper>
     );

--- a/packages/volto/src/components/manage/Widgets/__snapshots__/SelectWidget.test.jsx.snap
+++ b/packages/volto/src/components/manage/Widgets/__snapshots__/SelectWidget.test.jsx.snap
@@ -88,9 +88,18 @@ exports[`No 'No value' option when default value is 0 1`] = `
                 class="react-select__indicators css-1wy0on6"
               >
                 <div
-                  aria-hidden="true"
+                  aria-hidden="false"
+                  aria-labelledby="fieldset-default-field-label-my-field undefined-clear-label"
                   class="react-select__indicator react-select__clear-indicator css-mszz6t"
+                  role="button"
+                  tabindex="0"
                 >
+                  <span
+                    hidden=""
+                    id="undefined-clear-label"
+                  >
+                    Clear selection
+                  </span>
                   <svg
                     class="icon"
                     style="height: 18px; width: auto; fill: #e40166;"


### PR DESCRIPTION
## Summary

Backport of https://github.com/plone/volto/pull/8315 for Volto 18.

When a `Select` or `ArrayWidget` field is marked as `required`, the "clear" button should not be rendered — clearing a required field produces an invalid state, and exposing the button to assistive technologies is misleading.

This fix hides the clear button on those widgets when `required` is `true`, improving both accessibility and UX.

## Changes

- **`packages/volto/src/components/manage/Widgets/SelectStyling.jsx`** — conditionally omit the `ClearIndicator` component from the react-select styles/components when the field is required
- **`packages/volto/src/components/manage/Widgets/ArrayWidget.jsx`** — same conditional hiding of the clear button for array (multi-select) fields
- **Snapshots updated** to reflect the removed clear button in required state
- **Translations committed** for any extracted i18n strings