### PR TITLE
Move table row/column insertion controls to a floating menu (#8409)

### DIFF
--- a/packages/volto-slate/news/8409.feature
+++ b/packages/volto-slate/news/8409.feature
@@ -1,0 +1,1 @@
+Move table row and column insertion and deletion controls to a floating menu above the currently selected row. @r4-rahul123

--- a/packages/volto-slate/src/blocks/Table/TableBlockEdit.jsx
+++ b/packages/volto-slate/src/blocks/Table/TableBlockEdit.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import PropTypes from 'prop-types';
 import isEmpty from 'lodash/isEmpty';
 import map from 'lodash/map';
@@ -182,12 +182,33 @@ const Edit = (props) => {
     row: 0,
     cell: 0,
   });
+  const tableRef = useRef(null);
+  const [toolbarTop, setToolbarTop] = useState(-32);
+
   // If selected prop is unset, update the state
   useEffect(() => {
     if (!selected) {
       setSelectedCell(null);
     }
   }, [selected]);
+
+  useEffect(() => {
+    if (!selected || !selectedCell || !tableRef.current) {
+      setToolbarTop(-32);
+      return;
+    }
+    let rowEl;
+    if (!data.table?.hideHeaders && selectedCell.row === 0) {
+      rowEl = tableRef.current.querySelector('thead tr');
+    } else {
+      const bodyRows = tableRef.current.querySelectorAll('tbody tr');
+      const rowIndex = selectedCell.row > 0 ? selectedCell.row - 1 : 0;
+      rowEl = bodyRows[rowIndex];
+    }
+    if (rowEl) {
+      setToolbarTop(rowEl.offsetTop - 34);
+    }
+  }, [selected, selectedCell, data.table]);
 
   useEffect(() => {
     if (!data.table || isEmpty(data.table)) {
@@ -348,9 +369,15 @@ const Edit = (props) => {
   }, [data, block, onChangeBlock, selectedCell]);
 
   return (
-    <div className={cx('block table', { selected })}>
+    <div ref={tableRef} className={cx('block table', { selected })}>
       {selected && (
-        <div className="toolbar">
+        <div
+          className="toolbar"
+          style={{
+            top: `${toolbarTop}px`,
+            transition: 'top 0.15s ease-in-out',
+          }}
+        >
           <Button.Group>
             <Button
               icon

--- a/packages/volto-slate/src/blocks/Table/TableBlockEdit.jsx
+++ b/packages/volto-slate/src/blocks/Table/TableBlockEdit.jsx
@@ -208,6 +208,7 @@ const Edit = (props) => {
     if (rowEl) {
       setToolbarTop(rowEl.offsetTop);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selected, selectedCell?.row, data.table?.hideHeaders]);
 
   useEffect(() => {

--- a/packages/volto-slate/src/blocks/Table/TableBlockEdit.jsx
+++ b/packages/volto-slate/src/blocks/Table/TableBlockEdit.jsx
@@ -183,7 +183,7 @@ const Edit = (props) => {
     cell: 0,
   });
   const tableRef = useRef(null);
-  const [toolbarTop, setToolbarTop] = useState(-32);
+  const [toolbarTop, setToolbarTop] = useState(0);
 
   // If selected prop is unset, update the state
   useEffect(() => {
@@ -194,7 +194,7 @@ const Edit = (props) => {
 
   useEffect(() => {
     if (!selected || !selectedCell || !tableRef.current) {
-      setToolbarTop(-32);
+      setToolbarTop(0);
       return;
     }
     let rowEl;
@@ -206,9 +206,9 @@ const Edit = (props) => {
       rowEl = bodyRows[rowIndex];
     }
     if (rowEl) {
-      setToolbarTop(rowEl.offsetTop - 34);
+      setToolbarTop(rowEl.offsetTop);
     }
-  }, [selected, selectedCell, data.table]);
+  }, [selected, selectedCell?.row, data.table?.hideHeaders]);
 
   useEffect(() => {
     if (!data.table || isEmpty(data.table)) {
@@ -375,7 +375,6 @@ const Edit = (props) => {
           className="toolbar"
           style={{
             top: `${toolbarTop}px`,
-            transition: 'top 0.15s ease-in-out',
           }}
         >
           <Button.Group>

--- a/packages/volto/news/8409.feature
+++ b/packages/volto/news/8409.feature
@@ -1,0 +1,1 @@
+Move table row and column insertion and deletion controls to a floating menu above the currently selected row. @r4-rahul123

--- a/packages/volto/theme/themes/pastanaga/extras/blocks.less
+++ b/packages/volto/theme/themes/pastanaga/extras/blocks.less
@@ -292,8 +292,16 @@ body.has-toolbar.has-sidebar-collapsed .ui.wrapper > .ui.inner.block.full {
   line-height: @headerLineHeight;
 }
 
-.ui.block.table {
+.ui.block.table,
+.block.table {
+  --toolbar-gap: 2px;
   border: 0;
+
+  .toolbar {
+    top: 0;
+    transform: translate(-50%, calc(-100% - var(--toolbar-gap)));
+    transition: top 0.15s ease-in-out;
+  }
 }
 
 .block {


### PR DESCRIPTION
- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't other open [pull requests](https://github.com/plone/volto/pulls) for the same change.
- [x] I followed the guidelines in [Contributing to Volto](https://6.docs.plone.org/volto/contributing/index.html).
- [x] I successfully ran [code linting checks](https://6.docs.plone.org/volto/contributing/linting.html) on my changes locally.
- [x] I successfully ran [unit tests](https://6.docs.plone.org/volto/contributing/testing.html) on my changes locally.
- [ ] I successfully ran [acceptance tests](https://6.docs.plone.org/volto/contributing/acceptance-tests.html) on my changes locally.
- [ ] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/volto/contributing/documentation.html#narrative-documentation) for my changes, either in the Storybook or narrative documentation.
- [x] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

Closes #8409

### Summary of changes
- Updated the Table block edit component (`TableBlockEdit.jsx`) so that the row and column insertion/deletion controls float contextually above the currently selected row rather than staying fixed at the top of the table.
- Reuses the existing toolbar buttons and icons as guided in https://github.com/plone/volto/issues/8409#issuecomment-5512117592.
- Added smooth transition when navigating between table rows.
- Added Towncrier news entry (`8409.feature`).