### PR TITLE
Add loading feedback for working copy actions in More toolbar

### DIFF
--- a/packages/volto/locales/af/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/af/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr ""
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr ""
 

--- a/packages/volto/locales/ar/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ar/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr ""
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr ""
 

--- a/packages/volto/locales/bg/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/bg/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr ""
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr ""
 

--- a/packages/volto/locales/bn/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/bn/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr ""
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr ""
 

--- a/packages/volto/locales/ca/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ca/LC_MESSAGES/volto.po
@@ -2248,6 +2248,7 @@ msgstr "Carrega més..."
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr "Carregant."
 

--- a/packages/volto/locales/cs/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/cs/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr ""
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr ""
 

--- a/packages/volto/locales/cy/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/cy/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr ""
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr ""
 

--- a/packages/volto/locales/da/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/da/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr ""
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr ""
 

--- a/packages/volto/locales/de/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/de/LC_MESSAGES/volto.po
@@ -2248,6 +2248,7 @@ msgstr "Mehr laden"
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr "lädt"
 

--- a/packages/volto/locales/el/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/el/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr ""
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr ""
 

--- a/packages/volto/locales/en/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/en/LC_MESSAGES/volto.po
@@ -2246,6 +2246,7 @@ msgstr ""
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr ""
 

--- a/packages/volto/locales/en_AU/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/en_AU/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr ""
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr ""
 

--- a/packages/volto/locales/en_GB/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/en_GB/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr ""
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr ""
 

--- a/packages/volto/locales/eo/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/eo/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr ""
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr ""
 

--- a/packages/volto/locales/es/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/es/LC_MESSAGES/volto.po
@@ -2248,6 +2248,7 @@ msgstr "Cargar más"
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr "Cargando"
 

--- a/packages/volto/locales/et/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/et/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr ""
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr ""
 

--- a/packages/volto/locales/eu/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/eu/LC_MESSAGES/volto.po
@@ -2248,6 +2248,7 @@ msgstr "Kargatu gehiago"
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr "Kargatzen"
 

--- a/packages/volto/locales/fa/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/fa/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr ""
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr ""
 

--- a/packages/volto/locales/fi/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/fi/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr "Lataa lisää"
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr "Ladataan"
 

--- a/packages/volto/locales/fr/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/fr/LC_MESSAGES/volto.po
@@ -2248,6 +2248,7 @@ msgstr "Charger plus..."
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr "Chargement."
 

--- a/packages/volto/locales/fu/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/fu/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr ""
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr ""
 

--- a/packages/volto/locales/gl/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/gl/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr "Cargar máis"
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr "Cargando"
 

--- a/packages/volto/locales/he/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/he/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr ""
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr ""
 

--- a/packages/volto/locales/hi/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/hi/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr "अधिक लोड करें"
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr "लोड हो रहा है"
 

--- a/packages/volto/locales/hr/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/hr/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr ""
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr ""
 

--- a/packages/volto/locales/hu/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/hu/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr ""
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr ""
 

--- a/packages/volto/locales/hy/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/hy/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr ""
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr ""
 

--- a/packages/volto/locales/id/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/id/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr ""
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr ""
 

--- a/packages/volto/locales/it/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/it/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr "Carica altro"
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr "Caricamento"
 

--- a/packages/volto/locales/ja/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ja/LC_MESSAGES/volto.po
@@ -2248,6 +2248,7 @@ msgstr ""
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr "読み込み中"
 

--- a/packages/volto/locales/ka/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ka/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr ""
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr ""
 

--- a/packages/volto/locales/kn/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/kn/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr ""
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr ""
 

--- a/packages/volto/locales/ko/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ko/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr ""
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr ""
 

--- a/packages/volto/locales/lt/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/lt/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr ""
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr ""
 

--- a/packages/volto/locales/lv/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/lv/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr ""
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr ""
 

--- a/packages/volto/locales/mi/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/mi/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr ""
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr ""
 

--- a/packages/volto/locales/mk/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/mk/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr ""
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr ""
 

--- a/packages/volto/locales/my/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/my/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr ""
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr ""
 

--- a/packages/volto/locales/nb_NO/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/nb_NO/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr ""
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr ""
 

--- a/packages/volto/locales/nl/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/nl/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr "Meer laden..."
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr "Laden"
 

--- a/packages/volto/locales/nn/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/nn/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr ""
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr ""
 

--- a/packages/volto/locales/pl/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/pl/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr ""
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr ""
 

--- a/packages/volto/locales/pt/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/pt/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr "Carregar mais"
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr "A carregar"
 

--- a/packages/volto/locales/pt_BR/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/pt_BR/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr "Carregar mais"
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr "Carregando"
 

--- a/packages/volto/locales/rm/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/rm/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr ""
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr ""
 

--- a/packages/volto/locales/ro/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ro/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr "Incarcă mai mult"
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr "Se încarcă"
 

--- a/packages/volto/locales/ru/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ru/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr "Загрузить еще"
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr "Загрузка"
 

--- a/packages/volto/locales/sk/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/sk/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr ""
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr ""
 

--- a/packages/volto/locales/sl/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/sl/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr ""
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr ""
 

--- a/packages/volto/locales/sm/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/sm/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr ""
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr ""
 

--- a/packages/volto/locales/sq/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/sq/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr ""
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr ""
 

--- a/packages/volto/locales/sr/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/sr/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr ""
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr ""
 

--- a/packages/volto/locales/sr@cyrl/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/sr@cyrl/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr ""
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr ""
 

--- a/packages/volto/locales/sr@latn/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/sr@latn/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr ""
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr ""
 

