### PR TITLE
Fix random failure in test cypress blocks-table.js

### DIFF
--- a/packages/volto/cypress/tests/core/blocks/blocks-table.js
+++ b/packages/volto/cypress/tests/core/blocks/blocks-table.js
@@ -103,8 +103,8 @@ describe('Table Block Tests', () => {
     cy.intercept('GET', '/**/Document').as('schema2');
 
     cy.visit('/my-page/edit');
-    cy.wait('@schema2');
     cy.wait('@content2');
+    cy.wait('@schema2');
 
     // Wait for toolbar to be visible — this is the last reliable signal
     // that all async chunks (Widgets, dnd-kit, etc.) have finished loading
@@ -113,30 +113,19 @@ describe('Table Block Tests', () => {
     // Wait for the table and the target cell to be fully interactive.
     // Using a generous timeout since chunk loading in CI can be slow.
     cy.get('.celled.fixed.table', { timeout: 15000 }).should('be.visible');
-    cy.get('.celled.fixed.table tr:first-child() th:nth-child(2)', {
+    cy.get('.celled.fixed.table tr:first-child th:nth-child(2)', {
       timeout: 15000,
     })
       .should('be.visible')
-      .and('not.be.disabled');
-
-    cy.get('.celled.fixed.table tr:first-child() th:nth-child(2)').click({
-      waitForAnimations: false,
-    });
-
-    cy.get('.celled.fixed.table tr:first-child() th:nth-child(2)').click();
+      .and('not.be.disabled')
+      .click();
 
     cy.get('button[title="Delete col"]').click();
-    cy.get(
-      '.celled.fixed.table thead tr:first-child() th:nth-child(3)',
-    ).click();
+    cy.get('.celled.fixed.table thead tr:first-child th:nth-child(3)').click();
     cy.get('button[title="Delete col"]').click();
-    cy.get(
-      '.celled.fixed.table tbody tr:first-child() td:first-child()',
-    ).click();
+    cy.get('.celled.fixed.table tbody tr:first-child td:first-child').click();
     cy.get('button[title="Delete row"]').click();
-    cy.get(
-      '.celled.fixed.table tbody tr:nth-child(2) td:first-child()',
-    ).click();
+    cy.get('.celled.fixed.table tbody tr:nth-child(2) td:first-child').click();
     cy.get('button[title="Delete row"]').click();
 
     // Redefine intercept before second save
@@ -159,10 +148,11 @@ describe('Table Block Tests', () => {
       'have.text',
       'column 2 / row 1',
     );
-    cy.get(
-      '.celled.fixed.table tbody tr:first-child() td:first-child()',
-    ).should('contain', 'column 1 / row 2');
-    cy.get('.celled.fixed.table tbody tr:first-child() td:nth-child(2)').should(
+    cy.get('.celled.fixed.table tbody tr:first-child td:first-child').should(
+      'contain',
+      'column 1 / row 2',
+    );
+    cy.get('.celled.fixed.table tbody tr:first-child td:nth-child(2)').should(
       'contain',
       'column 2 / row 2',
     );

--- a/packages/volto/news/8345.internal
+++ b/packages/volto/news/8345.internal
@@ -1,0 +1,1 @@
+Fix random failure in test cypress blocks-table.js. @wesleybl


### PR DESCRIPTION
Avoid double-clicking on the same element.

This fix the error:

```javascript
  1) Table Block Tests
       Add table block:
     Error: The following error originated from your application code, not from Cypress.

  > Minified React error #185; visit https://reactjs.org/docs/error-decoder.html?invariant=185 for the full message or use the non-minified dev environment for full errors and additional helpful warnings.
```

See: https://github.com/plone/volto/actions/runs/27676188082/job/81851943031#step:4:779