### PR TITLE
Allow .cjs and .mjs files to be shadowed

### DIFF
--- a/packages/registry/__tests__/addon-registry.test.js
+++ b/packages/registry/__tests__/addon-registry.test.js
@@ -227,6 +227,9 @@ describe('AddonRegistry - Project', () => {
       '@plone/volto/LanguageSwitcher': `${base}/src/customizations/LanguageSwitcher.js`,
       '@plone/volto/TSComponent': `${base}/src/customizations/TSComponent.jsx`,
       '@plone/volto/client': `${base}/src/customizations/client.js`,
+      // .cjs is shadowable, and the alias key keeps its extension because
+      // such modules are imported with it. See #8366.
+      '@plone/volto/constants/Languages.cjs': `${base}/src/customizations/constants/Languages.cjs`,
       '@plone/volto/routes': `${base}/src/customizations/routes.tsx`,
       'test-addon/testaddon': `${base}/src/custom-addons/test-addon/testaddon.js`,
       '@plone/volto/server': `${base}/src/customizations/server.jsx`,

--- a/packages/registry/__tests__/fixtures/test-volto-project/node_modules/@plone/volto/src/constants/Languages.cjs
+++ b/packages/registry/__tests__/fixtures/test-volto-project/node_modules/@plone/volto/src/constants/Languages.cjs
@@ -1,0 +1,1 @@
+module.exports = { en: 'English' };

--- a/packages/registry/__tests__/fixtures/test-volto-project/src/customizations/constants/Languages.cjs
+++ b/packages/registry/__tests__/fixtures/test-volto-project/src/customizations/constants/Languages.cjs
@@ -1,0 +1,1 @@
+module.exports = { en: 'English', sv: 'Svenska' };

--- a/packages/registry/news/8366.bugfix
+++ b/packages/registry/news/8366.bugfix
@@ -1,0 +1,1 @@
+Include `.cjs` and `.mjs` in the customizations glob so core modules with those extensions can be shadowed. @kunalKumar-13

--- a/packages/registry/src/addon-registry/addon-registry.ts
+++ b/packages/registry/src/addon-registry/addon-registry.ts
@@ -684,7 +684,7 @@ class AddonRegistry {
 
       reg.forEach(({ customPath, name, sourcePath }) => {
         glob(
-          `${customPath}/**/*.*(svg|png|jpg|jpeg|gif|ico|less|js|jsx|ts|tsx)`,
+          `${customPath}/**/*.*(svg|png|jpg|jpeg|gif|ico|less|js|jsx|ts|tsx|cjs|mjs)`,
         ).map((filename) => {
           function changeFileExtension(filePath: string) {
             // Extract the current file extension


### PR DESCRIPTION
Backport of #8413 to `18.x.x`, as requested.

Cherry-picked from `799e67d81` with `-x`; it applied without conflicts, and the
glob line it changes is identical on this branch.

`packages/registry` is green here: 4 test files, 83 tests. I also checked the
backported test is doing its job on `18.x.x` rather than passing regardless —
reverting just the glob change fails `addon-registry.test.js` on the `.cjs`
alias assertion.
