### PR TITLE
Fix the Table of Contents links of headings with inline formatting

### DIFF
--- a/packages/volto-slate/news/8340.bugfix
+++ b/packages/volto-slate/news/8340.bugfix
@@ -1,0 +1,1 @@
+Fixed the anchor of a heading being built from its indexed plaintext, which broke it when the heading contained inline formatting or a link. The anchor is now built from the text of the heading as it is rendered, and is also reported as the third element of the block's `tocEntry`. @Somilg11

--- a/packages/volto-slate/src/blocks/Text/TextBlockView.jsx
+++ b/packages/volto-slate/src/blocks/Text/TextBlockView.jsx
@@ -1,11 +1,7 @@
-import {
-  serializeNodes,
-  serializeNodesToText,
-} from '@plone/volto-slate/editor/render';
+import { serializeNodes } from '@plone/volto-slate/editor/render';
+import { getAnchor } from '@plone/volto-slate/utils/toc';
 import config from '@plone/volto/registry';
 import isEqual from 'lodash/isEqual';
-import Slugger from 'github-slugger';
-import { normalizeString } from '@plone/volto/helpers/Utils/Utils';
 
 const TextBlockView = (props) => {
   const { id, data, styling = {} } = props;
@@ -17,9 +13,7 @@ const TextBlockView = (props) => {
     const res = { ...styling };
     if (node.type && isEqual(path, [0])) {
       if (topLevelTargetElements.includes(node.type) || override_toc) {
-        const text = serializeNodesToText(node?.children || []);
-        const slug = Slugger.slug(normalizeString(text));
-        res.id = slug || id;
+        res.id = getAnchor(node) || id;
       }
     }
     return res;

--- a/packages/volto-slate/src/blocks/Text/TextBlockView.test.jsx
+++ b/packages/volto-slate/src/blocks/Text/TextBlockView.test.jsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import config from '@plone/volto/registry';
+import TextBlockView from './TextBlockView';
+import { getAnchor } from '@plone/volto-slate/utils/toc';
+
+beforeAll(() => {
+  config.settings = {
+    slate: {
+      topLevelTargetElements: ['h2', 'h3'],
+      elements: {
+        default: ({ attributes, children }) => (
+          <p {...attributes}>{children}</p>
+        ),
+        h2: ({ attributes, children }) => <h2 {...attributes}>{children}</h2>,
+        link: ({ attributes, children }) => <a {...attributes}>{children}</a>,
+      },
+      leafs: {
+        italic: ({ children }) => <em>{children}</em>,
+      },
+    },
+  };
+});
+
+const getHeadingId = (value) => {
+  const component = renderer.create(
+    <TextBlockView id="block-id" data={{ value }} />,
+  );
+  return component.root.findByType('h2').props.id;
+};
+
+test('renders the anchor of a plain heading', () => {
+  expect(
+    getHeadingId([
+      { type: 'h2', children: [{ text: 'Subtitle 1: Everything is okay' }] },
+    ]),
+  ).toBe('subtitle-1-everything-is-okay');
+});
+
+test('renders the same anchor for a heading with inline formatting', () => {
+  const value = [
+    {
+      type: 'h2',
+      children: [
+        { text: 'Subtitle 2: Everything is ' },
+        { text: 'not', italic: true },
+        { text: ' okay' },
+      ],
+    },
+  ];
+  expect(getHeadingId(value)).toBe('subtitle-2-everything-is-not-okay');
+  // The table of contents entry of the block links to this anchor.
+  expect(getHeadingId(value)).toBe(getAnchor(value[0]));
+});
+
+test('renders the same anchor for a heading containing a link', () => {
+  const value = [
+    {
+      type: 'h2',
+      children: [
+        { text: 'Subtitle 3: Everything is ' },
+        {
+          type: 'link',
+          data: { url: '/some-page' },
+          children: [{ text: 'okay' }],
+        },
+        { text: '' },
+      ],
+    },
+  ];
+  expect(getHeadingId(value)).toBe('subtitle-3-everything-is-okay');
+  expect(getHeadingId(value)).toBe(getAnchor(value[0]));
+});
+
+test('falls back to the block id for an empty heading', () => {
+  expect(getHeadingId([{ type: 'h2', children: [{ text: '' }] }])).toBe(
+    'block-id',
+  );
+});

--- a/packages/volto-slate/src/blocks/Text/index.jsx
+++ b/packages/volto-slate/src/blocks/Text/index.jsx
@@ -20,6 +20,7 @@ import {
   cancelEsc,
 } from './keyboard';
 import { splitAtSeam } from './keyboard/splitAtSeam';
+import { getAnchor, getAnchorText } from '@plone/volto-slate/utils/toc';
 import { withDeleteSelectionOnEnter } from '@plone/volto-slate/editor/extensions';
 import {
   breakList,
@@ -129,10 +130,17 @@ export default function applyConfig(config) {
     tocEntry: (block = {}) => {
       const { value, override_toc, entry_text, level, plaintext } = block;
       const type = value?.[0]?.type;
+      // The anchor is computed from the current value, and not from the stored
+      // plaintext, so that it always matches the `id` rendered by the view.
+      const anchor = getAnchor(value?.[0]);
       return override_toc && level
-        ? [parseInt(level.slice(1)), entry_text]
+        ? [parseInt(level.slice(1)), entry_text, anchor]
         : config.settings.slate.topLevelTargetElements.includes(type)
-          ? [parseInt(type.slice(1)), plaintext]
+          ? [
+              parseInt(type.slice(1)),
+              getAnchorText(value?.[0]) || plaintext,
+              anchor,
+            ]
           : null;
     },
   };

--- a/packages/volto-slate/src/utils/index.js
+++ b/packages/volto-slate/src/utils/index.js
@@ -9,3 +9,4 @@ export * from './random';
 export * from './selection';
 export * from './volto-blocks';
 export * from './mime-types';
+export * from './toc';

--- a/packages/volto-slate/src/utils/toc.js
+++ b/packages/volto-slate/src/utils/toc.js
@@ -1,0 +1,51 @@
+import { Text } from 'slate';
+import Slugger from 'github-slugger';
+import { normalizeString } from '@plone/volto/helpers/Utils/Utils';
+
+/**
+ * Get the text of a node as it reads when rendered.
+ *
+ * Unlike `serializeNodesToText`, which is meant for indexing and separates the
+ * text of every node with whitespace, this concatenates the text of the inline
+ * children of a node without inserting or dropping any whitespace. This is
+ * required to build anchors, since a heading split into several leafs by inline
+ * formatting (bold, italic, links) must produce the same text as the same
+ * heading written without any formatting.
+ *
+ * @function serializeNodeToInlineText
+ * @param {Object} node A Slate node.
+ * @returns {string} The text of the node.
+ */
+export const serializeNodeToInlineText = (node) => {
+  if (!node) return '';
+  if (Text.isText(node)) return node.text;
+  return (node.children || []).map(serializeNodeToInlineText).join('');
+};
+
+/**
+ * Get the anchor text of a node, with the surrounding whitespace removed and
+ * the inner whitespace collapsed.
+ *
+ * The empty text nodes that Slate keeps around inline elements would otherwise
+ * end up as stray separators in the resulting slug.
+ *
+ * @function getAnchorText
+ * @param {Object} node A Slate node.
+ * @returns {string} The anchor text of the node.
+ */
+export const getAnchorText = (node) =>
+  serializeNodeToInlineText(node).replace(/\s+/g, ' ').trim();
+
+/**
+ * Get the anchor (the `id` attribute) that the view of a Slate block renders
+ * for the given node.
+ *
+ * Both the block view and the block's table of contents entry use it, so that
+ * the links of the table of contents always match the anchors in the page.
+ *
+ * @function getAnchor
+ * @param {Object} node A Slate node.
+ * @returns {string} The anchor of the node.
+ */
+export const getAnchor = (node) =>
+  Slugger.slug(normalizeString(getAnchorText(node)));

--- a/packages/volto-slate/src/utils/toc.test.js
+++ b/packages/volto-slate/src/utils/toc.test.js
@@ -1,0 +1,90 @@
+import { getAnchor, getAnchorText, serializeNodeToInlineText } from './toc';
+
+const plainHeading = {
+  type: 'h2',
+  children: [{ text: 'Subtitle 1: Everything is okay' }],
+};
+
+const italicHeading = {
+  type: 'h2',
+  children: [
+    { text: 'Subtitle 2: Everything is ' },
+    { text: 'not', italic: true },
+    { text: ' okay' },
+  ],
+};
+
+const partiallyItalicWordHeading = {
+  type: 'h2',
+  children: [
+    { text: 'Subtitle 3: n' },
+    { text: 'o', italic: true },
+    { text: 't okay' },
+  ],
+};
+
+const linkHeading = {
+  type: 'h2',
+  children: [
+    { text: 'Subtitle 4: Everything is ' },
+    {
+      type: 'link',
+      data: { url: '/some-page' },
+      children: [{ text: 'okay' }],
+    },
+    { text: '' },
+  ],
+};
+
+describe('serializeNodeToInlineText', () => {
+  it('returns the text of a node without a type', () => {
+    expect(serializeNodeToInlineText({ text: 'Hello' })).toBe('Hello');
+  });
+
+  it('does not add whitespace between the leafs of a node', () => {
+    expect(serializeNodeToInlineText(partiallyItalicWordHeading)).toBe(
+      'Subtitle 3: not okay',
+    );
+  });
+
+  it('includes the text of inline elements', () => {
+    expect(serializeNodeToInlineText(linkHeading)).toBe(
+      'Subtitle 4: Everything is okay',
+    );
+  });
+
+  it('returns an empty string for an empty node', () => {
+    expect(serializeNodeToInlineText(undefined)).toBe('');
+    expect(serializeNodeToInlineText({ type: 'h2' })).toBe('');
+  });
+});
+
+describe('getAnchorText', () => {
+  it('collapses the inner whitespace and trims the outer one', () => {
+    expect(
+      getAnchorText({
+        type: 'h2',
+        children: [{ text: '  Some  ' }, { text: '' }, { text: 'heading ' }],
+      }),
+    ).toBe('Some heading');
+  });
+});
+
+describe('getAnchor', () => {
+  it('slugs a heading', () => {
+    expect(getAnchor(plainHeading)).toBe('subtitle-1-everything-is-okay');
+  });
+
+  it('is not affected by inline formatting', () => {
+    expect(getAnchor(italicHeading)).toBe('subtitle-2-everything-is-not-okay');
+    expect(getAnchor(partiallyItalicWordHeading)).toBe('subtitle-3-not-okay');
+  });
+
+  it('is not affected by inline links', () => {
+    expect(getAnchor(linkHeading)).toBe('subtitle-4-everything-is-okay');
+  });
+
+  it('returns an empty string for an empty heading', () => {
+    expect(getAnchor({ type: 'h2', children: [{ text: '' }] })).toBe('');
+  });
+});

--- a/packages/volto/cypress/tests/core/blocks/block-anchors.js
+++ b/packages/volto/cypress/tests/core/blocks/block-anchors.js
@@ -114,4 +114,51 @@ describe('Block Tests: Anchors', () => {
     ).click();
     cy.get('h2[id="title-2-u-a"]').scrollIntoView().should('be.visible');
   });
+
+  it('Add Block: add content to TOC with inline formatting', () => {
+    // Change page title
+    cy.clearSlateTitle();
+    cy.getSlateTitle().type('Slate Heading Anchors with inline formatting');
+    cy.getSlate().click();
+
+    // Add TOC block
+    cy.get('.ui.basic.icon.button.block-add-button').first().click();
+    cy.get(".blocks-chooser .ui.form .field.searchbox input[type='text']").type(
+      'table of contents',
+    );
+    cy.get('.button.toc').click();
+
+    // Add a heading, and make one of its words italic
+    cy.get('.ui.basic.icon.button.block-add-button').first().click();
+    cy.get(".blocks-chooser .ui.form .field.searchbox input[type='text']").type(
+      'text',
+    );
+    cy.get('.button.slate').click();
+    cy.get('.ui.drag.block.inner.slate')
+      .click()
+      .type('Title 1 is not okay')
+      .click();
+    cy.get('.ui.drag.block.inner.slate span span span').setSelection(
+      'Title 1 is not okay',
+    );
+    cy.get('.slate-inline-toolbar .button-wrapper a[title="Title"]').click({
+      force: true,
+    });
+    cy.setSlateSelection('not');
+    cy.clickSlateButton('Italic');
+
+    // Save page
+    cy.get('#toolbar-save').click();
+    cy.url().should('eq', Cypress.config().baseUrl + '/my-page');
+
+    // The anchor of the heading ignores the inline formatting, and the TOC
+    // entry links to it
+    cy.get('h2[id="title-1-is-not-okay"] em').contains('not');
+    cy.get(
+      `.table-of-contents a[href="${subpathPrefix}/my-page#title-1-is-not-okay"]`,
+    ).click();
+    cy.get('h2[id="title-1-is-not-okay"]')
+      .scrollIntoView()
+      .should('be.visible');
+  });
 });