--- a/packages/volto/locales/sv/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/sv/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr ""
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr ""
 

--- a/packages/volto/locales/ta/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/ta/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr "மேலும் ஏற்றவும்"
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr "ஏற்றுகிறது"
 

--- a/packages/volto/locales/te/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/te/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr ""
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr ""
 

--- a/packages/volto/locales/th/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/th/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr ""
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr ""
 

--- a/packages/volto/locales/to/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/to/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr ""
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr ""
 

--- a/packages/volto/locales/tr/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/tr/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr ""
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr ""
 

--- a/packages/volto/locales/uk/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/uk/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr ""
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr ""
 

--- a/packages/volto/locales/vi/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/vi/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr ""
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr ""
 

--- a/packages/volto/locales/volto.pot
+++ b/packages/volto/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2026-06-22T08:55:07.777Z\n"
+"POT-Creation-Date: 2026-07-02T03:37:27.336Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Content-Type: text/plain; charset=utf-8\n"
@@ -2243,6 +2243,7 @@ msgstr ""
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr ""
 

--- a/packages/volto/locales/zh_CN/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/zh_CN/LC_MESSAGES/volto.po
@@ -2248,6 +2248,7 @@ msgstr "加载更多"
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr "加载中"
 

--- a/packages/volto/locales/zh_Hant/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/zh_Hant/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr ""
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr ""
 

--- a/packages/volto/locales/zh_Hant_HK/LC_MESSAGES/volto.po
+++ b/packages/volto/locales/zh_Hant_HK/LC_MESSAGES/volto.po
@@ -2247,6 +2247,7 @@ msgstr ""
 #: components/manage/Controlpanels/Groups/GroupsControlpanel
 #: components/manage/Controlpanels/Users/UsersControlpanel
 #: components/manage/Form/ModalForm
+#: components/manage/Toolbar/More
 msgid "Loading"
 msgstr ""
 

--- a/packages/volto/news/8362.feature
+++ b/packages/volto/news/8362.feature
@@ -1,0 +1,1 @@
+Add loading feedback for working copy actions in More toolbar. @wesleybl

--- a/packages/volto/src/components/manage/Toolbar/More.jsx
+++ b/packages/volto/src/components/manage/Toolbar/More.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { useDispatch, useSelector, shallowEqual } from 'react-redux';
 import { Link, useHistory } from 'react-router-dom';
 import find from 'lodash/find';
+import { Dimmer, Loader } from 'semantic-ui-react';
 import { toast } from 'react-toastify';
 
 import Toast from '@plone/volto/components/manage/Toast/Toast';
@@ -103,6 +104,10 @@ const messages = defineMessages({
     id: 'workingCopyGenericError',
     defaultMessage: 'An error occurred while performing this operation.',
   },
+  Loading: {
+    id: 'Loading',
+    defaultMessage: 'Loading',
+  },
 });
 
 const More = (props) => {
@@ -123,6 +128,8 @@ const More = (props) => {
   const workingCopyApply = workingCopy?.apply.loading;
   const workingCopyCreate = workingCopy?.create.loading;
   const workingCopyRemove = workingCopy?.remove.loading;
+  const isWorkingCopyLoading =
+    workingCopyApply || workingCopyCreate || workingCopyRemove;
 
   const prevWorkingCopyApplyLoading = usePrevious(workingCopyApply);
   const prevWorkingCopyCreateLoading = usePrevious(workingCopyCreate);
@@ -216,6 +223,9 @@ const More = (props) => {
           : null,
       }}
     >
+      <Dimmer active={isWorkingCopyLoading} inverted>
+        <Loader>{intl.formatMessage(messages.Loading)}</Loader>
+      </Dimmer>
       <header>
         <h2>{content.title}</h2>
         <button
@@ -335,6 +345,7 @@ const More = (props) => {
           <li>
             <button
               aria-label={intl.formatMessage(messages.CreateWorkingCopy)}
+              disabled={workingCopyCreate}
               onClick={() => {
                 dispatch(createWorkingCopy(path)).then((response) => {
                   history.push(flattenToAppURL(response['@id']));
@@ -354,6 +365,7 @@ const More = (props) => {
           <li>
             <button
               aria-label={intl.formatMessage(messages.applyWorkingCopy)}
+              disabled={workingCopyApply}
               onClick={() => {
                 dispatch(applyWorkingCopy(path)).then((response) => {
                   history.push(flattenToAppURL(content.working_copy_of['@id']));
@@ -395,6 +407,7 @@ const More = (props) => {
           <li>
             <button
               aria-label={intl.formatMessage(messages.removeWorkingCopy)}
+              disabled={workingCopyRemove}
               onClick={() => {
                 dispatch(removeWorkingCopy(path)).then((response) => {
                   history.push(flattenToAppURL(content.working_copy_of['@id']));

--- a/packages/volto/src/components/manage/Toolbar/__snapshots__/More.test.jsx.snap
+++ b/packages/volto/src/components/manage/Toolbar/__snapshots__/More.test.jsx.snap
@@ -6,6 +6,19 @@ exports[`Toolbar More component > renders a Toolbar More component 1`] = `
     class="menu-more pastanaga-menu"
     style="flex: 0 0 320px;"
   >
+    <div
+      class="ui inverted dimmer"
+    >
+      <div
+        class="content"
+      >
+        <div
+          class="ui text loader"
+        >
+          Loading
+        </div>
+      </div>
+    </div>
     <header>
       <h2 />
       <button


### PR DESCRIPTION
When applying, creating, or removing a working copy, the menu had no visual indication that an operation was in progress. Add a Dimmer overlay with a Loader spinner to provide clear feedback during these async actions.