### PR TITLE
Forces the use of webpack 5.105.4

### DIFF
--- a/packages/generator-volto/generators/app/templates/package.json.tpl
+++ b/packages/generator-volto/generators/app/templates/package.json.tpl
@@ -80,7 +80,8 @@
   "resolutions": {
     "@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
     "react-error-overlay": "6.0.9",
-    "react-refresh": "0.14.0"
+    "react-refresh": "0.14.0",
+    "webpack": "5.105.4"
   },
   "packageManager": "yarn@3.2.3"
 }

--- a/packages/generator-volto/news/8396.bugfix
+++ b/packages/generator-volto/news/8396.bugfix
@@ -1,0 +1,1 @@
+Forces the use of webpack 5.105.4. This avoids compatibility errors with the version required by Storybook. @wesleybl


### PR DESCRIPTION
This avoids compatibility errors with the version required by Storybook. It prevents the error:

`TypeError: Cannot use 'in' operator to search for 'start' in undefined`

Two incompatible versions of webpack were installed. Objects generated by one version were being processed by the other, causing the error. This enforces the use of a single version.

See the error in: https://github.com/plone/volto/actions/runs/30935387825/job/92080103014