### PR TITLE
fix(a11y): announce field name in Select and ArrayWidget via aria-label (backport #8314)

### DIFF
--- a/packages/volto/news/8337.bugfix
+++ b/packages/volto/news/8337.bugfix
@@ -1,0 +1,1 @@
+Improve screen reader support for `SelectWidget` and `ArrayWidget` by replacing `aria-labelledby` with a dynamic `aria-label` that announces the field name on focus. @Wagner3UB

--- a/packages/volto/src/components/manage/Widgets/ArrayWidget.jsx
+++ b/packages/volto/src/components/manage/Widgets/ArrayWidget.jsx
@@ -315,7 +315,8 @@ class ArrayWidget extends Component {
           // small fix for https://github.com/clauderic/react-sortable-hoc/pull/352:
           getHelperDimensions={({ node }) => node.getBoundingClientRect()}
           id={`field-${this.props.id}`}
-          aria-labelledby={`fieldset-${this.props.fieldSet}-field-label-${this.props.id}`}
+          fieldTitle={this.props.title}
+          aria-label={this.props.title || undefined}
           key={this.props.id}
           isDisabled={this.props.disabled || this.props.isDisabled}
           className="react-select-container"

--- a/packages/volto/src/components/manage/Widgets/SelectWidget.jsx
+++ b/packages/volto/src/components/manage/Widgets/SelectWidget.jsx
@@ -263,9 +263,10 @@ class SelectWidget extends Component {
       <FormFieldWrapper {...this.props}>
         <Select
           id={`field-${id}`}
+          fieldTitle={this.props.title}
           key={choices}
           name={id}
-          aria-labelledby={`fieldset-${this.props.fieldSet}-field-label-${id}`}
+          aria-label={this.props.title || undefined}
           menuShouldScrollIntoView={false}
           isDisabled={disabled}
           isSearchable={true}

--- a/packages/volto/src/components/manage/Widgets/__snapshots__/ArrayWidget.test.jsx.snap
+++ b/packages/volto/src/components/manage/Widgets/__snapshots__/ArrayWidget.test.jsx.snap
@@ -67,7 +67,7 @@ exports[`No 'No value' option when default value is 0 1`] = `
                   >
                     <input
                       aria-autocomplete="list"
-                      aria-labelledby="fieldset-default-field-label-my-field"
+                      aria-label="My field"
                       autocapitalize="none"
                       autocomplete="off"
                       autocorrect="off"
@@ -246,7 +246,7 @@ exports[`renders an array widget component 1`] = `
                 >
                   <input
                     aria-autocomplete="list"
-                    aria-labelledby="fieldset-default-field-label-my-field"
+                    aria-label="My field"
                     autoCapitalize="none"
                     autoComplete="off"
                     autoCorrect="off"

--- a/packages/volto/src/components/manage/Widgets/__snapshots__/SelectWidget.test.jsx.snap
+++ b/packages/volto/src/components/manage/Widgets/__snapshots__/SelectWidget.test.jsx.snap
@@ -67,7 +67,7 @@ exports[`No 'No value' option when default value is 0 1`] = `
                   >
                     <input
                       aria-autocomplete="list"
-                      aria-labelledby="fieldset-default-field-label-my-field"
+                      aria-label="My field"
                       autocapitalize="none"
                       autocomplete="off"
                       autocorrect="off"
@@ -261,7 +261,7 @@ exports[`renders a select widget component 1`] = `
                   >
                     <input
                       aria-autocomplete="list"
-                      aria-labelledby="fieldset-default-field-label-my-field"
+                      aria-label="My field"
                       autocapitalize="none"
                       autocomplete="off"
                       autocorrect="off"


### PR DESCRIPTION
## Summary

Backport of https://github.com/plone/volto/pull/8314 for Volto 18.

Replaces `aria-labelledby` with a dynamic `aria-label` on `SelectWidget` and `ArrayWidget`, so screen readers announce the field name on focus instead of relying on a separate label element reference.

## Changes

- **`packages/volto/src/components/manage/Widgets/SelectWidget.jsx`** — replaced `aria-labelledby` with `aria-label={this.props.title}` and added `fieldTitle` prop
- **`packages/volto/src/components/manage/Widgets/ArrayWidget.jsx`** — same change applied for multi-select fields
- **Snapshots updated** to reflect the new `aria-label` attribute