--- a/packages/volto/news/8340.bugfix
+++ b/packages/volto/news/8340.bugfix
@@ -1,0 +1,1 @@
+Fixed the links of the `Table of Contents` block breaking when a heading contains inline formatting or a link. The block now uses the anchor reported by the block that owns the heading, instead of slugging its indexed plaintext. @Somilg11

--- a/packages/volto/src/components/manage/Blocks/ToC/View.jsx
+++ b/packages/volto/src/components/manage/Blocks/ToC/View.jsx
@@ -55,6 +55,7 @@ export const getBlocksTocEntries = (properties, tocData) => {
       const i = `${id}-${index}`;
       const level = entry[0];
       const title = entry[1];
+      const anchor = entry[2];
       const items = [];
       if (!level || !levels.includes(level)) return;
       tocEntriesLayout.push(i);
@@ -63,6 +64,7 @@ export const getBlocksTocEntries = (properties, tocData) => {
         title: title || block.plaintext,
         items,
         id: i,
+        anchor,
       };
       if (level < rootLevel) {
         rootLevel = level;
@@ -119,6 +121,7 @@ const View = (props) => {
       if (entry) {
         const level = entry[0];
         const title = entry[1];
+        const anchor = entry[2];
         const items = [];
         if (!title?.trim() && !block.plaintext?.trim()) return;
         if (!level || !levels.includes(level)) return;
@@ -130,6 +133,7 @@ const View = (props) => {
           id,
           override_toc: block.override_toc,
           plaintext: block.plaintext,
+          anchor,
         };
       }
     });

--- a/packages/volto/src/components/manage/Blocks/ToC/View.test.jsx
+++ b/packages/volto/src/components/manage/Blocks/ToC/View.test.jsx
@@ -1,0 +1,33 @@
+import config from '@plone/volto/registry';
+import { getBlocksTocEntries } from './View';
+
+const properties = {
+  blocks: {
+    'block-1': { '@type': 'heading', text: 'Everything is not okay' },
+    'block-2': { '@type': 'heading', text: 'No anchor here' },
+  },
+  blocks_layout: { items: ['block-1', 'block-2'] },
+};
+
+beforeAll(() => {
+  config.blocks.blocksConfig.heading = {
+    id: 'heading',
+    title: 'Heading',
+    tocEntry: (block = {}) =>
+      block.text === 'Everything is not okay'
+        ? [2, block.text, 'everything-is-not-okay']
+        : [2, block.text],
+  };
+});
+
+test('passes the anchor provided by the block to the table of contents entry', () => {
+  const { tocEntries } = getBlocksTocEntries(properties, {});
+
+  expect(tocEntries['block-1-0'].anchor).toBe('everything-is-not-okay');
+});
+
+test('leaves the anchor undefined for blocks that do not provide one', () => {
+  const { tocEntries } = getBlocksTocEntries(properties, {});
+
+  expect(tocEntries['block-2-0'].anchor).toBeUndefined();
+});

--- a/packages/volto/src/components/manage/Blocks/ToC/variations/DefaultTocRenderer.jsx
+++ b/packages/volto/src/components/manage/Blocks/ToC/variations/DefaultTocRenderer.jsx
@@ -12,10 +12,15 @@ import { normalizeString } from '@plone/volto/helpers/Utils/Utils';
 
 const RenderListItems = ({ items, data }) => {
   return map(items, (item) => {
-    const { id, level, title, override_toc, plaintext } = item;
-    const slug = override_toc
-      ? Slugger.slug(normalizeString(plaintext))
-      : Slugger.slug(normalizeString(title)) || id;
+    const { id, level, title, override_toc, plaintext, anchor } = item;
+    // `anchor` is provided by the block itself, and is the anchor that its view
+    // renders. Fall back to slugging the entry for blocks that do not provide
+    // one.
+    const slug =
+      anchor ||
+      (override_toc
+        ? Slugger.slug(normalizeString(plaintext))
+        : Slugger.slug(normalizeString(title)) || id);
     return (
       item && (
         <List.Item key={id} className={`item headline-${level}`} as="li">

--- a/packages/volto/src/components/manage/Blocks/ToC/variations/DefaultTocRenderer.test.jsx
+++ b/packages/volto/src/components/manage/Blocks/ToC/variations/DefaultTocRenderer.test.jsx
@@ -52,3 +52,54 @@ test('renders a default toc renderer component', () => {
   const json = component.toJSON();
   expect(json).toMatchSnapshot();
 });
+
+const renderToc = (entries) => {
+  const store = mockStore({
+    intl: {
+      locale: 'en',
+      messages: {},
+    },
+  });
+  return renderer.create(
+    <Provider store={store}>
+      <MemoryRouter>
+        <DefaultTocRenderer
+          properties={properties}
+          data={data}
+          tocEntries={entries}
+        />
+      </MemoryRouter>
+    </Provider>,
+  );
+};
+
+test('links to the anchor provided by the block', () => {
+  const component = renderToc([
+    {
+      level: 2,
+      title: 'Everything is not okay',
+      items: [],
+      id: 'block-id-0',
+      anchor: 'subtitle-everything-is-not-okay',
+    },
+  ]);
+
+  expect(component.root.findByType('a').props.href).toMatch(
+    /#subtitle-everything-is-not-okay$/,
+  );
+});
+
+test('slugs the title of blocks that provide no anchor', () => {
+  const component = renderToc([
+    {
+      level: 2,
+      title: 'Everything is okay',
+      items: [],
+      id: 'block-id-0',
+    },
+  ]);
+
+  expect(component.root.findByType('a').props.href).toMatch(
+    /#everything-is-okay$/,
+  );
+});

--- a/packages/volto/src/components/manage/Blocks/ToC/variations/HorizontalMenu.jsx
+++ b/packages/volto/src/components/manage/Blocks/ToC/variations/HorizontalMenu.jsx
@@ -8,10 +8,15 @@ import { normalizeString } from '@plone/volto/helpers/Utils/Utils';
 
 const RenderMenuItems = ({ items }) => {
   return map(items, (item) => {
-    const { id, level, title, override_toc, plaintext } = item;
-    const slug = override_toc
-      ? Slugger.slug(normalizeString(plaintext))
-      : Slugger.slug(normalizeString(title)) || id;
+    const { id, level, title, override_toc, plaintext, anchor } = item;
+    // `anchor` is provided by the block itself, and is the anchor that its view
+    // renders. Fall back to slugging the entry for blocks that do not provide
+    // one.
+    const slug =
+      anchor ||
+      (override_toc
+        ? Slugger.slug(normalizeString(plaintext))
+        : Slugger.slug(normalizeString(title)) || id);
     return (
       item && (
         <React.Fragment key={id}>

--- a/packages/volto/src/components/manage/Blocks/ToC/variations/HorizontalMenu.test.jsx
+++ b/packages/volto/src/components/manage/Blocks/ToC/variations/HorizontalMenu.test.jsx
@@ -1,0 +1,40 @@
+import { render } from '@testing-library/react';
+import HorizontalMenu from './HorizontalMenu';
+
+const data = { '@type': 'toc', variation: 'horizontalMenu' };
+
+const renderToc = (tocEntries) =>
+  render(<HorizontalMenu data={data} tocEntries={tocEntries} />);
+
+test('links to the anchor provided by the block', () => {
+  const { getAllByRole } = renderToc([
+    {
+      level: 2,
+      title: 'Everything is not okay',
+      items: [],
+      id: 'block-id-0',
+      anchor: 'subtitle-everything-is-not-okay',
+    },
+  ]);
+
+  expect(getAllByRole('link')[0]).toHaveAttribute(
+    'href',
+    '#subtitle-everything-is-not-okay',
+  );
+});
+
+test('slugs the title of blocks that provide no anchor', () => {
+  const { getAllByRole } = renderToc([
+    {
+      level: 2,
+      title: 'Everything is okay',
+      items: [],
+      id: 'block-id-0',
+    },
+  ]);
+
+  expect(getAllByRole('link')[0]).toHaveAttribute(
+    'href',
+    '#everything-is-okay',
+  );
+});


### PR DESCRIPTION
- [x] I signed and returned the Plone Contributor Agreement, and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't other open pull requests for the same change.
- [x] I followed the guidelines in Contributing to Volto.
- [x] I successfully ran code linting checks on my changes locally.
- [x] I successfully ran unit tests on my changes locally.
- [x] I successfully ran acceptance tests on my changes locally.
- [x] If needed, I added new tests for my changes.
- [ ] If needed, I added documentation for my changes, either in the Storybook or narrative documentation.
- [x] I included a change log entry in my commits.

---

Closes #8340

## What happens

A Table of Contents block entry stops pointing to the correct heading when the heading contains inline formatting or a link. Clicking the entry does nothing because the link target does not match the `id` of the heading it should scroll to.

Examples reported in the issue:

| Heading | Broken anchor | Expected heading `id` |
| --- | --- | --- |
| `Subtitle 1: everything is okay` | `#kay` | `subtitle-1-everything-is-okay` |
| `Subtitle 2: everything is *not* okay` | `#ot-okay` | `subtitle-2-everything-is-not-okay` |
| `Subtitle 3: everything is [okay](/some-page)` | `#kay-` | `subtitle-3-everything-is-okay` |

Headings without inline formatting are not affected.

## Why

The heading `id` and the Table of Contents link were generated from two different representations of the same heading.

The heading `id` was generated by `serializeNodesToText` in `TextBlockView`, while the Table of Contents link was generated by slugging the stored plaintext of the block. Both paths used `serializeNodesToText`, which is intended for indexing and trims whitespace around individual leaves and nodes, as described in its docstring.

When a heading is split into multiple inline nodes, the two representations can differ. Applied to individual leaves, whitespace around formatted text is removed. Applied to the whole block, empty text nodes around inline elements can result in extra separators in the generated slug.

As a result, the heading and its Table of Contents entry end up with different anchors whenever the heading contains multiple inline nodes.

## The fix

The anchor is now generated from the heading text as it is rendered, and the block containing the heading reports the anchor it actually uses.

- Added `getAnchor`, `getAnchorText` and the required serialization helpers in `packages/volto-slate/src/utils/toc.js`. These concatenate the text from inline children without adding or removing whitespace, then collapse and trim the result before generating the anchor.
- `TextBlockView` now renders `getAnchor(node)` as the heading `id`.
- The text block's `tocEntry` now reports the third element of the entry, `[level, title, anchor]`, calculated from the current value instead of the stored plaintext.
- The ToC block passes the anchor through to its variations. Blocks that do not report an anchor fall back to the previous behavior.

The `tocEntry` change is backwards compatible. Add-on blocks that continue to return the usual `[level, title]` format work exactly as before.

`serializeNodesToText` and the stored plaintext are unchanged.

Anchors of headings without inline formatting remain unchanged, so existing working URLs are not affected. Only anchors that were already broken are changed.

## Before and after

Clicking the Table of Contents entry for a heading containing an italic word:

`comparison-italic-heading.png`

<img width="5176" height="1408" alt="comparison-italic-heading" src="https://github.com/user-attachments/assets/a6ca8e65-5a2d-4f04-b5b3-7e2c7e5ffac5" />

Clicking the Table of Contents entry for a heading containing a link:

`comparison-heading-with-link.png`

<img width="5176" height="1408" alt="comparison-heading-with-link" src="https://github.com/user-attachments/assets/9243b2be-f732-4186-bf70-e23649b22c01" />

## Tests

- Added `packages/volto-slate/src/utils/toc.test.js`, covering plain, italic, partially formatted and linked headings.
- Added tests in `packages/volto-slate/src/blocks/Text/TextBlockView.test.js` for the rendered `id` and verifying that it matches the anchor used by the Table of Contents link.
- Added tests in `packages/volto/src/components/manage/Blocks/ToC` for passing the anchor through the entries, including blocks that do not report one.
- Added anchor assertions to both ToC variations.
- Added a case to the `block-anchors.js` acceptance test that creates a heading with an italic word through the editor and follows its Table of Contents entry. It fails on `main` with:

```text
h2[id="title-1-is-not-okay"] em
```
## Local test runs
- Unit tests: 347 files, 1566 passed, 1 skipped
- block-anchors.js acceptance spec: 3 passing, including the new case
- Full core acceptance suite: development failures in recurrence-widget, blocks-search, and a11y/content reproduce identically on main in the same environment. Every other spec that failed during the full run passes when run individually.