### PR TITLE
backport for 18.x.x of fix: removed redundant depth field from querystring search

### DIFF
--- a/packages/volto/locales/af/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/af/LC_MESSAGES/volto.po
@@ -1115,11 +1115,6 @@ msgstr ""
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr ""
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/ar/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ar/LC_MESSAGES/volto.po
@@ -1115,11 +1115,6 @@ msgstr ""
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr ""
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/bg/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/bg/LC_MESSAGES/volto.po
@@ -1115,11 +1115,6 @@ msgstr ""
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr ""
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/bn/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/bn/LC_MESSAGES/volto.po
@@ -1115,11 +1115,6 @@ msgstr ""
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr ""
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/ca/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ca/LC_MESSAGES/volto.po
@@ -1116,11 +1116,6 @@ msgstr "Eliminat"
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr "Eliminar aquest element trenca {brokenReferences} {variation}."
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr "Profunditat"
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/cs/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/cs/LC_MESSAGES/volto.po
@@ -1115,11 +1115,6 @@ msgstr ""
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr ""
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/cy/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/cy/LC_MESSAGES/volto.po
@@ -1115,11 +1115,6 @@ msgstr ""
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr ""
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/da/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/da/LC_MESSAGES/volto.po
@@ -1115,11 +1115,6 @@ msgstr ""
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr ""
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/de/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/de/LC_MESSAGES/volto.po
@@ -1116,11 +1116,6 @@ msgstr "Gelöscht"
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr "Tiefe"
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/el/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/el/LC_MESSAGES/volto.po
@@ -1115,11 +1115,6 @@ msgstr ""
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr ""
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/en/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/en/LC_MESSAGES/volto.po
@@ -1110,11 +1110,6 @@ msgstr ""
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr ""
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/en_AU/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/en_AU/LC_MESSAGES/volto.po
@@ -1115,11 +1115,6 @@ msgstr ""
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr ""
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/en_GB/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/en_GB/LC_MESSAGES/volto.po
@@ -1115,11 +1115,6 @@ msgstr ""
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr ""
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/eo/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/eo/LC_MESSAGES/volto.po
@@ -1115,11 +1115,6 @@ msgstr ""
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr ""
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/es/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/es/LC_MESSAGES/volto.po
@@ -1111,11 +1111,6 @@ msgstr "Eliminado"
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr "Al eliminar este elemento se interrumpen {brokenReferences} {variation}."
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr "Profundidad"
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/et/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/et/LC_MESSAGES/volto.po
@@ -1115,11 +1115,6 @@ msgstr ""
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr ""
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/eu/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/eu/LC_MESSAGES/volto.po
@@ -1111,11 +1111,6 @@ msgstr "Ezabatuta"
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr "Elementu hau ezabatzean {brokenReferences} {variation} apurtuko dira."
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr "Sakonera"
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/fa/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/fa/LC_MESSAGES/volto.po
@@ -1115,11 +1115,6 @@ msgstr ""
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr ""
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/fi/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/fi/LC_MESSAGES/volto.po
@@ -1115,11 +1115,6 @@ msgstr "Poistettu"
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr "Syvyys"
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/fr/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/fr/LC_MESSAGES/volto.po
@@ -1117,11 +1117,6 @@ msgstr "Supprimé"
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr "Profondeur"
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/fu/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/fu/LC_MESSAGES/volto.po
@@ -1115,11 +1115,6 @@ msgstr ""
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr ""
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/gl/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/gl/LC_MESSAGES/volto.po
@@ -1116,11 +1116,6 @@ msgstr "Eliminado"
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr "Eliminar este elemento rompe {brokenReferences} {variation}."
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr "Profundidade"
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/he/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/he/LC_MESSAGES/volto.po
@@ -1115,11 +1115,6 @@ msgstr ""
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr ""
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/hi/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/hi/LC_MESSAGES/volto.po
@@ -1110,11 +1110,6 @@ msgstr "हटा दिया गया"
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr "इस आइटम को हटाने से {brokenReferences} {variation} टूट जाता है।"
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr "गहराई"
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/hr/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/hr/LC_MESSAGES/volto.po
@@ -1115,11 +1115,6 @@ msgstr ""
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr ""
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/hu/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/hu/LC_MESSAGES/volto.po
@@ -1115,11 +1115,6 @@ msgstr ""
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr ""
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/hy/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/hy/LC_MESSAGES/volto.po
@@ -1115,11 +1115,6 @@ msgstr ""
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr ""
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/id/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/id/LC_MESSAGES/volto.po
@@ -1115,11 +1115,6 @@ msgstr ""
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr ""
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/it/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/it/LC_MESSAGES/volto.po
@@ -1111,11 +1111,6 @@ msgstr "Cancellato"
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr "Eliminando questo elemento si romperanno {brokenReferences} {variation}."
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr "Profondità di ricerca"
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/ja/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ja/LC_MESSAGES/volto.po
@@ -1115,11 +1115,6 @@ msgstr ""
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr "深さ"
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/ka/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ka/LC_MESSAGES/volto.po
@@ -1115,11 +1115,6 @@ msgstr ""
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr ""
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/kn/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/kn/LC_MESSAGES/volto.po
@@ -1115,11 +1115,6 @@ msgstr ""
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr ""
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/ko/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ko/LC_MESSAGES/volto.po
@@ -1115,11 +1115,6 @@ msgstr ""
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr ""
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/lt/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/lt/LC_MESSAGES/volto.po
@@ -1115,11 +1115,6 @@ msgstr ""
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr ""
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/lv/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/lv/LC_MESSAGES/volto.po
@@ -1115,11 +1115,6 @@ msgstr ""
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr ""
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/mi/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/mi/LC_MESSAGES/volto.po
@@ -1115,11 +1115,6 @@ msgstr ""
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr ""
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/mk/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/mk/LC_MESSAGES/volto.po
@@ -1115,11 +1115,6 @@ msgstr ""
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr ""
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/my/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/my/LC_MESSAGES/volto.po
@@ -1115,11 +1115,6 @@ msgstr ""
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr ""
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/nb_NO/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/nb_NO/LC_MESSAGES/volto.po
@@ -1115,11 +1115,6 @@ msgstr ""
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr ""
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/nl/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/nl/LC_MESSAGES/volto.po
@@ -1111,11 +1111,6 @@ msgstr "Verwijderd"
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr "Dit item verwijderen breekt {brokenReferences} {variation}."
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr "Diepte"
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/nn/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/nn/LC_MESSAGES/volto.po
@@ -1115,11 +1115,6 @@ msgstr ""
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr ""
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/pl/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/pl/LC_MESSAGES/volto.po
@@ -1115,11 +1115,6 @@ msgstr ""
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr ""
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/pt/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/pt/LC_MESSAGES/volto.po
@@ -1110,11 +1110,6 @@ msgstr "Apagado"
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr "Apagar este elemento quebra {brokenReferences} {variation}."
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr "Profundidade"
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/pt_BR/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/pt_BR/LC_MESSAGES/volto.po
@@ -1116,11 +1116,6 @@ msgstr "Removida"
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr "A exclusão desse item quebra {brokenReferences} {variation}."
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr "Profundidade"
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/rm/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/rm/LC_MESSAGES/volto.po
@@ -1115,11 +1115,6 @@ msgstr ""
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr ""
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/ro/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ro/LC_MESSAGES/volto.po
@@ -1116,11 +1116,6 @@ msgstr "Șters"
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr "Ștergerea acestui element întrerupe {brokenReferences} {variation}."
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr "Adâncime"
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/ru/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ru/LC_MESSAGES/volto.po
@@ -1115,11 +1115,6 @@ msgstr "Удалено"
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr "Удаление этого элемента нарушает {brokenReferences} {variation}."
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr "Глубина"
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/sk/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/sk/LC_MESSAGES/volto.po
@@ -1115,11 +1115,6 @@ msgstr ""
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr ""
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/sl/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/sl/LC_MESSAGES/volto.po
@@ -1115,11 +1115,6 @@ msgstr ""
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr ""
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/sm/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/sm/LC_MESSAGES/volto.po
@@ -1115,11 +1115,6 @@ msgstr ""
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr ""
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/sq/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/sq/LC_MESSAGES/volto.po
@@ -1115,11 +1115,6 @@ msgstr ""
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr ""
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/sr/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/sr/LC_MESSAGES/volto.po
@@ -1115,11 +1115,6 @@ msgstr ""
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr ""
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/sr@cyrl/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/sr@cyrl/LC_MESSAGES/volto.po
@@ -1115,11 +1115,6 @@ msgstr ""
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr ""
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/sr@latn/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/sr@latn/LC_MESSAGES/volto.po
@@ -1115,11 +1115,6 @@ msgstr ""
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr ""
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/sv/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/sv/LC_MESSAGES/volto.po
@@ -1110,11 +1110,6 @@ msgstr "Raderad"
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr ""
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/ta/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ta/LC_MESSAGES/volto.po
@@ -1111,11 +1111,6 @@ msgstr "நீக்கப்பட்டது"
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr "இந்த உருப்படியை நீக்குதல் {brokenReferences} {variation}."
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr "ஆழம்"
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/te/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/te/LC_MESSAGES/volto.po
@@ -1115,11 +1115,6 @@ msgstr ""
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr ""
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/th/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/th/LC_MESSAGES/volto.po
@@ -1115,11 +1115,6 @@ msgstr ""
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr ""
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/to/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/to/LC_MESSAGES/volto.po
@@ -1115,11 +1115,6 @@ msgstr ""
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr ""
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/tr/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/tr/LC_MESSAGES/volto.po
@@ -1116,11 +1116,6 @@ msgstr ""
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr ""
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/uk/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/uk/LC_MESSAGES/volto.po
@@ -1115,11 +1115,6 @@ msgstr ""
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr ""
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/vi/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/vi/LC_MESSAGES/volto.po
@@ -1115,11 +1115,6 @@ msgstr ""
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr ""
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/volto.pot
+++ b/packages/volto/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2026-06-15T12:41:40.824Z\n"
+"POT-Creation-Date: 2026-06-22T10:21:12.096Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Content-Type: text/plain; charset=utf-8\n"
@@ -1110,11 +1110,6 @@ msgstr ""
 #. Default: "Deleting this item breaks {brokenReferences} {variation}."
 #: components/manage/Contents/ContentsDeleteModal
 msgid "Deleting this item breaks {brokenReferences} {variation}."
