### PR TITLE
Forward port fix #8410: copy/cut/paste blocks inside container blocks to …

### DIFF
--- a/packages/volto/cypress/support/commands.js
+++ b/packages/volto/cypress/support/commands.js
@@ -832,8 +832,8 @@ function shouldVerifyContent(type) {
   return !type.includes('{');
 }
 
-Cypress.Commands.add('getSlateEditorAndType', (type) => {
-  cy.getSlate().click().trigger('focus').type(type);
+Cypress.Commands.add('getSlateEditorAndType', (type, options = {}) => {
+  cy.getSlate().click(options).trigger('focus', options).type(type, options);
 
   if (shouldVerifyContent(type)) {
     return cy.getSlate().should('contain', type);

--- a/packages/volto/cypress/tests/core/blocks/blocks-copypaste.js
+++ b/packages/volto/cypress/tests/core/blocks/blocks-copypaste.js
@@ -38,11 +38,17 @@ describe('Blocks copy/paste', () => {
     cy.get('a[aria-label="Edit"]').click();
 
     // WHEN: I copy paste them
-    cy.getSlateTitle().focus().click().type('{shift}', { release: false });
+    // NOTE: focus the title without clicking, like the Delete test below.
+    // A click leaves a text-selection anchor in the title; when Cypress
+    // then scrolls the image block into view, the browser can re-anchor
+    // the scroll on that caret, moving the sticky page header over the
+    // image click point (Volto 17 layout), so the click lands on the
+    // header instead of the block. Focus alone already selects the title.
+    cy.getSlateTitle().focus().type('{shift}', { release: false });
     cy.get('.block-editor-maps').click();
     cy.get('#toolbar-copy-blocks').click();
 
-    cy.getSlateEditorAndType('{shift}').click();
+    cy.getSlateEditorAndType('{shift}', { force: true }).click({ force: true });
     cy.get('#toolbar-paste-blocks').should('be.visible');
     cy.get('#toolbar-paste-blocks').click();
 
@@ -77,11 +83,12 @@ describe('Blocks copy/paste', () => {
     cy.get('a[aria-label="Edit"]').click();
 
     // WHEN: I cut paste them
-    cy.getSlateTitle().focus().click().type('{shift}', { release: false });
+    // Same focus-without-click gesture as the Copy test (see note there).
+    cy.getSlateTitle().focus().type('{shift}', { release: false });
     cy.get('.block-editor-maps').click();
     cy.get('#toolbar-cut-blocks').click();
 
-    cy.getSlateEditorAndType('{shift}').click();
+    cy.getSlateEditorAndType('{shift}', { force: true }).click({ force: true });
 
     cy.get('#toolbar-paste-blocks').should('be.visible');
     cy.get('#toolbar-paste-blocks').click();

--- a/packages/volto/cypress/tests/core/blocks/blocks-grid.js
+++ b/packages/volto/cypress/tests/core/blocks/blocks-grid.js
@@ -114,5 +114,73 @@ context('Blocks Acceptance Tests', () => {
         .should('have.attr', 'href')
         .and('include', 'https://google.com');
     });
+
+    it('As editor I can copy a block into a Grid', function () {
+      cy.intercept('PATCH', '/**/document').as('edit');
+
+      // GIVEN: a text block outside the grid
+      cy.getSlate().click().type('Copy me into the grid');
+
+      // WHEN: shift+click the text block to multi-select it, then copy
+      cy.get('.block-editor-slate').first().click();
+      cy.get('.block-editor-slate').first().click({ shiftKey: true });
+      cy.get('#toolbar-copy-blocks').should('be.visible');
+      cy.get('#toolbar-copy-blocks').click();
+
+      // AND: add a grid block below and an empty text block inside it
+      cy.getSlate().click().type('{moveToEnd}{enter}');
+      cy.addNewBlock('grid', true);
+      cy.findByText('2 columns').click();
+
+      cy.get('button[aria-label="Add block in position 0"]').click();
+      cy.get('.blocks-chooser [aria-label="Unfold Text blocks"]').click();
+      cy.wait(200);
+      cy.get('.blocks-chooser .text .button.slate').click();
+
+      // THEN: the paste button appears and pastes inside the grid
+      cy.get('#toolbar-paste-blocks').should('be.visible');
+      cy.get('#toolbar-paste-blocks').click();
+
+      cy.get('#toolbar-save').click();
+      cy.wait('@edit');
+      cy.wait('@content');
+
+      cy.findAllByText('Copy me into the grid').should('have.length', 2);
+    });
+
+    it('As editor I can cut a block into a Grid', function () {
+      cy.intercept('PATCH', '/**/document').as('edit');
+
+      // GIVEN: a text block outside the grid
+      cy.getSlate().click().type('Copy me into the grid');
+
+      // WHEN: shift+click the text block to multi-select it, then copy
+      cy.get('.block-editor-slate').first().click();
+      cy.get('.block-editor-slate').first().click({ shiftKey: true });
+      cy.get('#toolbar-cut-blocks').should('be.visible');
+      cy.get('#toolbar-cut-blocks').click();
+
+      cy.getSlateTitle().focus().click().type('{enter}');
+      cy.getSlate().click();
+      cy.addNewBlock('grid', true);
+      // AND: add a grid block below and an empty text block inside it
+
+      cy.findByText('2 columns').click();
+
+      cy.get('button[aria-label="Add block in position 0"]').click();
+      cy.get('.blocks-chooser [aria-label="Unfold Text blocks"]').click();
+      cy.wait(200);
+      cy.get('.blocks-chooser .text .button.slate').click();
+
+      // THEN: the paste button appears and pastes inside the grid
+      cy.get('#toolbar-paste-blocks').should('be.visible');
+      cy.get('#toolbar-paste-blocks').click();
+
+      cy.get('#toolbar-save').click();
+      cy.wait('@edit');
+      cy.wait('@content');
+
+      cy.findAllByText('Copy me into the grid').should('have.length', 1);
+    });
   });
 });

--- a/packages/volto/news/8410.bugfix
+++ b/packages/volto/news/8410.bugfix
@@ -1,0 +1,1 @@
+Fixed multi-selection of blocks within container blocks (grid, group, columns) and ensured the copy/paste toolbar works reliably across nested forms. @nileshgulia1

--- a/packages/volto/src/components/manage/Blocks/Block/Edit.jsx
+++ b/packages/volto/src/components/manage/Blocks/Block/Edit.jsx
@@ -11,6 +11,7 @@ import { defineMessages, injectIntl } from 'react-intl';
 import cx from 'classnames';
 import { setSidebarTab } from '@plone/volto/actions/sidebar/sidebar';
 import { setUIState } from '@plone/volto/actions/form/form';
+
 import config from '@plone/volto/registry';
 import withObjectBrowser from '@plone/volto/components/manage/Sidebar/ObjectBrowser';
 import ViewDefaultBlock from '@plone/volto/components/manage/Blocks/Block/DefaultView';
@@ -58,6 +59,8 @@ export class Edit extends Component {
    * @property {Object} defaultProps Default properties.
    * @static
    */
+  blockNode = React.createRef();
+
   static defaultProps = {
     manage: false,
     editable: true,
@@ -113,7 +116,22 @@ export class Edit extends Component {
     }
   }
 
-  blockNode = React.createRef();
+  /**
+   * True when the event originates inside a nested block form rendered by
+   * this block (e.g. a child block of a Group, Columns, Grid, Tabs or
+   * Accordion container). Child modifier semantics belong to the nested
+   * form; the container may only activate itself as a single selection.
+   * @param {Event} event the synthetic event
+   * @returns {boolean}
+   */
+  isNestedFormEvent = (event) => {
+    const node = this.blockNode.current;
+    if (!node || !event?.target?.closest) {
+      return false;
+    }
+    const nestedForm = event.target.closest('.blocks-form');
+    return !!nestedForm && node.contains(nestedForm);
+  };
 
   /**
    * Render method.
@@ -154,25 +172,31 @@ export class Edit extends Component {
               e.stopPropagation();
               this.props.setUIState({ hovered: null });
             }}
-            onClick={(e) => {
+            onMouseDown={(e) => {
+              if (this.isNestedFormEvent(e)) {
+                return;
+              }
               const isMultipleSelection = e.shiftKey || e.ctrlKey || e.metaKey;
-              !this.props.selected &&
-                this.props.onSelectBlock(
-                  this.props.id,
-                  this.props.selected ? false : isMultipleSelection,
-                  e,
-                );
+              if (!this.props.selected && isMultipleSelection) {
+                e.preventDefault();
+              }
             }}
-            // onFocus={(e) => {
-            //   // TODO: This `onFocus` steals somehow the focus from the slate block
-            //   // we have to investigate why this is happening
-            //   // Apparently, I can't see any difference in the behavior
-            //   // If any, we can fix it in successive iterations
-            //   // if (this.props.hovered !== this.props.id) {
-            //   //   this.props.setUIState({ hovered: this.props.id });
-            //   // }
-            // }}
+            onClick={(e) => {
+              if (this.isNestedFormEvent(e)) {
+                !this.props.selected &&
+                  this.props.onSelectBlock(this.props.id, false);
+                return;
+              }
+              const isMultipleSelection = e.shiftKey || e.ctrlKey || e.metaKey;
+              (!this.props.selected || isMultipleSelection) &&
+                this.props.onSelectBlock(this.props.id, isMultipleSelection, e);
+            }}
             onFocus={(e) => {
+              if (this.isNestedFormEvent(e)) {
+                !this.props.selected &&
+                  this.props.onSelectBlock(this.props.id, false);
+                return;
+              }
               const isMultipleSelection = e.shiftKey || e.ctrlKey || e.metaKey;
               !this.props.selected &&
                 this.props.onSelectBlock(
@@ -227,7 +251,6 @@ export class Edit extends Component {
               e.stopPropagation();
               this.props.setUIState({ hovered: this.props.id });
             }}
-            // Mantenha apenas este onFocus ou remova se não for necessário
             onFocus={(e) => {
               e.preventDefault();
               e.stopPropagation();

--- a/packages/volto/src/components/manage/Blocks/Block/Edit.test.jsx
+++ b/packages/volto/src/components/manage/Blocks/Block/Edit.test.jsx
@@ -1,0 +1,258 @@
+import React from 'react';
+import { createEvent, fireEvent, render } from '@testing-library/react';
+import config from '@plone/volto/registry';
+import { Edit } from './Edit';
+
+const blockId = 'block-id';
+const TestBlock = () => <div data-testid="test-block" />;
+const NestedContainerBlock = () => (
+  <div>
+    <div className="blocks-form">
+      <div className="block child" data-testid="nested-child" />
+    </div>
+  </div>
+);
+
+const renderEdit = (extraProps = {}) => {
+  const onSelectBlock = jest.fn();
+
+  const result = render(
+    <Edit
+      type="test"
+      data={{ '@type': 'test' }}
+      properties={{}}
+      selected={false}
+      multiSelected={false}
+      index={0}
+      id={blockId}
+      manage={false}
+      editable
+      pathname="/test"
+      onMoveBlock={jest.fn()}
+      onDeleteBlock={jest.fn()}
+      onSelectBlock={onSelectBlock}
+      handleKeyDown={jest.fn()}
+      setSidebarTab={jest.fn()}
+      setUIState={jest.fn()}
+      intl={{ formatMessage: jest.fn() }}
+      hovered={null}
+      sidebarTab={0}
+      {...extraProps}
+    />,
+  );
+
+  return {
+    ...result,
+    block: result.getByRole('presentation'),
+    onSelectBlock,
+  };
+};
+
+describe('Block Edit modified mouse selection', () => {
+  beforeAll(() => {
+    config.blocks.blocksConfig.test = {
+      edit: TestBlock,
+      sidebarTab: 0,
+    };
+  });
+
+  afterAll(() => {
+    delete config.blocks.blocksConfig.test;
+  });
+
+  it.each([
+    ['Shift', { shiftKey: true }],
+    ['Control', { ctrlKey: true }],
+    ['Meta', { metaKey: true }],
+  ])(
+    'prevents %s-mousedown from focusing an unselected block first',
+    (_modifier, eventInit) => {
+      const { block } = renderEdit();
+      const event = createEvent.mouseDown(block, {
+        bubbles: true,
+        cancelable: true,
+        ...eventInit,
+      });
+
+      fireEvent(block, event);
+
+      expect(event.defaultPrevented).toBe(true);
+    },
+  );
+
+  it('does not prevent an ordinary mousedown', () => {
+    const { block } = renderEdit();
+    const event = createEvent.mouseDown(block, {
+      bubbles: true,
+      cancelable: true,
+    });
+
+    fireEvent(block, event);
+
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it('does not prevent modified mousedown on the already selected block', () => {
+    const { block } = renderEdit({ selected: true });
+    const event = createEvent.mouseDown(block, {
+      bubbles: true,
+      cancelable: true,
+      metaKey: true,
+    });
+
+    fireEvent(block, event);
+
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it('preserves ordinary focus selection for keyboard navigation', () => {
+    const { block, onSelectBlock } = renderEdit();
+
+    fireEvent.focus(block);
+
+    expect(onSelectBlock).toHaveBeenCalledWith(
+      blockId,
+      undefined,
+      expect.objectContaining({ type: 'focus' }),
+    );
+  });
+
+  it('preserves modified click selection after mousedown focus is suppressed', () => {
+    const { block, onSelectBlock } = renderEdit();
+
+    fireEvent.click(block, { metaKey: true });
+
+    expect(onSelectBlock).toHaveBeenCalledWith(
+      blockId,
+      true,
+      expect.objectContaining({ type: 'click' }),
+    );
+  });
+
+  it('forwards a modified click on the active block for promotion', () => {
+    const { block, onSelectBlock } = renderEdit({ selected: true });
+
+    fireEvent.click(block, { metaKey: true });
+
+    expect(onSelectBlock).toHaveBeenCalledWith(
+      blockId,
+      true,
+      expect.objectContaining({ type: 'click' }),
+    );
+  });
+});
+
+describe('Container block nested form events', () => {
+  beforeAll(() => {
+    config.blocks.blocksConfig.nestedContainer = {
+      edit: NestedContainerBlock,
+      sidebarTab: 0,
+    };
+  });
+
+  afterAll(() => {
+    delete config.blocks.blocksConfig.nestedContainer;
+  });
+
+  const renderContainer = (extraProps = {}) =>
+    renderEdit({ type: 'nestedContainer', ...extraProps });
+
+  it('activates the container singly when a nested form child is focused', () => {
+    const { onSelectBlock, getByTestId } = renderContainer();
+
+    fireEvent.focus(getByTestId('nested-child'));
+
+    expect(onSelectBlock).toHaveBeenCalledWith(blockId, false);
+  });
+
+  it('activates the container singly when a nested form child is clicked', () => {
+    const { onSelectBlock, getByTestId } = renderContainer();
+
+    fireEvent.click(getByTestId('nested-child'));
+
+    expect(onSelectBlock).toHaveBeenCalledWith(blockId, false);
+  });
+
+  it.each([
+    ['Control', { ctrlKey: true }],
+    ['Meta', { metaKey: true }],
+    ['Shift', { shiftKey: true }],
+  ])(
+    'activates the container without forwarding a child %s event',
+    (_modifier, eventInit) => {
+      const { onSelectBlock, getByTestId } = renderContainer();
+
+      fireEvent.click(getByTestId('nested-child'), eventInit);
+
+      expect(onSelectBlock).toHaveBeenCalledWith(blockId, false);
+    },
+  );
+
+  it.each([
+    ['Control', { ctrlKey: true }],
+    ['Meta', { metaKey: true }],
+    ['Shift', { shiftKey: true }],
+  ])(
+    'does not apply child %s selection to an active container',
+    (_modifier, eventInit) => {
+      const { onSelectBlock, getByTestId } = renderContainer({
+        selected: true,
+      });
+
+      fireEvent.click(getByTestId('nested-child'), eventInit);
+
+      expect(onSelectBlock).not.toHaveBeenCalled();
+    },
+  );
+
+  it('does not prevent modified mousedown inside a nested form', () => {
+    const { getByTestId } = renderContainer();
+    const nestedChild = getByTestId('nested-child');
+    const event = createEvent.mouseDown(nestedChild, {
+      bubbles: true,
+      cancelable: true,
+      metaKey: true,
+    });
+
+    fireEvent(nestedChild, event);
+
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it('still selects the container when its own chrome is clicked', () => {
+    const { block, onSelectBlock } = renderContainer();
+
+    fireEvent.click(block);
+
+    expect(onSelectBlock).toHaveBeenCalledWith(
+      blockId,
+      false,
+      expect.objectContaining({ type: 'click' }),
+    );
+  });
+
+  it('still forwards a modified click on the container chrome', () => {
+    const { block, onSelectBlock } = renderContainer({ selected: true });
+
+    fireEvent.click(block, { metaKey: true });
+
+    expect(onSelectBlock).toHaveBeenCalledWith(
+      blockId,
+      true,
+      expect.objectContaining({ type: 'click' }),
+    );
+  });
+
+  it('still prevents modified mousedown on the unselected container chrome', () => {
+    const { block } = renderContainer();
+    const event = createEvent.mouseDown(block, {
+      bubbles: true,
+      cancelable: true,
+      metaKey: true,
+    });
+
+    fireEvent(block, event);
+
+    expect(event.defaultPrevented).toBe(true);
+  });
+});

--- a/packages/volto/src/components/manage/Blocks/Container/Edit.jsx
+++ b/packages/volto/src/components/manage/Blocks/Container/Edit.jsx
@@ -1,14 +1,19 @@
 import { useState } from 'react';
 import { useIntl } from 'react-intl';
 import pickBy from 'lodash/pickBy';
+import without from 'lodash/without';
 import SidebarPortal from '@plone/volto/components/manage/Sidebar/SidebarPortal';
 import { BlocksForm } from '@plone/volto/components/manage/Form';
+import BlocksToolbar from '@plone/volto/components/manage/Form/BlocksToolbar';
 import PropTypes from 'prop-types';
 import ContainerData from './Data';
 import DefaultEditBlockWrapper from './EditBlockWrapper';
 import SimpleContainerToolbar from './SimpleContainerToolbar';
 import { v4 as uuid } from 'uuid';
-import { blocksFormGenerator } from '@plone/volto/helpers/Blocks/Blocks';
+import {
+  blocksFormGenerator,
+  getBlocksLayoutFieldname,
+} from '@plone/volto/helpers/Blocks/Blocks';
 
 import DefaultTemplateChooser from '@plone/volto/components/manage/TemplateChooser/TemplateChooser';
 
@@ -50,6 +55,63 @@ const ContainerBlockEdit = (props) => {
   if (props.setSelectedBlock) {
     ({ selectedBlock, setSelectedBlock } = props);
   }
+
+  let [multiSelected, setMultiSelected] = useState([]);
+  if (props.setMultiSelected) {
+    ({ multiSelected, setMultiSelected } = props);
+  }
+
+  // Mirror of the top-level Form selection state machine (Form.jsx
+  // onSelectBlock), operating on the container's own blocks layout
+  const onSelectBlock = (id, isMultipleSelection, event) => {
+    let newMultiSelected = [];
+    let newSelectedBlock = id;
+
+    if (isMultipleSelection) {
+      newSelectedBlock = null;
+      const blocksLayoutFieldname = getBlocksLayoutFieldname(properties);
+      const blocks_layout = properties[blocksLayoutFieldname].items;
+      // Keyboard navigation (shift + arrow keys) passes no event and is
+      // always a range extension
+      const isShift = event ? event.shiftKey : true;
+      const isToggle = event ? event.ctrlKey || event.metaKey : false;
+
+      if (isShift && !isToggle) {
+        const anchorId =
+          multiSelected.length > 0
+            ? multiSelected[0]
+            : selectedBlock && blocks_layout.includes(selectedBlock)
+              ? selectedBlock
+              : id;
+        const anchor = blocks_layout.indexOf(anchorId);
+        const focus = blocks_layout.indexOf(id);
+
+        if (anchor === focus) {
+          newMultiSelected = [id];
+        } else if (focus > anchor) {
+          newMultiSelected = [...blocks_layout.slice(anchor, focus + 1)];
+        } else {
+          newMultiSelected = [...blocks_layout.slice(focus, anchor + 1)];
+        }
+      }
+
+      if (isToggle && !isShift) {
+        if (multiSelected.includes(id)) {
+          newMultiSelected = without(multiSelected, id);
+        } else {
+          // Promote the active block when starting a multi-selection
+          const active =
+            selectedBlock && !multiSelected.includes(selectedBlock)
+              ? [selectedBlock]
+              : [];
+          newMultiSelected = [...active, ...multiSelected, id];
+        }
+      }
+    }
+
+    setSelectedBlock(newSelectedBlock);
+    setMultiSelected(newMultiSelected);
+  };
 
   const blockState = {};
 
@@ -97,6 +159,7 @@ const ContainerBlockEdit = (props) => {
     maxLength,
     metadata,
     onAddNewBlock,
+    onSelectBlock,
     onSelectTemplate,
     selectedBlock,
     setSelectedBlock,
@@ -108,6 +171,29 @@ const ContainerBlockEdit = (props) => {
       {data.headline && <h2 className="headline">{data.headline}</h2>}
 
       {selected && <ContainerToolbar {...containerProps} />}
+
+      {selected && (
+        <BlocksToolbar
+          formData={properties}
+          selectedBlock={selectedBlock}
+          selectedBlocks={multiSelected}
+          onSetSelectedBlocks={(blockIds) => {
+            setMultiSelected(blockIds);
+          }}
+          onSelectBlock={(id, isMultipleSelection, event) => {
+            const modifiers = event
+              ? event.shiftKey || event.ctrlKey || event.metaKey
+              : false;
+            onSelectBlock(id, isMultipleSelection || modifiers, event);
+          }}
+          onChangeBlocks={(newBlockData) => {
+            onChangeBlock(block, {
+              ...data,
+              ...newBlockData,
+            });
+          }}
+        />
+      )}
 
       {!isInitialized && templates && (
         <TemplateChooser
@@ -126,14 +212,18 @@ const ContainerBlockEdit = (props) => {
         direction={direction}
         manage={manage}
         selectedBlock={selected ? selectedBlock : null}
+        multiSelected={selected ? multiSelected : []}
         blocksConfig={allowedBlocksConfig}
         title={data.placeholder}
         isContainer
         isMainForm={false}
-        stopPropagation={selectedBlock}
+        stopPropagation={selectedBlock || multiSelected.length > 0}
         disableAddBlockOnEnterKey
-        onSelectBlock={(id) => {
-          setSelectedBlock(id);
+        onSelectBlock={(id, isMultipleSelection, event) => {
+          const modifiers = event
+            ? event.shiftKey || event.ctrlKey || event.metaKey
+            : false;
+          onSelectBlock(id, isMultipleSelection || modifiers, event);
         }}
         onChangeFormData={(newFormData) => {
           onChangeBlock(block, {

--- a/packages/volto/src/components/manage/Blocks/Container/Edit.test.jsx
+++ b/packages/volto/src/components/manage/Blocks/Container/Edit.test.jsx
@@ -1,0 +1,293 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import configureStore from 'redux-mock-store';
+import { Provider } from 'react-redux';
+import { IntlProvider } from 'react-intl';
+import {
+  PluggablesProvider,
+  Pluggable,
+} from '@plone/volto/components/manage/Pluggable';
+import config from '@plone/volto/registry';
+import ContainerBlockEdit from './Edit';
+
+const mockStore = configureStore();
+
+const DummyEdit = () => <div className="dummy-content" />;
+
+// The container imports the loadable BlocksForm from the Form barrel; use the
+// real BlocksForm component instead
+vi.mock('@plone/volto/components/manage/Form', async () => {
+  const actual = await vi.importActual(
+    '@plone/volto/components/manage/Blocks/Block/BlocksForm',
+  );
+  return {
+    BlocksForm: actual.default,
+    BlockDataForm: () => <div />,
+  };
+});
+
+vi.mock('@plone/volto/helpers/Loadable/Loadable', async () => {
+  return await import('@plone/volto/helpers/Loadable/__mocks__/Loadable.jsx');
+});
+
+vi.mock('react-beautiful-dnd', () => ({
+  DragDropContext: ({ children }) => <div>{children}</div>,
+  Droppable: ({ children }) =>
+    children({
+      innerRef: () => {},
+      droppableProps: {},
+      placeholder: <div />,
+    }),
+  Draggable: ({ children }) =>
+    children({
+      innerRef: () => {},
+      draggableProps: {},
+      dragHandleProps: {},
+    }),
+}));
+
+let mockSerial = 0;
+vi.mock('uuid', () => ({
+  v4: vi.fn().mockImplementation(() => `pasted-uuid-${mockSerial++}`),
+}));
+
+const innerBlocks = {
+  a: { '@type': 'dummy' },
+  b: { '@type': 'dummy' },
+  c: { '@type': 'dummy' },
+};
+
+const containerData = {
+  '@type': 'testContainer',
+  blocks: innerBlocks,
+  blocks_layout: { items: ['a', 'b', 'c'] },
+};
+
+beforeAll(async () => {
+  const { __setLoadables } = await import(
+    '@plone/volto/helpers/Loadable/Loadable'
+  );
+  await __setLoadables();
+
+  config.blocks.blocksConfig.dummy = { id: 'dummy', edit: DummyEdit };
+  config.blocks.blocksConfig.testContainer = {
+    id: 'testContainer',
+    allowedBlocks: ['dummy'],
+    blocksConfig: {
+      dummy: config.blocks.blocksConfig.dummy,
+    },
+    blockSchema: () => ({
+      title: 'Test container',
+      fieldsets: [],
+      properties: {},
+    }),
+    dataAdapter: () => {},
+  };
+});
+
+afterAll(() => {
+  delete config.blocks.blocksConfig.dummy;
+  delete config.blocks.blocksConfig.testContainer;
+});
+
+const renderContainer = ({ clipboard = {}, wrapInBlock = false } = {}) => {
+  const store = mockStore({
+    blocksClipboard: clipboard,
+    form: { ui: { selected: 'container-1', gridSelected: null } },
+    sidebar: { tab: 0 },
+    intl: { locale: 'en', messages: {} },
+  });
+
+  const onChangeBlock = jest.fn();
+
+  const containerElement = (
+    <ContainerBlockEdit
+      block="container-1"
+      data={containerData}
+      onChangeBlock={onChangeBlock}
+      onChangeField={jest.fn()}
+      pathname="/test"
+      selected
+      manage={false}
+      properties={{}}
+    />
+  );
+
+  const rendered = render(
+    <Provider store={store}>
+      <IntlProvider locale="en">
+        <PluggablesProvider>
+          <Pluggable name="main.toolbar.bottom">
+            {(pluggables) => (
+              <>
+                {pluggables.map((p) => (
+                  <span key={p.id}>{p()}</span>
+                ))}
+              </>
+            )}
+          </Pluggable>
+          {wrapInBlock ? (
+            <div className="block gridBlock">{containerElement}</div>
+          ) : (
+            containerElement
+          )}
+        </PluggablesProvider>
+      </IntlProvider>
+    </Provider>,
+  );
+
+  return {
+    ...rendered,
+    root: rendered.container,
+    store,
+    onChangeBlock,
+    // The block content divs, one per inner block in layout order. The
+    // `.block.dummy` elements would also match the cell drag wrappers
+    innerBlockElements: rendered.container.querySelectorAll('.dummy-content'),
+    cellWrappers: rendered.container.querySelectorAll('.cell-wrapper'),
+  };
+};
+
+describe('Container block nested multi-selection', () => {
+  it('selects a contiguous Shift-click range of inner blocks', () => {
+    const { root, innerBlockElements } = renderContainer();
+
+    fireEvent.click(innerBlockElements[0]);
+    fireEvent.click(innerBlockElements[2], { shiftKey: true });
+
+    expect(root.querySelectorAll('.block.multiSelected')).toHaveLength(3);
+  });
+
+  it('toggles inner blocks in the multi-selection with Control-click', () => {
+    const { root, innerBlockElements } = renderContainer();
+
+    fireEvent.click(innerBlockElements[0], { ctrlKey: true });
+    fireEvent.click(innerBlockElements[2], { ctrlKey: true });
+
+    expect(root.querySelectorAll('.block.multiSelected')).toHaveLength(2);
+
+    fireEvent.click(innerBlockElements[2], { ctrlKey: true });
+
+    expect(root.querySelectorAll('.block.multiSelected')).toHaveLength(1);
+  });
+
+  it('extends the multi-selection from the cell wrapper (cell padding)', () => {
+    const { root, innerBlockElements, cellWrappers } = renderContainer();
+
+    fireEvent.click(innerBlockElements[0]);
+    fireEvent.click(cellWrappers[2], { shiftKey: true });
+
+    expect(root.querySelectorAll('.block.multiSelected')).toHaveLength(3);
+  });
+
+  it('selects the cell from its padding even under a container .block ancestor', () => {
+    // This mirrors the real Grid structure, where the page-level grid block
+    // (.block.gridBlock) is an ancestor of the cell wrappers
+    const { root, cellWrappers, innerBlockElements } = renderContainer({
+      wrapInBlock: true,
+    });
+
+    fireEvent.click(cellWrappers[0]);
+    expect(root.querySelectorAll('.block.dummy.selected')).toHaveLength(1);
+
+    fireEvent.click(innerBlockElements[2], { shiftKey: true });
+    expect(root.querySelectorAll('.block.multiSelected')).toHaveLength(3);
+  });
+});
+
+describe('Container block clipboard toolbar', () => {
+  it('shows the copy/cut/delete buttons only for a multi-selection', () => {
+    const { innerBlockElements } = renderContainer();
+
+    // Single selection: no clipboard buttons
+    fireEvent.click(innerBlockElements[0]);
+    expect(screen.queryByLabelText('Copy blocks')).toBeNull();
+    expect(screen.queryByLabelText('Cut blocks')).toBeNull();
+    expect(screen.queryByLabelText('Delete blocks')).toBeNull();
+
+    // Multi-selection: clipboard buttons appear
+    fireEvent.click(innerBlockElements[2], { shiftKey: true });
+    expect(screen.getByLabelText('Copy blocks')).toBeTruthy();
+    expect(screen.getByLabelText('Cut blocks')).toBeTruthy();
+    expect(screen.getByLabelText('Delete blocks')).toBeTruthy();
+  });
+
+  it('copies the multi-selected inner blocks to the clipboard', () => {
+    const { innerBlockElements, store } = renderContainer();
+
+    fireEvent.click(innerBlockElements[0]);
+    fireEvent.click(innerBlockElements[2], { shiftKey: true });
+    fireEvent.click(screen.getByLabelText('Copy blocks'));
+
+    const action = store
+      .getActions()
+      .find((a) => a.type === 'SET_BLOCKS_CLIPBOARD' && a.copy);
+
+    expect(action.copy).toEqual([
+      ['a', { '@type': 'dummy' }],
+      ['b', { '@type': 'dummy' }],
+      ['c', { '@type': 'dummy' }],
+    ]);
+  });
+
+  it('pastes clipboard blocks after the selected inner block', () => {
+    const { innerBlockElements, onChangeBlock, store } = renderContainer({
+      clipboard: {
+        copy: [['x-1', { '@type': 'dummy' }]],
+      },
+    });
+
+    fireEvent.click(innerBlockElements[1]);
+    fireEvent.click(screen.getByLabelText('Paste blocks'));
+
+    expect(
+      store.getActions().some((a) => a.type === 'RESET_BLOCKS_CLIPBOARD'),
+    ).toBe(true);
+
+    expect(onChangeBlock).toHaveBeenCalledTimes(1);
+    const [blockId, newData] = onChangeBlock.mock.calls[0];
+    expect(blockId).toBe('container-1');
+    expect(Object.keys(newData.blocks)).toHaveLength(4);
+    // The pasted block (with a fresh id) is inserted right after the
+    // selected inner block 'b'
+    const items = newData.blocks_layout.items;
+    expect(items).toHaveLength(4);
+    expect(items.slice(0, 2)).toEqual(['a', 'b']);
+    expect(items[2]).toMatch(/^pasted-uuid-/);
+    expect(items[3]).toBe('c');
+  });
+
+  it('cuts the multi-selected inner blocks out of the container', () => {
+    const { innerBlockElements, onChangeBlock, store } = renderContainer();
+
+    fireEvent.click(innerBlockElements[0]);
+    fireEvent.click(innerBlockElements[2], { shiftKey: true });
+    fireEvent.click(screen.getByLabelText('Cut blocks'));
+
+    const action = store
+      .getActions()
+      .find((a) => a.type === 'SET_BLOCKS_CLIPBOARD' && a.cut);
+
+    expect(action.cut).toHaveLength(3);
+
+    expect(onChangeBlock).toHaveBeenCalledWith('container-1', {
+      '@type': 'testContainer',
+      blocks: {},
+      blocks_layout: { items: [] },
+    });
+  });
+
+  it('deletes the multi-selected inner blocks', () => {
+    const { innerBlockElements, onChangeBlock } = renderContainer();
+
+    fireEvent.click(innerBlockElements[0]);
+    fireEvent.click(innerBlockElements[1], { shiftKey: true });
+    fireEvent.click(screen.getByLabelText('Delete blocks'));
+
+    expect(onChangeBlock).toHaveBeenCalledWith('container-1', {
+      '@type': 'testContainer',
+      blocks: { c: { '@type': 'dummy' } },
+      blocks_layout: { items: ['c'] },
+    });
+  });
+});

--- a/packages/volto/src/components/manage/Blocks/Container/EditBlockWrapper.jsx
+++ b/packages/volto/src/components/manage/Blocks/Container/EditBlockWrapper.jsx
@@ -66,7 +66,18 @@ const EditBlockWrapper = (props) => {
         className="cell-wrapper"
         onClick={(e) => {
           e.block = block;
-          onSelectBlock(block);
+          // Clicks inside the child block are already handled by the child's
+          // own selection handler (including modifier semantics), don't
+          // clobber them with a plain single selection. The nearest .block
+          // ancestor can also be the container itself (e.g. the page-level
+          // grid block), only skip when it is a child of this wrapper
+          const innerBlock = e.target.closest('.block');
+          if (innerBlock && e.currentTarget.contains(innerBlock)) {
+            return;
+          }
+          const isMultipleSelection =
+            e.shiftKey || e.ctrlKey || e.metaKey || false;
+          onSelectBlock(block, isMultipleSelection, e);
         }}
       >
         {type !== 'empty' ? (

--- a/packages/volto/src/components/manage/Form/BlocksToolbar.jsx
+++ b/packages/volto/src/components/manage/Form/BlocksToolbar.jsx
@@ -10,7 +10,6 @@ import {
 import Icon from '@plone/volto/components/theme/Icon/Icon';
 import { Plug } from '@plone/volto/components/manage/Pluggable';
 import { v4 as uuid } from 'uuid';
-import { load } from 'redux-localstorage-simple';
 import isEqual from 'lodash/isEqual';
 import omit from 'lodash/omit';
 import without from 'lodash/without';
@@ -25,7 +24,10 @@ import copySVG from '@plone/volto/icons/copy.svg';
 import cutSVG from '@plone/volto/icons/cut.svg';
 import pasteSVG from '@plone/volto/icons/paste.svg';
 import trashSVG from '@plone/volto/icons/delete.svg';
-import { cloneBlocks } from '@plone/volto/helpers/Blocks/cloneBlocks';
+import {
+  cloneBlocks,
+  loadBlocksClipboardFromStorage,
+} from '@plone/volto/helpers/Blocks/cloneBlocks';
 
 export class BlocksToolbarComponent extends React.Component {
   constructor(props) {
@@ -39,18 +41,32 @@ export class BlocksToolbarComponent extends React.Component {
     this.setBlocksClipboard = this.setBlocksClipboard.bind(this);
   }
 
-  loadFromStorage() {
-    const clipboard = load({ states: ['blocksClipboard'] })?.blocksClipboard;
-    if (!isEqual(clipboard, this.props.blocksClipboard))
+  loadFromStorage(event) {
+    if (event?.key && !event.key.includes('blocksClipboard')) {
+      return;
+    }
+
+    const clipboard = loadBlocksClipboardFromStorage();
+    const currentClipboard = this.props.blocksClipboard || {};
+    const currentClipboardHasBlocks =
+      currentClipboard?.cut || currentClipboard?.copy;
+
+    if (!event && !clipboard && currentClipboardHasBlocks) {
+      return;
+    }
+
+    if (!isEqual(clipboard || {}, currentClipboard)) {
       this.props.setBlocksClipboard(clipboard || {});
+    }
   }
 
   componentDidMount() {
+    this.loadFromStorage();
     window.addEventListener('storage', this.loadFromStorage, true);
   }
 
   componentWillUnmount() {
-    window.removeEventListener('storage', this.loadFromStorage);
+    window.removeEventListener('storage', this.loadFromStorage, true);
   }
 
   deleteBlocks() {
@@ -143,7 +159,7 @@ export class BlocksToolbarComponent extends React.Component {
     } = this.props;
     return (
       <>
-        {selectedBlocks.length > 0 ? (
+        {selectedBlocks?.length > 0 ? (
           <>
             <Plug pluggable="main.toolbar.bottom" id="blocks-delete-btn">
               <button

--- a/packages/volto/src/components/manage/Form/Form.jsx
+++ b/packages/volto/src/components/manage/Form/Form.jsx
@@ -66,7 +66,7 @@ const noop = () => {};
  * @class Form
  * @extends Component
  */
-class Form extends Component {
+export class Form extends Component {
   /**
    * Property types.
    * @property {Object} propTypes Property types.
@@ -505,15 +505,16 @@ class Form extends Component {
       }
 
       if ((event.ctrlKey || event.metaKey) && !event.shiftKey) {
+        const activeBlock = this.props.uiState.selected;
         multiSelected = this.props.uiState.multiSelected || [];
-        if (!this.props.uiState.multiSelected.includes(this.state.selected)) {
-          multiSelected = [...multiSelected, this.props.uiState.selected];
-          selected = null;
+
+        if (activeBlock && !multiSelected.includes(activeBlock)) {
+          multiSelected = [...multiSelected, activeBlock];
         }
+
         if (this.props.uiState.multiSelected.includes(id)) {
-          selected = null;
           multiSelected = without(multiSelected, id);
-        } else {
+        } else if (!multiSelected.includes(id)) {
           multiSelected = [...multiSelected, id];
         }
       }

--- a/packages/volto/src/components/manage/Form/Form.test.jsx
+++ b/packages/volto/src/components/manage/Form/Form.test.jsx
@@ -3,7 +3,7 @@ import renderer from 'react-test-renderer';
 import configureStore from 'redux-mock-store';
 import { Provider } from 'react-intl-redux';
 import { MemoryRouter } from 'react-router-dom';
-import Form from './Form';
+import Form, { Form as FormComponent } from './Form';
 import config from '@plone/volto/registry';
 
 const mockStore = configureStore();
@@ -183,5 +183,94 @@ describe('Form', () => {
     expect(
       component.root.findAllByProps({ 'data-autosave-wrapper': 'true' }),
     ).toHaveLength(1);
+  });
+});
+const layout = ['a', 'b', 'c', 'd'];
+
+const selectBlock = ({
+  id,
+  selected = null,
+  multiSelected = [],
+  ctrlKey = false,
+  metaKey = true,
+  shiftKey = false,
+}) => {
+  const setUIState = vi.fn();
+  const form = Object.create(FormComponent.prototype);
+  form.state = {
+    formData: {
+      blocks: Object.fromEntries(
+        layout.map((blockId) => [blockId, { '@type': 'slate' }]),
+      ),
+      blocks_layout: { items: layout },
+    },
+  };
+  form.props = {
+    uiState: { selected, multiSelected },
+    setUIState,
+    onSelectForm: null,
+  };
+
+  form.onSelectBlock(id, true, {
+    ctrlKey,
+    metaKey,
+    shiftKey,
+  });
+
+  return setUIState.mock.calls[0][0];
+};
+
+describe('Form top-level block selection', () => {
+  it.each([
+    ['Meta', { metaKey: true }],
+    ['Control', { ctrlKey: true, metaKey: false }],
+  ])('promotes the active block with %s-click', (_modifier, eventModifiers) => {
+    expect(selectBlock({ id: 'a', selected: 'a', ...eventModifiers })).toEqual({
+      selected: null,
+      multiSelected: ['a'],
+      gridSelected: null,
+    });
+  });
+
+  it('includes the active block when adding another block', () => {
+    expect(selectBlock({ id: 'b', selected: 'a' }).multiSelected).toEqual([
+      'a',
+      'b',
+    ]);
+  });
+
+  it('adds blocks without inserting null ghost selections', () => {
+    expect(
+      selectBlock({ id: 'c', multiSelected: ['a', 'b'] }).multiSelected,
+    ).toEqual(['a', 'b', 'c']);
+  });
+
+  it('removes only the clicked multi-selection member', () => {
+    expect(
+      selectBlock({ id: 'b', multiSelected: ['a', 'b', 'c'] }).multiSelected,
+    ).toEqual(['a', 'c']);
+  });
+
+  it('returns an empty selection after removing the final member', () => {
+    expect(
+      selectBlock({ id: 'a', multiSelected: ['a'] }).multiSelected,
+    ).toEqual([]);
+  });
+
+  it('selects a contiguous Shift-click range from the active block', () => {
+    const getSelection = vi
+      .spyOn(window, 'getSelection')
+      .mockReturnValue({ empty: vi.fn() });
+
+    expect(
+      selectBlock({
+        id: 'd',
+        selected: 'b',
+        metaKey: false,
+        shiftKey: true,
+      }).multiSelected,
+    ).toEqual(['b', 'c', 'd']);
+
+    getSelection.mockRestore();
   });
 });

--- a/packages/volto/src/helpers/Blocks/cloneBlocks.ts
+++ b/packages/volto/src/helpers/Blocks/cloneBlocks.ts
@@ -1,6 +1,8 @@
 // @ts-nocheck
 import { v4 as uuid } from 'uuid';
+import { load } from 'redux-localstorage-simple';
 import {
+  getBlocks,
   getBlocksFieldname,
   getBlocksLayoutFieldname,
   hasBlocksData,
@@ -12,10 +14,9 @@ export function cloneBlocks(blocksData) {
     const blocksFieldname = getBlocksFieldname(blocksData);
     const blocksLayoutFieldname = getBlocksLayoutFieldname(blocksData);
 
-    const cloneWithIds = Object.keys(blocksData.blocks)
-      .map((key) => {
-        const block = blocksData.blocks[key];
-        const blockConfig = config.blocks.blocksConfig[blocksData['@type']];
+    const cloneWithIds = getBlocks(blocksData)
+      .map(([, block]) => {
+        const blockConfig = config.blocks.blocksConfig[block['@type']];
         return blockConfig?.cloneData
           ? blockConfig.cloneData(block)
           : [uuid(), cloneBlocks(block)];
@@ -41,3 +42,30 @@ export function cloneBlocks(blocksData) {
 
   return blocksData;
 }
+
+const fallbackBlocksClipboardStates = [
+  'blocksClipboard.cut',
+  'blocksClipboard.copy',
+];
+
+const getBlocksClipboardStates = () => {
+  const persistentReducers = config.settings?.persistentReducers || [];
+  const blocksClipboardStates = persistentReducers.filter(
+    (state) =>
+      state === 'blocksClipboard' || state.startsWith('blocksClipboard.'),
+  );
+
+  return blocksClipboardStates.length
+    ? blocksClipboardStates
+    : fallbackBlocksClipboardStates;
+};
+
+export const loadBlocksClipboardFromStorage = () =>
+  load({
+    states: getBlocksClipboardStates(),
+    disableWarnings: true,
+  })?.blocksClipboard ||
+  load({
+    states: ['blocksClipboard'],
+    disableWarnings: true,
+  })?.blocksClipboard;


### PR DESCRIPTION
…main

Ports the container-level multi-selection and clipboard toolbar from fix-copy-blocks-eea-style (Volto 18) to main (Volto 19).

Changes:
- Container/Edit.jsx: container-local selected/multiSelected state and BlocksToolbar for child blocks.
- Container/EditBlockWrapper.jsx: pass modifier clicks through to child selection instead of forcing single selection.
- Block/Edit.jsx: detect events originating in nested block forms and only activate the container as a single selection; preserve modifier click semantics on the container chrome.
- Form/Form.jsx: use props.uiState.selected when promoting the active block into a multi-selection; avoid null ghost selections.
- BlocksToolbar.jsx + cloneBlocks.ts: read blocksClipboard from the split localStorage keys (blocksClipboard.cut / blocksClipboard.copy) written by persistentReducers, fixing cross-tab sync/remount restore.
- Add unit tests for Block/Edit, Container/Edit, and Form selection.
- Add Cypress tests for copy/cut into Grid.

Adapted for main:
- Kept Volto 19 saveAsDraft wiring in Form.jsx/Form.test.jsx.
- Container/Edit.test.jsx uses main's Loadable.jsx mock path.

Refs #8410

- [ ] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [ ] I verified there aren't other open [pull requests](https://github.com/plone/volto/pulls) for the same change.
- [ ] I followed the guidelines in [Contributing to Volto](https://6.docs.plone.org/volto/contributing/index.html).
- [ ] I successfully ran [code linting checks](https://6.docs.plone.org/volto/contributing/linting.html) on my changes locally.
- [ ] I successfully ran [unit tests](https://6.docs.plone.org/volto/contributing/testing.html) on my changes locally.
- [ ] I successfully ran [acceptance tests](https://6.docs.plone.org/volto/contributing/acceptance-tests.html) on my changes locally.
- [ ] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/volto/contributing/documentation.html#narrative-documentation) for my changes, either in the Storybook or narrative documentation.
- [ ] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

If your pull request closes an open issue, include the exact text below, immediately followed by the issue number. When your pull request gets merged, then that issue will close automatically.

Closes #8407

-----

If your pull request includes changes to the documentation—either in narrative documentation, Storybook, or configuration—then a pull request preview will be generated and a link will populate in the description of your pull request below.
By clicking that link, you can use the visual diff menu in the upper right corner to navigate to pages that have changes, then display the diff by checking the `Show diff` checkbox.
