### PR TITLE
Skip config entries that are not blocks in the Block Types control panel

### DIFF
--- a/packages/volto/news/8384.bugfix
+++ b/packages/volto/news/8384.bugfix
@@ -1,0 +1,1 @@
+Stopped the Block Types control panel from crashing when an add-on configures a block that was never registered, which leaves behind an entry with no id or no title. Those entries are not blocks, and are no longer listed. @ericof

--- a/packages/volto/src/components/manage/Controlpanels/BlockTypes.test.ts
+++ b/packages/volto/src/components/manage/Controlpanels/BlockTypes.test.ts
@@ -1,0 +1,132 @@
+import { createIntl, createIntlCache } from 'react-intl';
+import type { BlocksConfigData } from '@plone/types';
+import { sortConfigBlocks } from './BlockTypes';
+
+const intl = createIntl(
+  { locale: 'en', messages: { Teaser: 'Destaque' } },
+  createIntlCache(),
+);
+
+// `BlockConfigBase` types id and title as required, so a malformed entry
+// cannot be expressed through it. That mismatch between the type and the
+// configuration is the bug these tests cover, so the fixtures go around it.
+const asBlocksConfig = (config: Record<string, unknown>) =>
+  config as unknown as BlocksConfigData;
+
+describe('sortConfigBlocks', () => {
+  it('lists a registered block', () => {
+    const blocks = sortConfigBlocks(
+      asBlocksConfig({ image: { id: 'image', title: 'Image' } }),
+      intl,
+    );
+
+    expect(blocks).toEqual([{ id: 'image', title: 'Image' }]);
+  });
+
+  it('translates the title', () => {
+    const blocks = sortConfigBlocks(
+      asBlocksConfig({ teaser: { id: 'teaser', title: 'Teaser' } }),
+      intl,
+    );
+
+    expect(blocks[0].title).toEqual('Destaque');
+  });
+
+  it('sorts by the translated title, not by the config order', () => {
+    const blocks = sortConfigBlocks(
+      asBlocksConfig({
+        zebra: { id: 'zebra', title: 'Zebra' },
+        apple: { id: 'apple', title: 'Apple' },
+        // 'Teaser' translates to 'Destaque', so it sorts before 'Zebra'.
+        teaser: { id: 'teaser', title: 'Teaser' },
+      }),
+      intl,
+    );
+
+    expect(blocks.map((block) => block.title)).toEqual([
+      'Apple',
+      'Destaque',
+      'Zebra',
+    ]);
+  });
+
+  it('keeps the rest of the block config', () => {
+    const blocks = sortConfigBlocks(
+      asBlocksConfig({
+        image: {
+          id: 'image',
+          title: 'Image',
+          icon: 'image.svg',
+          group: 'media',
+        },
+      }),
+      intl,
+    );
+
+    expect(blocks[0]).toMatchObject({ icon: 'image.svg', group: 'media' });
+  });
+
+  describe('entries that are not blocks', () => {
+    // An add-on that configures a block which was never registered leaves an
+    // entry behind carrying only what it set. Listing it would link to a block
+    // that does not exist, and a row with no id crashes the table.
+    it('drops an entry with neither an id nor a title', () => {
+      const blocks = sortConfigBlocks(
+        asBlocksConfig({
+          image: { id: 'image', title: 'Image' },
+          accordion: { addPermission: [] },
+        }),
+        intl,
+      );
+
+      expect(blocks).toEqual([{ id: 'image', title: 'Image' }]);
+    });
+
+    it('drops an entry with an id but no title', () => {
+      const blocks = sortConfigBlocks(
+        asBlocksConfig({ accordion: { id: 'accordion' } }),
+        intl,
+      );
+
+      expect(blocks).toEqual([]);
+    });
+
+    it('drops an entry with a title but no id', () => {
+      const blocks = sortConfigBlocks(
+        asBlocksConfig({ accordion: { title: 'Accordion' } }),
+        intl,
+      );
+
+      expect(blocks).toEqual([]);
+    });
+
+    it('does not fall back to the config key for a missing id', () => {
+      const blocks = sortConfigBlocks(
+        asBlocksConfig({ accordion: { title: 'Accordion' } }),
+        intl,
+      );
+
+      expect(blocks.map((block) => block.id)).not.toContain('accordion');
+    });
+
+    it('gives every listed block an id, so the table can key its rows', () => {
+      const blocks = sortConfigBlocks(
+        asBlocksConfig({
+          image: { id: 'image', title: 'Image' },
+          accordion: { addPermission: [] },
+          teaser: { id: 'teaser' },
+        }),
+        intl,
+      );
+
+      expect(blocks.length).toBeGreaterThan(0);
+      for (const block of blocks) {
+        expect(block.id).toBeTruthy();
+      }
+    });
+  });
+
+  it('returns nothing when no block is configured', () => {
+    expect(sortConfigBlocks(asBlocksConfig({}), intl)).toEqual([]);
+  });
+});

--- a/packages/volto/src/components/manage/Controlpanels/BlockTypes.tsx
+++ b/packages/volto/src/components/manage/Controlpanels/BlockTypes.tsx
@@ -5,6 +5,7 @@ import { useClient } from '@plone/volto/hooks';
 import config from '@plone/volto/registry';
 import { createPortal } from 'react-dom';
 import { defineMessages, useIntl, FormattedMessage } from 'react-intl';
