### PR TITLE
Fix SelectWidget test

### DIFF
--- a/packages/volto/news/8343.internal
+++ b/packages/volto/news/8343.internal
@@ -1,0 +1,1 @@
+Fix SelectWidget test. @wesleybl

--- a/packages/volto/src/components/manage/Widgets/__snapshots__/SelectWidget.test.jsx.snap
+++ b/packages/volto/src/components/manage/Widgets/__snapshots__/SelectWidget.test.jsx.snap
@@ -89,7 +89,7 @@ exports[`No 'No value' option when default value is 0 1`] = `
               >
                 <div
                   aria-hidden="false"
-                  aria-labelledby="fieldset-default-field-label-my-field undefined-clear-label"
+                  aria-label="Clear selection"
                   class="react-select__indicator react-select__clear-indicator css-mszz6t"
                   role="button"
                   tabindex="0"


### PR DESCRIPTION
- [ ] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [ ] I verified there aren't other open [pull requests](https://github.com/plone/volto/pulls) for the same change.
- [ ] I followed the guidelines in [Contributing to Volto](https://6.docs.plone.org/volto/contributing/index.html).
- [ ] I successfully ran [code linting checks](https://6.docs.plone.org/volto/contributing/linting.html) on my changes locally.
- [ ] I successfully ran [unit tests](https://6.docs.plone.org/volto/contributing/testing.html) on my changes locally.
- [ ] I successfully ran [acceptance tests](https://6.docs.plone.org/volto/contributing/acceptance-tests.html) on my changes locally.
- [ ] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/volto/contributing/documentation.html#narrative-documentation) for my changes, either in the Storybook or narrative documentation.
- [ ] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

If your pull request closes an open issue, include the exact text below, immediately followed by the issue number. When your pull request gets merged, then that issue will close automatically.

Closes #

-----

If your pull request includes changes to the documentation—either in narrative documentation, Storybook, or configuration—then a pull request preview will be generated and a link will populate in the description of your pull request below.
By clicking that link, you can use the visual diff menu in the upper right corner to navigate to pages that have changes, then display the diff by checking the `Show diff` checkbox.