-msgstr ""
-
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
 msgstr ""
 
 #. Default: "Descending"

--- a/packages/volto/locales/zh_CN/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/zh_CN/LC_MESSAGES/volto.po
@@ -1116,11 +1116,6 @@ msgstr "已删除"
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr "深度"
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/zh_Hant/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/zh_Hant/LC_MESSAGES/volto.po
@@ -1115,11 +1115,6 @@ msgstr ""
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr ""
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/locales/zh_Hant_HK/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/zh_Hant_HK/LC_MESSAGES/volto.po
@@ -1115,11 +1115,6 @@ msgstr ""
 msgid "Deleting this item breaks {brokenReferences} {variation}."
 msgstr ""
 
-#. Default: "Depth"
-#: components/manage/Widgets/QuerystringWidget
-msgid "Depth"
-msgstr ""
-
 #. Default: "Descending"
 #: components/manage/Blocks/Search/components/SortOn
 #: components/manage/Contents/Contents

--- a/packages/volto/news/8351.bugfix
+++ b/packages/volto/news/8351.bugfix
@@ -1,0 +1,3 @@
+Removed redundant depth field from QuerystringWidget as it is already
+in QueryWidget when Location criteria is selected and when a path is
+selected in ObjectBrowserWidget. @sabrina-bongiovanni