+import type { IntlShape } from 'react-intl';
 import { Link } from 'react-router-dom';
 import { useEffect } from 'react';
 import { getBlockTypes } from '@plone/volto/actions/blockTypes/blockTypes';
@@ -15,6 +16,7 @@ import UniversalLink from '@plone/volto/components/manage/UniversalLink/Universa
 
 import backSVG from '@plone/volto/icons/back.svg';
 import type { Location } from 'history';
+import type { BlocksConfigData } from '@plone/types';
 
 const messages = defineMessages({
   back: {
@@ -53,6 +55,35 @@ type SelectorState = {
   blockTypes: BlockTypesState;
 };
 
+/**
+ * List the configured blocks, by title.
+ *
+ * An add-on can configure a block that was never registered — enhancing one
+ * that ships with another add-on, say — which leaves an entry behind that is
+ * not a block at all, with no id or no title. `BlockConfigBase` says both are
+ * always there, but the config disagrees, so drop those entries rather than
+ * list a block that does not exist.
+ * @function sortConfigBlocks
+ * @param {BlocksConfigData} blocksConfig The blocks configuration.
+ * @param {IntlShape} intl Used to translate each block title.
+ * @returns {Array} The configured blocks, sorted by translated title.
+ */
+export function sortConfigBlocks(
+  blocksConfig: BlocksConfigData,
+  intl: IntlShape,
+) {
+  return Object.entries(blocksConfig)
+    .filter(([, blockConfig]) => blockConfig.id && blockConfig.title)
+    .map(([, blockConfig]) => ({
+      ...blockConfig,
+      title: intl.formatMessage({
+        id: blockConfig.title,
+        defaultMessage: blockConfig.title,
+      }),
+    }))
+    .sort((a, b) => (a.title === b.title ? 0 : a.title > b.title ? 1 : -1));
+}
+
 const BlockTypesControlpanel = (props: RouteProps) => {
   const { location } = props;
   const intl = useIntl();
@@ -62,17 +93,7 @@ const BlockTypesControlpanel = (props: RouteProps) => {
   const pathname = location.pathname;
   const isClient = useClient();
 
-  const blocks = Object.entries(blocksConfig)
-    .map(([key, blockConfig]) => ({
-      ...blockConfig,
-      title: blockConfig.title
-        ? intl.formatMessage({
-            id: blockConfig.title,
-            defaultMessage: blockConfig.title,
-          })
-        : blockConfig.id ?? key,
-    }))
-    .sort((a, b) => (a.title === b.title ? 0 : a.title > b.title ? 1 : -1));
+  const blocks = sortConfigBlocks(blocksConfig, intl);
 
   useEffect(() => {
     dispatch(getBlockTypes());


### PR DESCRIPTION
## Problem

An add-on can configure a block that was never registered — typically by enhancing a block that ships with another add-on that is not installed. `applyConfig` happily writes to `blocksConfig[key]`, and what it leaves behind is not a block: it carries only what the add-on set, with no `id` or no `title`.

The Block Types control panel listed those entries anyway, and a row with no `id` crashed the table.

The case in #8384 is Volto Light Theme configuring `volto-accordion-block` when it is not installed (kitconcept/volto-light-theme#903).

## Fix

Skip them. They are not blocks, so listing them would link to a block that does not exist.

The filter reads the configuration **before** the title falls back to the id:

```js
Object.entries(blocksConfig)
  .filter(([, blockConfig]) => blockConfig.id && blockConfig.title)
  .map(...)
```

Order matters here. Filtering after the map does not work: the fallback (`blockConfig.title ? … : blockConfig.id ?? key`) hands a title to an entry that has none, so an entry carrying an id but no title survives the `block.title` check and is listed. With the filter first, id and title are guaranteed and the map no longer needs the ternary or the key.

## Notes for reviewers

- **`sortConfigBlocks` is now exported**, so the behaviour can be tested directly. `BlockTypes.test.ts` is the first test for this component: 10 tests covering the three malformed shapes (no id + no title, id only, title only), the sort order, the title translation, and the invariant the table's row key depends on — every listed block has an id.
- **The tests were verified to fail.** Against the previous logic exactly one goes red — `drops an entry with an id but no title` — and the other nine stay green.
- **A rejected alternative is pinned by a test.** Falling back to the config key for a missing id (`id: blockConfig.id ?? key`) looks tempting, since Volto's convention is that the key *is* the id. It is wrong here: it resurrects the phantom entry and lists a block that does not exist. `does not fall back to the config key for a missing id` guards against reintroducing it.

## The open question

This answers the first half of #8384 — the control panel is now defensive. It does not answer the second half: *should Volto code in general assume blocks always have an id?*

Right now the types say yes. `BlockConfigBase` declares both `id: string` and `title: string` as required, so TypeScript believes this bug is impossible, and the test fixtures have to cast around the type to describe what the configuration really holds. If the answer is "no, do not assume", the type is where that belongs, and this fix is a workaround for a contract that is not enforced.

Worth deciding before other call sites grow the same guard.

Closes #8384
Ref: https://github.com/kitconcept/volto-light-theme/issues/903