### PR TITLE
Resolve drag-and-drop position desync when reordering contents items fast

### DIFF
--- a/packages/volto/news/8372.bugfix
+++ b/packages/volto/news/8372.bugfix
@@ -1,0 +1,2 @@
+ Fix incorrect item positioning when rapidly dragging and dropping items in ``/contents``. @wesleybl
+ 

--- a/packages/volto/src/components/manage/Contents/Contents.jsx
+++ b/packages/volto/src/components/manage/Contents/Contents.jsx
@@ -724,9 +724,9 @@ class Contents extends Component {
         delta,
       );
     } else {
-      this.setState({
-        items: move(this.state.items, itemIndex, itemIndex + delta),
-      });
+      this.setState((prevState) => ({
+        items: move(prevState.items, itemIndex, itemIndex + delta),
+      }));
     }
   }
 

--- a/packages/volto/src/components/manage/Contents/ContentsItem.jsx
+++ b/packages/volto/src/components/manage/Contents/ContentsItem.jsx
@@ -364,15 +364,13 @@ const DragDropConnector = (props) => {
           drop(props, monitor) {
             const id = monitor.getItem().id;
             const dragOrder = monitor.getItem().startOrder;
-            const dropOrder = props.order;
+            const dropOrder = monitor.getItem().order;
 
             if (dragOrder === dropOrder) {
               return;
             }
 
             props.onOrderItem(id, dragOrder, dropOrder - dragOrder, true);
-
-            monitor.getItem().order = dropOrder;
           },
         },
         (connect) => ({


### PR DESCRIPTION
Use functional setState in onOrderItem to ensure each hover swap chains on the latest queued state instead of stale rendered state. Use monitor's tracked order in the drop handler to avoid stale props.order for the backend API call.

Note: This problem does not occur in the new drag-and-drop implementation in Volto 19.