### PR TITLE
Allow .cjs and .mjs files to be shadowed

### DIFF
--- a/packages/registry/__tests__/addon-registry.test.js
+++ b/packages/registry/__tests__/addon-registry.test.js
@@ -230,6 +230,9 @@ describe('AddonRegistry - Project', () => {
       '@plone/volto/LanguageSwitcher': `${base}/src/customizations/LanguageSwitcher.js`,
       '@plone/volto/TSComponent': `${base}/src/customizations/TSComponent.jsx`,
       '@plone/volto/client': `${base}/src/customizations/client.js`,
+      // .cjs is shadowable, and the alias key keeps its extension because
+      // such modules are imported with it. See #8366.
+      '@plone/volto/constants/Languages.cjs': `${base}/src/customizations/constants/Languages.cjs`,
       '@plone/volto/routes': `${base}/src/customizations/routes.tsx`,
       'test-addon/testaddon': `${base}/src/custom-addons/test-addon/testaddon.js`,
       '@plone/volto/server': `${base}/src/customizations/server.jsx`,

--- a/packages/registry/__tests__/fixtures/test-volto-project/node_modules/@plone/volto/src/constants/Languages.cjs
+++ b/packages/registry/__tests__/fixtures/test-volto-project/node_modules/@plone/volto/src/constants/Languages.cjs
@@ -1,0 +1,1 @@
+module.exports = { en: 'English' };

--- a/packages/registry/__tests__/fixtures/test-volto-project/src/customizations/constants/Languages.cjs
+++ b/packages/registry/__tests__/fixtures/test-volto-project/src/customizations/constants/Languages.cjs
@@ -1,0 +1,1 @@
+module.exports = { en: 'English', sv: 'Svenska' };

--- a/packages/registry/news/8366.bugfix
+++ b/packages/registry/news/8366.bugfix
@@ -1,0 +1,1 @@
+Include `.cjs` and `.mjs` in the customizations glob so core modules with those extensions can be shadowed. @kunalKumar-13

--- a/packages/registry/src/addon-registry/addon-registry.ts
+++ b/packages/registry/src/addon-registry/addon-registry.ts
@@ -743,7 +743,7 @@ class AddonRegistry {
 
       reg.forEach(({ customPath, name, sourcePath }) => {
         glob(
-          `${customPath}/**/*.*(svg|png|jpg|jpeg|gif|ico|less|js|jsx|ts|tsx)`,
+          `${customPath}/**/*.*(svg|png|jpg|jpeg|gif|ico|less|js|jsx|ts|tsx|cjs|mjs)`,
         ).map((filename) => {
           function changeFileExtension(filePath: string) {
             // Extract the current file extension


### PR DESCRIPTION
Closes #8366.

The customizations glob listed `svg|png|jpg|jpeg|gif|ico|less|js|jsx|ts|tsx`, so a shadow of a core `.cjs` module — canonically `constants/Languages.cjs` — was never collected and never became a webpack alias. Nothing warned: the shadow was simply ignored, which is what made it expensive to diagnose.

Adds `cjs|mjs` to that glob.

The alias-key extension strip (`/\.(js|jsx|ts|tsx)$/`) is deliberately left alone, per @mpalomaki's note on the issue. `.cjs` and `.mjs` modules are imported *with* their extension, so the alias key must keep it. That regex already does the right thing — `.cjs` does not match `\.js$`, since the character before `js` is `c`, not a dot — so the key comes out as `@plone/volto/constants/Languages.cjs`, which is what the exact-specifier match needs.

### Test

A `.cjs` shadow pair is added to the existing `test-volto-project` fixture, and the alias assertion in `addon-registry.test.js` now expects `@plone/volto/constants/Languages.cjs` mapped to the customization — which also pins the extension-retention behaviour above.

The fixture's source side lives under `__tests__/fixtures/.../node_modules/`, so it needed `git add -f` like its neighbours.

`packages/registry`: 17/17 in `addon-registry.test.js`, 112 passing overall. `src/vite-plugin.test.tsx` fails to resolve `@plone/registry/addon-registry` in my environment, but it fails identically on a clean `main`, so it is unrelated to this change. Prettier clean.

I did not implement the optional build-time warning suggested in the issue — happy to add it here or in a follow-up if you'd like it.
