### PR TITLE
Fix portrait passthrough API traversal

### DIFF
--- a/packages/volto/news/8390.bugfix
+++ b/packages/volto/news/8390.bugfix
@@ -1,0 +1,1 @@
+Fix development-mode portrait passthrough for Plone by routing requests through the `++api++` traversal layer. @sneridagh

--- a/packages/volto/src/config/server.js
+++ b/packages/volto/src/config/server.js
@@ -1,5 +1,6 @@
 import imagesMiddleware from '@plone/volto/express-middleware/images';
 import filesMiddleware from '@plone/volto/express-middleware/files';
+import portraitsMiddleware from '@plone/volto/express-middleware/portraits';
 import robotstxtMiddleware from '@plone/volto/express-middleware/robotstxt';
 import sitemapMiddleware from '@plone/volto/express-middleware/sitemap';
 import staticsMiddleware from '@plone/volto/express-middleware/static';
@@ -10,6 +11,7 @@ const settings = {
     devProxyMiddleware(),
     filesMiddleware(),
     imagesMiddleware(),
+    portraitsMiddleware(),
     robotstxtMiddleware(),
     sitemapMiddleware(),
     staticsMiddleware(),

--- a/packages/volto/src/express-middleware/portraits.js
+++ b/packages/volto/src/express-middleware/portraits.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import { getAPIResourceWithAuth } from '@plone/volto/helpers/Api/APIResourceWithAuth';
+import { getPloneBackendAPIResourceWithAuth } from '@plone/volto/helpers/Api/PloneBackendAPIResourceWithAuth';
 
 const HEADERS = [
   'content-type',
@@ -11,8 +11,8 @@ const HEADERS = [
   'x-robots-tag',
 ];
 
-function imageMiddlewareFn(req, res, next) {
-  getAPIResourceWithAuth(req)
+function portraitMiddlewareFn(req, res, next) {
+  getPloneBackendAPIResourceWithAuth(req)
     .then((resource) => {
       // Just forward the headers that we need
       HEADERS.forEach((header) => {
@@ -25,11 +25,10 @@ function imageMiddlewareFn(req, res, next) {
     .catch(next);
 }
 
-export default function imagesMiddleware() {
+export default function portraitsMiddleware() {
   const middleware = express.Router();
 
-  middleware.all(['**/@@images/*'], imageMiddlewareFn);
-  middleware.all(['/@@site-logo/*'], imageMiddlewareFn);
-  middleware.id = 'imageResourcesProcessor';
+  middleware.all(['/@portrait/*'], portraitMiddlewareFn);
+  middleware.id = 'portraitResourcesProcessor';
   return middleware;
 }

--- a/packages/volto/src/helpers/Api/PloneBackendAPIResourceWithAuth.js
+++ b/packages/volto/src/helpers/Api/PloneBackendAPIResourceWithAuth.js
@@ -1,0 +1,39 @@
+import superagent from 'superagent';
+import config from '@plone/volto/registry';
+import { addHeadersFactory } from '@plone/volto/helpers/Proxy/Proxy';
+import { stripSubpathPrefix } from '@plone/volto/helpers/Url/Url';
+
+/**
+ * Get a resource from Plone Backend (/++api++) with authenticated (if token exist) API headers
+ * @function getPloneBackendAPIResourceWithAuth
+ * @param {Object} req Request object
+ * @return {string} The response with the image
+ */
+export const getPloneBackendAPIResourceWithAuth = (req) =>
+  new Promise((resolve, reject) => {
+    const { settings } = config;
+    const apiSuffix = settings.legacyTraverse ? '' : '/++api++';
+    let apiPath = '';
+
+    if (settings.internalApiPath && __SERVER__) {
+      apiPath = settings.internalApiPath;
+    } else if (__DEVELOPMENT__ && settings.devProxyToApiPath) {
+      apiPath = settings.devProxyToApiPath;
+    } else {
+      apiPath = settings.apiPath;
+    }
+
+    //strip subpath if any
+    const contentPath = stripSubpathPrefix(req.path);
+
+    const request = superagent
+      .get(`${apiPath}${apiSuffix}${contentPath}`)
+      .maxResponseSize(settings.maxResponseSize)
+      .responseType('blob');
+    const authToken = req.universalCookies.get('auth_token');
+    if (authToken) {
+      request.set('Authorization', `Bearer ${authToken}`);
+    }
+    request.use(addHeadersFactory(req));
+    request.then(resolve).catch(reject);
+  });

--- a/packages/volto/src/helpers/Api/PloneBackendAPIResourceWithAuth.test.js
+++ b/packages/volto/src/helpers/Api/PloneBackendAPIResourceWithAuth.test.js
@@ -1,0 +1,60 @@
+import superagent from 'superagent';
+import config from '@plone/volto/registry';
+import { getPloneBackendAPIResourceWithAuth } from './PloneBackendAPIResourceWithAuth';
+
+vi.mock('superagent', () => ({
+  default: {
+    get: vi.fn(() => ({
+      maxResponseSize: vi.fn().mockReturnThis(),
+      responseType: vi.fn().mockReturnThis(),
+      set: vi.fn(),
+      use: vi.fn(),
+      then: vi.fn((resolve) => resolve()),
+    })),
+  },
+}));
+
+const request = {
+  path: '/@portrait/admin',
+  universalCookies: { get: vi.fn() },
+  headers: {},
+};
+
+describe('getPloneBackendAPIResourceWithAuth', () => {
+  const originalSettings = { ...config.settings };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('__DEVELOPMENT__', true);
+    Object.assign(config.settings, originalSettings, {
+      apiPath: 'http://localhost:3000',
+      devProxyToApiPath: 'http://localhost:8080/Plone',
+      internalApiPath: undefined,
+    });
+  });
+
+  afterAll(() => {
+    vi.unstubAllGlobals();
+    Object.assign(config.settings, originalSettings);
+  });
+
+  it('uses the API traversal path for Plone in development', async () => {
+    config.settings.legacyTraverse = false;
+
+    await getPloneBackendAPIResourceWithAuth(request);
+
+    expect(superagent.get).toHaveBeenCalledWith(
+      'http://localhost:8080/Plone/++api++/@portrait/admin',
+    );
+  });
+
+  it('omits the API traversal path for legacy backends in development', async () => {
+    config.settings.legacyTraverse = true;
+
+    await getPloneBackendAPIResourceWithAuth(request);
+
+    expect(superagent.get).toHaveBeenCalledWith(
+      'http://localhost:8080/Plone/@portrait/admin',
+    );
+  });
+});


### PR DESCRIPTION
## What

Move the `/@portrait/*` server passthrough out of the general image middleware into a dedicated portrait middleware.

The dedicated helper preserves the backend traversal choice while using the development backend URL:

- Plone uses `/++api++/@portrait/...`, so the portrait endpoint is served through the API traversal layer.
- Backends configured with legacy traversal use `/@portrait/...` without the `++api++` segment.

Other image resources (`@@images` and `@@site-logo`) retain their existing passthrough behavior.

## Why

This addresses a regression introduced by [#5429](https://github.com/plone/volto/pull/5429). That change intentionally omitted `++api++` for development passthroughs to support the Nick backend, but it also made the Plone `@portrait` passthrough bypass the API traversal layer.

## Compatibility note

This may break portraits in development for Nick installations that have not enabled legacy traversal. Configure the development environment with **`RAZZLE_LEGACY_TRAVERSE`** to keep the portrait request on the non-`++api++` route.

## Tests

- `pnpm --filter @plone/volto test --run src/helpers/Api/PloneBackendAPIResourceWithAuth.test.js src/express-middleware/images.test.js`