--- a/packages/volto/src/actions/querystringsearch/querystringsearch.js
+++ b/packages/volto/src/actions/querystringsearch/querystringsearch.js
@@ -17,7 +17,10 @@ export function getQueryStringResults(path, data, subrequest, page) {
     delete requestData.depth;
     requestData.query.forEach((q) => {
       if (q.i === 'path') {
-        q.v += '::' + data.depth;
+        // fixes https://github.com/plone/volto/issues/8349
+        // Skip if depth is already embedded in the path value (e.g. set via object browser)
+        const hasEmbeddedDepth = /::\d+$/.test(q.v);
+        if (!hasEmbeddedDepth) q.v += '::' + data.depth;
       }
     });
   }

--- a/packages/volto/src/actions/querystringsearch/querystringsearch.test.js
+++ b/packages/volto/src/actions/querystringsearch/querystringsearch.test.js
@@ -73,4 +73,81 @@ describe('querystringsearch action', () => {
     expect(action.request.path).toEqual('/@querystring-search');
     expect(action.request.data.sort_order).toEqual('descending');
   });
+
+  describe('depth handling', () => {
+    it('appends depth to path value when depth is set and path has no embedded depth', () => {
+      const data = {
+        query: [
+          {
+            i: 'path',
+            o: 'plone.app.querystring.operation.string.path',
+            v: '/folder',
+          },
+        ],
+        depth: 2,
+      };
+      const action = getQueryStringResults('', data);
+
+      const pathQuery = action.request.data.query.find((q) => q.i === 'path');
+      expect(pathQuery.v).toEqual('/folder::2');
+    });
+
+    it('does not double-append depth when path value already contains an embedded depth', () => {
+      const data = {
+        query: [
+          {
+            i: 'path',
+            o: 'plone.app.querystring.operation.string.path',
+            v: '/folder::1',
+          },
+        ],
+        depth: 3,
+      };
+      const action = getQueryStringResults('', data);
+
+      const pathQuery = action.request.data.query.find((q) => q.i === 'path');
+      expect(pathQuery.v).toEqual('/folder::1');
+    });
+
+    it('removes depth from the top-level request data', () => {
+      const data = {
+        query: [
+          {
+            i: 'path',
+            o: 'plone.app.querystring.operation.string.path',
+            v: '/folder',
+          },
+        ],
+        depth: 2,
+      };
+      const action = getQueryStringResults('', data);
+
+      expect(action.request.data.depth).toBeUndefined();
+    });
+
+    it('handles mixed path entries: appends depth only to those without embedded depth', () => {
+      const data = {
+        query: [
+          {
+            i: 'path',
+            o: 'plone.app.querystring.operation.string.path',
+            v: '/folder-a',
+          },
+          {
+            i: 'path',
+            o: 'plone.app.querystring.operation.string.path',
+            v: '/folder-b::5',
+          },
+        ],
+        depth: 2,
+      };
+      const action = getQueryStringResults('', data);
+
+      const [pathA, pathB] = action.request.data.query.filter(
+        (q) => q.i === 'path',
+      );
+      expect(pathA.v).toEqual('/folder-a::2');
+      expect(pathB.v).toEqual('/folder-b::5');
+    });
+  });
 });

