### PR TITLE
Guard /change-password against anonymous visitors

### DIFF
--- a/packages/volto/news/8367.bugfix
+++ b/packages/volto/news/8367.bugfix
@@ -1,0 +1,1 @@
+Redirect anonymous visitors away from `/change-password` instead of rendering a password form that can never submit successfully. @kunalKumar-13

--- a/packages/volto/src/components/manage/Preferences/ChangePassword.jsx
+++ b/packages/volto/src/components/manage/Preferences/ChangePassword.jsx
@@ -12,6 +12,7 @@ import { Form } from '@plone/volto/components/manage/Form';
 import Icon from '@plone/volto/components/theme/Icon/Icon';
 import Toast from '@plone/volto/components/manage/Toast/Toast';
 import Toolbar from '@plone/volto/components/manage/Toolbar/Toolbar';
+import Unauthorized from '@plone/volto/components/theme/Unauthorized/Unauthorized';
 import { updatePassword } from '@plone/volto/actions/users/users';
 import { getBaseUrl } from '@plone/volto/helpers/Url/Url';
 import backSVG from '@plone/volto/icons/back.svg';
@@ -69,6 +70,7 @@ const ChangePassword = () => {
   const dispatch = useDispatch();
   const isClient = useClient();
 
+  const token = useSelector((state) => state.userSession.token);
   const userId = useSelector(
     (state) =>
       state.userSession.token ? jwtDecode(state.userSession.token).sub : '',
@@ -97,6 +99,13 @@ const ChangePassword = () => {
   const onCancel = () => {
     history.goBack();
   };
+
+  // Without a token the form can only ever fail: userId is empty and the
+  // backend rejects updatePassword. Unauthorized redirects to the login route
+  // with a return_url, matching the other manage surfaces.
+  if (!token) {
+    return <Unauthorized />;
+  }
 
   return (
     <Container id="page-change-password">

--- a/packages/volto/src/components/manage/Preferences/ChangePassword.test.jsx
+++ b/packages/volto/src/components/manage/Preferences/ChangePassword.test.jsx
@@ -69,7 +69,7 @@ describe('ChangePassword', () => {
           <MemoryRouter initialEntries={['/change-password']}>
             <Switch>
               <Route exact path="/change-password" component={ChangePassword} />
-              <Route path="*" render={() => <div id="redirected" />} />
+              <Route render={() => <div id="redirected" />} />
             </Switch>
           </MemoryRouter>
         </CookiesProvider>

--- a/packages/volto/src/components/manage/Preferences/ChangePassword.test.jsx
+++ b/packages/volto/src/components/manage/Preferences/ChangePassword.test.jsx
@@ -3,7 +3,7 @@ import { render } from '@testing-library/react';
 import { Provider } from 'react-intl-redux';
 import configureStore from 'redux-mock-store';
 import jwt from 'jsonwebtoken';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, Route, Switch } from 'react-router-dom';
 import { CookiesProvider } from 'react-cookie';
 
 import ChangePassword from './ChangePassword';
@@ -51,5 +51,33 @@ describe('ChangePassword', () => {
     );
 
     expect(container).toMatchSnapshot();
+  });
+
+  it('does not render the form to an anonymous visitor', () => {
+    const store = mockStore({
+      userSession: { token: null },
+      apierror: {},
+      intl: { locale: 'en', messages: {} },
+      users: { update_password: { loading: false } },
+      content: { data: {}, create: { loading: false, loaded: true } },
+    });
+    // Rendered through a Route so the Unauthorized redirect navigates away
+    // instead of re-mounting this component at the new path.
+    const { container } = render(
+      <Provider store={store}>
+        <CookiesProvider>
+          <MemoryRouter initialEntries={['/change-password']}>
+            <Switch>
+              <Route exact path="/change-password" component={ChangePassword} />
+              <Route path="*" render={() => <div id="redirected" />} />
+            </Switch>
+          </MemoryRouter>
+        </CookiesProvider>
+      </Provider>,
+    );
+
+    expect(container.querySelector('#page-change-password')).toBeNull();
+    expect(container.querySelector('input[type="password"]')).toBeNull();
+    expect(container.querySelector('#redirected')).not.toBeNull();
   });
 });


### PR DESCRIPTION
Closes #8367.

A signed-out visitor loading `/change-password` was served the complete form — Current password / New password / Confirm — fully rendered and interactive. As @mpalomaki noted on the issue, submitting could only ever fail: with no token `userId` resolves to `''` and the backend rejects `updatePassword`. So it is a form that cannot succeed rather than a data leak, but it is still the wrong thing to show.

Took the component-level guard suggested in the issue, as the smallest change that covers every registration: `ChangePassword` now renders `Unauthorized` when there is no token.

`Unauthorized` already does exactly what the issue asks for in that state — it redirects to the login route with `?return_url=`, so a signed-out visitor lands on login and is returned afterwards. No new redirect logic was needed.

I left `nonContentRoutesPublic` alone. The guard covers the behaviour, and removing `/change-password` from that list looked like it could affect route classification more broadly than this issue calls for. Happy to do that too if you'd prefer both.

### Test

`ChangePassword.test.jsx` gains an anonymous case asserting the form is not rendered and that the router has navigated away.

Worth flagging: it renders through a `Switch`/`Route` rather than mounting the component directly. Mounted directly, the redirect re-mounts `ChangePassword` at the new path and it redirects again — "Maximum update depth exceeded". That is an artefact of rendering a redirecting component outside a route, not a loop in the product, but it is why the test is shaped this way.

2/2 passing in that file. Prettier clean.

Note for anyone reproducing locally: `packages/registry` has to be built (`npx tsup` in that package) before volto's tests can resolve `@plone/registry`, otherwise every test file fails to transform on a clean checkout too.