--- a/packages/volto/src/components/manage/Widgets/QuerystringWidget.jsx
+++ b/packages/volto/src/components/manage/Widgets/QuerystringWidget.jsx
@@ -7,10 +7,6 @@ const messages = defineMessages({
     id: 'Criteria',
     defaultMessage: 'Criteria',
   },
-  depth: {
-    id: 'Depth',
-    defaultMessage: 'Depth',
-  },
   SortOn: {
     id: 'Sort on',
     defaultMessage: 'Sort on',
@@ -38,26 +34,13 @@ export const objectSchema = ({ intl, isDisabled, value }) => ({
     {
       id: 'default',
       title: 'Default',
-      fields: [
-        'query',
-        ...(value?.query?.filter((q) => q.i === 'path').length > 0
-          ? ['depth']
-          : []),
-        'sort_on',
-        'sort_order_boolean',
-        'limit',
-        'b_size',
-      ],
+      fields: ['query', 'sort_on', 'sort_order_boolean', 'limit', 'b_size'],
     },
   ],
   properties: {
     query: {
       title: intl.formatMessage(messages.Criteria),
       widget: 'query',
-    },
-    depth: {
-      title: intl.formatMessage(messages.depth),
-      type: 'number',
     },
     sort_on: {
       title: intl.formatMessage(messages.SortOn),

--- a/packages/volto/src/components/manage/Widgets/QuerystringWidget.test.jsx
+++ b/packages/volto/src/components/manage/Widgets/QuerystringWidget.test.jsx
@@ -4,7 +4,7 @@ import configureStore from 'redux-mock-store';
 import { Provider } from 'react-intl-redux';
 import { waitFor } from '@testing-library/react';
 
-import QuerystringWidget from './QuerystringWidget';
+import QuerystringWidget, { objectSchema } from './QuerystringWidget';
 
 const mockStore = configureStore();
 
@@ -23,6 +23,47 @@ test('renders an querystring widget component', async () => {
   );
   await waitFor(() => {});
   expect(component.toJSON()).toMatchSnapshot();
+});
+
+describe('objectSchema', () => {
+  const mockIntl = { formatMessage: ({ defaultMessage }) => defaultMessage };
+
+  it('does not include depth in the default fieldset', () => {
+    const schema = objectSchema({ intl: mockIntl });
+    const fields = schema.fieldsets[0].fields;
+
+    expect(fields).not.toContain('depth');
+    expect(fields).toEqual([
+      'query',
+      'sort_on',
+      'sort_order_boolean',
+      'limit',
+      'b_size',
+    ]);
+  });
+
+  it('does not include depth in the schema properties', () => {
+    const schema = objectSchema({ intl: mockIntl });
+
+    expect(schema.properties).not.toHaveProperty('depth');
+  });
+
+  it('does not include depth even when value contains a path criterion', () => {
+    const value = {
+      query: [
+        {
+          i: 'path',
+          o: 'plone.app.querystring.operation.string.path',
+          v: '/folder',
+        },
+      ],
+    };
+    const schema = objectSchema({ intl: mockIntl, value });
+    const fields = schema.fieldsets[0].fields;
+
+    expect(fields).not.toContain('depth');
+    expect(schema.properties).not.toHaveProperty('depth');
+  });
 });
 
 test('can take a schemaEnhancer', async () => {
@@ -51,6 +92,8 @@ test('can take a schemaEnhancer', async () => {
       />
     </Provider>,
   );
-  await waitFor(() => {});
+  await waitFor(() => {
+    expect(component.toJSON()?.children).toHaveLength(3);
+  });
   expect(component.toJSON()).toMatchSnapshot();
 });

--- a/packages/volto/src/components/manage/Widgets/__snapshots__/QuerystringWidget.test.jsx.snap
+++ b/packages/volto/src/components/manage/Widgets/__snapshots__/QuerystringWidget.test.jsx.snap
@@ -3,7 +3,32 @@
 exports[`can take a schemaEnhancer 1`] = `
 <div
   className="querystring-widget"
-/>
+>
+  <div
+    className="mocked-default-widget"
+    id="mocked-field-query-0-my-field"
+  >
+    Criteria
+     -
+    No description
+  </div>
+  <div
+    className="mocked-default-widget"
+    id="mocked-field-sort_on-1-my-field"
+  >
+    Sort on
+     -
+    No description
+  </div>
+  <div
+    className="mocked-boolean-widget"
+    id="mocked-field-sort_order_boolean-2-my-field"
+  >
+    Reversed order
+     -
+    No description
+  </div>
+</div>
 `;
 
 exports[`renders an querystring widget component 1`] = `

--- a/packages/volto/src/components/manage/Widgets/__snapshots__/QuerystringWidget.test.jsx.snap
+++ b/packages/volto/src/components/manage/Widgets/__snapshots__/QuerystringWidget.test.jsx.snap
@@ -9,7 +9,7 @@ exports[`can take a schemaEnhancer 1`] = `
     id="mocked-field-query-0-my-field"
   >
     Criteria
-     -
+     - 
     No description
   </div>
   <div
@@ -17,7 +17,7 @@ exports[`can take a schemaEnhancer 1`] = `
     id="mocked-field-sort_on-1-my-field"
   >
     Sort on
-     -
+     - 
     No description
   </div>
   <div
@@ -25,7 +25,7 @@ exports[`can take a schemaEnhancer 1`] = `
     id="mocked-field-sort_order_boolean-2-my-field"
   >
     Reversed order
-     -
+     - 
     No description
   </div>
 </div>


### PR DESCRIPTION
- [ ] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [ ] I verified there aren't other open [pull requests](https://github.com/plone/volto/pulls) for the same change.
- [ ] I followed the guidelines in [Contributing to Volto](https://6.docs.plone.org/volto/contributing/index.html).
- [ ] I successfully ran [code linting checks](https://6.docs.plone.org/volto/contributing/linting.html) on my changes locally.
- [ ] I successfully ran [unit tests](https://6.docs.plone.org/volto/contributing/testing.html) on my changes locally.
- [ ] I successfully ran [acceptance tests](https://6.docs.plone.org/volto/contributing/acceptance-tests.html) on my changes locally.
- [ ] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/volto/contributing/documentation.html#narrative-documentation) for my changes, either in the Storybook or narrative documentation.
- [ ] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

If your pull request closes an open issue, include the exact text below, immediately followed by the issue number. When your pull request gets merged, then that issue will close automatically.

Closes #8349 
Backport of https://github.com/plone/volto/pull/8350


-----

If your pull request includes changes to the documentation—either in narrative documentation, Storybook, or configuration—then a pull request preview will be generated and a link will populate in the description of your pull request below.
By clicking that link, you can use the visual diff menu in the upper right corner to navigate to pages that have changes, then display the diff by checking the `Show diff` checkbox.
